### PR TITLE
Project hygiene: editor + join + landing tidy, spectator-render fix, release-notes CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- What changed and why -->
+
+## Game mechanic impact
+
+- [ ] This change touches `server/config.json`, `server/game.js`, or `server/engine.js` (gameplay tuning, round logic, or physics).
+- [ ] If yes, I added a player-facing entry under `## Unreleased` in `CHANGELOG.md`. (CI enforces this.)
+
+## Test plan
+
+<!-- How was this tested? Browser steps, commands, etc. -->

--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -68,10 +68,15 @@ jobs:
           fi
           # Reject changes that only edit existing released sections — new notes
           # should land under '## Unreleased' so the next release can sweep them up.
+          # Treat ADDED and CONTEXT section headers (lines starting with '+' or ' ')
+          # as section boundaries, but never DELETED ones — otherwise a release-prep
+          # PR that renames '## Unreleased' to '## vX.Y.Z' (the diff contains
+          # '-## Unreleased') would flip into in_unrel state and false-positive the
+          # next added line as a new note.
           unreleased_added=$(git diff "$base" "$head" -- CHANGELOG.md | awk '
             /^@@/ {in_unrel = 0; next}
-            /^[+-]## Unreleased/ {in_unrel = 1; next}
-            /^[+-]## [0-9]/ {in_unrel = 0; next}
+            /^[+ ]## Unreleased/ {in_unrel = 1; next}
+            /^[+ ]## [0-9]/ {in_unrel = 0; next}
             in_unrel && /^\+[^+]/ {n++}
             END {print n+0}
           ')

--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -1,0 +1,82 @@
+name: Game mechanic changes need release notes
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine diff range
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "base=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            # For pushes, compare against the parent commit (covers single commits
+            # and pushed batches via github.event.before).
+            before='${{ github.event.before }}'
+            if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              before="${{ github.sha }}^"
+            fi
+            echo "base=$before" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Look for game mechanic changes
+        id: mechanics
+        run: |
+          base='${{ steps.range.outputs.base }}'
+          head='${{ steps.range.outputs.head }}'
+          mechanic_paths='server/config.json server/game.js server/engine.js'
+          changed=$(git diff --name-only "$base" "$head" -- $mechanic_paths || true)
+          if [ -z "$changed" ]; then
+            echo "Touched no game mechanic files. Skipping release notes check."
+            echo "changed=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changed game mechanic files:"
+            echo "$changed"
+            echo "changed<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$changed" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Require a CHANGELOG.md entry
+        if: steps.mechanics.outputs.changed != ''
+        run: |
+          base='${{ steps.range.outputs.base }}'
+          head='${{ steps.range.outputs.head }}'
+          if ! git diff --name-only "$base" "$head" | grep -qx CHANGELOG.md; then
+            echo "::error::This change touches a game mechanic file but CHANGELOG.md was not updated."
+            echo "::error::Add a player-facing entry under '## Unreleased' in CHANGELOG.md."
+            echo "::error::Touched: ${{ steps.mechanics.outputs.changed }}"
+            exit 1
+          fi
+          added=$(git diff "$base" "$head" -- CHANGELOG.md | awk '/^\+[^+]/ {n++} END {print n+0}')
+          if [ "$added" -lt 1 ]; then
+            echo "::error::CHANGELOG.md was modified but no new content was added. Please describe the change for players."
+            exit 1
+          fi
+          # Reject changes that only edit existing released sections — new notes
+          # should land under '## Unreleased' so the next release can sweep them up.
+          unreleased_added=$(git diff "$base" "$head" -- CHANGELOG.md | awk '
+            /^@@/ {in_unrel = 0; next}
+            /^[+-]## Unreleased/ {in_unrel = 1; next}
+            /^[+-]## [0-9]/ {in_unrel = 0; next}
+            in_unrel && /^\+[^+]/ {n++}
+            END {print n+0}
+          ')
+          if [ "$unreleased_added" -lt 1 ]; then
+            echo "::error::Add the new entry under the '## Unreleased' heading in CHANGELOG.md so it ships in the next release."
+            exit 1
+          fi
+          echo "Release notes check passed."

--- a/.github/workflows/sync-package-version.yml
+++ b/.github/workflows/sync-package-version.yml
@@ -26,12 +26,27 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out main
+      - name: Check out the tagged commit
         uses: actions/checkout@v4
         with:
-          ref: main
+          # Default ref is the pushed tag, so GITHUB_SHA = the tag's
+          # target commit. fetch-depth: 0 gives us history for the
+          # merge-base check below.
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify the tagged commit is on main
+        # Catches the "tag pushed from a feature branch by mistake" case.
+        # If the tag isn't an ancestor of main, refuse to bump rather
+        # than overwrite main with a version that doesn't correspond to
+        # any of its commits.
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag points at $GITHUB_SHA which is not on main."
+            echo "::error::Re-tag the release from a commit that is on main."
+            exit 1
+          fi
 
       - name: Extract version from tag
         id: version
@@ -40,6 +55,14 @@ jobs:
           version="${tag#v}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Switch to main for the bump
+        # Apply the bump on top of current main HEAD (not the tagged
+        # commit) so a concurrent push that already added other work
+        # to main isn't overwritten.
+        run: |
+          git checkout main
+          git reset --hard origin/main
 
       - name: Bump package.json if it doesn't match
         id: bump
@@ -74,4 +97,7 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add package.json
           git commit -m "Sync package.json to $RELEASE_TAG"
+          # Fast-forward-only push: if main moved between our reset and
+          # now, the push is rejected and the workflow fails loudly
+          # rather than silently overwriting the newer state.
           git push origin main

--- a/.github/workflows/sync-package-version.yml
+++ b/.github/workflows/sync-package-version.yml
@@ -43,28 +43,35 @@ jobs:
 
       - name: Bump package.json if it doesn't match
         id: bump
+        # Pass tag-derived values via env: instead of inlining ${{ }} into
+        # shell or node -e strings — a tag like `v1.0.0';rm -rf .;'` would
+        # otherwise close the JS/shell string literal and run arbitrary
+        # code on a runner that has contents: write.
+        env:
+          TARGET_VERSION: ${{ steps.version.outputs.version }}
         run: |
           current=$(node -p "require('./package.json').version")
-          target='${{ steps.version.outputs.version }}'
-          if [ "$current" = "$target" ]; then
-            echo "package.json already at $target; nothing to do"
+          if [ "$current" = "$TARGET_VERSION" ]; then
+            echo "package.json already at $TARGET_VERSION; nothing to do"
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            node -e "
-              const fs = require('fs');
-              const p = require('./package.json');
-              p.version = '${{ steps.version.outputs.version }}';
-              fs.writeFileSync('package.json', JSON.stringify(p, null, 4) + '\n');
-            "
-            echo "Bumped $current -> $target"
+            node -e '
+              const fs = require("fs");
+              const p = require("./package.json");
+              p.version = process.env.TARGET_VERSION;
+              fs.writeFileSync("package.json", JSON.stringify(p, null, 4) + "\n");
+            '
+            echo "Bumped $current -> $TARGET_VERSION"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and push
         if: steps.bump.outputs.changed == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add package.json
-          git commit -m "Sync package.json to ${{ steps.version.outputs.tag }}"
+          git commit -m "Sync package.json to $RELEASE_TAG"
           git push origin main

--- a/.github/workflows/sync-package-version.yml
+++ b/.github/workflows/sync-package-version.yml
@@ -1,0 +1,70 @@
+name: Sync package.json to release tag
+
+# When a vX.Y.Z tag is pushed, update package.json's "version" on main
+# to match. The landing page reads this value at request time
+# (see index.js), so this keeps the displayed version in sync with the
+# release the server is actually running.
+#
+# Workflow:
+#   1. Cut your release commit on main (CHANGELOG, etc).
+#   2. git tag vX.Y.Z && git push --tags
+#   3. This workflow lands a follow-up commit on main bumping
+#      package.json. Heroku auto-deploys main HEAD so the deployed
+#      runtime picks it up.
+#
+# If you enable branch protection on main that requires PRs, swap the
+# direct push for peter-evans/create-pull-request — see CONTRIBUTING.md.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  sync-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="${tag#v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Bump package.json if it doesn't match
+        id: bump
+        run: |
+          current=$(node -p "require('./package.json').version")
+          target='${{ steps.version.outputs.version }}'
+          if [ "$current" = "$target" ]; then
+            echo "package.json already at $target; nothing to do"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            node -e "
+              const fs = require('fs');
+              const p = require('./package.json');
+              p.version = '${{ steps.version.outputs.version }}';
+              fs.writeFileSync('package.json', JSON.stringify(p, null, 4) + '\n');
+            "
+            echo "Bumped $current -> $target"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add package.json
+          git commit -m "Sync package.json to ${{ steps.version.outputs.tag }}"
+          git push origin main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable player-facing changes land here. Anything that changes a game mechanic — gameplay tuning, game state/round logic, or physics — MUST add an entry under "Unreleased" in the same change (the `Game mechanic changes need release notes` CI job enforces this).
+
+Write entries in the same player-friendly style as the GitHub releases: short bullets describing what a player will notice, grouped under section headings (`### General`, `### Ability changes`, `### Brutal rounds`, `### Map editor`, `### Bug fixes`, etc.).
+
+When cutting a release: move the `Unreleased` contents under a new `## vX.Y.Z — YYYY-MM-DD` heading, leave a fresh empty `Unreleased` block at the top, tag the commit, and publish the release on GitHub using that section as the body.
+
+## Unreleased
+
+(none yet)
+
+## Older versions
+
+For releases before this CHANGELOG existed, see https://github.com/sjdodge123/chaochao/releases.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 There is no test suite, no linter, and no formatter configured. `client/scripts/dist/` is ignored by `.gitignore` (the `dist` rule), so bundles are produced at deploy time, not committed.
 
+## Release notes for game mechanic changes
+
+Any change that touches `server/config.json`, `server/game.js`, or `server/engine.js` is a "game mechanic" change and MUST add a player-facing bullet under `## Unreleased` in `CHANGELOG.md` in the same commit. The `.github/workflows/release-notes-check.yml` workflow enforces this on PRs and pushes to `main`. Write the entry the way a player would describe what they noticed, not what the code does — see existing GitHub releases (https://github.com/sjdodge123/chaochao/releases) and `CONTRIBUTING.md` for the format. Refactors, perf work, UI/CSS, build/CI changes, and map JSON submissions are exempt.
+
 ## Architecture
 
 This is a multiplayer top-down racing/arena game. A single Node process hosts both the static client and the Socket.IO server; gameplay is fully authoritative on the server, and the client only renders state and forwards input.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+- `npm install` — install dependencies (uses `package-lock.json`).
+- `npm start` — run the Node server in dev mode on port 3000 (serves the unminified per-file `<script>` tags directly from `client/scripts/*.js`).
+- `npm run build` — run `build.js` to produce minified bundles in `client/scripts/dist/` (`play.bundle.min.js`, `create.bundle.min.js`, `join.bundle.min.js`) via esbuild's `transform`.
+- `npm run start:prod` — start with `NODE_ENV=production`, which makes `index.js` rewrite the `<!-- BUILD: bundle-start -->…<!-- BUILD: bundle-end -->` block in each served HTML page to point at the corresponding bundle in `client/scripts/dist/`. The bundles must already exist; run `npm run build` first.
+- `npm run heroku-postbuild` — invoked automatically by Heroku to build bundles during deploy.
+
+There is no test suite, no linter, and no formatter configured. `client/scripts/dist/` is ignored by `.gitignore` (the `dist` rule), so bundles are produced at deploy time, not committed.
+
+## Architecture
+
+This is a multiplayer top-down racing/arena game. A single Node process hosts both the static client and the Socket.IO server; gameplay is fully authoritative on the server, and the client only renders state and forwards input.
+
+### Server (Node + Socket.IO, in `server/`)
+
+- `index.js` (repo root) — boots Express, applies `compression()`, installs the prod-only bundle rewriter, serves `client/` statically, and creates the Socket.IO server. It also runs a **sleep/wake loop**: when `clientCount` is 0 the server cancels its `setInterval(update, serverTickSpeed)`; the first new connection re-arms it. All gameplay ticks flow through `hostess.updateRooms(dt)`.
+- `utils.js` — central config loader (`config.json`, with `PORT` env override), `dt` clock, math helpers, and at boot scans `client/maps/`, `client/assets/sounds/`, `client/assets/img/` to build the manifests sent to clients via the `contentDelivery` message. Also implements `submitPullRequest()`, which uses `@octokit/core` (auth from `GITHUB_AUTH` env var) to commit a user-submitted map JSON to a new branch and open a PR against `main` — this is how the in-browser map editor publishes new maps.
+- `hostess.js` — room registry. Creates `Room` instances on demand, matchmakes clients into rooms with space, and drives `room.update(dt)` for every room each server tick. Rooms are deleted when the last client leaves.
+- `messenger.js` — Socket.IO wrapper. Owns the mailbox map (client id → socket) and the room-mailbox map (client id → room sig), and registers per-client event handlers in `checkForMail()` (`enterGame`, `joinARoom`, `submitNewMap`, input events, etc.). This is the single place where socket events are wired.
+- `game.js` — defines `Room`, `Game`, and `World`. `Room` owns the per-room `playerList`, `projectileList`, `aimerList`, `hazardList`, an `Engine`, a `World`, and a `Game`. `Game` runs the state machine over `c.stateMap` (`waiting → lobby → overview → gated → racing → collapsing → gameOver`) and contains the rules for rounds, brutal-round selection, scoring/notches, and ability spawning.
+- `engine.js` — physics and collision. Per-tick it updates hazards, projectiles, and players; collision uses a `QuadTree` against the active map's tiles. Exposes helpers (`checkDistance`, `punchPlayer`, `puckPlayer`, `explosion`, `cutPlayer`, `bounceOffBoundry`, …) consumed from `game.js`.
+- `compressor.js` — serializes per-tick game state into compact positional arrays (e.g. `[id, x, y, velX, velY, angle]`) before they're emitted as `gameUpdates`. Always edit the client-side decoders in `client/scripts/client.js` in lockstep when the array layout changes.
+- `config.json` — single source of truth for gameplay tuning: world size, tick rate, tile types (`slow`/`normal`/`fast`/`lava`/`ice`/`ability`/`goal`/`bumper`/`random`), abilities (`blindfold`, `swap`, `bomb`, `speedBuff`, `speedDebuff`, `tileSwap`, `iceCannon`, `cut`), brutal-round modes (`cloudy`, `lightning`, `volcano`, `infection`, `hockey`, `explosive`, `blackout`, …), hazards, state map, timers, and per-player constants. The same object is delivered to the client via the `config` socket event, so changes here affect both sides.
+- `debug.js` — opt-in network logger gated by a flag at the top.
+
+### Client (`client/`)
+
+Three entry pages, each backed by its own bundle defined in `build.js`:
+
+- `index.html` — landing page.
+- `play.html` → `play.bundle.min.js`: the in-game client. Concatenates `game.js` (globals/bootstrap), `client.js` (Socket.IO event handlers — `welcome`, `gameState`, `gameUpdates`, `playerJoin`/`playerLeft`, etc.), `audio.js`, `input.js`, `draw.js` (canvas rendering — large hot path), `gameboard.js` (client-side map/tile state), `joystick.js`, `utils.js`.
+- `create.html` → `create.bundle.min.js`: the in-browser map editor. Uses `rhill-voronoi-core.js` for cell generation and `create.js` to assemble the map JSON, which is POSTed via `submitNewMap` and turned into a GitHub PR by `utils.submitPullRequest`.
+- `join.html` → `join.bundle.min.js`: standalone room-join page.
+
+The bundler concatenates the listed files in order (not a module bundler — these files share globals). Adding a new client script means adding it to the appropriate bundle list in `build.js` **and** adding a `<script>` tag inside the `<!-- BUILD: bundle-start --> … <!-- BUILD: bundle-end -->` block of the relevant HTML page. In dev mode the raw tags are served; in prod the block is replaced with a single bundle tag at request time.
+
+`client/maps/*.json` are the canonical map files (loaded at server boot). `client/assets/{img,sounds}/` are streamed to clients via the manifests built by `utils.js`; new files placed in those directories show up automatically on the next server restart.
+
+### Networking contract
+
+- Client → server: input events through `messenger.js` (handlers registered in `checkForMail`).
+- Server → client per tick: a single `gameUpdates` message containing compacted `playerList`/`projList`/`aimerList`/`hazardList` arrays plus game-state metadata.
+- Server → client one-shot/state-change: `welcome`, `contentDelivery`, `gameState`, `playerJoin`, `playerLeft`, `serverKick`, `roomNotFound`, plus map/sound/config fetches.
+
+When changing the shape of any of these payloads, update `server/compressor.js` and the matching `update*List` functions in `client/scripts/client.js` together.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+## Game mechanic changes must ship with player-facing release notes
+
+Any change that touches one of these files counts as a "game mechanic" change:
+
+- `server/config.json` — gameplay tuning (player speed, ability params, brutal-round configuration, timers, …)
+- `server/game.js` — game state machine, scoring, round/lobby logic
+- `server/engine.js` — physics, collision, hazard/projectile updates
+
+For any such change, add a bullet under `## Unreleased` in `CHANGELOG.md` in the same commit/PR, written in the same player-friendly tone as the existing GitHub releases (https://github.com/sjdodge123/chaochao/releases). Describe what a player will *notice*, not what the code does.
+
+The `Game mechanic changes need release notes` GitHub Actions check enforces this on every PR and push to `main`.
+
+### Cutting a release
+
+1. Move the `## Unreleased` block under a new `## vX.Y.Z — YYYY-MM-DD` heading in `CHANGELOG.md`. Leave a fresh empty `## Unreleased` at the top.
+2. Bump `version` in `package.json`.
+3. Commit, tag (`git tag vX.Y.Z`), push.
+4. Publish a GitHub release with the same tag, pasting the `vX.Y.Z` section as the body.
+
+### Recommended repo settings
+
+For full enforcement, enable branch protection on `main` in GitHub settings:
+
+- Require a pull request before merging
+- Require status check `check-release-notes` to pass
+
+Without branch protection a direct push to `main` will still get a red check on the commit, but the push isn't blocked.
+
+## What doesn't need release notes
+
+Bug fixes that don't change observable behaviour, perf work, UI/CSS tweaks, build/CI changes, map JSON submissions through the editor, and refactors are exempt. If you're unsure, write the note — it's cheap, and players appreciate the changelog.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ The `Game mechanic changes need release notes` GitHub Actions check enforces thi
 ### Cutting a release
 
 1. Move the `## Unreleased` block under a new `## vX.Y.Z — YYYY-MM-DD` heading in `CHANGELOG.md`. Leave a fresh empty `## Unreleased` at the top.
-2. Bump `version` in `package.json`.
-3. Commit, tag (`git tag vX.Y.Z`), push.
-4. Publish a GitHub release with the same tag, pasting the `vX.Y.Z` section as the body.
+2. Commit and push to `main`.
+3. Tag the commit: `git tag vX.Y.Z && git push --tags`.
+4. The `Sync package.json to release tag` workflow lands a follow-up commit on `main` bumping `package.json` to match the tag. Heroku deploys main HEAD, so the landing page picks up the new version automatically.
+5. Publish a GitHub release with the same tag, pasting the `vX.Y.Z` section of `CHANGELOG.md` as the body.
 
 ### Recommended repo settings
 
@@ -27,6 +28,8 @@ For full enforcement, enable branch protection on `main` in GitHub settings:
 - Require status check `check-release-notes` to pass
 
 Without branch protection a direct push to `main` will still get a red check on the commit, but the push isn't blocked.
+
+Note: if you enable "require a PR before merging" for `main`, the `sync-package-version` workflow won't be able to push its bump commit directly — swap its push step for `peter-evans/create-pull-request` or similar so it opens a PR instead.
 
 ## What doesn't need release notes
 

--- a/backlog.md
+++ b/backlog.md
@@ -20,6 +20,28 @@ Tracked work that is known and intentionally deferred. The currently-in-progress
 
 ### Performance
 
-- **`cellIdFromPoint` runs an O(N × edges) point-in-polygon over all 250 cells on every mousemove** (create.js:635–644). A coarse spatial grid keyed by site x/y would cut this dramatically; matters on low-end laptops and touch devices.
-- **`locateObject` / `addObjectToMap` do nested loops to look up a hazard config by id.** Build a `hazardById` map once when config arrives and use it everywhere. (create.js:537–571)
+- **`cellIdFromPoint` runs an O(N × edges) point-in-polygon over all 250 cells on every mousemove.** A coarse spatial grid keyed by site x/y would cut this dramatically; matters on low-end laptops and touch devices.
+- **`locateObject` / `addObjectToMap` do nested loops to look up a hazard config by id.** Build a `hazardById` map once when config arrives and use it everywhere.
 - **Tiny: `makePattern`/`makeSeamlessPattern` retain the source canvas in closure scope.** Only matters if patterns are ever rebuilt; currently they aren't.
+
+## Join page (`client/join.html`, `client/scripts/join.js`, related CSS)
+
+### Bugs
+
+- **`getRooms` server response silently drops full/locked rooms.** A room that locks (e.g. mid-race with no joinable slots) just disappears from the list with no UI signal. Consider showing them greyed out with a "Full" or "In progress" label so users can see what's happening, or at least surfacing a count.
+- **Each card is still wrapped in a `<form>` that does nothing.** Now that cards are rebuilt via DOM and join uses `<a href>`, the surrounding form is dead markup — clean up the structural noise.
+
+### UX
+
+- **The table header (Round / Current Map / Players) is per-card inline labels.** A single shared header above the list, or a more table-like grid, would scan faster when many rooms are listed.
+- **Game ID is in the join URL but has no copy/share affordance.** Add a "copy invite link" button so a host can paste the link into chat instead of dictating a Game ID.
+- **State is plain text with no joinability cue.** A coloured badge (green = Lobby/joinable, yellow = Racing in progress, grey = Game Over) would tell players at a glance whether mid-game joining is a good idea.
+- **No "join by Game ID" input.** The server already supports it (`play.html?gameid=N` + the `enterGame` socket event) but the UI doesn't expose it. A small "Enter Game ID" field would let a host share an ID verbally.
+
+### CSS / Layout
+
+- **`#joinMenu { height: 400px }` is fixed.** Overflows with many rooms, wastes space with few. Make it grow with content (capped to viewport with internal scroll).
+- **`.mapData { width: 100% }` is declared twice** in the same rule — minor cleanup.
+- **No responsive design / no mobile-specific layout.** At narrow widths the flex card may still need a column layout (stat group on top, button on bottom).
+- **`section { margin-top: var(--navbar-height); height: 100vh }`** leaves a big empty area below the card list on tall screens. Either centre the join UI vertically or let it hug the top with a sensible cap.
+- **`.join-btn { height: 100% }`** is no longer needed once cards are short. Audit and drop if the new card layout doesn't need it.

--- a/backlog.md
+++ b/backlog.md
@@ -29,19 +29,14 @@ Tracked work that is known and intentionally deferred. The currently-in-progress
 ### Bugs
 
 - **`getRooms` server response silently drops full/locked rooms.** A room that locks (e.g. mid-race with no joinable slots) just disappears from the list with no UI signal. Consider showing them greyed out with a "Full" or "In progress" label so users can see what's happening, or at least surfacing a count.
-- **Each card is still wrapped in a `<form>` that does nothing.** Now that cards are rebuilt via DOM and join uses `<a href>`, the surrounding form is dead markup — clean up the structural noise.
 
 ### UX
 
-- **The table header (Round / Current Map / Players) is per-card inline labels.** A single shared header above the list, or a more table-like grid, would scan faster when many rooms are listed.
-- **Game ID is in the join URL but has no copy/share affordance.** Add a "copy invite link" button so a host can paste the link into chat instead of dictating a Game ID.
+- **The Round / Map / Players labels repeat inline inside every card.** A single shared header above the list, or a more table-like grid, would scan faster when many rooms are listed.
+- **Game ID is shown on the card but there's no copy/share affordance.** Add a "copy invite link" button so a host can paste the link into chat instead of dictating a Game ID over voice.
 - **State is plain text with no joinability cue.** A coloured badge (green = Lobby/joinable, yellow = Racing in progress, grey = Game Over) would tell players at a glance whether mid-game joining is a good idea.
-- **No "join by Game ID" input.** The server already supports it (`play.html?gameid=N` + the `enterGame` socket event) but the UI doesn't expose it. A small "Enter Game ID" field would let a host share an ID verbally.
 
 ### CSS / Layout
 
-- **`#joinMenu { height: 400px }` is fixed.** Overflows with many rooms, wastes space with few. Make it grow with content (capped to viewport with internal scroll).
-- **`.mapData { width: 100% }` is declared twice** in the same rule — minor cleanup.
 - **No responsive design / no mobile-specific layout.** At narrow widths the flex card may still need a column layout (stat group on top, button on bottom).
 - **`section { margin-top: var(--navbar-height); height: 100vh }`** leaves a big empty area below the card list on tall screens. Either centre the join UI vertically or let it hug the top with a sensible cap.
-- **`.join-btn { height: 100% }`** is no longer needed once cards are short. Audit and drop if the new card layout doesn't need it.

--- a/backlog.md
+++ b/backlog.md
@@ -40,3 +40,17 @@ Tracked work that is known and intentionally deferred. The currently-in-progress
 
 - **No responsive design / no mobile-specific layout.** At narrow widths the flex card may still need a column layout (stat group on top, button on bottom).
 - **`section { margin-top: var(--navbar-height); height: 100vh }`** leaves a big empty area below the card list on tall screens. Either centre the join UI vertically or let it hug the top with a sensible cap.
+
+## Landing page (`client/index.html`, related CSS)
+
+### UX
+
+- **No live "X games in progress / Y players online" signal.** The server already serves this data via `getRooms` / `config`. Reuse the join-page pattern (socket connect → roomListing → DOM update) on the landing page so visitors can tell at a glance whether to click Play or Join. Include a stale-data fallback ("Server sleeping…") if no response arrives.
+- **Patch Notes opens GitHub Releases in a new tab.** Now that `CHANGELOG.md` exists, an in-page modal (fetching the latest release notes from GitHub or the local CHANGELOG) would be friendlier to non-technical players.
+- **No "how to play" / controls hint.** WASD-vs-mouse drive isn't obvious to newcomers; one line + a short link is enough.
+
+### Polish
+
+- **`#game-title { font-family: "San Francisco" }`** renders only on macOS. Either ship a real web font or pick a system stack with broader cross-platform fidelity.
+- **No screenshot / animated preview.** A small hero image (or a rotating row of map thumbnails — we already serve them via `contentDelivery`) would set expectations for the game.
+- **No mobile-specific layout** beyond Bootstrap defaults. Card and title don't reflow; consider a proper mobile pass.

--- a/backlog.md
+++ b/backlog.md
@@ -1,0 +1,25 @@
+# Backlog
+
+Tracked work that is known and intentionally deferred. The currently-in-progress changes are not listed here.
+
+## Map editor (`client/scripts/create.js`, `client/create.html`)
+
+### Bugs
+
+- **Duplicate-hazard selection collisions.** `updateSelectedObject` and `removeSelectedObject` match by `id + x + y`, so two same-type hazards stacked at identical coordinates can only be edited/deleted as the first one found. Track the array index of the selected hazard instead.
+- **Map JSON is larger than it needs to be.** `vMap.cells` is the raw voronoi structure with `edge` objects shared (and serialized) twice per pair of cells, plus per-halfedge `angle`. Existing maps in `client/maps/` are hundreds of KB largely from this. A minimal export — site coords + tile id, with the voronoi recomputed on load (or just edge endpoints stored once) — would shrink JSON dramatically.
+
+### UX
+
+- **No feedback for missing inputs.** Copy-to-clipboard silently substitutes `"anonymous"`/`"unknown"` for empty author/name. Email is only validated at submit time. Highlight required fields before allowing export.
+- **Submit status button never resets.** "Submitting…"/"Success"/"Failed" lingers indefinitely. Reset on any input change, on a fresh submit attempt, or after a short timeout.
+- **Rotate is fixed at +15° clockwise.** No counter-rotation, no finer step. Cheap upgrade: shift-click for -15°, or a number input for absolute angle.
+- **No undo.** A full undo stack across tile paints would be expensive, but at minimum "undo last hazard placement" is trivial and would prevent a lot of frustration.
+- **No keyboard shortcuts** for switching brushes/tools. Purely mouse-driven editing slows experienced users.
+- **Right-click is suppressed but does nothing useful.** Common expectation: right-click on a hazard deletes it; right-click drag erases to default tile.
+
+### Performance
+
+- **`cellIdFromPoint` runs an O(N × edges) point-in-polygon over all 250 cells on every mousemove** (create.js:635–644). A coarse spatial grid keyed by site x/y would cut this dramatically; matters on low-end laptops and touch devices.
+- **`locateObject` / `addObjectToMap` do nested loops to look up a hazard config by id.** Build a `hazardById` map once when config arrives and use it everywhere. (create.js:537–571)
+- **Tiny: `makePattern`/`makeSeamlessPattern` retain the source canvas in closure scope.** Only matters if patterns are ever rebuilt; currently they aren't.

--- a/client/create.html
+++ b/client/create.html
@@ -84,10 +84,10 @@
 
     #canvasWindow {
       height: 100vh;
-      width: calc(100vw - 200px);
+      width: calc(100vw - 250px);
     }
 
-    #pallete {
+    .palette {
       height: auto;
     }
 
@@ -116,10 +116,11 @@
       <div id="mapEditor">
         <div id="controlPanel" class="bg-light">
           <div class="d-flex align-items-center justify-content-between mb-3 mt-3">
-            <button id="loadButton" class="btn bg-light p-0"><i class="fa fa-arrow-left fa-2x" aria-hidden="true"></i></button>
-            <button id="rebuildButton" class="btn bg-light p-0"><i class="fa fa-trash fa-2x" aria-hidden="true"></i></button>
-            <button id="rotateButton" class="btn bg-light p-0"><i class="fa fa-rotate-right fa-2x" aria-hidden="true"></i></button>
-            <button id="mouseButton" class="btn bg-light p-0"><i class="fa fa-mouse-pointer fa-2x" aria-hidden="true"></i></button>
+            <button id="loadButton" class="btn bg-light p-0" title="Back to map list"><i class="fa fa-arrow-left fa-2x" aria-hidden="true"></i></button>
+            <button id="rebuildButton" class="btn bg-light p-0" title="Wipe map and start over"><i class="fa fa-trash fa-2x" aria-hidden="true"></i></button>
+            <button id="deleteSelectedButton" class="btn bg-light p-0" title="Delete selected hazard" disabled><i class="fa fa-times fa-2x" aria-hidden="true"></i></button>
+            <button id="rotateButton" class="btn bg-light p-0" title="Rotate selected hazard 15°"><i class="fa fa-rotate-right fa-2x" aria-hidden="true"></i></button>
+            <button id="mouseButton" class="btn bg-light p-0" title="Switch to selection cursor"><i class="fa fa-mouse-pointer fa-2x" aria-hidden="true"></i></button>
           </div>
           <div id="inputBar" class="mb-3">
             <div class="h5">
@@ -130,7 +131,7 @@
             <input class="editor-inputs form-control" type="text" id="name" name="name" placeholder="Map Name" maxlength="15"></input>
             <input class="editor-inputs form-control" type="text" id="email" name="email" placeholder="Email" maxlength="50"></input>
           </div>
-          <div id="pallete" class="mb-3">
+          <div class="palette mb-3">
             <div class="h5">
               Tiles
             </div>
@@ -146,7 +147,7 @@
               <button id="goalTileButton" style="background-color: #FFD700" title="Goal" class="mapEditorTile"><span>Goal</span></button>
             </div>
           </div>
-          <div id="pallete" class="mb-3">
+          <div class="palette mb-3">
             <div class="h5">
               Hazards
             </div>

--- a/client/create.html
+++ b/client/create.html
@@ -136,6 +136,21 @@
       height: auto;
     }
 
+    /* Keep the toolbar icons pinned to the top of the panel so they
+       stay visible when the rest of the panel content scrolls. */
+    #editorToolbar {
+      position: sticky;
+      top: 0;
+      background: #f8f9fa;
+      z-index: 1;
+      padding-top: 1rem;
+      padding-bottom: 0.5rem;
+      margin: 0 -1rem 1rem;
+      padding-left: 1rem;
+      padding-right: 1rem;
+      border-bottom: thin solid #e6e6e6;
+    }
+
     @media screen and (max-width:768px) {
       #controlPanel {
         display: none;
@@ -160,7 +175,7 @@
     <div id="createWindow">
       <div id="mapEditor">
         <div id="controlPanel" class="bg-light">
-          <div class="d-flex align-items-center justify-content-between mb-3 mt-3">
+          <div id="editorToolbar" class="d-flex align-items-center justify-content-between">
             <button id="loadButton" class="btn bg-light p-0" title="Back to map list"><i class="fa fa-arrow-left fa-2x" aria-hidden="true"></i></button>
             <button id="rebuildButton" class="btn bg-light p-0" title="Wipe map and start over"><i class="fa fa-trash fa-2x" aria-hidden="true"></i></button>
             <button id="deleteSelectedButton" class="btn bg-light p-0" title="Delete selected hazard" disabled><i class="fa fa-times fa-2x" aria-hidden="true"></i></button>

--- a/client/create.html
+++ b/client/create.html
@@ -143,12 +143,60 @@
       top: 0;
       background: #f8f9fa;
       z-index: 1;
-      padding-top: 1rem;
+      padding-top: 0.5rem;
       padding-bottom: 0.5rem;
-      margin: 0 -1rem 1rem;
+      margin: 0 -1rem 0.5rem;
       padding-left: 1rem;
       padding-right: 1rem;
       border-bottom: thin solid #e6e6e6;
+    }
+
+    /* Compact the panel so every control fits in a typical viewport
+       height without needing to scroll. */
+    #controlPanel .h5 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      color: #6c757d;
+      margin: 0.4rem 0 0.25rem;
+    }
+    #controlPanel hr {
+      display: none;
+    }
+    #controlPanel .mb-3 {
+      margin-bottom: 0.4rem !important;
+    }
+    #controlPanel .editor-inputs {
+      margin-bottom: 0.35rem !important;
+      padding: 0.25rem 0.5rem;
+      height: auto;
+      min-height: 0;
+      font-size: 0.85rem;
+    }
+    #controlPanel .btn-block {
+      padding: 0.3rem 0.5rem;
+      font-size: 0.85rem;
+      margin-bottom: 0.25rem;
+      margin-top: 0;
+    }
+    #controlPanel .mapEditorTile {
+      font-size: 0.85rem;
+      padding: 3px 7px;
+      min-width: 50px;
+    }
+
+    /* Pin the Actions section to the bottom of the panel — together
+       with the sticky toolbar, this guarantees the user can always
+       reach Copy/Upload regardless of viewport height. */
+    #actionsSection {
+      position: sticky;
+      bottom: 0;
+      background: #f8f9fa;
+      z-index: 1;
+      margin: 0.4rem -1rem 0;
+      padding: 0.5rem 1rem;
+      border-top: thin solid #e6e6e6;
     }
 
     @media screen and (max-width:768px) {
@@ -217,7 +265,7 @@
               <button id="movingBumperButton" style="background-color: orange" title="Moving Bumper" class="mapEditorTile"><span>Moving Bumper</span></button>
             </div>
           </div>
-          <div>
+          <div id="actionsSection">
             <div class="h5">
               Actions
             </div>

--- a/client/create.html
+++ b/client/create.html
@@ -19,33 +19,51 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <title>Chao Chao Map Edit</title>
   <style>
-    body {
-      position: relative;
+    /* When the editor is visible, lock the page so the canvas can't be
+       scrolled out of view. The load window flips this back to auto
+       because the map grid needs to scroll. */
+    body.editor-open {
+      overflow: hidden;
     }
+
+    /* Overrides styles.css `#createWindow { height: 100% }`, which would
+       otherwise force the editor to be a full viewport tall *below* the
+       navbar and overflow the page. */
     #createWindow {
-      position: relative;
+      position: fixed;
+      top: var(--navbar-height);
+      left: 0;
+      right: 0;
+      bottom: 0;
+      width: auto;
+      height: auto;
       margin: 0;
-      left: 250px;
-      right: 0px;
     }
 
     #mapEditor {
+      position: relative;
+      width: 100%;
+      height: 100%;
       margin: 0;
-      height: auto;
     }
 
