### PR TITLE
Fix: don't stop player movement when using an ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ When cutting a release: move the `Unreleased` contents under a new `## vX.Y.Z â€
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- Using an ability no longer brings your character to a stop. Only punching without an ability slows you down now.
 
 ## Older versions
 

--- a/server/game.js
+++ b/server/game.js
@@ -1922,6 +1922,11 @@ class Player extends Circle {
 				this.punchedTimer = Date.now();
 				this.resourceful += 1;
 				this.ability.use();
+				// Clear the attack input so using an ability doesn't bleed into the
+				// next tick. Otherwise, once checkAbilities() nulls out the consumed
+				// ability, the still-true attack flag would trigger the punch
+				// slow-down in the engine (and throw a stray punch), stopping movement.
+				this.attack = false;
 				return;
 			}
 			if (this.checkPunchCoolDown()) {


### PR DESCRIPTION
## Problem

Using an ability stopped your character's movement. That slow-down should only happen when you **punch with no ability**, not when using an ability.

## Root cause

In `Player.checkAttack` (`server/game.js`), the punch branch resets `this.attack = false` after firing, but the **ability branch did not** — it called `this.ability.use()` and returned with `attack` still `true`.

The game loop order is `engine.update()` → `updatePlayers()` (`checkAttack`) → `checkAbilities()` (which nulls out the consumed ability). So the next tick, `attack` was still `true` while `ability` had become `null`, which satisfies the engine's punch slow-down gate:

```js
// server/engine.js
if (player.attack && player.ability == null) {
    punchingSlowDown = c.playerPunchSlowAmt;
}
```

→ movement got slowed/stopped (and a stray punch was thrown) right after using an ability.

## Fix

Clear `this.attack = false` in the ability branch too, mirroring the punch branch, so a spent ability can't be mistaken for a punch on the following tick.

## Behavior after fix
- Use an ability while moving → movement continues (bug fixed).
- Punch with no ability while moving → still slows/stops (preserved).

Verified locally: applies cleanly on top of latest `main`, server boots, and both behaviors confirmed in-game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)