### PR TITLE
Client perf overhaul + audio silence fix + prod bundling for Heroku

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,42 @@
+const esbuild = require('esbuild');
+const fs = require('fs');
+const path = require('path');
+
+const bundles = {
+    'play.bundle.min.js': [
+        'client/scripts/game.js',
+        'client/scripts/client.js',
+        'client/scripts/audio.js',
+        'client/scripts/input.js',
+        'client/scripts/draw.js',
+        'client/scripts/gameboard.js',
+        'client/scripts/joystick.js',
+        'client/scripts/utils.js'
+    ],
+    'create.bundle.min.js': [
+        'client/scripts/rhill-voronoi-core.js',
+        'client/scripts/create.js',
+        'client/scripts/utils.js'
+    ],
+    'join.bundle.min.js': [
+        'client/scripts/join.js'
+    ]
+};
+
+const outDir = 'client/scripts/dist';
+
+async function buildAll() {
+    fs.mkdirSync(outDir, { recursive: true });
+    for (const [outFile, sources] of Object.entries(bundles)) {
+        const code = sources.map(f => fs.readFileSync(f, 'utf8')).join('\n;\n');
+        const result = await esbuild.transform(code, { minify: true, loader: 'js' });
+        const target = path.join(outDir, outFile);
+        fs.writeFileSync(target, result.code);
+        console.log(target + ' (' + result.code.length + ' bytes)');
+    }
+}
+
+buildAll().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/client/create.html
+++ b/client/create.html
@@ -186,9 +186,11 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 
   <script src='socket.io/socket.io.js'></script>
+  <!-- BUILD: bundle-start -->
   <script src="scripts/rhill-voronoi-core.js"></script>
   <script src="scripts/create.js"></script>
   <script src="scripts/utils.js"></script>
+  <!-- BUILD: bundle-end -->
 </body>
 
 </html>

--- a/client/join.html
+++ b/client/join.html
@@ -58,7 +58,9 @@
         </div>
     </section>
     <script src='socket.io/socket.io.js'></script>
+    <!-- BUILD: bundle-start -->
     <script src="scripts/join.js"></script>
+    <!-- BUILD: bundle-end -->
 
 </body>
 

--- a/client/play.html
+++ b/client/play.html
@@ -47,6 +47,7 @@
         </section>
         <!-- Load game files -->
         <script src='socket.io/socket.io.js'></script>
+        <!-- BUILD: bundle-start -->
         <script src="scripts/game.js"></script>
         <script src="scripts/client.js"></script>
         <script src="scripts/audio.js"></script>
@@ -55,5 +56,6 @@
         <script src="scripts/gameboard.js"></script>
         <script src="scripts/joystick.js"></script>
         <script src="scripts/utils.js"></script>
+        <!-- BUILD: bundle-end -->
     </body>
 </html>

--- a/client/scripts/audio.js
+++ b/client/scripts/audio.js
@@ -1,8 +1,17 @@
 var gameMuted = false;
-var playingSounds = [];
+var playingSounds = new Set();
+var fadeTimers = new Map();
 var masterVolume = 1,
     effectsVolume = 1,
     musicVolume = 1;
+
+function clearFade(sound) {
+    var timer = fadeTimers.get(sound);
+    if (timer != null) {
+        clearInterval(timer);
+        fadeTimers.delete(sound);
+    }
+}
 
 var calmBackgroundMusicList = [];
 var excitingBackgroundMusicList = [];