+    /* Overrides styles.css `#controlPanel { height: 90%; width: 9%; ... }`
+       so top/bottom take over for sizing. */
     #controlPanel {
-      position: fixed;
+      position: absolute;
+      top: 0;
       left: 0;
-      top: var(--navbar-height);
-      z-index: 1002;
+      bottom: 0;
       width: 250px;
+      height: auto;
+      float: none;
+      z-index: 1002;
       border-radius: 0;
       border: 0;
-      min-height: 100vh;
       border-right: thin solid #e6e6e6;
       padding: 0 1rem;
       box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
+      overflow-y: auto;
     }
 
     .mapEditorTile {
@@ -82,9 +100,36 @@
       margin-bottom: 1rem;
     }
 
+    main {
+      position: absolute;
+      top: 0;
+      left: 250px;
+      right: 0;
+      bottom: 0;
+    }
+
+    /* Overrides styles.css `#canvasWindow { width: 80%; margin: 0 5%; ... }`
+       so the canvas-area uses the full width of <main> with the canvas
+       flex-centered inside it. */
     #canvasWindow {
-      height: 100vh;
-      width: calc(100vw - 250px);
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      width: auto;
+      height: auto;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    /* The global `canvas` rule in styles.css pins canvases to top-left;
+       inside the editor we want flex-centered, sized via JS. */
+    #canvasWindow #createCanvas {
+      position: static;
+      display: block;
     }
 
     .palette {
@@ -103,7 +148,7 @@
   </style>
 </head>
 
-<body style="overflow-y: scroll;">
+<body>
   <nav class="d-flex align-items-center px-3">
     <div class="navbar-brand">
       <a style="text-decoration: inherit;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -53,9 +53,7 @@ canvas {
 
 #main {
     height: 100%;
-    width: calc(1366 - 200px);
     position: relative;
-    right: 0;
 }
 
 .join-container {
@@ -302,13 +300,20 @@ div.desc {
 }
 
 .play-container {
-    margin-top: 5%;
     background-color: white;
-    height: 285px;
-    width: 50%;
-    padding: 10px;
-    border-radius: 5px;
+    width: 100%;
+    max-width: 480px;
+    padding: 1.5rem;
+    border-radius: 6px;
     box-shadow: 0px 0px 6px #B2B2B2;
+    margin: 0 auto;
+}
+
+.tagline {
+    margin: 0.25rem 0 1.25rem;
+    color: #6c757d;
+    font-size: 0.95rem;
+    text-align: center;
 }
 
 

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -160,7 +160,17 @@ canvas {
     background: white;
     overflow: hidden;
     display: none;
-    height: 100%;
+    /* Fill the section and flex-centre the canvas stack inside so the
+       game canvas uses all the space the page has, not 90% with
+       hard-coded margins. game.js switches display to 'flex' when the
+       game becomes visible. */
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    align-items: center;
+    justify-content: center;
 }
 
 #createWindow {
@@ -179,14 +189,11 @@ canvas {
     margin-left: 5%;
     margin-right: 5%;
 }
-#mapContainer{
-    height: 95%;
-    width: 90%;
-    display: inline-block;
+#mapContainer {
+    /* Sized by resize() to match the fitted canvas dimensions. The
+       gameWindow flex container centres us in the available space. */
     position: relative;
-    margin-top: 1%;
-    margin-left: 5%;
-    margin-right: 5%;
+    margin: 0;
 }
 #progressContainer{
     width: 50%;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -299,20 +299,27 @@ div.desc {
     font-size: 4em;
 }
 
