### PR TITLE
Cut v0.1.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ When cutting a release: move the `Unreleased` contents under a new `## vX.Y.Z â€
 
 ## Unreleased
 
+(none yet)
+
+## v0.1.3 â€” 2026-05-23
+
 ### Bug fixes
 
 - Using an ability no longer brings your character to a stop. Only punching without an ability slows you down now.


### PR DESCRIPTION
Release-cut for **v0.1.3**.

Moves the ability-movement bug-fix note from `## Unreleased` under a new `## v0.1.3 — 2026-05-23` heading and resets `Unreleased` to empty.

After this merges, the next step is to tag `v0.1.3` on `main`, which triggers `sync-package-version.yml` to bump `package.json` to `0.1.3`, then publish the GitHub release using this section as the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)