@@ -183,7 +192,7 @@ function volumeChange() {
 
 
 function playSound(sound) {
-    playingSounds.push(sound);
+    playingSounds.add(sound);
     if (!gameMuted) {
         if (sound.currentTime > 0) {
             sound.currentTime = 0;
@@ -193,10 +202,7 @@ function playSound(sound) {
 }
 
 function stopSound(sound) {
-    var index = playingSounds.indexOf(sound);
-    if (index != -1) {
-        playingSounds.splice(index, 1);
-    }
+    playingSounds.delete(sound);
     if (!gameMuted) {
         sound.pause();
         if (sound.currentTime > 0) {
@@ -206,9 +212,10 @@ function stopSound(sound) {
 }
 
 function stopAllSounds() {
-    for (var i = 0; i < playingSounds.length; i++) {
-        playingSounds[i].pause();
-    }
+    playingSounds.forEach(function (sound) {
+        sound.pause();
+    });
+    playingSounds.clear();
 }
 
 function playBackgroundSound() {
@@ -237,7 +244,7 @@ function playBackgroundSound() {
 }
 
 function playSoundAfterFinish(sound) {
-    playingSounds.push(sound);
+    playingSounds.add(sound);
     if (!gameMuted) {
         if (sound.currentTime > 0 && !sound.ended) {
             return;
@@ -250,7 +257,7 @@ function playSoundAfterFinish(sound) {
 
 function changeBackgroundMusic(musicList) {
     //No existing background sounds, set musiclist provided
-    if (currentBackgroundMusic == null || currentBackgroundMusic.ended) {
+    if (currentBackgroundMusic == null || currentBackgroundMusic.ended || currentBackgroundMusic.paused) {
         currentBackgroundMusic = musicList[getRandomInt(0, musicList.length - 1)];
         fadeSoundIn(currentBackgroundMusic);
         playSound(currentBackgroundMusic);
@@ -274,28 +281,33 @@ function changeBackgroundMusic(musicList) {
 }
 
 function fadeSoundIn(sound) {
+    clearFade(sound);
     sound.volume = .001 * masterVolume;
-    var backgroundBuildTimer = setInterval(function () {
+    var timer = setInterval(function () {
         if (sound.volume < sound.targetVolume) {
             sound.volume = sound.volume * 1.2 * masterVolume * musicVolume;
         } else {
             sound.volume = sound.targetVolume;
-            clearInterval(backgroundBuildTimer);
+            clearInterval(timer);
+            fadeTimers.delete(sound);
         }
     }, 500);
+    fadeTimers.set(sound, timer);
 }
 
 function fadeSoundOut(sound) {
-    if (sound != null) {
-        var backGroundFadeTimer = setInterval(function () {
-            if (sound.volume > 0.0025) {
-                sound.volume *= .95;
-            } else {
-                stopSound(sound);
-                clearInterval(backGroundFadeTimer);
-            }
-        }, 500);
-    }
+    if (sound == null) return;
+    clearFade(sound);
+    var timer = setInterval(function () {
+        if (sound.volume > 0.0025) {
+            sound.volume *= .95;
+        } else {
+            stopSound(sound);
+            clearInterval(timer);
+            fadeTimers.delete(sound);
+        }
+    }, 500);
+    fadeTimers.set(sound, timer);
 }
 
 function isExcitingPlaylist(sound) {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -12,6 +12,7 @@ function clientConnect() {
 	var server = io();
 
 	server.on('welcome', function (id) {
+		debugLog("welcome, myID=", id);
 		myID = id;
 	});
 
@@ -23,12 +24,14 @@ function clientConnect() {
 	})
 
 	server.on("serverKick", function () {
+		debugLog("serverKick received -- being booted");
 		server.disconnect();
 		window.parent.location.href = "./index.html";
 	});
 
 
 	server.on("gameState", function (gameState) {
+		debugLog("gameState received, gameID=", gameState.gameID, "myID=", gameState.myID, "players=", Object.keys(gameState.clientList || {}).length);
 		config = gameState.config;
 		round = gameState.round;
 		gameLength = config.baseNotchesToWin;
@@ -40,8 +43,9 @@ function clientConnect() {
 		interval = config.serverTickSpeed;
 		gameRunning = true;
 		playSoundAfterFinish(lobbyMusic);
-		init();
 		loadPatterns();
+		loadSpriteSheets();
+		init();
 		if (gameState.myID != null) {
 			myID = gameState.myID;
 		}
@@ -156,15 +160,18 @@ function clientConnect() {
 
 	//Game State Map changes
 	server.on("startWaiting", function (packet) {
+		debugLog("startWaiting");
 		currentState = config.stateMap.waiting;
 		playSoundAfterFinish(lobbyMusic);
 	});
 	server.on("startLobby", function (packet) {
+		debugLog("startLobby, packet=", packet);
 		spawnLobbyStartButton(packet);
 		playSoundAfterFinish(lobbyMusic);
 		currentState = config.stateMap.lobby;
 	});
 	server.on("startGated", function (packet) {
+		debugLog("startGated");
 		stopSound(lobbyMusic);
 		playSound(gameStart);
 		currentState = config.stateMap.gated;
@@ -176,10 +183,6 @@ function clientConnect() {
 		resetTrails();
 		resetPlayerRanks();
 		currentState = config.stateMap.racing;
-		for (var i = 0; i < pingIntervals.length; i++) {
-			clearInterval(pingIntervals[i]);
-		}
-
 	});
 	server.on("startOverview", function (packet) {
 		resetRound();
@@ -480,6 +483,7 @@ function calcPing() {
 function checkForTimeout() {
 	timeSinceLastCom++;
 	if (timeSinceLastCom > serverTimeoutWait) {
+		debugLog("client timeout -- no server comm for " + timeSinceLastCom + "s, reloading");
 		server.disconnect();
 		window.parent.location.reload();
 	}

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -108,6 +108,23 @@ function discardMapCache() {
 }
 
 var playerSpriteCache = {};
+
+var blackoutHoleSprite = null;
+function getBlackoutHoleSprite() {
+    if (blackoutHoleSprite != null) return blackoutHoleSprite;
+    var size = 512;
+    var canvas = document.createElement("canvas");
+    canvas.width = size;
+    canvas.height = size;
+    var ctx = canvas.getContext("2d");
+    ctx.filter = "blur(50px)";
+    ctx.beginPath();
+    ctx.arc(size / 2, size / 2, 50, 0, 2 * Math.PI);
+    ctx.fillStyle = "white";
+    ctx.fill();
+    blackoutHoleSprite = canvas;
+    return canvas;
+}
 function getPlayerSprite(color, radius, strokeColor) {
     var key = color + '|' + radius + '|' + strokeColor;
     var cached = playerSpriteCache[key];
@@ -475,14 +492,10 @@ function drawOverlay() {
         overlayContext.fillRect(0, 0, overlayCanvas.width, overlayCanvas.height);
         overlayContext.restore();
 
-
         overlayContext.save();
-        var radius = 50;
         overlayContext.globalCompositeOperation = 'destination-out';
-        overlayContext.filter = "blur(50px)";
-        overlayContext.beginPath();
-        overlayContext.arc(myPlayer.x, myPlayer.y, radius, 0, 2 * Math.PI, false);
-        overlayContext.fill();
+        var sprite = getBlackoutHoleSprite();
+        overlayContext.drawImage(sprite, myPlayer.x - sprite.width / 2, myPlayer.y - sprite.height / 2);
         overlayContext.restore();
     }
 }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -94,6 +94,46 @@ sand.scale = 0.25;
 
 var playerAnimating = null;
 
+var mapCanvas = null;
+var mapCtx = null;
+var mapDirty = true;
+var mapCanvasPad = 8;
+function invalidateMapCache() {
+    mapDirty = true;
+}
+function discardMapCache() {
+    mapCanvas = null;
+    mapCtx = null;
+    mapDirty = true;
+}
+
+var playerSpriteCache = {};
+function getPlayerSprite(color, radius, strokeColor) {
+    var key = color + '|' + radius + '|' + strokeColor;
+    var cached = playerSpriteCache[key];
+    if (cached != null) {
+        return cached;
+    }
+    var pad = 8;
+    var size = (radius + pad) * 2;
+    var canvas = document.createElement("canvas");
+    canvas.width = size;
+    canvas.height = size;
+    var ctx = canvas.getContext("2d");
+    ctx.translate(size / 2, size / 2);
+    ctx.shadowColor = color;
+    ctx.shadowBlur = 3;
+    ctx.beginPath();
+    ctx.arc(0, 0, radius, 0, 2 * Math.PI);
+    ctx.fillStyle = color;
+    ctx.fill();
+    ctx.strokeStyle = strokeColor;
+    ctx.stroke();
+    canvas.halfSize = size / 2;
+    playerSpriteCache[key] = canvas;
+    return canvas;
+}
+
 //Flames
 var redFire = new Image(32, 128);
 redFire.src = "../assets/img/redFire.png";
@@ -535,6 +575,9 @@ function drawPlayer(player, dt) {
         gameContext.stroke();
         gameContext.restore();
     }
+    if (DEBUG_FORCE_FIRE && player.id == myID) {
+        player.onFire = 500;
+    }
     if (player.onFire > 0) {
         drawFire(player);
     }
@@ -545,18 +588,12 @@ function drawPlayer(player, dt) {
             playerStrokeColor = "red"
         }
     }
-    gameContext.save();
-    gameContext.beginPath();
-    gameContext.shadowColor = player.color;
-    gameContext.shadowBlur = 3;
-    gameContext.arc(player.x + camera.getCameraX(), player.y + camera.getCameraY(), player.radius, 0, 2 * Math.PI);
-    gameContext.fillStyle = player.color;
-    gameContext.fill();
-    gameContext.strokeStyle = playerStrokeColor;
-    gameContext.stroke();
-    gameContext.restore();
-
-
+    var sprite = getPlayerSprite(player.color, player.radius, playerStrokeColor);
+    gameContext.drawImage(
+        sprite,
+        player.x + camera.getCameraX() - sprite.halfSize,
+        player.y + camera.getCameraY() - sprite.halfSize
+    );
 
     if (player.ability != null) {
         drawAbilityIndicator(player.x, player.y, player);
@@ -636,7 +673,6 @@ function drawFire(player) {
 }
 
 function drawFlameColor(player, size) {
-    loadSpriteSheets();
     if (player.onFire < 1000) {
         redFire.spriteSheet.update(dt);
         redFire.spriteSheet.draw(size, size);
@@ -808,28 +844,9 @@ function drawCutAimer(x, y, angle, color) {
 }
 
 function drawTrail(player) {
-    if (player.trail.vertices[0] != null) {
-        gameContext.save();
-        gameContext.beginPath();
-        gameContext.moveTo(player.trail.vertices[0].x, player.trail.vertices[0].y);
-        var len = player.trail.vertices.length;
-        for (var i = 0; i < len; i++) {
-            var point = player.trail.vertices[i];
-            gameContext.lineTo(point.x, point.y);
-        }
-        gameContext.lineWidth = 5;
-        gameContext.shadowBlur = 3;
-        gameContext.shadowColor = "black";
-        gameContext.strokeStyle = player.color;
-
-        if (player.notches == gameLength) {
-            gameContext.lineWidth = 6;
-            gameContext.setLineDash([20, 3, 3, 3, 3, 3, 3, 3]);
-        }
-        gameContext.stroke();
-        gameContext.restore();
+    if (player.trail.canvas != null) {
+        gameContext.drawImage(player.trail.canvas, player.trail.canvasOriginX, player.trail.canvasOriginY);
     }
-
 }
 
 function drawWorld() {
@@ -931,75 +948,94 @@ function drawPingCircles() {
     gameContext.save();
     gameContext.lineWidth = 3;
     gameContext.strokeStyle = config.tileMap.goal.color;
-    gameContext.shadowBlur = 3;
-    gameContext.shadowColor = "black";
+    gameContext.beginPath();
     for (var i = 0; i < pingCircles.length; i++) {
-        gameContext.beginPath();
-        gameContext.arc(pingCircles[i].x, pingCircles[i].y, pingCircles[i].radius, 0, 2 * Math.PI);
-        gameContext.stroke();
+        var ping = pingCircles[i];
+        gameContext.moveTo(ping.x + ping.radius, ping.y);
+        gameContext.arc(ping.x, ping.y, ping.radius, 0, 2 * Math.PI);
     }
+    gameContext.stroke();
     gameContext.restore();
 }
 function drawMap() {
-    if (Object.keys(currentMap).length > 0) {
-        gameContext.save();
-        var cells = currentMap.cells,
-            iCell = cells.length;
-
-        while (iCell--) {
-            gameContext.beginPath();
-            var cell = cells[iCell];
-            var halfedges = cell.halfedges;
-            var nHalfedges = halfedges.length;
-            if (nHalfedges == 0) {
-                continue;
-            }
-            var v = getStartpoint(halfedges[0]);
-            gameContext.moveTo(v.x, v.y);
-            for (var i = 0; i < nHalfedges; i++) {
-                v = getEndpoint(halfedges[i]);
-                gameContext.lineTo(v.x, v.y);
-            }
-            var color = null;
-
-
-            if (cell.id > 99) {
-                //Ability Tiles
-                gameContext.setLineDash([2, 2]);
-                gameContext.lineWidth = 5;
-                gameContext.strokeStyle = '#FFFF00';
-                color = patterns[cell.id];
-            } else if (patterns[cell.id] != null) {
-                // Textured Tiles
-                color = patterns[cell.id];
-                gameContext.setLineDash([]);
-                gameContext.lineWidth = 1;
-                gameContext.strokeStyle = patterns[cell.id];
-            } else if (cell.id == config.tileMap.goal.id) {
-                gameContext.setLineDash([0, 0]);
-                gameContext.lineWidth = 5;
-                gameContext.strokeStyle = '#756300';
-                color = locateColor(cell.id);
-            } else {
-                //Regular colors
-                color = locateColor(cell.id);
-                gameContext.setLineDash([]);
-                gameContext.lineWidth = 3;
-                gameContext.strokeStyle = color;
-            }
-            gameContext.shadowBlur = null;
-            gameContext.shadowColor = null;
-            gameContext.fillStyle = color;
-            gameContext.fill();
-            gameContext.stroke();
-        }
-        gameContext.restore();
-        if (Object.keys(hazardList).length > 0) {
-            for (var id in hazardList) {
-                drawHazard(hazardList[id]);
-            }
+    if (currentMap == null || currentMap.cells == null || currentMap.cells.length === 0) {
+        return;
+    }
+    if (mapDirty || mapCanvas == null) {
+        renderMapToCache();
+        mapDirty = false;
+    }
+    if (mapCanvas != null) {
+        gameContext.drawImage(mapCanvas, world.x - mapCanvasPad, world.y - mapCanvasPad);
+    }
+    if (Object.keys(hazardList).length > 0) {
+        for (var id in hazardList) {
+            drawHazard(hazardList[id]);
         }
     }
+}
+
+function renderMapToCache() {
+    if (world == null) {
+        return;
+    }
+    if (mapCanvas == null) {
+        mapCanvas = document.createElement("canvas");
+        mapCanvas.width = world.width + mapCanvasPad * 2;
+        mapCanvas.height = world.height + mapCanvasPad * 2;
+        mapCtx = mapCanvas.getContext("2d");
+    } else {
+        mapCtx.clearRect(0, 0, mapCanvas.width, mapCanvas.height);
+    }
+    mapCtx.save();
+    mapCtx.translate(-world.x + mapCanvasPad, -world.y + mapCanvasPad);
+
+    var cells = currentMap.cells;
+    var iCell = cells.length;
+    while (iCell--) {
+        mapCtx.beginPath();
+        var cell = cells[iCell];
+        var halfedges = cell.halfedges;
+        var nHalfedges = halfedges.length;
+        if (nHalfedges == 0) {
+            continue;
+        }
+        var v = getStartpoint(halfedges[0]);
+        mapCtx.moveTo(v.x, v.y);
+        for (var i = 0; i < nHalfedges; i++) {
+            v = getEndpoint(halfedges[i]);
+            mapCtx.lineTo(v.x, v.y);
+        }
+        var color = null;
+
+        if (cell.id > 99) {
+            mapCtx.setLineDash([2, 2]);
+            mapCtx.lineWidth = 5;
+            mapCtx.strokeStyle = '#FFFF00';
+            color = patterns[cell.id];
+        } else if (patterns[cell.id] != null) {
+            color = patterns[cell.id];
+            mapCtx.setLineDash([]);
+            mapCtx.lineWidth = 1;
+            mapCtx.strokeStyle = patterns[cell.id];
+        } else if (cell.id == config.tileMap.goal.id) {
+            mapCtx.setLineDash([0, 0]);
+            mapCtx.lineWidth = 5;
+            mapCtx.strokeStyle = '#756300';
+            color = locateColor(cell.id);
+        } else {
+            color = locateColor(cell.id);
+            mapCtx.setLineDash([]);
+            mapCtx.lineWidth = 3;
+            mapCtx.strokeStyle = color;
+        }
+        mapCtx.shadowBlur = 0;
+        mapCtx.shadowColor = "transparent";
+        mapCtx.fillStyle = color;
+        mapCtx.fill();
+        mapCtx.stroke();
+    }
+    mapCtx.restore();
 }
 function drawHazard(hazard) {
     if (hazard.id == config.hazards.bumper.id) {

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -1,3 +1,12 @@
+// DEBUG: set to true to log network events and state changes. Defaults to false.
+var DEBUG_NETWORK = false;
+function debugLog() {
+    if (!DEBUG_NETWORK) return;
+    var args = Array.prototype.slice.call(arguments);
+    args.unshift("[debug]");
+    console.log.apply(console, args);
+}
+
 var server = null,
     interval = null,
     gameLength = null,

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -20,10 +20,14 @@ var mousex,
 	timerList = [],
 	playersNearVictory = [],
 	pingCircles = [],
-	pingIntervals = [],
 	brutalRound = false,
 	brutalRoundConfig = null,
 	clientList;
+
+// DEBUG: force my player's trail to render in near-victory (dashed) style. Set to false for real play.
+var DEBUG_FORCE_NEAR_VICTORY = false;
+// DEBUG: force my player to be on fire for testing flame animation. Set to false for real play.
+var DEBUG_FORCE_FIRE = false;
 
 resetGameboard();
 
@@ -54,7 +58,30 @@ function updateGameboard(dt) {
 	if (currentState == config.stateMap.racing || currentState == config.stateMap.overview || currentState == config.stateMap.collapsing) {
 		updateTrails();
 	}
+	updatePingCircles(dt);
 	checkTimers(dt);
+}
+
+function updatePingCircles(dt) {
+	if (pingCircles.length == 0) return;
+	if (currentState != config.stateMap.gated) return;
+	var wrapped = false;
+	for (var i = pingCircles.length - 1; i >= 0; i--) {
+		var ping = pingCircles[i];
+		if (ping.pass >= 2) {
+			pingCircles.splice(i, 1);
+			continue;
+		}
+		ping.radius += 200 * dt / 1000;
+		if (ping.radius > 500) {
+			ping.radius = 0;
+			ping.pass++;
+			wrapped = true;
+		}
+	}
+	if (wrapped) {
+		playSound(countDownA);
+	}
 }
 function resetTrails() {
 	for (var id in playerList) {
@@ -69,7 +96,7 @@ function updateTrails() {
 		if (player.alive == false || player.infected == true) {
 			continue;
 		}
-		player.trail.update({ x: player.x, y: player.y });
+		player.trail.update({ x: player.x, y: player.y }, player);
 	}
 }
 
@@ -271,6 +298,7 @@ function checkGameState(payload) {
 function loadNewMap(id) {
 	currentMap = {};
 	pingCircles = [];
+	invalidateMapCache();
 	for (var i = 0; i < maps.length; i++) {
 		if (id == maps[i].id) {
 			currentMap = JSON.parse(JSON.stringify(maps[i]));
@@ -278,26 +306,15 @@ function loadNewMap(id) {
 		}
 	}
 	if (currentState == config.stateMap.gated) {
+		var goalFound = false;
 		for (var j = 0; j < currentMap.cells.length; j++) {
 			if (currentMap.cells[j].id == config.tileMap.goal.id) {
-				playSound(countDownA);
-				var pingCircle = { x: currentMap.cells[j].site.x, y: currentMap.cells[j].site.y, radius: 0, pass: 0 };
-				pingCircles.push(pingCircle);
-				pingIntervals.push(setInterval(function (ping) {
-					if (ping.pass == 2) {
-						var index = pingCircles.indexOf(ping);
-						pingCircles.splice(index, 1);
-					}
-					if (ping.radius > 500) {
-						ping.radius = 0;
-						playSound(countDownA);
-						ping.pass++;
-					} else {
-						ping.radius += 10;
-					}
-
-				}, 50, pingCircle));
+				goalFound = true;
+				pingCircles.push({ x: currentMap.cells[j].site.x, y: currentMap.cells[j].site.y, radius: 0, pass: 0 });
 			}
+		}
+		if (goalFound) {
+			playSound(countDownA);
 		}
 	}
 }
@@ -320,6 +337,7 @@ function applyAbilites(abilities) {
 			currentMap.cells[i].id = abilities[currentMap.cells[i].site.voronoiId];
 		}
 	}
+	invalidateMapCache();
 }
 function applyRandomTiles(randomTiles) {
 	if (randomTiles.length == 0) {
@@ -330,6 +348,7 @@ function applyRandomTiles(randomTiles) {
 			currentMap.cells[i].id = randomTiles[currentMap.cells[i].site.voronoiId];
 		}
 	}
+	invalidateMapCache();
 }
 function applyHazards(payload) {
 	if (payload == null) {
@@ -552,7 +571,7 @@ function collapseCells(cells) {
 			}
 		}
 	}
-
+	invalidateMapCache();
 }
 function explodedCells(cells) {
 	for (var i = 0; i < currentMap.cells.length; i++) {
@@ -564,7 +583,7 @@ function explodedCells(cells) {
 			}
 		}
 	}
-
+	invalidateMapCache();
 }
 
 function playerPickedUpAbility(payload) {
@@ -576,6 +595,7 @@ function playerPickedUpAbility(payload) {
 		var cell = currentMap.cells[i];
 		if (cell.site.voronoiId == payload.voronoiId) {
 			cell.id = config.tileMap.normal.id;
+			invalidateMapCache();
 			return;
 		}
 	}
@@ -592,6 +612,7 @@ function changeTilesBulk(tileChanges) {
 
 		}
 	}
+	invalidateMapCache();
 }
 
 
@@ -626,20 +647,102 @@ function setupEmojiWheel() {
 class Trail {
 	constructor(initialPosition) {
 		this.vertices = [];
-		this.maxLength = 10000;
+		this.maxLength = 100000;
+		this.canvas = null;
+		this.ctx = null;
+		this.canvasOriginX = 0;
+		this.canvasOriginY = 0;
+		this.wasNearVictory = false;
+		this.accumulatedLength = 0;
 	}
-	update(currentPosition) {
-		if (this.vertices.length > 0 &&
-			currentPosition.x == this.vertices[this.vertices.length - 1].x &&
-			currentPosition.y == this.vertices[this.vertices.length - 1].y) {
+	_ensureCanvas() {
+		if (this.canvas != null || world == null) {
+			return;
+		}
+		var pad = 8;
+		this.canvas = document.createElement("canvas");
+		this.canvas.width = world.width + pad * 2;
+		this.canvas.height = world.height + pad * 2;
+		this.ctx = this.canvas.getContext("2d");
+		this.canvasOriginX = world.x - pad;
+		this.canvasOriginY = world.y - pad;
+	}
+	_applyStrokeStyle(color, dashed) {
+		this.ctx.lineWidth = dashed ? 6 : 5;
+		this.ctx.shadowBlur = 3;
+		this.ctx.shadowColor = "black";
+		this.ctx.strokeStyle = color;
+		this.ctx.setLineDash(dashed ? [20, 3, 3, 3, 3, 3, 3, 3] : []);
+	}
+	_redrawAll(color, dashed) {
+		this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+		var total = 0;
+		for (var i = 1; i < this.vertices.length; i++) {
+			var dx = this.vertices[i].x - this.vertices[i - 1].x;
+			var dy = this.vertices[i].y - this.vertices[i - 1].y;
+			total += Math.sqrt(dx * dx + dy * dy);
+		}
+		this.accumulatedLength = total;
+		if (this.vertices.length < 2) {
+			return;
+		}
+		this._applyStrokeStyle(color, dashed);
+		this.ctx.lineDashOffset = 0;
+		this.ctx.beginPath();
+		var v0 = this.vertices[0];
+		this.ctx.moveTo(v0.x - this.canvasOriginX, v0.y - this.canvasOriginY);
+		for (var j = 1; j < this.vertices.length; j++) {
+			var v = this.vertices[j];
+			this.ctx.lineTo(v.x - this.canvasOriginX, v.y - this.canvasOriginY);
+		}
+		this.ctx.stroke();
+	}
+	update(currentPosition, player) {
+		var last = this.vertices.length > 0 ? this.vertices[this.vertices.length - 1] : null;
+		if (last != null && currentPosition.x == last.x && currentPosition.y == last.y) {
 			return;
 		}
 		if (this.vertices.length > this.maxLength) {
 			this.vertices.shift();
 		}
 		this.vertices.push(currentPosition);
+
+		this._ensureCanvas();
+		if (this.canvas == null || player == null) {
+			return;
+		}
+
+		var isNearVictory = player.notches == gameLength;
+		if (DEBUG_FORCE_NEAR_VICTORY && player.id == myID) {
+			isNearVictory = true;
+		}
+		if (isNearVictory != this.wasNearVictory) {
+			this._redrawAll(player.color, isNearVictory);
+			this.wasNearVictory = isNearVictory;
+			return;
+		}
+		if (last == null) {
+			return;
+		}
+		var sdx = currentPosition.x - last.x;
+		var sdy = currentPosition.y - last.y;
+		var segLen = Math.sqrt(sdx * sdx + sdy * sdy);
+
+		this._applyStrokeStyle(player.color, isNearVictory);
+		this.ctx.lineDashOffset = isNearVictory ? this.accumulatedLength : 0;
+		this.ctx.beginPath();
+		this.ctx.moveTo(last.x - this.canvasOriginX, last.y - this.canvasOriginY);
+		this.ctx.lineTo(currentPosition.x - this.canvasOriginX, currentPosition.y - this.canvasOriginY);
+		this.ctx.stroke();
+
+		this.accumulatedLength += segLen;
 	}
 	reset(player) {
 		this.vertices = [];
+		this.wasNearVictory = false;
+		this.accumulatedLength = 0;
+		if (this.ctx != null) {
+			this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+		}
 	}
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 const express = require('express');
+const compression = require('compression');
+const fs = require('fs');
 const app = express();
 const http = require('http');
 const server = http.createServer(app);
@@ -6,6 +8,27 @@ const { Server } = require("socket.io");
 const io = new Server(server);
 const path = require('path');
 const htmlPath = path.join(__dirname, 'client');
+
+app.use(compression());
+
+const bundleMap = {
+    '/play.html': 'scripts/dist/play.bundle.min.js',
+    '/create.html': 'scripts/dist/create.bundle.min.js',
+    '/join.html': 'scripts/dist/join.bundle.min.js'
+};
+app.use(function (req, res, next) {
+    if (process.env.NODE_ENV !== 'production') return next();
+    var url = req.path === '/' ? '/index.html' : req.path;
+    if (!(url in bundleMap)) return next();
+    fs.readFile(path.join(htmlPath, url), 'utf8', function (err, html) {
+        if (err) return next();
+        var bundleTag = '<script src="' + bundleMap[url] + '"></script>';
+        var modified = html.replace(/<!-- BUILD: bundle-start -->[\s\S]*?<!-- BUILD: bundle-end -->/g, bundleTag);
+        res.set('Content-Type', 'text/html');
+        res.send(modified);
+    });
+});
+
 app.use(express.static(htmlPath));
 
 var utils = require('./server/utils.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,404 @@
             "version": "0.0.1",
             "dependencies": {
                 "@octokit/core": "^4.2.0",
+                "compression": "^1.7.4",
                 "express": "^4.17.1",
                 "jquery": "^3.6.0",
                 "socket.io": "^4.1.3"
+            },
+            "devDependencies": {
+                "esbuild": "^0.20.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@octokit/auth-token": {
@@ -206,6 +601,45 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/compression": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
+                "debug": "2.6.9",
+                "negotiator": "~0.6.4",
+                "on-headers": "~1.1.0",
+                "safe-buffer": "5.2.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/negotiator": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/content-disposition": {
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -349,6 +783,45 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/esbuild": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.20.2",
+                "@esbuild/android-arm": "0.20.2",
+                "@esbuild/android-arm64": "0.20.2",
+                "@esbuild/android-x64": "0.20.2",
+                "@esbuild/darwin-arm64": "0.20.2",
+                "@esbuild/darwin-x64": "0.20.2",
+                "@esbuild/freebsd-arm64": "0.20.2",
+                "@esbuild/freebsd-x64": "0.20.2",
+                "@esbuild/linux-arm": "0.20.2",
+                "@esbuild/linux-arm64": "0.20.2",
+                "@esbuild/linux-ia32": "0.20.2",
+                "@esbuild/linux-loong64": "0.20.2",
+                "@esbuild/linux-mips64el": "0.20.2",
+                "@esbuild/linux-ppc64": "0.20.2",
+                "@esbuild/linux-riscv64": "0.20.2",
+                "@esbuild/linux-s390x": "0.20.2",
+                "@esbuild/linux-x64": "0.20.2",
+                "@esbuild/netbsd-x64": "0.20.2",
+                "@esbuild/openbsd-x64": "0.20.2",
+                "@esbuild/sunos-x64": "0.20.2",
+                "@esbuild/win32-arm64": "0.20.2",
+                "@esbuild/win32-ia32": "0.20.2",
+                "@esbuild/win32-x64": "0.20.2"
+            }
         },
         "node_modules/escape-html": {
             "version": "1.0.3",
@@ -635,6 +1108,15 @@
             "dependencies": {
                 "ee-first": "1.1.1"
             },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/on-headers": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -973,6 +1455,167 @@
         }
     },
     "dependencies": {
+        "@esbuild/aix-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-s390x": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/sunos-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+            "dev": true,
+            "optional": true
+        },
         "@octokit/auth-token": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
@@ -1131,6 +1774,35 @@
                 "get-intrinsic": "^1.0.2"
             }
         },
+        "compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "requires": {
+                "mime-db": ">= 1.43.0 < 2"
+            }
+        },
+        "compression": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+            "requires": {
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
+                "debug": "2.6.9",
+                "negotiator": "~0.6.4",
+                "on-headers": "~1.1.0",
+                "safe-buffer": "5.2.1",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "negotiator": {
+                    "version": "0.6.4",
+                    "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+                    "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="
+                }
+            }
+        },
         "content-disposition": {
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1237,6 +1909,37 @@
             "version": "5.0.6",
             "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
             "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw=="
+        },
+        "esbuild": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "dev": true,
+            "requires": {
+                "@esbuild/aix-ppc64": "0.20.2",
+                "@esbuild/android-arm": "0.20.2",
+                "@esbuild/android-arm64": "0.20.2",
+                "@esbuild/android-x64": "0.20.2",
+                "@esbuild/darwin-arm64": "0.20.2",
+                "@esbuild/darwin-x64": "0.20.2",
+                "@esbuild/freebsd-arm64": "0.20.2",
+                "@esbuild/freebsd-x64": "0.20.2",
+                "@esbuild/linux-arm": "0.20.2",
+                "@esbuild/linux-arm64": "0.20.2",
+                "@esbuild/linux-ia32": "0.20.2",
+                "@esbuild/linux-loong64": "0.20.2",
+                "@esbuild/linux-mips64el": "0.20.2",
+                "@esbuild/linux-ppc64": "0.20.2",
+                "@esbuild/linux-riscv64": "0.20.2",
+                "@esbuild/linux-s390x": "0.20.2",
+                "@esbuild/linux-x64": "0.20.2",
+                "@esbuild/netbsd-x64": "0.20.2",
+                "@esbuild/openbsd-x64": "0.20.2",
+                "@esbuild/sunos-x64": "0.20.2",
+                "@esbuild/win32-arm64": "0.20.2",
+                "@esbuild/win32-ia32": "0.20.2",
+                "@esbuild/win32-x64": "0.20.2"
+            }
         },
         "escape-html": {
             "version": "1.0.3",
@@ -1446,6 +2149,11 @@
             "requires": {
                 "ee-first": "1.1.1"
             }
+        },
+        "on-headers": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A=="
         },
         "once": {
             "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,17 @@
     "description": "Multiplayer web based slow paced racing game",
     "dependencies": {
         "@octokit/core": "^4.2.0",
+        "compression": "^1.7.4",
         "express": "^4.17.1",
         "jquery": "^3.6.0",
         "socket.io": "^4.1.3"
     },
+    "devDependencies": {
+        "esbuild": "^0.20.0"
+    },
     "scripts": {
-        "start": "node index.js"
+        "build": "node build.js",
+        "start": "node index.js",
+        "start:prod": "NODE_ENV=production node index.js"
     }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "scripts": {
         "build": "node build.js",
         "start": "node index.js",
-        "start:prod": "NODE_ENV=production node index.js"
+        "start:prod": "NODE_ENV=production node index.js",
+        "heroku-postbuild": "npm run build"
     }
 }

--- a/server/debug.js
+++ b/server/debug.js
@@ -1,0 +1,8 @@
+// Debug logging for the server. Flip `enabled` to true to turn on. Defaults to false.
+exports.enabled = false;
+exports.log = function () {
+    if (!exports.enabled) return;
+    var args = Array.prototype.slice.call(arguments);
+    args.unshift("[debug]");
+    console.log.apply(console, args);
+};

--- a/server/debug.js
+++ b/server/debug.js
@@ -6,3 +6,7 @@ exports.log = function () {
     args.unshift("[debug]");
     console.log.apply(console, args);
 };
+
+// DEBUG: force every round to be a brutal blackout round for testing.
+// Defaults to false.
+exports.forceBlackout = false;

--- a/server/game.js
+++ b/server/game.js
@@ -1412,6 +1412,10 @@ class GameBoard {
 	checkForBrutalRound() {
 		var brutalRoundConfig = { brutal: false, brutalTypes: [] };
 		this.brutalRound = false;
+		if (debug.forceBlackout) {
+			this.brutalRound = true;
+			return { brutal: true, brutalTypes: [c.brutalRounds.blackout.id] };
+		}
 		var brutalChance = utils.getRandomInt(1, 100);
 
 		//console.log("Initial roll: " + brutalChance);

--- a/server/game.js
+++ b/server/game.js
@@ -5,6 +5,7 @@ var messenger = require('./messenger.js');
 var hostess = require('./hostess.js');
 var _engine = require('./engine.js');
 var compressor = require('./compressor.js');
+var debug = require('./debug.js');
 
 exports.getRoom = function (sig, size) {
 	return new Room(sig, size);
@@ -200,6 +201,7 @@ class Game {
 		client.emit("allAbilityHoldings", JSON.stringify(this.gameBoard.gatherAbilities()));
 	}
 	checkLobbyStart() {
+		debug.log("checkLobbyStart: playerCount=", this.playerCount, " min=", c.minPlayersToStart, " state=", this.currentState);
 		if (this.playerCount >= c.minPlayersToStart) {
 			this.startLobby();
 		}
@@ -361,6 +363,7 @@ class Game {
 	}
 	startLobby() {
 		console.log("Start Lobby")
+		debug.log("startLobby: from state=", this.currentState, " playerCount=", this.playerCount);
 		this.currentState = this.stateMap.lobby;
 		this.world.resize();
 		this.gameBoard.startLobby();
@@ -2076,6 +2079,7 @@ class Player extends Circle {
 	checkAFK(currentState) {
 		if (this.awake == true) {
 			if (currentState == c.stateMap.waiting || currentState == c.stateMap.lobby) {
+				debug.log("checkAFK: kicking player id=", this.id, " from state=", currentState, " (awake AFK)");
 				this.kick = true;
 				return;
 			}
@@ -2087,6 +2091,7 @@ class Player extends Circle {
 			if (this.kickTimeLeft > 0) {
 				return;
 			}
+			debug.log("checkAFK: kicking player id=", this.id, " from state=", currentState, " (kickTimer expired)");
 			this.kick = true;
 			return;
 		}

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -2,6 +2,7 @@ var utils = require('./utils.js');
 var hostess = require('./hostess.js');
 var c = utils.loadConfig();
 var compressor = require('./compressor.js');
+var debug = require('./debug.js');
 var mailBoxList = {},
 	roomMailList = {},
 	io;
@@ -76,7 +77,7 @@ function checkForMail(client) {
 	});
 
 	client.on('enterGame', function (id) {
-
+		debug.log("enterGame: client=", client.id, " requestedId=", id);
 		var roomSig = '';
 		if (id == -1) {
 			roomSig = hostess.findARoom(client.id);
@@ -85,9 +86,11 @@ function checkForMail(client) {
 		}
 		var room = hostess.joinARoom(roomSig, client.id);
 		if (room == false) {
+			debug.log("enterGame: joinARoom FAILED for client=", client.id, " roomSig=", roomSig);
 			client.emit("roomNotFound");
 			return;
 		}
+		debug.log("enterGame: client=", client.id, " joined room=", roomSig, " state=", room.game.currentState, " playerCount=", room.game.playerCount);
 		//client.emit("maplisting", utils.getMapListings());
 
 		//Add this player to the list of current clients in the room


### PR DESCRIPTION
## Summary

Five commits, three independent concerns:

**Client rendering performance** (frame-rate work on the hot path)
- `d0b59fc` — Cache the Voronoi tile map, player sprites, and trail rendering to offscreen canvases; redraw only on mutation. Move spritesheet init out of per-frame. Fix the ping-circle lag at the gated→racing transition (drop shadowBlur, batch arcs into one path, drive ping animation from rAF instead of N setIntervals, dedupe the simultaneous playSound calls).
- `da2d5c8` — Pre-bake the blackout overlay's blurred vision-hole into a 512px sprite so `filter: blur(50px)` doesn't run every frame.

**Audio bug fix**
- `ef9a9ea` — Fix the long-standing "music goes silent after several brutal↔calm transitions" bug. Root cause was stacked fade `setInterval`s on the same Audio element: a stale fade-out from a prior round would eventually call `stopSound()` on the currently-playing track, pausing it mid-play, and `changeBackgroundMusic`'s bail-out check only looked at `.ended`, not `.paused`. Now each sound has at most one fade interval (tracked in a `fadeTimers` Map), and `changeBackgroundMusic` treats paused as needs-restart. `playingSounds` also converted from Array to Set so it doesn't accumulate duplicates.

**Load-time / deploy pipeline**
- `516c1b1` — Always-on gzip via `compression()` middleware (~64% reduction on HTML, similar on the 1.35MB map JSONs). Adds a prod-only build step using `esbuild.transform` to minify-and-concatenate the 8 game scripts into a single bundle in `client/scripts/dist/`. A tiny middleware in `index.js` swaps the script block (marked by `<!-- BUILD: bundle-start/end -->`) for the bundle tag only when `NODE_ENV=production`. Dev mode is unchanged — individual unminified files load as today for easy debugging.
- `eb6021b` — Adds `heroku-postbuild` so the bundle is produced on Heroku's build dyno. Heroku's `NODE_ENV=production` default flips the middleware on automatically.

**Net wire reduction in prod:** play.html assets go from ~200KB across 8 requests to a single ~19KB gzipped bundle.

## Test plan
- [ ] Smoke test the local app — load, lobby, gated, racing, brutal blackout, game over.
- [ ] Watch ping-circles when transitioning from gated to racing on a map with many goals (used `YouGotOptions`, 8 goals, during dev).
- [ ] Play 6+ rounds cycling brutal↔calm to verify background music doesn't go silent.
- [ ] `npm start` (dev) → DevTools Network shows individual unminified script files; identifiers are readable.
- [ ] `npm run build && npm run start:prod` → DevTools Network shows only `play.bundle.min.js`; identifiers mangled.
- [ ] On first Heroku deploy, watch the build log for the three bundle-size lines (once, not twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)