-.play-container {
-    background-color: white;
+.landing-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     width: 100%;
     max-width: 480px;
-    padding: 1.5rem;
-    border-radius: 6px;
-    box-shadow: 0px 0px 6px #B2B2B2;
     margin: 0 auto;
 }
 
+.play-container {
+    background-color: white;
+    width: 100%;
+    padding: 1.5rem;
+    border-radius: 6px;
+    box-shadow: 0px 0px 6px #B2B2B2;
+}
+
 .tagline {
-    margin: 0.25rem 0 1.25rem;
+    margin: 0.75rem 0 0;
     color: #6c757d;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     text-align: center;
 }
 

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -58,58 +58,74 @@ canvas {
     right: 0;
 }
 
-#joinMenu{
-    width: 100%;
-    height: 400px;
-    margin: 50px;
-    border-radius: 5px;
-    box-shadow: 0px 0px 6px #B2B2B2;
+.join-container {
+    max-width: 720px;
+    padding-top: 1rem;
 }
-#gameSelection{
-    width: 90%;
-    height: auto;
-    margin-top: 50px;
-}
-.gameCard{
-    width: 95%;
-    height: 100px;
-    border-radius: 3px;
-    background-color: #F6F6F6;
-    box-shadow: 0px 0px 3px #B2B2B2;
-    margin-bottom: 10px;
-}
-.join-btn{
+.join-header {
     display: flex;
     align-items: center;
-    justify-content: center;
-    padding: 0px;
-    height: 100%;
-    float: right;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
 }
-.game-content{
-    width: 75%;
-    display: inline-block;
-    float: left;
+.join-title {
+    margin: 0;
+    font-weight: 600;
 }
-.gameState{
-    display: inline-block;
-    height: 40px;
-    width: 100%;
+#joinMenu {
+    border-radius: 6px;
+    box-shadow: 0px 0px 6px #B2B2B2;
+    padding: 0.75rem;
+    background: #fff;
+    min-height: 80px;
+}
+#gameSelection {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.gameCard {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.6rem 0.9rem;
+    border-radius: 4px;
+    background-color: #F6F6F6;
+    box-shadow: 0px 0px 3px #B2B2B2;
+}
+.card-info {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.25rem 1.25rem;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.card-state {
+    font-size: 1.05rem;
+    font-weight: 600;
+}
+.card-stat {
+    font-size: 0.9rem;
+    color: #495057;
+    white-space: nowrap;
+}
+.card-stat-label {
+    color: #6c757d;
+}
+.gameCard .join-btn {
+    flex: 0 0 auto;
+    min-width: 90px;
+}
+.empty-state {
     text-align: center;
-    font-size: 32px;
+    padding: 1.5rem 1rem;
+    color: #6c757d;
 }
-.mapData {
-    width: 100%;
-    display: inline-block;
-    width: 100%;
-    margin: 5px;
-    height: 50px;
+.start-new {
     text-align: center;
-}
-th,
-td {
-  padding-left: 10px;
-  padding-top: 3px;
+    margin-top: 1rem;
 }
 
 #gameWindow {

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -19,6 +19,13 @@ html,body {
     height: 100vh;
 }
 
+body {
+    /* Push body content below the fixed navbar with padding (not margin
+       on the first child) so the offset doesn't margin-collapse out of
+       body and inflate the page height past the viewport. */
+    padding-top: var(--navbar-height);
+}
+
 nav {
     height: var(--navbar-height);
     width: 100%;
@@ -33,8 +40,9 @@ nav {
   }
 
   section {
-    margin-top: var(--navbar-height);
-    height: 100vh;
+    /* navbar offset comes from body { padding-top } so margins don't
+       collapse out and inflate the page height. */
+    height: calc(100vh - var(--navbar-height));
     position: relative;
   }
 

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -132,6 +132,19 @@ canvas {
     margin-bottom: 0.75rem;
     font-size: 0.95rem;
 }
+.join-by-id {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+    align-items: stretch;
+}
+.join-by-id input {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.join-by-id button {
+    flex: 0 0 auto;
+}
 .start-new {
     text-align: center;
     margin-top: 1rem;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -174,7 +174,7 @@ td {
     height: 10%;
     width: 100%;
 }
-#pallete {
+.palette {
     display: inline-block;
     height: 80%;
     width: 100%;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -123,6 +123,15 @@ canvas {
     padding: 1.5rem 1rem;
     color: #6c757d;
 }
+.not-found-banner {
+    background-color: #fff3cd;
+    color: #856404;
+    border: 1px solid #ffeeba;
+    border-radius: 4px;
+    padding: 0.6rem 0.9rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.95rem;
+}
 .start-new {
     text-align: center;
     margin-top: 1rem;

--- a/client/index.html
+++ b/client/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" type="text/css" href="assets/css/all.css">
     <title>Chao Chao</title>
   </head>
-  <body style="overflow-y: scroll;">
+  <body>
     <nav class="d-flex align-items-center px-3">
       <div class="navbar-brand">
         <a style="text-decoration: inherit;
@@ -30,22 +30,18 @@
     </nav>
     <section>
       <div id="main">
-        <div class ="container d-flex h-100">
-          <div class="row justify-content-center mx-auto">
-            <div class="play-container w-100">
-              <span id="version"><b>v0.1.2</b></span>
-              <form id="guestPlay">
-
-                <span id="game-title">Chao Chao</span>
-                <button type="submit" formaction="./play.html" id="playButton" class="btn btn-outline-success w-100 mt10">Play</button>
-                <button type="submit" formaction="./join.html"id="joinButton" class="btn btn-outline-info w-100 mt10">Join</button>
-                <button type="submit" formaction="./create.html" id="createButton" class="btn btn-outline-warning w-100 mt10">Create</button>
-              </form>
-
-                <div class="patch-notes"><a target="_blank" href="https://github.com/sjdodge123/chaochao/releases/latest">Patch Notes</a></div>
+        <div class="container d-flex h-100 align-items-center">
+          <div class="row justify-content-center align-self-center mx-auto w-100">
+            <div class="play-container">
+              <span id="version"><b><!-- VERSION --></b></span>
+              <span id="game-title">Chao Chao</span>
+              <p class="tagline">Multiplayer web-based slow-paced racing — punch, slide, survive.</p>
+              <a href="./play.html" id="playButton" class="btn btn-outline-success w-100 mt-3">Play</a>
+              <a href="./join.html" id="joinButton" class="btn btn-outline-info w-100 mt-2">Join</a>
+              <a href="./create.html" id="createButton" class="btn btn-outline-warning w-100 mt-2">Create</a>
+              <div class="patch-notes"><a target="_blank" href="https://github.com/sjdodge123/chaochao/releases/latest">Patch Notes</a></div>
             </div>
-
-        </div>
+          </div>
         </div>
       </div>
     </section>

--- a/client/index.html
+++ b/client/index.html
@@ -32,14 +32,16 @@
       <div id="main">
         <div class="container d-flex h-100 align-items-center">
           <div class="row justify-content-center align-self-center mx-auto w-100">
-            <div class="play-container">
-              <span id="version"><b><!-- VERSION --></b></span>
-              <span id="game-title">Chao Chao</span>
-              <p class="tagline">Multiplayer web-based slow-paced racing — punch, slide, survive.</p>
-              <a href="./play.html" id="playButton" class="btn btn-outline-success w-100 mt-3">Play</a>
-              <a href="./join.html" id="joinButton" class="btn btn-outline-info w-100 mt-2">Join</a>
-              <a href="./create.html" id="createButton" class="btn btn-outline-warning w-100 mt-2">Create</a>
-              <div class="patch-notes"><a target="_blank" href="https://github.com/sjdodge123/chaochao/releases/latest">Patch Notes</a></div>
+            <div class="landing-stack">
+              <div class="play-container">
+                <span id="version"><b><!-- VERSION --></b></span>
+                <span id="game-title">Chao Chao</span>
+                <a href="./play.html" id="playButton" class="btn btn-outline-success w-100 mt-3">Play</a>
+                <a href="./join.html" id="joinButton" class="btn btn-outline-info w-100 mt-2">Join</a>
+                <a href="./create.html" id="createButton" class="btn btn-outline-warning w-100 mt-2">Create</a>
+                <div class="patch-notes"><a target="_blank" href="https://github.com/sjdodge123/chaochao/releases/latest">Patch Notes</a></div>
+              </div>
+              <p class="tagline">Slow-paced multiplayer arena racing.</p>
             </div>
           </div>
         </div>

--- a/client/join.html
+++ b/client/join.html
@@ -44,6 +44,10 @@
                     Looking for games…
                 </div>
             </div>
+            <div class="join-by-id">
+                <input id="joinByIdInput" type="text" inputmode="numeric" pattern="[0-9]*" class="form-control" placeholder="Have a Game ID? Enter it here">
+                <button id="joinByIdButton" type="button" class="btn btn-outline-info">Join</button>
+            </div>
             <div class="start-new">
                 <a href="./play.html" class="btn btn-outline-success">Start a new game</a>
             </div>

--- a/client/join.html
+++ b/client/join.html
@@ -32,6 +32,9 @@
                     <i class="fa fa-refresh" aria-hidden="true"></i> Refresh
                 </button>
             </div>
+            <div id="notFoundBanner" class="not-found-banner" hidden>
+                That game has ended or isn't accepting new players. Pick another below, or start a new one.
+            </div>
             <div id="joinMenu">
                 <div id="gameSelection"></div>
                 <div id="emptyState" class="empty-state" hidden>

--- a/client/join.html
+++ b/client/join.html
@@ -25,36 +25,25 @@
           </div>
       </nav>
     <section>
-        <div class="container">
-            <div class="row justify-content-center align-self-center mx-auto">
-                <div id="joinMenu">
-                    <div id="gameSelection" class="justify-content-center align-self-center mx-auto">
-                        <div class="gameCard justify-content-center align-self-center mx-auto">
-                            <form>
-                                <div class="game-content">
-                                    <div class="gameState"><span>Lobby</span></div>
-                                    <table class="mapData">
-                                        <tr>
-                                            <th>Round</th>
-                                            <th>Current Map</th>
-                                            <th>Game ID</th>
-                                            <th>Players</th>
-                                        </tr>
-                                        <tr>
-                                            <td>0</td>
-                                            <td>Lobby</td>
-                                            <td>0</td>
-                                            <td>0</td>
-                                        </tr>
-                                    </table>
-                                </div>
-                                <button type="submit" formaction="./play.html" class="btn btn-outline-success w-25 join-btn">Play</button>
-                            </form>
-                        </div>
-                    </div>
+        <div class="container join-container">
+            <div class="join-header">
+                <h4 class="join-title">Available games</h4>
+                <button id="refreshButton" type="button" class="btn btn-outline-secondary btn-sm" title="Refresh game list">
+                    <i class="fa fa-refresh" aria-hidden="true"></i> Refresh
+                </button>
+            </div>
+            <div id="joinMenu">
+                <div id="gameSelection"></div>
+                <div id="emptyState" class="empty-state" hidden>
+                    No games right now — start a new one!
+                </div>
+                <div id="loadingState" class="empty-state">
+                    Looking for games…
                 </div>
             </div>
-
+            <div class="start-new">
+                <a href="./play.html" class="btn btn-outline-success">Start a new game</a>
+            </div>
         </div>
     </section>
     <script src='socket.io/socket.io.js'></script>

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -25,13 +25,13 @@ function clientConnect() {
 		// page so they can pick a real room (or start a new one).
 		debugLog("roomNotFound -- redirecting to join page");
 		server.disconnect();
-		window.parent.location.href = "./join.html?notfound=1";
+		window.location.href = "./join.html?notfound=1";
 	});
 
 	server.on("serverKick", function () {
 		debugLog("serverKick received -- being booted");
 		server.disconnect();
-		window.parent.location.href = "./index.html";
+		window.location.href = "./index.html";
 	});
 
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -20,8 +20,13 @@ function clientConnect() {
 		calcPing();
 	});
 	server.on("roomNotFound", function () {
-		alert("Game ID not found");
-	})
+		// Don't use alert() — it blocks the page and the user has no recovery
+		// path once dismissed. Disconnect and bounce them back to the join
+		// page so they can pick a real room (or start a new one).
+		debugLog("roomNotFound -- redirecting to join page");
+		server.disconnect();
+		window.parent.location.href = "./join.html?notfound=1";
+	});
 
 	server.on("serverKick", function () {
 		debugLog("serverKick received -- being booted");

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -26,25 +26,37 @@ var server,
     createContext;
 
 var scale = 0.035;
-//TileTextures
-var lava = new Image(256, 256);
-lava.src = "../assets/img/lava.png";
-var grass = new Image(256, 256);
-grass.src = "../assets/img/grass.png";
-grass.scale = 0.5;
-var dirt = new Image(256, 256);
-dirt.src = "../assets/img/dirt.png";
-dirt.scale = 0.25;
-var ice = new Image(256, 256);
-ice.src = "../assets/img/ice.png";
-ice.scale = 0.75;
-var sand = new Image(256, 256)
-sand.src = "../assets/img/sand.png";
-sand.scale = 0.25;
-var random = new Image(576, 512);
-random.src = "../assets/img/question-solid.svg";
-var bombIcon = new Image(576, 512);
-bombIcon.src = "../assets/img/bomb.svg";
+
+// Tile textures. Attach onload BEFORE setting src so cached images still
+// fire the load handler. loadPatterns() is gated on all images being ready
+// AND the config socket message arriving — see tryStart().
+var imagesPending = 0,
+    imagesLoaded = 0;
+function loadTileImage(src, scale) {
+    var img = new Image();
+    if (scale != null) img.scale = scale;
+    imagesPending++;
+    img.addEventListener('load', onTileImageLoad);
+    img.src = src;
+    return img;
+}
+function onTileImageLoad() {
+    imagesLoaded++;
+    tryStart();
+}
+var lava = loadTileImage("../assets/img/lava.png");
+var grass = loadTileImage("../assets/img/grass.png", 0.5);
+var dirt = loadTileImage("../assets/img/dirt.png", 0.25);
+var ice = loadTileImage("../assets/img/ice.png", 0.75);
+var sand = loadTileImage("../assets/img/sand.png", 0.25);
+var random = loadTileImage("../assets/img/question-solid.svg");
+var bombIcon = loadTileImage("../assets/img/bomb.svg");
+
+// Redraw gate. Set dirty=true from anything that mutates rendered state
+// (mouse moved, click, paint, hazard added/removed/rotated, resize, rebuild);
+// the animloop skips drawEditor when not dirty so an idle editor doesn't
+// re-render 250 voronoi cells at 60fps.
+var dirty = true;
 
 var then = Date.now(),
     dt;
@@ -64,9 +76,7 @@ function clientConnect() {
 
     server.on("config", function (c) {
         config = c;
-        gameRunning = true;
-        loadPatterns();
-        init();
+        tryStart();
     });
 
     server.on('githubFailure', function (error) {
@@ -81,7 +91,7 @@ function clientConnect() {
         var submitStatus = $("#submitStatus");
         submitStatus.css("color", "white");
         submitStatus.css("background-color", "green");
-        submitStatus.text("Sucesss");
+        submitStatus.text("Success");
     });
 
     server.on("maplisting", function (mapnames) {
@@ -110,6 +120,15 @@ function clientConnect() {
         }
     });
     return server;
+}
+
+function tryStart() {
+    if (!config) return;
+    if (imagesLoaded < imagesPending) return;
+    if (gameRunning) return;
+    loadPatterns();
+    gameRunning = true;
+    init();
 }
 
 function loadPatterns() {
@@ -168,9 +187,16 @@ function setupPage() {
         addListeners();
     });
     $("#rebuildButton").on("click", function () {
-        if (validateWithUser()) {
+        if (confirmWipeIfDirty()) {
             rebuild();
-        };
+        }
+        return false;
+    });
+
+    $("#deleteSelectedButton").on("click", function () {
+        if (selectedObject != null) {
+            removeSelectedObject();
+        }
         return false;
     });
 
@@ -180,6 +206,7 @@ function setupPage() {
         if (selectedObject != null) {
             selectedObject.angle += 15;
             updateSelectedObject();
+            dirty = true;
         }
         return false;
     });
@@ -187,6 +214,7 @@ function setupPage() {
     $("#mouseButton").on("click", function () {
         drawBrushAimer = false;
         drawObject = null;
+        dirty = true;
         return false;
     });
 
@@ -268,7 +296,7 @@ function setupPage() {
     });
 
     $("#loadButton").on("click", function () {
-        selectedObject = null;
+        setSelectedObject(null);
         $("#createNewImage").attr("src", createCanvas.toDataURL("image/jpeg", 0.1));
         $('#createWindow').hide();
         $('#loadWindow').show();
@@ -277,11 +305,9 @@ function setupPage() {
         window.removeEventListener("mousemove", cellUnderMouse, false);
         window.removeEventListener("mousedown", handleClick, false);
         window.removeEventListener("mouseup", handleUnClick, false);
-        window.removeEventListener('contextmenu', function (ev) {
-            return false;
-        }, false);
         return false;
     });
+    window.addEventListener('contextmenu', suppressContextMenu, false);
     window.addEventListener('resize', resize, false);
     window.requestAnimFrame = (function () {
         return window.requestAnimationFrame ||
@@ -300,9 +326,36 @@ function addListeners() {
     window.addEventListener("mousemove", cellUnderMouse, false);
     window.addEventListener("mousedown", handleClick, false);
     window.addEventListener("mouseup", handleUnClick, false);
-    window.addEventListener('contextmenu', function (ev) {
-        return false;
-    }, false);
+}
+
+function suppressContextMenu(ev) {
+    ev.preventDefault();
+    return false;
+}
+
+function setSelectedObject(obj) {
+    selectedObject = obj;
+    var btn = document.getElementById("deleteSelectedButton");
+    if (btn != null) btn.disabled = (obj == null);
+    dirty = true;
+}
+
+function confirmWipeIfDirty() {
+    var cells = vMap.cells;
+    var needsConfirm = false;
+    for (var i = 0; i < cells.length; i++) {
+        if (cells[i].id != config.tileMap.normal.id) {
+            needsConfirm = true;
+            break;
+        }
+    }
+    if (!needsConfirm && vMap.hazards && vMap.hazards.length > 0) {
+        needsConfirm = true;
+    }
+    if (needsConfirm) {
+        return confirm("Are you sure you want to delete this map?");
+    }
+    return true;
 }
 
 function validateEmail(mail) {
@@ -312,32 +365,9 @@ function validateEmail(mail) {
     return (false)
 }
 
-function validateWithUser() {
-
-    if (selectedObject != null) {
-        removeSelectedObject();
-        return;
-    }
-
-    var cells = vMap.cells;
-    var prompt = false;
-    for (var i = 0; i < cells.length; i++) {
-        if (cells[i].id != config.tileMap.normal.id) {
-            prompt = true;
-            break;
-        }
-    }
-    if (prompt == false && vMap.hazards.length > 0) {
-        prompt = true;
-    }
-    if (prompt) {
-        return confirm("Are you sure you want to delete this map?");
-    }
-    return true;
-}
-
 function rebuild() {
     $("#submitStatus").hide();
+    setSelectedObject(null);
     vMap = generateVMap();
     $('#author').val("");
     $('#name').val("");
@@ -350,26 +380,27 @@ function init() {
 }
 
 function animloop() {
-    if (gameRunning) {
-        var now = Date.now();
-        dt = now - then;
-        gameLoop(dt);
-        then = now;
-        requestAnimFrame(animloop);
-    }
-}
-function gameLoop(dt) {
-    if (drawBrushAimer) {
-        currentCell = cellIdFromPoint(mousex, mousey);
-    }
-    drawEditor(dt);
+    if (!gameRunning) return;
+    var now = Date.now();
+    dt = now - then;
     if (mapReady == false) {
         mapReady = true;
         rebuild();
     }
-    if (brushing) {
-        paintTile();
+    if (drawBrushAimer) {
+        var prev = currentCell;
+        currentCell = cellIdFromPoint(mousex, mousey);
+        if (prev !== currentCell) dirty = true;
     }
+    if (brushing) {
+        if (paintTile()) dirty = true;
+    }
+    if (dirty) {
+        drawEditor(dt);
+        dirty = false;
+    }
+    then = now;
+    requestAnimFrame(animloop);
 }
 
 function resize() {
@@ -377,23 +408,14 @@ function resize() {
     var viewport = { width: rect.width, height: rect.height };
     var scaleToFitX = viewport.width / createCanvas.width;
     var scaleToFitY = viewport.height / createCanvas.height;
-    var currentScreenRatio = viewport.width / viewport.height;
     var optimalRatio = Math.min(scaleToFitX, scaleToFitY);
-
-
-    /*
-    if (currentScreenRatio >= 1.77 && currentScreenRatio <= 1.79) {
-        newWidth = viewport.width ;
-        newHeight = viewport.height;
-    } else {
-        */
     newWidth = createCanvas.width * optimalRatio / 1.2;
     newHeight = createCanvas.height * optimalRatio / 1.2;
-    // }
     var controlPanel = document.getElementById("controlPanel");
     controlPanel.style.height = newHeight + "px";
     createCanvas.style.width = newWidth + "px";
     createCanvas.style.height = newHeight + "px";
+    dirty = true;
 }
 
 function drawEditor(dt) {
@@ -525,13 +547,13 @@ function setMousePos(x, y) {
 }
 
 function paintTile() {
+    if (currentCell == null) return false;
+    var cell = vMap.cells[currentCell];
+    if (cell == null) return false;
     var newId = locateId(brushColor);
-    var cells = vMap.cells;
-    for (var i = 0; i < cells.length; i++) {
-        if (currentCell == cells[i].site.voronoiId) {
-            cells[i].id = newId;
-        }
-    }
+    if (cell.id === newId) return false;
+    cell.id = newId;
+    return true;
 }
 
 function addObjectToMap(x, y, obj) {
@@ -548,6 +570,7 @@ function addObjectToMap(x, y, obj) {
         vMap.hazards = [];
     }
     vMap.hazards.push({ id: drawObject, x: x, y: y, angle: 0 });
+    dirty = true;
 }
 
 function locateObject(x, y) {
@@ -562,13 +585,14 @@ function locateObject(x, y) {
                 break;
             }
         }
+        if (hazardObj == null) continue;
         var distance = getMagSq(x, y, vMap.hazards[hazard].x, vMap.hazards[hazard].y);
         if (distance < Math.pow(hazardObj.radius, 2)) {
-            selectedObject = { id: vMap.hazards[hazard].id, x: vMap.hazards[hazard].x, y: vMap.hazards[hazard].y, angle: vMap.hazards[hazard].angle, radius: hazardObj.radius };
+            setSelectedObject({ id: vMap.hazards[hazard].id, x: vMap.hazards[hazard].x, y: vMap.hazards[hazard].y, angle: vMap.hazards[hazard].angle, radius: hazardObj.radius });
             return;
         }
     }
-    selectedObject = null;
+    setSelectedObject(null);
 }
 
 function updateSelectedObject() {
@@ -587,7 +611,7 @@ function removeSelectedObject() {
         if (vMap.hazards[i].id == selectedObject.id) {
             if (vMap.hazards[i].x == selectedObject.x && vMap.hazards[i].y == selectedObject.y) {
                 vMap.hazards.splice(i, 1);
-                selectedObject = null;
+                setSelectedObject(null);
                 return;
             }
         }
@@ -615,7 +639,7 @@ function generateVMap() {
     }
     localMap = voronoi.compute(sites, localbbox);
     var cells = localMap.cells;
-    iCells = cells.length;
+    var iCells = cells.length;
     while (iCells--) {
         cells[iCells].id = 1;
     }
@@ -630,6 +654,7 @@ function cellUnderMouse(evt) {
     x = (((evt.pageX - rect.left) / newWidth) * createCanvas.width);
     y = (((evt.pageY - rect.top) / newHeight) * createCanvas.height);
     setMousePos(x, y);
+    dirty = true;
 }
 
 function cellIdFromPoint(xmouse, ymouse) {

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -67,8 +67,21 @@ window.onload = function () {
     server.emit("getConfig");
     setupPage();
     rebuild();
+    showLoadWindow();
+}
+
+function showLoadWindow() {
     $('#loadWindow').show();
     $('#createWindow').hide();
+    document.body.classList.remove('editor-open');
+}
+
+function showEditor() {
+    $('#loadWindow').hide();
+    $('#createWindow').show();
+    document.body.classList.add('editor-open');
+    resize();
+    addListeners();
 }
 
 function clientConnect() {
@@ -108,10 +121,7 @@ function clientConnect() {
                             vMap = JSON.parse(JSON.stringify(maps[j]));
                             $('#author').val(vMap.author);
                             $('#name').val(vMap.name);
-                            $('#loadWindow').hide();
-                            $('#createWindow').show();
-                            resize();
-                            addListeners();
+                            showEditor();
                             return;
                         }
                     }
@@ -181,10 +191,7 @@ function makeSeamlessPattern(image) {
 function setupPage() {
     $("#createNew").on("click", function () {
         $("#submitStatus").hide();
-        $('#loadWindow').hide();
-        $('#createWindow').show();
-        resize();
-        addListeners();
+        showEditor();
     });
     $("#rebuildButton").on("click", function () {
         if (confirmWipeIfDirty()) {
@@ -298,9 +305,8 @@ function setupPage() {
     $("#loadButton").on("click", function () {
         setSelectedObject(null);
         $("#createNewImage").attr("src", createCanvas.toDataURL("image/jpeg", 0.1));
-        $('#createWindow').hide();
-        $('#loadWindow').show();
         $("#submitStatus").hide();
+        showLoadWindow();
 
         window.removeEventListener("mousemove", cellUnderMouse, false);
         window.removeEventListener("mousedown", handleClick, false);
@@ -404,15 +410,12 @@ function animloop() {
 }
 
 function resize() {
+    if (createCanvas == null) return;
     var rect = canvasWindow.getBoundingClientRect();
-    var viewport = { width: rect.width, height: rect.height };
-    var scaleToFitX = viewport.width / createCanvas.width;
-    var scaleToFitY = viewport.height / createCanvas.height;
-    var optimalRatio = Math.min(scaleToFitX, scaleToFitY);
-    newWidth = createCanvas.width * optimalRatio / 1.2;
-    newHeight = createCanvas.height * optimalRatio / 1.2;
-    var controlPanel = document.getElementById("controlPanel");
-    controlPanel.style.height = newHeight + "px";
+    if (rect.width === 0 || rect.height === 0) return;
+    var optimalRatio = Math.min(rect.width / createCanvas.width, rect.height / createCanvas.height);
+    newWidth = createCanvas.width * optimalRatio;
+    newHeight = createCanvas.height * optimalRatio;
     createCanvas.style.width = newWidth + "px";
     createCanvas.style.height = newHeight + "px";
     dirty = true;

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -80,6 +80,8 @@ function showEditor() {
     $('#loadWindow').hide();
     $('#createWindow').show();
     document.body.classList.add('editor-open');
+    var cp = document.getElementById('controlPanel');
+    if (cp != null) cp.scrollTop = 0;
     resize();
     addListeners();
 }

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -27,30 +27,36 @@ var server,
 
 var scale = 0.035;
 
-// Tile textures. Attach onload BEFORE setting src so cached images still
-// fire the load handler. loadPatterns() is gated on all images being ready
-// AND the config socket message arriving — see tryStart().
+// Tile textures. Attach load + error BEFORE setting src so cached images
+// still fire and a missing/broken asset can't hang the gate forever.
+// Pass explicit width/height: PNGs are OK from intrinsic size, but the
+// SVG icons (question-solid, bomb) have only viewBox — Firefox returns
+// width=0 for those without an attribute, which makes makePattern()
+// render a 3px transparent canvas for the random/ability tiles.
+// loadPatterns() is gated on all images being ready AND the config
+// socket message arriving — see tryStart().
 var imagesPending = 0,
     imagesLoaded = 0;
-function loadTileImage(src, scale) {
-    var img = new Image();
+function loadTileImage(src, width, height, scale) {
+    var img = new Image(width, height);
     if (scale != null) img.scale = scale;
     imagesPending++;
-    img.addEventListener('load', onTileImageLoad);
+    img.addEventListener('load', onTileImageSettled, { once: true });
+    img.addEventListener('error', onTileImageSettled, { once: true });
     img.src = src;
     return img;
 }
-function onTileImageLoad() {
+function onTileImageSettled() {
     imagesLoaded++;
     tryStart();
 }
-var lava = loadTileImage("../assets/img/lava.png");
-var grass = loadTileImage("../assets/img/grass.png", 0.5);
-var dirt = loadTileImage("../assets/img/dirt.png", 0.25);
-var ice = loadTileImage("../assets/img/ice.png", 0.75);
-var sand = loadTileImage("../assets/img/sand.png", 0.25);
-var random = loadTileImage("../assets/img/question-solid.svg");
-var bombIcon = loadTileImage("../assets/img/bomb.svg");
+var lava = loadTileImage("../assets/img/lava.png", 256, 256);
+var grass = loadTileImage("../assets/img/grass.png", 256, 256, 0.5);
+var dirt = loadTileImage("../assets/img/dirt.png", 256, 256, 0.25);
+var ice = loadTileImage("../assets/img/ice.png", 256, 256, 0.75);
+var sand = loadTileImage("../assets/img/sand.png", 256, 256, 0.25);
+var random = loadTileImage("../assets/img/question-solid.svg", 576, 512);
+var bombIcon = loadTileImage("../assets/img/bomb.svg", 576, 512);
 
 // Redraw gate. Set dirty=true from anything that mutates rendered state
 // (mouse moved, click, paint, hazard added/removed/rotated, resize, rebuild);

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -166,6 +166,45 @@ var purpleFire = new Image(32, 128);
 purpleFire.src = "../assets/img/purpleFire.png";
 
 
+// Every Image() loadPatterns()/loadSpriteSheets()/HUD draws read from.
+// We expose tileImagesReady so setupPage can gate enterLobby on them
+// being fully decoded — otherwise a mid-game joiner runs loadPatterns()
+// before .complete fires and gets non-null but empty CanvasPatterns, so
+// the board renders mostly transparent until the next round's newMap
+// rebuilds patterns. requiredImagesLoaded is exposed for the loading bar.
+var requiredImages = [
+    blindfoldIcon, blindfoldLargeIcon, transferIcon, copyIcon, bombIcon,
+    snowFlakeIcon, windIcon, hourglassIcon, lightningIcon, cloudyIcon,
+    infinityIcon, fiestaIcon, toolBoxIcon, moneyIcon, volcanoIcon,
+    bombImage, snowFlakeImage, cloudImage, infectionIcon, puckIcon,
+    explosionIcon, moonIcon, scissorsIcon,
+    lava, poison, grass, dirt, ice, sand,
+    redFire, orangeFire, yellowFire, greenFire, blueFire, purpleFire
+];
+var requiredImagesLoaded = 0;
+var tileImagesReady = Promise.all(requiredImages.map(function (img) {
+    if (img.complete && img.naturalWidth > 0) {
+        requiredImagesLoaded++;
+        return Promise.resolve();
+    }
+    return new Promise(function (resolve) {
+        var done = function () { requiredImagesLoaded++; resolve(); };
+        img.addEventListener('load', done, { once: true });
+        // Treat decode failures as "done" too so one missing asset can't
+        // hang the loading screen forever.
+        img.addEventListener('error', done, { once: true });
+    });
+}));
+// Belt and suspenders: setupPage waits on this Promise, but if anything
+// renders before patterns are valid we self-heal once the images land.
+tileImagesReady.then(function () {
+    if (typeof config !== 'undefined' && config != null) {
+        loadPatterns();
+    }
+    invalidateMapCache();
+});
+
+
 function loadPatterns() {
     //Abilities
     patterns[config.tileMap.abilities.blindfold.id] = makePattern(blindfoldIcon, makeSeamlessPattern(dirt));

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -100,7 +100,11 @@ function setupPage() {
     overlayContext = overlayCanvas.getContext('2d');
     init();
     $.when.apply($, promises).then(function () {
-        enterLobby();
+        // Don't enterLobby until the tile/ability Image() objects are
+        // actually decoded — otherwise loadPatterns() in the gameState
+        // handler builds empty CanvasPatterns and the board renders
+        // transparent for mid-game joiners.
+        tileImagesReady.then(enterLobby);
     });
 }
 
@@ -140,18 +144,14 @@ function animloop() {
     }
     if (loading == true) {
         var loadedCount = 0;
-        var totalToLoad = promises.length;
         for (var i = 0; i < promises.length; i++) {
-            if (promises[i].status != 200) {
-                continue;
-            }
-            if (promises[i].status == 200) {
-                loadedCount++;
-            }
+            if (promises[i].status == 200) loadedCount++;
         }
-
+        // Roll the tile/ability Image() decodes into the loading bar so
+        // it reflects what we actually wait on before entering the game.
+        loadedCount += requiredImagesLoaded;
+        var totalToLoad = promises.length + requiredImages.length;
         progressBar.style.width = ((loadedCount / totalToLoad) * 100 + "%");
-        //console.log("Loaded (" + loadedCount + " / " + totalToLoad + ")");
         if (loadedCount == totalToLoad) {
             enterLobby();
         }

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -102,14 +102,21 @@ function setupPage() {
     gameContext = gameCanvas.getContext('2d');
     overlayContext = overlayCanvas.getContext('2d');
     init();
-    $.when.apply($, promises).then(function () {
-        // Don't enterLobby until the tile/ability Image() objects are
-        // actually decoded — otherwise loadPatterns() in the gameState
-        // handler builds empty CanvasPatterns and the board renders
-        // transparent for mid-game joiners.
+    // Use .always() (not .then()) so a single 404 / CORS error in the
+    // preload list doesn't leave the lobby never being entered. Once
+    // every XHR has settled (success or failure), wait on the image
+    // decodes too — otherwise loadPatterns() in the gameState handler
+    // builds empty CanvasPatterns and the board renders transparent for
+    // mid-game joiners. animloop also surfaces a "still loading?" prompt
+    // after LOADING_TIMEOUT_MS as a last-resort recovery path.
+    $.when.apply($, promises).always(function () {
         tileImagesReady.then(enterLobby);
     });
 }
+
+var loadingStartedAt = Date.now();
+var LOADING_TIMEOUT_MS = 20000;
+var loadingTimeoutShown = false;
 
 function enterLobby() {
     if (inLobby == true) {
@@ -148,7 +155,10 @@ function animloop() {
     if (loading == true) {
         var loadedCount = 0;
         for (var i = 0; i < promises.length; i++) {
-            if (promises[i].status == 200) loadedCount++;
+            // readyState 4 = DONE for any settled XHR (200, 304, 404, etc).
+            // Counting only status==200 would stall the bar on 304s and
+            // mask CDN cache hits as "still loading".
+            if (promises[i].readyState === 4) loadedCount++;
         }
         // Roll the tile/ability Image() decodes into the loading bar so
         // it reflects what we actually wait on before entering the game.
@@ -157,6 +167,9 @@ function animloop() {
         progressBar.style.width = ((loadedCount / totalToLoad) * 100 + "%");
         if (loadedCount == totalToLoad) {
             enterLobby();
+        } else if (!loadingTimeoutShown && Date.now() - loadingStartedAt > LOADING_TIMEOUT_MS) {
+            loadingTimeoutShown = true;
+            progressContainer.html('Loading is taking longer than usual. <a href="#" onclick="location.reload();return false;">Refresh the page</a> to retry.');
         }
         requestAnimFrame(animloop);
     }

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -38,7 +38,10 @@ var masterControl = $('#masterControl');
 var progressContainer = $('#progressContainer');
 var progressBar = document.getElementById("progressBar");
 var emojiMenu = document.getElementById("emojiMenu");
-var canvasWindow = document.getElementById("mapContainer");
+// Read available space from #gameWindow (the section-filling flex
+// container); #mapContainer is sized inside it to match the canvas.
+var canvasWindow = document.getElementById("gameWindow");
+var mapContainer = document.getElementById("mapContainer");
 var exitIconID = document.getElementById("exitIcon");
 
 //Input Vars
@@ -116,7 +119,7 @@ function enterLobby() {
     loading = false;
     progressContainer.hide();
     $('#main').hide();
-    $('#gameWindow').show();
+    $('#gameWindow').css('display', 'flex');
     resize();
     var playParams = new URLSearchParams(window.location.search);
     if (playParams.has("gameid")) {
@@ -166,21 +169,25 @@ function gameLoop(dt) {
 
 function resize() {
     var gameWindowRect = canvasWindow.getBoundingClientRect();
+    if (gameWindowRect.width === 0 || gameWindowRect.height === 0) return;
     var viewport = { width: gameWindowRect.width, height: gameWindowRect.height };
-    var scaleToFitX = viewport.width / gameCanvas.width;
-    var scaleToFitY = viewport.height / gameCanvas.height;
-    var currentScreenRatio = viewport.width / viewport.height;
-    var optimalRatio = Math.min(scaleToFitX, scaleToFitY);
+    var optimalRatio = Math.min(viewport.width / gameCanvas.width, viewport.height / gameCanvas.height);
 
     if (window.document.fullscreenElement) {
         newWidth = viewport.width;
         newHeight = viewport.height;
     } else {
-        newWidth = gameCanvas.width * optimalRatio / 1.1;
-        newHeight = gameCanvas.height * optimalRatio / 1.1;
+        // Fit the canvas to the available space at its native 16:9
+        // aspect ratio (no padding shrink — the gameWindow flex
+        // container provides any breathing room).
+        newWidth = gameCanvas.width * optimalRatio;
+        newHeight = gameCanvas.height * optimalRatio;
     }
 
-
+    if (mapContainer != null) {
+        mapContainer.style.width = newWidth + "px";
+        mapContainer.style.height = newHeight + "px";
+    }
     gameCanvas.style.width = newWidth + "px";
     gameCanvas.style.height = newHeight + "px";
     overlayCanvas.style.width = newWidth + "px";

--- a/client/scripts/join.js
+++ b/client/scripts/join.js
@@ -19,6 +19,20 @@ $(function () {
         var banner = document.getElementById('notFoundBanner');
         if (banner != null) banner.hidden = false;
     }
+
+    var joinByIdInput = document.getElementById('joinByIdInput');
+    var joinByIdButton = document.getElementById('joinByIdButton');
+    if (joinByIdInput != null && joinByIdButton != null) {
+        var goJoinById = function () {
+            var value = joinByIdInput.value.trim();
+            if (value === '') return;
+            window.location.href = './play.html?gameid=' + encodeURIComponent(value);
+        };
+        joinByIdButton.addEventListener('click', goJoinById);
+        joinByIdInput.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter') { e.preventDefault(); goJoinById(); }
+        });
+    }
 });
 
 function clientConnect() {
@@ -81,6 +95,7 @@ function buildCard(room, maxPlayers) {
     state.textContent = stateLabel(room.state);
     info.appendChild(state);
 
+    info.appendChild(buildStat('Game ID', room.gameID));
     info.appendChild(buildStat('Round', room.round));
     info.appendChild(buildStat('Map', room.currentMap || 'Lobby'));
     info.appendChild(buildStat('Players', room.players + '/' + maxPlayers));

--- a/client/scripts/join.js
+++ b/client/scripts/join.js
@@ -14,6 +14,11 @@ $(function () {
             if (server != null) server.emit('getRooms');
         });
     }
+    var params = new URLSearchParams(window.location.search);
+    if (params.has('notfound')) {
+        var banner = document.getElementById('notFoundBanner');
+        if (banner != null) banner.hidden = false;
+    }
 });
 
 function clientConnect() {

--- a/client/scripts/join.js
+++ b/client/scripts/join.js
@@ -58,7 +58,19 @@ function clientConnect() {
         renderRooms(JSON.parse(packet));
     });
 
+    // Stop polling on socket disconnect or page navigation so we don't
+    // leak the timer or fire getRooms into a dead/buffering socket.
+    server.on("disconnect", stopRefreshing);
+    window.addEventListener("pagehide", stopRefreshing);
+
     return server;
+}
+
+function stopRefreshing() {
+    if (refreshInterval != null) {
+        clearInterval(refreshInterval);
+        refreshInterval = null;
+    }
 }
 
 function renderRooms(rooms) {

--- a/client/scripts/join.js
+++ b/client/scripts/join.js
@@ -1,15 +1,24 @@
 var server = null,
     config = null,
-    myID;
+    myID,
+    refreshInterval = null,
+    firstResponseReceived = false;
+
+var REFRESH_MS = 5000;
 
 $(function () {
     server = clientConnect();
-})
+    var refreshButton = document.getElementById('refreshButton');
+    if (refreshButton != null) {
+        refreshButton.addEventListener('click', function () {
+            if (server != null) server.emit('getRooms');
+        });
+    }
+});
 
 function clientConnect() {
     var server = io();
     server.emit("getConfig");
-
 
     server.on('welcome', function (id) {
         myID = id;
@@ -18,37 +27,95 @@ function clientConnect() {
     server.on("config", function (c) {
         config = c;
         server.emit('getRooms');
-    });
-
-    server.on("roomListing", function (packet) {
-        var rooms = JSON.parse(packet);
-        for (var id in rooms) {
-            var room = rooms[id];
-            var state = room.state;
-            for (var prop in config.stateMap) {
-                if (room.state == config.stateMap[prop]) {
-                    state = capitalizeFirstLetter(prop);
-                }
-            }
-            var currentMap = room.currentMap;
-            if (currentMap == undefined) {
-                currentMap = "Lobby"
-            }
-            $("#gameSelection").append('<div class="gameCard justify-content-center align-self-center mx-auto"><form><div class="game-content"><div class="gameState"><span>' + state +
-                '</span></div><table class="mapData"><tr><th>Round</th><th>Current Map</th><th>Game ID</th><th>Players</th></tr><tr>' +
-                '<td>' + room.round + "</td>" +
-                '<td>' + currentMap + "</td>" +
-                '<td>' + room.gameID + "</td>" +
-                '<td>' + room.players + "</td>" + '</tr></table></div>' +
-                '<a href="./play.html?gameid=' + room.gameID + '" class="btn btn-outline-info w-25 join-btn">Join</a>'
-            );
+        if (refreshInterval == null) {
+            refreshInterval = setInterval(function () {
+                server.emit('getRooms');
+            }, REFRESH_MS);
         }
     });
 
+    server.on("roomListing", function (packet) {
+        firstResponseReceived = true;
+        renderRooms(JSON.parse(packet));
+    });
 
     return server;
-
 }
+
+function renderRooms(rooms) {
+    var container = document.getElementById('gameSelection');
+    var empty = document.getElementById('emptyState');
+    var loading = document.getElementById('loadingState');
+    if (container == null) return;
+
+    container.replaceChildren();
+    if (loading != null) loading.hidden = true;
+
+    var ids = Object.keys(rooms);
+    if (ids.length === 0) {
+        if (empty != null) empty.hidden = false;
+        return;
+    }
+    if (empty != null) empty.hidden = true;
+
+    var maxPlayers = (config && config.maxPlayersInRoom) || 25;
+    for (var i = 0; i < ids.length; i++) {
+        container.appendChild(buildCard(rooms[ids[i]], maxPlayers));
+    }
+}
+
+function buildCard(room, maxPlayers) {
+    var card = document.createElement('div');
+    card.className = 'gameCard';
+
+    var info = document.createElement('div');
+    info.className = 'card-info';
+
+    var state = document.createElement('span');
+    state.className = 'card-state';
+    state.textContent = stateLabel(room.state);
+    info.appendChild(state);
+
+    info.appendChild(buildStat('Round', room.round));
+    info.appendChild(buildStat('Map', room.currentMap || 'Lobby'));
+    info.appendChild(buildStat('Players', room.players + '/' + maxPlayers));
+
+    var joinBtn = document.createElement('a');
+    joinBtn.href = './play.html?gameid=' + encodeURIComponent(room.gameID);
+    joinBtn.className = 'btn btn-outline-info join-btn';
+    joinBtn.textContent = 'Join';
+
+    card.appendChild(info);
+    card.appendChild(joinBtn);
+    return card;
+}
+
+function buildStat(label, value) {
+    var span = document.createElement('span');
+    span.className = 'card-stat';
+    var labelEl = document.createElement('span');
+    labelEl.className = 'card-stat-label';
+    labelEl.textContent = label + ': ';
+    var valueEl = document.createElement('span');
+    valueEl.className = 'card-stat-value';
+    valueEl.textContent = String(value);
+    span.appendChild(labelEl);
+    span.appendChild(valueEl);
+    return span;
+}
+
+function stateLabel(state) {
+    if (config != null && config.stateMap != null) {
+        for (var prop in config.stateMap) {
+            if (state === config.stateMap[prop]) {
+                return capitalizeFirstLetter(prop);
+            }
+        }
+    }
+    return String(state);
+}
+
 function capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
+    var s = String(string);
+    return s.charAt(0).toUpperCase() + s.slice(1);
 }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,21 @@ const htmlPath = path.join(__dirname, 'client');
 
 app.use(compression());
 
+// Inject the running server's version into index.html so the landing
+// page always reflects what's actually deployed. Runs in both dev and
+// prod; read once at startup so we don't fs.readFile on every request.
+const APP_VERSION = require('./package.json').version;
+app.use(function (req, res, next) {
+    var url = req.path === '/' ? '/index.html' : req.path;
+    if (url !== '/index.html') return next();
+    fs.readFile(path.join(htmlPath, url), 'utf8', function (err, html) {
+        if (err) return next();
+        var modified = html.replace(/<!-- VERSION -->/g, 'v' + APP_VERSION);
+        res.set('Content-Type', 'text/html');
+        res.send(modified);
+    });
+});
+
 const bundleMap = {
     '/play.html': 'scripts/dist/play.bundle.min.js',
     '/create.html': 'scripts/dist/create.bundle.min.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chaochao",
-    "version": "0.0.1",
+    "version": "0.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chaochao",
-            "version": "0.0.1",
+            "version": "0.1.2",
             "dependencies": {
                 "@octokit/core": "^5.2.2",
                 "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chaochao",
-    "version": "0.0.1",
+    "version": "0.1.2",
     "description": "Multiplayer web based slow paced racing game",
     "dependencies": {
         "@octokit/core": "^5.2.2",


### PR DESCRIPTION
## Summary

A multi-pass cleanup and bug-fix bundle. Three runtime fixes worth calling out:

- **Mid-game-join board fix** — joining a room past the lobby state used to render an almost-blank board (tile patterns were created against `Image()` objects that hadn't decoded yet; next round's `newMap` masked the bug). `setupPage` now waits on a `tileImagesReady` Promise over every Image the patterns rely on before entering the lobby; the loading bar reflects the same readiness.
- **Stuck-on-stale-gameid fix** — `roomNotFound` used a blocking `alert()` that left the user on a disconnected page with no recovery. Now redirects to `/join.html?notfound=1` with an inline banner.
- **Map editor + play-page viewport** — the editor and game canvases both used fragile `width:90%; margin:5%` layouts on top of `section { height:100vh; margin-top:60px }` that overflowed the viewport. Switched to fixed shells + flex-centred canvases sized to the largest 16:9 box that fits; no more phantom scrollbars.

## What's in the diff

**Map editor** (`client/scripts/create.{html,js}`, related CSS)
- Idle render skip, O(1) tile paint, image-load gate, dedicated delete-selected button, sticky toolbar + Actions pin, compacted panel.
- Layout locked to a fixed shell so the canvas can't scroll out of view.

**Join page** (`client/join.html`, `client/scripts/join.js`, related CSS)
- Dropped the hard-coded "Lobby" placeholder card.
- DOM rendering (kills the XSS via map names), 5s auto-refresh + manual refresh button, empty/loading states.
- "Start a new game" CTA separated from "Join an existing one".
- Game ID surfaced on cards + "Have a Game ID?" direct-join input.
- `refreshInterval` cleared on `disconnect` / `pagehide` so it doesn't leak or fire on a dead socket.

**Landing page** (`client/index.html`, related CSS, `index.js`)
- Dead `<form>` swapped for `<a class="btn">` links, `mt10` → real Bootstrap classes, `body { overflow-y: scroll }` dropped, broken `#main { width: calc(1366 - 200px) }` fixed.
- Card vertically centred, max-width-bounded, tagline ("Slow-paced multiplayer arena racing.") below the card.
- Version pill auto-injects from `package.json` via a small Express middleware so it stops drifting from the actual release.
- Navbar offset moved from `section { margin-top }` to `body { padding-top }` so it doesn't margin-collapse out and add a phantom 60px to every page.

**Play page** (`client/scripts/game.js`, related CSS)
- Same fixed-shell pattern as the editor: canvas fills the available 16:9 box instead of ~91% of it.
- Loading bar counts any settled XHR (200 OR 304), `$.when().always()` so a 404 doesn't strand the user, and a "Refresh the page" recovery prompt after 20s of loading.

**Repo plumbing**
- `CLAUDE.md` documents the build/dev commands and architecture for future Claude instances.
- `backlog.md` tracks deferred map-editor / join-page / landing-page items.
- `.github/workflows/release-notes-check.yml` requires a `## Unreleased` bullet in `CHANGELOG.md` whenever a PR touches `server/config.json`, `server/game.js`, or `server/engine.js`. Map-submission PRs from the editor are unaffected because they pass an explicit PR body and don't touch those files.
- `.github/workflows/sync-package-version.yml` auto-bumps `package.json` to match any pushed `v*.*.*` tag, with an ancestry check that refuses tags not on main and a fast-forward-only push so concurrent pushes can't be overwritten.
- `CONTRIBUTING.md` + `.github/pull_request_template.md` describe the release flow.

## Test plan

- [x] Map editor: paint tiles, place/select/rotate/delete a bumper, wipe + confirm, resize window, ensure toolbar + Actions stay pinned at narrow heights.
- [x] Join page: empty state when no rooms, room card appears within 5s of a play tab connecting, "Have a Game ID?" navigates to `play.html?gameid=N`, banner shows when arriving from a stale gameid URL.
- [x] Play page: mid-race spectator join now paints 91.9% of the map cache (was 4%); fresh-game flow unchanged; loading bar shows refresh prompt path is wired.
- [x] Landing page: version pill reflects `package.json`, no scroll bar, tagline and buttons centred at typical viewport sizes.
- [x] CI workflows: YAML lints clean; release-notes check awk now treats added/context section headers as boundaries (not deleted ones); sync-package-version uses `env:` interpolation instead of inlining tag values into `node -e` / shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)