### PR TITLE
Route v0.1.3 through the automated release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ When cutting a release: move the `Unreleased` contents under a new `## vX.Y.Z â€
 
 ## Unreleased
 
-(none yet)
-
-## v0.1.3 â€” 2026-05-23
-
 ### Bug fixes
 
 - Using an ability no longer brings your character to a stop. Only punching without an ability slows you down now.


### PR DESCRIPTION
Fixes the half-cut v0.1.3 so the new automation can release it cleanly.

## Background
PR #121 moved the ability-movement bug-fix note under a `## v0.1.3` heading, but the tag, GitHub release, and `package.json` bump never happened (they need a push to protected `main`). So v0.1.3 is documented-only, and because `Unreleased` is now empty, the automated release workflow (#123) won't pick it up.

## This PR
Moves the note back under `## Unreleased` (removing the premature `## v0.1.3` heading). With the automation in place, merging this triggers a proper v0.1.3 release: tag `v0.1.3` + GitHub release + `package.json` → `0.1.3`.

## ⚠️ Merge order
1. Set the **`RELEASE_TOKEN`** secret (admin PAT, Contents: read/write).
2. Merge **#123** (the release automation) first.
3. Then merge **this PR** — the automation cuts v0.1.3 on merge. (Or, if needed, trigger it via Actions → *Release on merge to main* → Run workflow.)

Merging this before #123 just leaves the note under `Unreleased` until the automation lands — no harm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)