### PR TITLE
Add basic PR-validation CI

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,45 @@
+name: PR validation
+
+# Basic standards gate for pull requests into main:
+#   1. dependencies install cleanly against the committed lockfile,
+#   2. every JavaScript file parses (no syntax errors), and
+#   3. the client bundles build.
+# Keep this fast and dependency-light so it stays a low-friction check.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        # `npm ci` also fails if package.json and package-lock.json drift.
+        run: npm ci
+
+      - name: Syntax-check all JavaScript
+        # Parse every tracked .js file; skip vendored deps and build output.
+        run: |
+          fail=0
+          while IFS= read -r f; do
+            if ! node --check "$f"; then
+              echo "::error file=$f::Syntax check failed"
+              fail=1
+            fi
+          done < <(find . \
+            \( -path ./node_modules -o -path ./client/scripts/dist \) -prune -o \
+            -name '*.js' -print)
+          exit $fail
+
+      - name: Build client bundles
+        run: npm run build


### PR DESCRIPTION
Adds a lightweight standards gate that runs on every PR into `main` (`.github/workflows/pr-validation.yml`):

1. **Install** — `npm ci` (also fails if `package.json` / `package-lock.json` drift apart).
2. **Syntax-check** — `node --check` on every tracked `.js` file (server, client scripts, entry points); skips `node_modules` and `client/scripts/dist`.
3. **Build** — `npm run build` to confirm the client bundles compile.

Kept intentionally minimal and dependency-light so it stays low-friction. No linter is configured in the repo yet; ESLint could be layered on later as a follow-up.

Verified locally: all 22 JS files pass `node --check`, `npm ci` matches the lockfile, and `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)