### PR TITLE
Add game controller support (in-game, menus, map editor) + on-screen keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Releases are cut automatically on merge to `main` by the `Release on merge to ma
 
 ## Unreleased
 
-(none yet)
+### General
+- Now with controller support! Plug in a controller and play
 
 ## v0.1.3 — 2026-05-23
 

--- a/build.js
+++ b/build.js
@@ -17,10 +17,14 @@ const bundles = {
     'create.bundle.min.js': [
         'client/scripts/rhill-voronoi-core.js',
         'client/scripts/create.js',
+        'client/scripts/osk.js',
+        'client/scripts/editorGamepad.js',
         'client/scripts/utils.js'
     ],
     'join.bundle.min.js': [
-        'client/scripts/join.js'
+        'client/scripts/join.js',
+        'client/scripts/osk.js',
+        'client/scripts/menuGamepad.js'
     ]
 };
 

--- a/build.js
+++ b/build.js
@@ -8,6 +8,7 @@ const bundles = {
         'client/scripts/client.js',
         'client/scripts/audio.js',
         'client/scripts/input.js',
+        'client/scripts/gamepad.js',
         'client/scripts/draw.js',
         'client/scripts/gameboard.js',
         'client/scripts/joystick.js',

--- a/client/create.html
+++ b/client/create.html
@@ -17,6 +17,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
   <link rel="stylesheet" type="text/css" href="css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/css/index.css">
   <title>Chao Chao Map Edit</title>
   <style>
     /* When the editor is visible, lock the page so the canvas can't be
@@ -295,9 +296,12 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 
   <script src='socket.io/socket.io.js'></script>
+  <script src="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/index.js"></script>
   <!-- BUILD: bundle-start -->
   <script src="scripts/rhill-voronoi-core.js"></script>
   <script src="scripts/create.js"></script>
+  <script src="scripts/osk.js"></script>
+  <script src="scripts/editorGamepad.js"></script>
   <script src="scripts/utils.js"></script>
   <!-- BUILD: bundle-end -->
 </body>

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -439,3 +439,69 @@ div.desc {
 .mt10{
     margin-top: 10px;
 }
+
+/* --- gamepad / controller prompts --- */
+.gamepad-prompts {
+    position: fixed;
+    bottom: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 8px 16px;
+    background-color: rgba(255, 255, 255, 0.92);
+    border-radius: 22px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 14px;
+    color: #555;
+    z-index: 1006;
+    pointer-events: none;
+    transition: opacity 0.3s;
+}
+
+.gamepad-prompts.hidden {
+    opacity: 0;
+    display: none;
+}
+
+.gamepad-prompts.visible {
+    opacity: 1;
+}
+
+.gamepad-prompts .gp-hint {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
+}
+
+.gamepad-prompts .gp-glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 5px;
+    border-radius: 11px;
+    background-color: #c87f8a;
+    color: white;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.gamepad-prompts .gp-glyph.gp-stick {
+    border-radius: 50%;
+    background-color: #555;
+}
+
+.gamepad-prompts .gp-toast {
+    font-weight: 600;
+    color: #c87f8a;
+}
+
+/* once connected the toast fades, leaving just the control hints */
+.gamepad-prompts.compact .gp-toast {
+    display: none;
+}

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -338,6 +338,45 @@ div.desc {
     text-align: center;
 }
 
+/* news banner under the landing description, surfacing the latest release headline */
+.news-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    width: 100%;
+    margin-top: 0.75rem;
+    padding: 0.6rem 0.9rem;
+    background-color: #fff;
+    border: 1px solid #f0d6da;
+    border-left: 4px solid #c87f8a;
+    border-radius: 6px;
+    box-shadow: 0px 0px 6px #B2B2B2;
+    text-decoration: none;
+    color: #444;
+    transition: box-shadow 0.2s, transform 0.2s;
+}
+.news-banner:hover {
+    text-decoration: none;
+    color: #444;
+    box-shadow: 0px 2px 10px rgba(200, 127, 138, 0.35);
+    transform: translateY(-1px);
+}
+.news-badge {
+    flex: 0 0 auto;
+    background-color: #c87f8a;
+    color: #fff;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+}
+.news-headline {
+    font-size: 0.9rem;
+    line-height: 1.3;
+}
+
 
 .create-container {
     background-color: white;
@@ -470,6 +509,13 @@ div.desc {
     opacity: 1;
 }
 
+/* after ~60s with no control-scheme change the bar dims out of the way; it
+   fades slowly but restores instantly (scheme change / Select button). */
+.gamepad-prompts.visible.faded {
+    opacity: 0.15;
+    transition: opacity 0.8s;
+}
+
 .gamepad-prompts .gp-hint {
     display: inline-flex;
     align-items: center;
@@ -504,4 +550,102 @@ div.desc {
 /* once connected the toast fades, leaving just the control hints */
 .gamepad-prompts.compact .gp-toast {
     display: none;
+}
+
+/* focus ring for controller navigation of DOM menus (landing + join) */
+.gp-focus {
+    outline: 3px solid #c87f8a !important;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(200, 127, 138, 0.25);
+}
+
+/* highlighted slot while navigating the in-game emoji wheel */
+#emojiMenu a.gp-emoji-focus {
+    color: #c87f8a;
+    transform: scale(1.6);
+    font-weight: 700;
+}
+
+/* keyboard/mouse hint chips look like keycaps rather than pad buttons */
+.gamepad-prompts .gp-glyph.gp-key {
+    background-color: #fff;
+    color: #333;
+    border: 1px solid #bbb;
+    border-radius: 4px;
+    font-weight: 600;
+}
+
+/* on-screen keyboard (simple-keyboard) for controller text entry */
+.osk-container {
+    position: fixed;
+    left: 50%;
+    bottom: 16px;
+    transform: translateX(-50%);
+    width: min(720px, 96vw);
+    z-index: 2000;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
+    background: #ececec;
+}
+.osk-container.hidden {
+    display: none;
+}
+.osk-container .hg-button.osk-focus {
+    background: #c87f8a;
+    color: #fff;
+    outline: 3px solid #c87f8a;
+    outline-offset: 1px;
+}
+
+/* leave-game confirmation modal (controller + mouse) */
+.confirm-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 3000;
+}
+.confirm-modal.hidden {
+    display: none;
+}
+.confirm-dialog {
+    background: #fff;
+    border-radius: 10px;
+    padding: 1.5rem 1.75rem;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+    text-align: center;
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    max-width: 90vw;
+}
+.confirm-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 1.1rem;
+}
+.confirm-buttons {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+}
+.confirm-btn {
+    min-width: 110px;
+    padding: 0.5rem 1.1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    background: #f6f6f6;
+    color: #333;
+    cursor: pointer;
+}
+.confirm-btn.confirm-leave {
+    background: #c87f8a;
+    border-color: #c87f8a;
+    color: #fff;
 }

--- a/client/index.html
+++ b/client/index.html
@@ -39,7 +39,7 @@
                 <a href="./play.html" id="playButton" class="btn btn-outline-success w-100 mt-3">Play</a>
                 <a href="./join.html" id="joinButton" class="btn btn-outline-info w-100 mt-2">Join</a>
                 <a href="./create.html" id="createButton" class="btn btn-outline-warning w-100 mt-2">Create</a>
-                <div class="patch-notes"><a target="_blank" href="https://github.com/sjdodge123/chaochao/releases/latest">Patch Notes</a></div>
+                <!-- NEWS_BANNER -->
               </div>
               <p class="tagline">Slow-paced multiplayer arena racing.</p>
             </div>
@@ -51,5 +51,6 @@
     <!-- Load bootstrap -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <script src="scripts/menuGamepad.js"></script>
   </body>
 </html>

--- a/client/join.html
+++ b/client/join.html
@@ -15,6 +15,7 @@
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
         <link rel="stylesheet" type="text/css" href="css/styles.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/css/index.css">
         <title>Chao Chao Join a game</title>
     </head>
 <body>
@@ -54,8 +55,11 @@
         </div>
     </section>
     <script src='socket.io/socket.io.js'></script>
+    <script src="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/index.js"></script>
     <!-- BUILD: bundle-start -->
     <script src="scripts/join.js"></script>
+    <script src="scripts/osk.js"></script>
+    <script src="scripts/menuGamepad.js"></script>
     <!-- BUILD: bundle-end -->
 
 </body>

--- a/client/play.html
+++ b/client/play.html
@@ -52,6 +52,7 @@
         <script src="scripts/client.js"></script>
         <script src="scripts/audio.js"></script>
         <script src="scripts/input.js"></script>
+        <script src="scripts/gamepad.js"></script>
         <script src="scripts/draw.js"></script>
         <script src="scripts/gameboard.js"></script>
         <script src="scripts/joystick.js"></script>

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -390,11 +390,13 @@ function rebuild() {
 }
 
 function init() {
+    initEditorGamepad();
     animloop();
 }
 
 function animloop() {
     if (!gameRunning) return;
+    pollEditorGamepad();
     var now = Date.now();
     dt = now - then;
     if (mapReady == false) {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1255,6 +1255,7 @@ function drawTouchControls() {
         gameContext.fill();
         gameContext.stroke();
         gameContext.restore();
+        drawTouchLabel("Move", joystickMovement.baseX, joystickMovement.baseY + joystickMovement.baseRadius + 20);
     }
     if (joystickCamera != null && joystickCamera.isVisible()) {
         gameContext.save();
@@ -1287,6 +1288,7 @@ function drawTouchControls() {
         gameContext.fill();
         gameContext.stroke();
         gameContext.restore();
+        drawTouchLabel("Attack", attackButton.baseX, attackButton.baseY + attackButton.radius + 20);
     }
     if (exitButton != null && exitButton.isVisible()) {
         if (window.document.fullscreenElement) {
@@ -1302,6 +1304,7 @@ function drawTouchControls() {
             gameContext.drawImage(fullScreenToUse, exitButton.baseX - iconWidth / 2, exitButton.baseY - iconHeight / 2, iconWidth, iconHeight);
             gameContext.restore();
         }
+        drawTouchLabel(window.document.fullscreenElement ? "Exit" : "Fullscreen", exitButton.baseX, exitButton.baseY + 28);
     }
     if (chatButton != null && chatButton.isVisible()) {
         gameContext.save();
@@ -1309,7 +1312,21 @@ function drawTouchControls() {
         var iconHeight = chatToUse.height * 0.1;
         gameContext.drawImage(chatToUse, chatButton.baseX - iconWidth / 2, chatButton.baseY - iconHeight / 2, iconWidth, iconHeight);
         gameContext.restore();
+        drawTouchLabel("Emoji", chatButton.baseX, chatButton.baseY + 28);
     }
+}
+
+// Small caption under a touch control so mobile players know what it does.
+function drawTouchLabel(text, x, y) {
+    gameContext.save();
+    gameContext.font = "bold 16px Arial";
+    gameContext.textAlign = "center";
+    gameContext.lineWidth = 4;
+    gameContext.strokeStyle = "white";
+    gameContext.fillStyle = "black";
+    gameContext.strokeText(text, x, y);
+    gameContext.fillText(text, x, y);
+    gameContext.restore();
 }
 
 function drawTitle() {

--- a/client/scripts/editorGamepad.js
+++ b/client/scripts/editorGamepad.js
@@ -1,0 +1,460 @@
+// Controller support for the map editor (create.html). This page does NOT load
+// menuGamepad.js — editorGamepad owns the pad here. It's polled each frame from
+// create.js's animloop via pollEditorGamepad(), and reuses the editor's own
+// state (mousex/mousey, drawPointerCircle, handleClick) so painting goes through
+// the exact same paths as the mouse.
+//
+// Two modes, toggled with RB:
+//   panel  - d-pad / left stick move a focus ring over the editor controls; A
+//            activates (select a tile/tool/action; a text field opens the
+//            on-screen keyboard).
+//   canvas - left stick moves the paint cursor; A paints / places / selects
+//            (synthesises a left click; hold to keep painting); B or RB goes
+//            back to the panel.
+
+var egConnected = false;
+var egIndex = null;
+var egType = "generic";
+var egMode = "panel"; // "panel" | "canvas"
+var egPrevButtons = [];
+var egFocusEl = null;
+var egCursorX = 683; // canvas/world coords (world is 1366 x 768)
+var egCursorY = 384;
+var egAttackHeld = false;
+var egLastStepAt = 0;
+var egPromptEl = null;
+
+var EG_DEADZONE = 0.35;
+var EG_CURSOR_SPEED = 14; // px/frame at full stick deflection
+var EG_DPAD_NUDGE = 3;    // px/frame for fine d-pad cursor moves
+var EG_REPEAT_DELAY = 220; // ms between focus steps while a stick is held
+
+var EG_BTN_A = 0;
+var EG_BTN_B = 1;
+var EG_BTN_RB = 5; // toggle panel <-> canvas
+var EG_DPAD_UP = 12;
+var EG_DPAD_DOWN = 13;
+var EG_DPAD_LEFT = 14;
+var EG_DPAD_RIGHT = 15;
+
+// Every actionable control in whichever window is visible. Hidden ones (the
+// editor while the load grid is up, and vice versa) are filtered out by
+// egItems() via offsetParent, so the same selector serves both screens.
+var EG_NAV_SELECTOR = "#controlPanel button:not([disabled]), #controlPanel input, #loadWindow button:not([disabled])";
+
+function initEditorGamepad() {
+    window.addEventListener("gamepadconnected", egOnConnect, false);
+    window.addEventListener("gamepaddisconnected", egOnDisconnect, false);
+    egBuildPrompt();
+}
+
+function egOnConnect(e) {
+    egConnected = true;
+    egIndex = e.gamepad.index;
+    egType = egDetectType(e.gamepad.id);
+    egPrevButtons = [];
+    egShowPrompt(true);
+}
+
+function egOnDisconnect(e) {
+    if (e.gamepad.index !== egIndex) {
+        return;
+    }
+    egConnected = false;
+    egIndex = null;
+    egReleaseBrush(); // don't leave the editor painting if the pad drops mid-stroke
+    egShowPrompt(false);
+}
+
+function egDetectType(id) {
+    var s = (id || "").toLowerCase();
+    if (s.indexOf("playstation") !== -1 || s.indexOf("dualshock") !== -1 ||
+        s.indexOf("dualsense") !== -1 || s.indexOf("054c") !== -1) {
+        return "playstation";
+    }
+    return "generic";
+}
+
+function egGetPad() {
+    var pads = navigator.getGamepads ? navigator.getGamepads() : [];
+    if (egIndex != null && pads[egIndex]) {
+        return pads[egIndex];
+    }
+    for (var i = 0; i < pads.length; i++) {
+        if (pads[i]) {
+            egIndex = i;
+            if (!egConnected) {
+                egConnected = true;
+                egType = egDetectType(pads[i].id);
+                egShowPrompt(true);
+            }
+            return pads[i];
+        }
+    }
+    return null;
+}
+
+function egPressed(pad, idx) {
+    var now = pad.buttons[idx] && pad.buttons[idx].pressed;
+    var was = egPrevButtons[idx] || false;
+    return !!now && !was;
+}
+
+function egHeld(pad, idx) {
+    return !!(pad.buttons[idx] && pad.buttons[idx].pressed);
+}
+
+function egRecord(pad) {
+    egPrevButtons = [];
+    for (var i = 0; i < pad.buttons.length; i++) {
+        egPrevButtons[i] = pad.buttons[i].pressed;
+    }
+}
+
+// Called every frame from create.js animloop().
+function pollEditorGamepad() {
+    var pad = egGetPad();
+    if (!pad) {
+        return;
+    }
+
+    if (typeof oskIsOpen === "function" && oskIsOpen()) {
+        egHandleOsk(pad);
+        egRecord(pad);
+        return;
+    }
+
+    // B always goes back one screen (editor -> map list -> home), in any mode.
+    if (egPressed(pad, EG_BTN_B)) {
+        if (egAttackHeld && typeof handleUnClick === "function") {
+            handleUnClick({ which: 1 }); // stop an in-progress paint
+            egAttackHeld = false;
+        }
+        egBack();
+        egRecord(pad);
+        return;
+    }
+
+    var inEditor = document.body.classList.contains("editor-open");
+
+    // RB toggles panel <-> canvas, but only once inside the editor.
+    if (inEditor && egPressed(pad, EG_BTN_RB)) {
+        egSetMode(egMode === "panel" ? "canvas" : "panel");
+    }
+
+    if (egMode === "canvas" && inEditor) {
+        egPollCanvas(pad);
+    } else {
+        egPollPanel(pad);
+    }
+
+    egRecord(pad);
+}
+
+// Back one screen: from the editor to the map list, from the map list home.
+function egBack() {
+    egMode = "panel";
+    if (document.body.classList.contains("editor-open")) {
+        var lb = document.getElementById("loadButton");
+        if (lb) {
+            lb.click();
+        }
+        egShowPrompt(true);
+    } else {
+        location.href = "./index.html";
+    }
+}
+
+// Release an in-progress paint (A held in canvas mode). Must run before we stop
+// polling the canvas, or the editor's brushing flag stays true and paints forever.
+function egReleaseBrush() {
+    if (egAttackHeld) {
+        if (typeof handleUnClick === "function") {
+            handleUnClick({ which: 1 });
+        }
+        egAttackHeld = false;
+    }
+}
+
+function egSetMode(mode) {
+    if (mode !== "canvas") {
+        egReleaseBrush(); // leaving the canvas — stop any held paint
+    }
+    egMode = mode;
+    if (mode === "canvas") {
+        if (egFocusEl) {
+            egFocusEl.classList.remove("gp-focus");
+        }
+        if (typeof setMousePos === "function") {
+            setMousePos(egCursorX, egCursorY);
+        }
+        dirty = true;
+    } else {
+        var items = egItems();
+        if (items.length) {
+            egSetFocus(egIndexOf(items) === -1 ? items[0] : egFocusEl);
+        }
+    }
+    egShowPrompt(true);
+}
+
+// --- panel (DOM control) navigation ---
+
+function egItems() {
+    var all = document.querySelectorAll(EG_NAV_SELECTOR);
+    var out = [];
+    for (var i = 0; i < all.length; i++) {
+        var el = all[i];
+        if (el.offsetParent === null && el.getClientRects().length === 0) {
+            continue; // hidden (wrong window, or panel collapsed on mobile)
+        }
+        out.push(el);
+    }
+    return out;
+}
+
+function egIndexOf(items) {
+    for (var i = 0; i < items.length; i++) {
+        if (items[i] === egFocusEl) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+function egSetFocus(el) {
+    if (egFocusEl && egFocusEl !== el) {
+        egFocusEl.classList.remove("gp-focus");
+    }
+    egFocusEl = el;
+    if (el) {
+        el.classList.add("gp-focus");
+        try { el.focus({ preventScroll: false }); } catch (e) { el.focus(); }
+    }
+}
+
+function egCenter(el) {
+    var r = el.getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+}
+
+// 2D spatial move: focus the nearest control in the pressed direction. This is
+// what makes "down" go to the row below on the map grid instead of just to the
+// next element in DOM order (which reads as "right").
+function egMove(dir) {
+    var items = egItems();
+    if (!items.length) {
+        return;
+    }
+    if (!egFocusEl || egIndexOf(items) === -1) {
+        egSetFocus(items[0]);
+        return;
+    }
+    var f = egCenter(egFocusEl);
+    var best = null;
+    var bestScore = Infinity;
+    for (var i = 0; i < items.length; i++) {
+        if (items[i] === egFocusEl) {
+            continue;
+        }
+        var p = egCenter(items[i]);
+        var dx = p.x - f.x;
+        var dy = p.y - f.y;
+        var primary, secondary;
+        if (dir === "right") { if (dx <= 2) { continue; } primary = dx; secondary = Math.abs(dy); }
+        else if (dir === "left") { if (dx >= -2) { continue; } primary = -dx; secondary = Math.abs(dy); }
+        else if (dir === "down") { if (dy <= 2) { continue; } primary = dy; secondary = Math.abs(dx); }
+        else if (dir === "up") { if (dy >= -2) { continue; } primary = -dy; secondary = Math.abs(dx); }
+        else { continue; }
+        var score = primary + secondary * 2;
+        if (score < bestScore) {
+            bestScore = score;
+            best = items[i];
+        }
+    }
+    if (best) {
+        egSetFocus(best);
+    }
+}
+
+function egActivate() {
+    var items = egItems();
+    if (egIndexOf(items) === -1) {
+        egSetFocus(items[0]);
+        return;
+    }
+    if (!egFocusEl) {
+        return;
+    }
+    if (egFocusEl.tagName.toLowerCase() === "input") {
+        if (typeof oskOpen === "function") {
+            oskOpen(egFocusEl);
+        } else {
+            egFocusEl.focus();
+        }
+        return;
+    }
+    egFocusEl.click();
+    // Clicking a map tile / Create-new enters the editor; refresh the prompt so
+    // it reflects the new screen (canvas toggle + back target).
+    egShowPrompt(true);
+}
+
+function egPollPanel(pad) {
+    if (egPressed(pad, EG_BTN_A)) {
+        egActivate();
+    }
+    var now = Date.now();
+    var ly = pad.axes[1] || 0;
+    var lx = pad.axes[0] || 0;
+    var dir = null;
+    if (egPressed(pad, EG_DPAD_UP)) { dir = "up"; }
+    else if (egPressed(pad, EG_DPAD_DOWN)) { dir = "down"; }
+    else if (egPressed(pad, EG_DPAD_LEFT)) { dir = "left"; }
+    else if (egPressed(pad, EG_DPAD_RIGHT)) { dir = "right"; }
+    else if (now - egLastStepAt > EG_REPEAT_DELAY) {
+        if (ly < -EG_DEADZONE) { dir = "up"; }
+        else if (ly > EG_DEADZONE) { dir = "down"; }
+        else if (lx < -EG_DEADZONE) { dir = "left"; }
+        else if (lx > EG_DEADZONE) { dir = "right"; }
+    }
+    if (dir) {
+        egMove(dir);
+        egLastStepAt = now;
+    }
+}
+
+// --- canvas (paint cursor) ---
+
+// Remap a stick axis so motion starts at 0 at the deadzone edge and scales to 1
+// at full deflection. Without this, stick drift just past the deadzone moves the
+// cursor at a constant ~deadzone speed (and paints a streak if A is held).
+function egAxis(v) {
+    var a = Math.abs(v);
+    if (a <= EG_DEADZONE) {
+        return 0;
+    }
+    var scaled = (a - EG_DEADZONE) / (1 - EG_DEADZONE);
+    return (v < 0 ? -scaled : scaled);
+}
+
+function egPollCanvas(pad) {
+    var lx = egAxis(pad.axes[0] || 0);
+    var ly = egAxis(pad.axes[1] || 0);
+    var moved = false;
+    if (lx !== 0) { egCursorX += lx * EG_CURSOR_SPEED; moved = true; }
+    if (ly !== 0) { egCursorY += ly * EG_CURSOR_SPEED; moved = true; }
+    if (egHeld(pad, EG_DPAD_LEFT)) { egCursorX -= EG_DPAD_NUDGE; moved = true; }
+    if (egHeld(pad, EG_DPAD_RIGHT)) { egCursorX += EG_DPAD_NUDGE; moved = true; }
+    if (egHeld(pad, EG_DPAD_UP)) { egCursorY -= EG_DPAD_NUDGE; moved = true; }
+    if (egHeld(pad, EG_DPAD_DOWN)) { egCursorY += EG_DPAD_NUDGE; moved = true; }
+
+    if (egCursorX < 0) { egCursorX = 0; }
+    if (egCursorX > 1366) { egCursorX = 1366; }
+    if (egCursorY < 0) { egCursorY = 0; }
+    if (egCursorY > 768) { egCursorY = 768; }
+
+    if (moved) {
+        if (typeof setMousePos === "function") {
+            setMousePos(egCursorX, egCursorY);
+        }
+        dirty = true;
+    }
+
+    // A behaves like a left mouse button: press to paint/place/select, hold to
+    // keep painting (the editor's brushing flag does the repeating).
+    var aDown = egHeld(pad, EG_BTN_A);
+    if (aDown && !egAttackHeld) {
+        egAttackHeld = true;
+        if (typeof handleClick === "function") {
+            handleClick({ which: 1 });
+        }
+    } else if (!aDown && egAttackHeld) {
+        egAttackHeld = false;
+        if (typeof handleUnClick === "function") {
+            handleUnClick({ which: 1 });
+        }
+    }
+}
+
+function egHandleOsk(pad) {
+    if (egPressed(pad, EG_BTN_A)) {
+        oskActivateFocused();
+    }
+    if (egPressed(pad, EG_BTN_B)) {
+        oskClose();
+        return;
+    }
+    var now = Date.now();
+    if (egPressed(pad, EG_DPAD_UP)) {
+        oskMoveFocus("up");
+    } else if (egPressed(pad, EG_DPAD_DOWN)) {
+        oskMoveFocus("down");
+    } else if (egPressed(pad, EG_DPAD_LEFT)) {
+        oskMoveFocus("left");
+    } else if (egPressed(pad, EG_DPAD_RIGHT)) {
+        oskMoveFocus("right");
+    } else if (now - egLastStepAt > EG_REPEAT_DELAY) {
+        var lx = pad.axes[0] || 0;
+        var ly = pad.axes[1] || 0;
+        if (ly < -EG_DEADZONE) { oskMoveFocus("up"); egLastStepAt = now; }
+        else if (ly > EG_DEADZONE) { oskMoveFocus("down"); egLastStepAt = now; }
+        else if (lx < -EG_DEADZONE) { oskMoveFocus("left"); egLastStepAt = now; }
+        else if (lx > EG_DEADZONE) { oskMoveFocus("right"); egLastStepAt = now; }
+    }
+}
+
+// --- prompt overlay (reuses .gamepad-prompts styles) ---
+
+function egBuildPrompt() {
+    if (egPromptEl || !document.body) {
+        return;
+    }
+    var el = document.createElement("div");
+    el.id = "gamepadPrompts";
+    el.className = "gamepad-prompts hidden";
+    document.body.appendChild(el);
+    egPromptEl = el;
+}
+
+function egGlyphA() {
+    return egType === "playstation" ? "✕" : "A";
+}
+
+function egGlyphB() {
+    return egType === "playstation" ? "○" : "B";
+}
+
+function egShowPrompt(on) {
+    if (!egPromptEl) {
+        egBuildPrompt();
+    }
+    if (!egPromptEl) {
+        return;
+    }
+    if (!on) {
+        egPromptEl.className = "gamepad-prompts hidden";
+        return;
+    }
+    var inEditor = document.body.classList.contains("editor-open");
+    var backHint = '<span class="gp-hint"><span class="gp-glyph gp-face">' + egGlyphB() + '</span>Back</span>';
+    var html = '<span class="gp-toast">🎮 Editor</span>';
+    if (inEditor && egMode === "canvas") {
+        html += '<span class="gp-hint"><span class="gp-glyph gp-stick">L</span>Cursor</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-face">' + egGlyphA() + '</span>Paint / Place</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-trigger">RB</span>Panel</span>' +
+            backHint;
+    } else if (inEditor) {
+        html += '<span class="gp-hint"><span class="gp-glyph gp-dpad">✛</span>Navigate</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-face">' + egGlyphA() + '</span>Select</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-trigger">RB</span>Canvas</span>' +
+            backHint;
+    } else {
+        // map-selection / load window
+        html += '<span class="gp-hint"><span class="gp-glyph gp-dpad">✛</span>Navigate</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-face">' + egGlyphA() + '</span>Select</span>' +
+            backHint;
+    }
+    egPromptEl.innerHTML = html;
+    egPromptEl.className = "gamepad-prompts visible";
+}

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -143,6 +143,7 @@ function init() {
     }
     animloop();
     initEventHandlers();
+    initGamepad();
 }
 function animloop() {
     if (gameRunning) {
@@ -175,6 +176,7 @@ function animloop() {
     }
 }
 function gameLoop(dt) {
+    pollGamepad(dt);
     drawObjects(dt);
     updateGameboard(dt);
 }

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -1,0 +1,303 @@
+"use strict";
+
+// Gamepad (controller) support for in-game play.
+//
+// Polled once per frame from gameLoop(). A standard-mapping controller is
+// mapped onto the same movement/aim/attack channels already used by the
+// keyboard/mouse/touch paths, so the server needs no changes:
+//   - left stick  -> the existing 4 movement booleans, quantized to 8-way
+//   - right stick -> the facing/aim angle (twin-stick), sent via 'mousemove'
+//   - A / right trigger -> attack (which also fires the held ability)
+//   - Start -> fullscreen
+//
+// The rest of the game is event-driven and only emits on input change, so the
+// poll loop here is careful to do the same: it diffs against the pad's own
+// previous reading and only touches the socket when something actually changed.
+
+// --- connection state ---
+var gamepadConnected = false;
+var gamepadIndex = null;
+var gamepadType = "generic"; // "xbox" | "playstation" | "generic"
+
+// --- tuning ---
+var GP_MOVE_DEADZONE = 0.30;     // left stick: ignore drift below this
+var GP_AIM_DEADZONE = 0.35;      // right stick: only re-aim when pushed past this
+var GP_TRIGGER_THRESHOLD = 0.5;  // analog trigger counts as "pressed" past this
+var GP_AIM_MIN_DELTA = 2;        // deg; skip aim emits smaller than this
+var GP_AIM_MIN_INTERVAL = 50;    // ms; cap aim emits at ~20 Hz
+
+// --- standard-mapping button indices ---
+var GP_BTN_A = 0;     // attack / confirm
+var GP_BTN_RT = 7;    // right trigger (analog) -> attack
+var GP_BTN_START = 9; // fullscreen
+
+// --- per-frame remembered state (so we only emit on change) ---
+var gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+var gpHadMoveInput = false; // did the pad drive movement on the previous frame?
+var gpAimActive = false;    // is the right stick currently aiming?
+var gpPrevAimAngle = null;
+var gpLastAimEmit = 0;
+var gpPrevButtons = [];     // pressed-state per button, for edge detection
+
+// --- prompt overlay ---
+var gamepadPromptEl = null;
+var gpPromptTimer = null;
+
+function initGamepad() {
+    window.addEventListener("gamepadconnected", onGamepadConnected, false);
+    window.addEventListener("gamepaddisconnected", onGamepadDisconnected, false);
+    buildGamepadPromptUI();
+}
+
+function onGamepadConnected(e) {
+    gamepadConnected = true;
+    gamepadIndex = e.gamepad.index;
+    gamepadType = detectGamepadType(e.gamepad.id);
+    gpPrevButtons = [];
+    showGamepadPrompts(true);
+    debugLog("gamepad connected:", e.gamepad.id, "->", gamepadType);
+}
+
+function onGamepadDisconnected(e) {
+    if (e.gamepad.index !== gamepadIndex) {
+        return;
+    }
+    gamepadConnected = false;
+    gamepadIndex = null;
+    // Release anything the pad was holding so the player doesn't keep moving.
+    if (gpHadMoveInput) {
+        cancelMovement();
+        gpHadMoveInput = false;
+    }
+    gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+    showGamepadPrompts(false);
+    debugLog("gamepad disconnected");
+}
+
+function detectGamepadType(id) {
+    var s = (id || "").toLowerCase();
+    if (s.indexOf("xbox") !== -1 || s.indexOf("xinput") !== -1) {
+        return "xbox";
+    }
+    if (s.indexOf("playstation") !== -1 || s.indexOf("dualshock") !== -1 ||
+        s.indexOf("dualsense") !== -1 || s.indexOf("054c") !== -1) {
+        return "playstation";
+    }
+    return "generic";
+}
+
+// Chrome only surfaces a pad after the first button press, and a pad held at
+// page load never fires 'gamepadconnected'. So we also adopt the first live
+// pad we see while polling.
+function getActiveGamepad() {
+    var pads = navigator.getGamepads ? navigator.getGamepads() : [];
+    if (gamepadIndex != null && pads[gamepadIndex]) {
+        return pads[gamepadIndex];
+    }
+    for (var i = 0; i < pads.length; i++) {
+        if (pads[i]) {
+            gamepadIndex = i;
+            if (!gamepadConnected) {
+                gamepadConnected = true;
+                gamepadType = detectGamepadType(pads[i].id);
+                showGamepadPrompts(true);
+            }
+            return pads[i];
+        }
+    }
+    return null;
+}
+
+// Called once per frame from gameLoop().
+function pollGamepad(dt) {
+    var pad = getActiveGamepad();
+    if (!pad) {
+        return;
+    }
+    // Aim first so movement knows whether the right stick owns the facing angle.
+    pollAim(pad);
+    pollMovementAndAttack(pad);
+    pollEdgeButtons(pad);
+}
+
+function pollAim(pad) {
+    var rx = pad.axes[2] || 0;
+    var ry = pad.axes[3] || 0;
+    var mag = Math.sqrt(rx * rx + ry * ry);
+    gpAimActive = mag >= GP_AIM_DEADZONE;
+    if (!gpAimActive) {
+        return;
+    }
+    if (typeof playerList === "undefined" || !playerList || myID == null || !playerList[myID]) {
+        return;
+    }
+
+    // Same angle convention as utils.angle(): 0=right, 90=down, 180=left, 270=up.
+    var deg = Math.atan2(ry, rx) * 180 / Math.PI;
+    if (deg < 0) {
+        deg += 360;
+    }
+
+    // Throttle: skip tiny changes and cap the emit rate so we don't flood the socket.
+    if (gpPrevAimAngle != null) {
+        var delta = Math.abs(deg - gpPrevAimAngle);
+        if (delta > 180) {
+            delta = 360 - delta;
+        }
+        if (delta < GP_AIM_MIN_DELTA) {
+            return;
+        }
+    }
+    var now = Date.now();
+    if (now - gpLastAimEmit < GP_AIM_MIN_INTERVAL) {
+        return;
+    }
+
+    playerList[myID].angle = deg;
+    if (server) {
+        server.emit('mousemove', deg);
+    }
+    gpPrevAimAngle = deg;
+    gpLastAimEmit = now;
+}
+
+function pollMovementAndAttack(pad) {
+    var lx = pad.axes[0] || 0;
+    var ly = pad.axes[1] || 0;
+    var mag = Math.sqrt(lx * lx + ly * ly);
+
+    var mf = false, mb = false, tl = false, tr = false;
+    var moveActive = mag >= GP_MOVE_DEADZONE;
+    if (moveActive) {
+        // Quantize the stick into 8 octants (45 deg each) to match the engine's
+        // 8-way movement. Screen coords: -y is up/forward, +y is down/backward.
+        var deg = Math.atan2(ly, lx) * 180 / Math.PI; // 0=right, 90=down
+        if (deg < 0) {
+            deg += 360;
+        }
+        switch (Math.round(deg / 45) % 8) {
+            case 0: tr = true; break;             // E
+            case 1: tr = true; mb = true; break;  // SE
+            case 2: mb = true; break;             // S
+            case 3: tl = true; mb = true; break;  // SW
+            case 4: tl = true; break;             // W
+            case 5: tl = true; mf = true; break;  // NW
+            case 6: mf = true; break;             // N
+            case 7: tr = true; mf = true; break;  // NE
+        }
+    }
+
+    var atk = readAttack(pad);
+    applyInputState(mf, mb, tl, tr, atk, moveActive);
+}
+
+function readAttack(pad) {
+    var a = pad.buttons[GP_BTN_A] && pad.buttons[GP_BTN_A].pressed;
+    var rt = pad.buttons[GP_BTN_RT] && pad.buttons[GP_BTN_RT].value > GP_TRIGGER_THRESHOLD;
+    return !!(a || rt);
+}
+
+function applyInputState(mf, mb, tl, tr, atk, moveActive) {
+    // Only let the pad drive when it is actually providing input, or when it is
+    // releasing input it held last frame. This keeps keyboard/mouse usable while
+    // the pad sits idle.
+    var padDriving = moveActive || atk || gpHadMoveInput;
+    if (padDriving) {
+        var changed = (mf !== gpPrevMove.moveForward) ||
+            (mb !== gpPrevMove.moveBackward) ||
+            (tl !== gpPrevMove.turnLeft) ||
+            (tr !== gpPrevMove.turnRight) ||
+            (atk !== gpPrevMove.attack);
+
+        if (changed) {
+            moveForward = mf;
+            moveBackward = mb;
+            turnLeft = tl;
+            turnRight = tr;
+            attack = atk;
+            // When the right stick isn't aiming, face the movement direction
+            // (mirrors the keyboard behaviour).
+            if (!gpAimActive && typeof playerList !== "undefined" && playerList && myID != null && playerList[myID]) {
+                calcAngleFromKeys(playerList[myID]);
+                if (server) {
+                    server.emit('mousemove', playerList[myID].angle);
+                }
+            }
+            emitMovement();
+            gpPrevMove = { moveForward: mf, moveBackward: mb, turnLeft: tl, turnRight: tr, attack: atk };
+        }
+    }
+    gpHadMoveInput = moveActive || atk;
+}
+
+function emitMovement() {
+    if (server) {
+        server.emit('movement', {
+            turnLeft: turnLeft,
+            moveForward: moveForward,
+            turnRight: turnRight,
+            moveBackward: moveBackward,
+            attack: attack
+        });
+    }
+}
+
+function pollEdgeButtons(pad) {
+    if (buttonPressedThisFrame(pad, GP_BTN_START)) {
+        goFullScreen();
+    }
+    gpPrevButtons = [];
+    for (var i = 0; i < pad.buttons.length; i++) {
+        gpPrevButtons[i] = pad.buttons[i].pressed;
+    }
+}
+
+function buttonPressedThisFrame(pad, idx) {
+    var now = pad.buttons[idx] && pad.buttons[idx].pressed;
+    var was = gpPrevButtons[idx] || false;
+    return !!now && !was;
+}
+
+// --- on-screen glyphs / prompts (in-game) ---
+
+function buildGamepadPromptUI() {
+    if (gamepadPromptEl || typeof document === "undefined" || !document.body) {
+        return;
+    }
+    var el = document.createElement("div");
+    el.id = "gamepadPrompts";
+    el.className = "gamepad-prompts hidden";
+    document.body.appendChild(el);
+    gamepadPromptEl = el;
+}
+
+function attackGlyph() {
+    return gamepadType === "playstation" ? "✕" : "A"; // PlayStation cross vs Xbox A
+}
+
+function showGamepadPrompts(connected) {
+    if (!gamepadPromptEl) {
+        buildGamepadPromptUI();
+    }
+    if (!gamepadPromptEl) {
+        return;
+    }
+    if (!connected) {
+        gamepadPromptEl.className = "gamepad-prompts hidden";
+        return;
+    }
+    gamepadPromptEl.innerHTML =
+        '<span class="gp-toast">🎮 Controller connected</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-stick">L</span>Move</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-stick">R</span>Aim</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-face">' + attackGlyph() + '</span>/<span class="gp-glyph gp-trigger">RT</span>Attack</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-menu">☰</span>Fullscreen</span>';
+    gamepadPromptEl.className = "gamepad-prompts visible";
+    // Drop the "connected" toast after a few seconds; keep the control hints.
+    clearTimeout(gpPromptTimer);
+    gpPromptTimer = setTimeout(function () {
+        if (gamepadPromptEl) {
+            gamepadPromptEl.className = "gamepad-prompts visible compact";
+        }
+    }, 4000);
+}

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -28,8 +28,15 @@ var GP_AIM_MIN_INTERVAL = 50;    // ms; cap aim emits at ~20 Hz
 
 // --- standard-mapping button indices ---
 var GP_BTN_A = 0;     // attack / confirm
+var GP_BTN_B = 1;     // cancel (emoji wheel)
+var GP_BTN_EMOJI = 2; // X / Square -> open emoji wheel
 var GP_BTN_RT = 7;    // right trigger (analog) -> attack
+var GP_BTN_SELECT = 8; // Select/Back/View -> restore faded hint bar
 var GP_BTN_START = 9; // fullscreen
+var GP_DPAD_UP = 12;
+var GP_DPAD_DOWN = 13;
+var GP_DPAD_LEFT = 14;
+var GP_DPAD_RIGHT = 15;
 
 // --- per-frame remembered state (so we only emit on change) ---
 var gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
@@ -38,15 +45,75 @@ var gpAimActive = false;    // is the right stick currently aiming?
 var gpPrevAimAngle = null;
 var gpLastAimEmit = 0;
 var gpPrevButtons = [];     // pressed-state per button, for edge detection
+var gpEmojiIndex = 0;       // highlighted slot while the emoji wheel is open
+var gpEmojiStepAt = 0;      // last d-pad step time (for repeat throttling)
 
 // --- prompt overlay ---
-var gamepadPromptEl = null;
-var gpPromptTimer = null;
+var hintBarEl = null;          // single hint bar; its glyphs swap per active input
+var activeInputMethod = null;  // "kbm" | "pad" | "touch" — whichever was used last
+var lastTouchAt = 0;           // to ignore the synthetic mouse events a tap emits
+var lastPadInputAt = 0;        // to ignore stray mouse motion during active pad play
+var gpPromptTimer = null;      // drops the toast a few seconds after a scheme change
+var gpFadeTimer = null;        // dims the hint bar after a period of no scheme change
+var HINT_FADE_MS = 60000;      // ~60s on screen, then fade to mostly transparent
+
+// --- leave-game confirmation modal ---
+var leaveModalEl = null;
+var leaveFocusIdx = 1;   // 0 = Leave, 1 = Cancel (default to the safe choice)
+var gpLeaveStepAt = 0;
 
 function initGamepad() {
     window.addEventListener("gamepadconnected", onGamepadConnected, false);
     window.addEventListener("gamepaddisconnected", onGamepadDisconnected, false);
-    buildGamepadPromptUI();
+    // Esc opens (and closes) the leave-game modal for keyboard players.
+    window.addEventListener("keydown", onGamepadKeyDown, false);
+    // Detect which input method is actually in use and swap the glyphs to match.
+    // mousedown is deliberate (switch); mousemove is noisy (guarded so a stray
+    // bump during controller play doesn't flip the glyphs).
+    window.addEventListener("mousedown", markKbmUsed, false);
+    window.addEventListener("mousemove", markKbmMoved, false);
+    window.addEventListener("touchstart", markTouchUsed, false);
+    buildHintBar();
+    buildLeaveModalUI();
+    // Start on the device's most likely method; live usage swaps it.
+    setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
+}
+
+function markKbmUsed() {
+    // Touchscreens emit synthetic mouse events shortly after a tap; ignore those
+    // so a tap doesn't immediately flip touch -> keyboard/mouse. Real mouse use
+    // on a hybrid device isn't preceded by a touch, so it still registers.
+    if (Date.now() - lastTouchAt < 700) {
+        return;
+    }
+    setInputMethod("kbm");
+}
+
+function markKbmMoved() {
+    // Same touch guard, plus: ignore mouse motion while the pad is actively in
+    // use, so a nudged mouse / trackpad twitch doesn't flicker the glyphs.
+    if (Date.now() - lastTouchAt < 700 || Date.now() - lastPadInputAt < 1000) {
+        return;
+    }
+    setInputMethod("kbm");
+}
+
+function markTouchUsed() {
+    lastTouchAt = Date.now();
+    setInputMethod("touch");
+}
+
+function onGamepadKeyDown(e) {
+    setInputMethod("kbm"); // a key press means keyboard/mouse is in use
+    if (e.key === "Escape" || e.keyCode === 27) {
+        if (leaveModalIsOpen()) {
+            closeLeaveModal();
+        } else {
+            openLeaveModal();
+        }
+    } else if (e.key === "h" || e.key === "H" || e.keyCode === 72) {
+        toggleHintFade(); // hide/show the control hints
+    }
 }
 
 function onGamepadConnected(e) {
@@ -54,7 +121,9 @@ function onGamepadConnected(e) {
     gamepadIndex = e.gamepad.index;
     gamepadType = detectGamepadType(e.gamepad.id);
     gpPrevButtons = [];
-    showGamepadPrompts(true);
+    // Don't swap the glyphs yet — wait until the pad is actually used (see
+    // padHasInput in pollGamepad), so a connected-but-idle pad doesn't override
+    // a player still on keyboard/mouse.
     debugLog("gamepad connected:", e.gamepad.id, "->", gamepadType);
 }
 
@@ -70,7 +139,10 @@ function onGamepadDisconnected(e) {
         gpHadMoveInput = false;
     }
     gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
-    showGamepadPrompts(false);
+    // The pad is gone — fall back to the device's other input method.
+    if (activeInputMethod === "pad") {
+        setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
+    }
     debugLog("gamepad disconnected");
 }
 
@@ -100,9 +172,22 @@ function getActiveGamepad() {
             if (!gamepadConnected) {
                 gamepadConnected = true;
                 gamepadType = detectGamepadType(pads[i].id);
-                showGamepadPrompts(true);
             }
             return pads[i];
+        }
+    }
+    // No pad present. If we thought one was connected, it vanished without a
+    // 'gamepaddisconnected' event — release any held movement so the player
+    // doesn't keep drifting, and fall back to keyboard/touch hints.
+    if (gamepadConnected) {
+        gamepadConnected = false;
+        gamepadIndex = null;
+        if (gpHadMoveInput && typeof cancelMovement === "function") {
+            cancelMovement();
+            gpHadMoveInput = false;
+        }
+        if (activeInputMethod === "pad") {
+            setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
         }
     }
     return null;
@@ -114,10 +199,38 @@ function pollGamepad(dt) {
     if (!pad) {
         return;
     }
-    // Aim first so movement knows whether the right stick owns the facing angle.
-    pollAim(pad);
-    pollMovementAndAttack(pad);
-    pollEdgeButtons(pad);
+
+    // Using the pad swaps the glyphs to the controller scheme.
+    if (padHasInput(pad)) {
+        lastPadInputAt = Date.now();
+        setInputMethod("pad");
+    }
+
+    // Select toggles the hint bar between hidden (transparent) and shown.
+    if (buttonPressedThisFrame(pad, GP_BTN_SELECT)) {
+        toggleHintFade();
+    }
+
+    if (leaveModalIsOpen()) {
+        // The confirm modal owns input while it's up.
+        pollLeaveModal(pad);
+    } else if (typeof menuOpen !== "undefined" && menuOpen) {
+        // The emoji wheel owns input while it's up.
+        pollEmojiWheel(pad);
+    } else if (buttonPressedThisFrame(pad, GP_BTN_B)) {
+        openLeaveModal();
+    } else if (buttonPressedThisFrame(pad, GP_BTN_EMOJI)) {
+        openEmojiFromPad();
+    } else {
+        // Aim first so movement knows whether the right stick owns the facing.
+        pollAim(pad);
+        pollMovementAndAttack(pad);
+        if (buttonPressedThisFrame(pad, GP_BTN_START)) {
+            goFullScreen();
+        }
+    }
+
+    rememberButtons(pad);
 }
 
 function pollAim(pad) {
@@ -162,28 +275,45 @@ function pollAim(pad) {
 }
 
 function pollMovementAndAttack(pad) {
-    var lx = pad.axes[0] || 0;
-    var ly = pad.axes[1] || 0;
-    var mag = Math.sqrt(lx * lx + ly * ly);
-
     var mf = false, mb = false, tl = false, tr = false;
-    var moveActive = mag >= GP_MOVE_DEADZONE;
-    if (moveActive) {
-        // Quantize the stick into 8 octants (45 deg each) to match the engine's
-        // 8-way movement. Screen coords: -y is up/forward, +y is down/backward.
-        var deg = Math.atan2(ly, lx) * 180 / Math.PI; // 0=right, 90=down
-        if (deg < 0) {
-            deg += 360;
-        }
-        switch (Math.round(deg / 45) % 8) {
-            case 0: tr = true; break;             // E
-            case 1: tr = true; mb = true; break;  // SE
-            case 2: mb = true; break;             // S
-            case 3: tl = true; mb = true; break;  // SW
-            case 4: tl = true; break;             // W
-            case 5: tl = true; mf = true; break;  // NW
-            case 6: mf = true; break;             // N
-            case 7: tr = true; mf = true; break;  // NE
+    var moveActive = false;
+
+    // The d-pad maps straight onto the 4 movement booleans (and their diagonals),
+    // so it gives exact 8-way control with no deadzone. It takes priority over the
+    // left stick when held.
+    var dUp = pad.buttons[GP_DPAD_UP] && pad.buttons[GP_DPAD_UP].pressed;
+    var dDown = pad.buttons[GP_DPAD_DOWN] && pad.buttons[GP_DPAD_DOWN].pressed;
+    var dLeft = pad.buttons[GP_DPAD_LEFT] && pad.buttons[GP_DPAD_LEFT].pressed;
+    var dRight = pad.buttons[GP_DPAD_RIGHT] && pad.buttons[GP_DPAD_RIGHT].pressed;
+
+    if (dUp || dDown || dLeft || dRight) {
+        mf = !!dUp;
+        mb = !!dDown;
+        tl = !!dLeft;
+        tr = !!dRight;
+        moveActive = true;
+    } else {
+        var lx = pad.axes[0] || 0;
+        var ly = pad.axes[1] || 0;
+        var mag = Math.sqrt(lx * lx + ly * ly);
+        moveActive = mag >= GP_MOVE_DEADZONE;
+        if (moveActive) {
+            // Quantize the stick into 8 octants (45 deg each) to match the engine's
+            // 8-way movement. Screen coords: -y is up/forward, +y is down/backward.
+            var deg = Math.atan2(ly, lx) * 180 / Math.PI; // 0=right, 90=down
+            if (deg < 0) {
+                deg += 360;
+            }
+            switch (Math.round(deg / 45) % 8) {
+                case 0: tr = true; break;             // E
+                case 1: tr = true; mb = true; break;  // SE
+                case 2: mb = true; break;             // S
+                case 3: tl = true; mb = true; break;  // SW
+                case 4: tl = true; break;             // W
+                case 5: tl = true; mf = true; break;  // NW
+                case 6: mf = true; break;             // N
+                case 7: tr = true; mf = true; break;  // NE
+            }
         }
     }
 
@@ -242,10 +372,7 @@ function emitMovement() {
     }
 }
 
-function pollEdgeButtons(pad) {
-    if (buttonPressedThisFrame(pad, GP_BTN_START)) {
-        goFullScreen();
-    }
+function rememberButtons(pad) {
     gpPrevButtons = [];
     for (var i = 0; i < pad.buttons.length; i++) {
         gpPrevButtons[i] = pad.buttons[i].pressed;
@@ -258,46 +385,350 @@ function buttonPressedThisFrame(pad, idx) {
     return !!now && !was;
 }
 
-// --- on-screen glyphs / prompts (in-game) ---
+// --- in-game lobby: emoji wheel navigation ---
 
-function buildGamepadPromptUI() {
-    if (gamepadPromptEl || typeof document === "undefined" || !document.body) {
+function emojiItems() {
+    // #emojiMenu's first <a> is the static close button (onclick=...'cancel');
+    // setupEmojiWheel appends the real emoji anchors after it. Exclude the close
+    // button from navigation — it's reached with B, never selected — so index 0
+    // is a real emoji and A can't broadcast the close-icon markup as an emoji.
+    var all = document.querySelectorAll("#emojiMenu a");
+    var out = [];
+    for (var i = 0; i < all.length; i++) {
+        var onclick = all[i].getAttribute("onclick") || "";
+        if (onclick.indexOf("cancel") !== -1) {
+            continue;
+        }
+        out.push(all[i]);
+    }
+    return out;
+}
+
+// Index of the emoji whose on-screen direction from the wheel centre best
+// matches the stick — aligns with the actual (scattered) CSS layout.
+function nearestEmojiToDir(items, lx, ly) {
+    var menu = document.getElementById("emojiMenu");
+    if (!menu) {
+        return gpEmojiIndex;
+    }
+    var mr = menu.getBoundingClientRect();
+    var mcx = mr.left + mr.width / 2;
+    var mcy = mr.top + mr.height / 2;
+    var stickAng = Math.atan2(ly, lx);
+    var best = gpEmojiIndex;
+    var bestDiff = Infinity;
+    for (var i = 0; i < items.length; i++) {
+        var r = items[i].getBoundingClientRect();
+        var ia = Math.atan2((r.top + r.height / 2) - mcy, (r.left + r.width / 2) - mcx);
+        var d = Math.abs(ia - stickAng);
+        if (d > Math.PI) {
+            d = 2 * Math.PI - d;
+        }
+        if (d < bestDiff) {
+            bestDiff = d;
+            best = i;
+        }
+    }
+    return best;
+}
+
+function openEmojiFromPad() {
+    // Stop driving the player while the wheel is up.
+    if (gpHadMoveInput) {
+        cancelMovement();
+        gpHadMoveInput = false;
+    }
+    gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+    gpEmojiIndex = 0;
+    var w = window.innerWidth || 800;
+    var h = window.innerHeight || 600;
+    openEmojiWindow(w / 2 - 50, h / 2 - 50);
+}
+
+function pollEmojiWheel(pad) {
+    var items = emojiItems();
+    if (items.length === 0) {
+        return;
+    }
+    if (gpEmojiIndex < 0 || gpEmojiIndex >= items.length) {
+        gpEmojiIndex = 0;
+    }
+
+    // Confirm sends the highlighted emoji; B / X cancels.
+    if (buttonPressedThisFrame(pad, GP_BTN_A)) {
+        var chosen = items[gpEmojiIndex].innerHTML;
+        clearEmojiHighlight(items);
+        closeEmojiWindow(chosen);
+        return;
+    }
+    if (buttonPressedThisFrame(pad, GP_BTN_B) || buttonPressedThisFrame(pad, GP_BTN_EMOJI)) {
+        clearEmojiHighlight(items);
+        closeEmojiWindow("cancel");
+        return;
+    }
+
+    // Left stick points directly at the emoji in that direction; the d-pad
+    // nudges one slot at a time.
+    var lx = pad.axes[0] || 0;
+    var ly = pad.axes[1] || 0;
+    if (Math.sqrt(lx * lx + ly * ly) > 0.5) {
+        gpEmojiIndex = nearestEmojiToDir(items, lx, ly);
+    }
+    var now = Date.now();
+    if (buttonPressedThisFrame(pad, GP_DPAD_RIGHT) || buttonPressedThisFrame(pad, GP_DPAD_DOWN)) {
+        gpEmojiIndex = (gpEmojiIndex + 1) % items.length;
+        gpEmojiStepAt = now;
+    } else if (buttonPressedThisFrame(pad, GP_DPAD_LEFT) || buttonPressedThisFrame(pad, GP_DPAD_UP)) {
+        gpEmojiIndex = (gpEmojiIndex - 1 + items.length) % items.length;
+        gpEmojiStepAt = now;
+    }
+
+    highlightEmoji(items, gpEmojiIndex);
+}
+
+function highlightEmoji(items, idx) {
+    for (var i = 0; i < items.length; i++) {
+        if (i === idx) {
+            items[i].classList.add("gp-emoji-focus");
+        } else {
+            items[i].classList.remove("gp-emoji-focus");
+        }
+    }
+}
+
+function clearEmojiHighlight(items) {
+    for (var i = 0; i < items.length; i++) {
+        items[i].classList.remove("gp-emoji-focus");
+    }
+}
+
+// --- leave-game confirmation modal ---
+
+function buildLeaveModalUI() {
+    if (leaveModalEl || typeof document === "undefined" || !document.body) {
         return;
     }
     var el = document.createElement("div");
-    el.id = "gamepadPrompts";
+    el.id = "leaveModal";
+    el.className = "confirm-modal hidden";
+    el.innerHTML =
+        '<div class="confirm-dialog">' +
+        '<div class="confirm-title">Leave the game?</div>' +
+        '<div class="confirm-buttons">' +
+        '<button type="button" class="confirm-btn confirm-leave">Leave</button>' +
+        '<button type="button" class="confirm-btn confirm-cancel">Cancel</button>' +
+        '</div></div>';
+    document.body.appendChild(el);
+    leaveModalEl = el;
+    // Mouse users can click either button directly.
+    el.querySelector(".confirm-leave").addEventListener("click", doLeaveGame);
+    el.querySelector(".confirm-cancel").addEventListener("click", closeLeaveModal);
+}
+
+function leaveModalIsOpen() {
+    return !!leaveModalEl && leaveModalEl.classList.contains("visible");
+}
+
+function openLeaveModal() {
+    if (!leaveModalEl) {
+        buildLeaveModalUI();
+    }
+    if (!leaveModalEl) {
+        return;
+    }
+    // Stop the player while they decide — for both pad and keyboard. (keyDown in
+    // input.js also bails while the modal is open, so WASD can't restart it.)
+    if (typeof cancelMovement === "function") {
+        cancelMovement();
+    }
+    gpHadMoveInput = false;
+    gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+    leaveModalEl.className = "confirm-modal visible";
+    setLeaveFocus(1); // default to Cancel
+}
+
+function closeLeaveModal() {
+    if (leaveModalEl) {
+        leaveModalEl.className = "confirm-modal hidden";
+    }
+}
+
+function doLeaveGame() {
+    // Navigating away drops the socket; the server kicks us from the room.
+    window.location.href = "./index.html";
+}
+
+function leaveButtons() {
+    if (!leaveModalEl) {
+        return [];
+    }
+    return [leaveModalEl.querySelector(".confirm-leave"), leaveModalEl.querySelector(".confirm-cancel")];
+}
+
+function setLeaveFocus(idx) {
+    var btns = leaveButtons();
+    leaveFocusIdx = idx;
+    for (var i = 0; i < btns.length; i++) {
+        if (!btns[i]) {
+            continue;
+        }
+        if (i === idx) {
+            btns[i].classList.add("gp-focus");
+            try { btns[i].focus(); } catch (e) { /* ignore */ }
+        } else {
+            btns[i].classList.remove("gp-focus");
+        }
+    }
+}
+
+function pollLeaveModal(pad) {
+    if (buttonPressedThisFrame(pad, GP_BTN_B)) {
+        closeLeaveModal();
+        return;
+    }
+    if (buttonPressedThisFrame(pad, GP_BTN_A)) {
+        var btns = leaveButtons();
+        if (btns[leaveFocusIdx]) {
+            btns[leaveFocusIdx].click();
+        }
+        return;
+    }
+    if (buttonPressedThisFrame(pad, GP_DPAD_LEFT)) {
+        setLeaveFocus(0);
+    } else if (buttonPressedThisFrame(pad, GP_DPAD_RIGHT)) {
+        setLeaveFocus(1);
+    } else {
+        var lx = pad.axes[0] || 0;
+        var now = Date.now();
+        if (Math.abs(lx) > 0.5 && now - gpLeaveStepAt > 250) {
+            setLeaveFocus(lx < 0 ? 0 : 1);
+            gpLeaveStepAt = now;
+        }
+    }
+}
+
+// --- input-method hint bar (one bar; glyphs swap to the active input) ---
+
+function buildHintBar() {
+    if (hintBarEl || typeof document === "undefined" || !document.body) {
+        return;
+    }
+    var el = document.createElement("div");
+    el.id = "inputHints";
     el.className = "gamepad-prompts hidden";
     document.body.appendChild(el);
-    gamepadPromptEl = el;
+    hintBarEl = el;
 }
 
 function attackGlyph() {
     return gamepadType === "playstation" ? "✕" : "A"; // PlayStation cross vs Xbox A
 }
 
-function showGamepadPrompts(connected) {
-    if (!gamepadPromptEl) {
-        buildGamepadPromptUI();
+function emojiGlyph() {
+    return gamepadType === "playstation" ? "□" : "X"; // PlayStation square vs Xbox X
+}
+
+function leaveGlyph() {
+    return gamepadType === "playstation" ? "○" : "B"; // PlayStation circle vs Xbox B
+}
+
+function hintsForMethod(method) {
+    if (method === "pad") {
+        return '<span class="gp-toast">🎮 Controller</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-stick">L</span><span class="gp-glyph gp-dpad">✛</span>Move</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-stick">R</span>Aim</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-face">' + attackGlyph() + '</span>/<span class="gp-glyph gp-trigger">RT</span>Attack</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-face">' + emojiGlyph() + '</span>Emoji</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-face">' + leaveGlyph() + '</span>Leave</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-menu">☰</span>Fullscreen</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-menu">⧉</span>Hide</span>';
     }
-    if (!gamepadPromptEl) {
+    if (method === "touch") {
+        return '<span class="gp-toast">📱 Touch</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-key">🕹️</span>Move</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-key">👆</span>Attack</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-key">💬</span>Emoji</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-key">⛶</span>Fullscreen</span>';
+    }
+    // keyboard / mouse
+    return '<span class="gp-hint"><span class="gp-glyph gp-key">W</span><span class="gp-glyph gp-key">A</span><span class="gp-glyph gp-key">S</span><span class="gp-glyph gp-key">D</span>Move</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-key">🖱</span>Aim</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-key">Click</span>/<span class="gp-glyph gp-key">Space</span>Attack</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-key">Right-click</span>Emoji</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-key">Esc</span>Leave</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-key">H</span>Hide</span>';
+}
+
+// Swap the hint bar to the given input method ("kbm" | "pad" | "touch"). No-op
+// when unchanged, so continuing to use the same input doesn't keep resetting the
+// fade — only an actual scheme change (or Select) brings the bar back.
+function setInputMethod(method) {
+    if (method === activeInputMethod) {
         return;
     }
-    if (!connected) {
-        gamepadPromptEl.className = "gamepad-prompts hidden";
+    activeInputMethod = method;
+    if (!hintBarEl) {
+        buildHintBar();
+    }
+    if (!hintBarEl) {
         return;
     }
-    gamepadPromptEl.innerHTML =
-        '<span class="gp-toast">🎮 Controller connected</span>' +
-        '<span class="gp-hint"><span class="gp-glyph gp-stick">L</span>Move</span>' +
-        '<span class="gp-hint"><span class="gp-glyph gp-stick">R</span>Aim</span>' +
-        '<span class="gp-hint"><span class="gp-glyph gp-face">' + attackGlyph() + '</span>/<span class="gp-glyph gp-trigger">RT</span>Attack</span>' +
-        '<span class="gp-hint"><span class="gp-glyph gp-menu">☰</span>Fullscreen</span>';
-    gamepadPromptEl.className = "gamepad-prompts visible";
-    // Drop the "connected" toast after a few seconds; keep the control hints.
+    hintBarEl.innerHTML = hintsForMethod(method);
+    hintBarEl.className = "gamepad-prompts visible";
+    // Drop the toast (pad/touch) after a few seconds, keep the control hints.
     clearTimeout(gpPromptTimer);
-    gpPromptTimer = setTimeout(function () {
-        if (gamepadPromptEl) {
-            gamepadPromptEl.className = "gamepad-prompts visible compact";
+    if (method === "pad" || method === "touch") {
+        gpPromptTimer = setTimeout(function () {
+            if (hintBarEl) {
+                hintBarEl.classList.add("compact");
+            }
+        }, 4000);
+    }
+    scheduleHintFade();
+}
+
+// True if the pad is actively in use this frame (a button down or a stick past
+// its deadzone) — used to swap the glyphs to the controller on real usage.
+function padHasInput(pad) {
+    var lx = pad.axes[0] || 0, ly = pad.axes[1] || 0;
+    if (Math.sqrt(lx * lx + ly * ly) > GP_MOVE_DEADZONE) {
+        return true;
+    }
+    var rx = pad.axes[2] || 0, ry = pad.axes[3] || 0;
+    if (Math.sqrt(rx * rx + ry * ry) > GP_AIM_DEADZONE) {
+        return true;
+    }
+    for (var i = 0; i < pad.buttons.length; i++) {
+        if (pad.buttons[i] && (pad.buttons[i].pressed || pad.buttons[i].value > GP_TRIGGER_THRESHOLD)) {
+            return true;
         }
-    }, 4000);
+    }
+    return false;
+}
+
+// Show the hint bar at full opacity and (re)start the ~60s countdown to fade.
+function scheduleHintFade() {
+    if (!hintBarEl) {
+        return;
+    }
+    hintBarEl.classList.remove("faded");
+    clearTimeout(gpFadeTimer);
+    gpFadeTimer = setTimeout(function () {
+        if (hintBarEl && hintBarEl.classList.contains("visible")) {
+            hintBarEl.classList.add("faded");
+        }
+    }, HINT_FADE_MS);
+}
+
+// Manual toggle (Select button / H key): hide the bar now, or restore it.
+function toggleHintFade() {
+    if (!hintBarEl) {
+        return;
+    }
+    if (hintBarEl.classList.contains("faded")) {
+        scheduleHintFade(); // restore to full opacity + restart the auto-fade
+    } else {
+        clearTimeout(gpFadeTimer);
+        hintBarEl.classList.add("faded"); // hide on demand
+    }
 }

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -97,6 +97,11 @@ function handleDblClick(event) {
     movingByMouse = !movingByMouse;
 }
 function keyDown(evt) {
+    // While the leave-game confirmation is up, don't let movement keys drive the
+    // player (gamepad.js owns that modal; openLeaveModal already stopped motion).
+    if (typeof leaveModalIsOpen === "function" && leaveModalIsOpen()) {
+        return;
+    }
     if (movingByMouse) {
         movingByMouse = false;
     }

--- a/client/scripts/menuGamepad.js
+++ b/client/scripts/menuGamepad.js
@@ -1,0 +1,323 @@
+// Gamepad navigation for the DOM menu pages (landing + join).
+//
+// These pages have no game loop, so this module runs its own requestAnimationFrame
+// poll. It collects the actionable elements on the page, lets the d-pad / left
+// stick move a focus ring between them, and maps A -> activate, B -> back.
+// Wrapped in an IIFE so it can be safely concatenated into the join bundle
+// alongside join.js without leaking globals.
+(function () {
+    "use strict";
+
+    // Actionable elements, in document order. Covers the landing buttons, the
+    // join page's refresh / join-by-id / start-new controls, and the dynamically
+    // rendered room "Join" buttons (a.join-btn is also a.btn).
+    var NAV_SELECTOR = "a.btn, button.btn, input.form-control";
+
+    var MOVE_DEADZONE = 0.5;   // stick must be pushed clearly to step focus
+    var REPEAT_DELAY = 250;    // ms between focus steps while a direction is held
+
+    // Standard-mapping indices
+    var BTN_A = 0;        // activate
+    var BTN_B = 1;        // back
+    var DPAD_UP = 12;
+    var DPAD_DOWN = 13;
+    var DPAD_LEFT = 14;
+    var DPAD_RIGHT = 15;
+
+    var connected = false;
+    var padIndex = null;
+    var padType = "generic";
+    var focusEl = null;        // the element we consider focused
+    var prevButtons = [];
+    var lastStepAt = 0;
+    var rafId = null;
+    var promptEl = null;
+
+    function init() {
+        window.addEventListener("gamepadconnected", onConnected, false);
+        window.addEventListener("gamepaddisconnected", onDisconnected, false);
+        buildPrompt();
+        // Always poll: a pad held at load never fires 'connected' until a button
+        // press, and Chrome only exposes pads while polling anyway.
+        loop();
+    }
+
+    function onConnected(e) {
+        connected = true;
+        padIndex = e.gamepad.index;
+        padType = detectType(e.gamepad.id);
+        prevButtons = [];
+        showPrompt(true);
+    }
+
+    function onDisconnected(e) {
+        if (e.gamepad.index !== padIndex) {
+            return;
+        }
+        connected = false;
+        padIndex = null;
+        showPrompt(false);
+    }
+
+    function detectType(id) {
+        var s = (id || "").toLowerCase();
+        if (s.indexOf("playstation") !== -1 || s.indexOf("dualshock") !== -1 ||
+            s.indexOf("dualsense") !== -1 || s.indexOf("054c") !== -1) {
+            return "playstation";
+        }
+        return "generic";
+    }
+
+    function getPad() {
+        var pads = navigator.getGamepads ? navigator.getGamepads() : [];
+        if (padIndex != null && pads[padIndex]) {
+            return pads[padIndex];
+        }
+        for (var i = 0; i < pads.length; i++) {
+            if (pads[i]) {
+                padIndex = i;
+                if (!connected) {
+                    connected = true;
+                    padType = detectType(pads[i].id);
+                    showPrompt(true);
+                }
+                return pads[i];
+            }
+        }
+        return null;
+    }
+
+    // Visible, actionable elements in document order.
+    function collectItems() {
+        var all = document.querySelectorAll(NAV_SELECTOR);
+        var items = [];
+        for (var i = 0; i < all.length; i++) {
+            var el = all[i];
+            // skip hidden / zero-size elements (e.g. controls in a hidden panel)
+            if (el.offsetParent === null && el.getClientRects().length === 0) {
+                continue;
+            }
+            items.push(el);
+        }
+        return items;
+    }
+
+    function indexOfFocus(items) {
+        for (var i = 0; i < items.length; i++) {
+            if (items[i] === focusEl) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    function setFocus(el) {
+        if (focusEl && focusEl !== el) {
+            focusEl.classList.remove("gp-focus");
+        }
+        focusEl = el;
+        if (el) {
+            el.classList.add("gp-focus");
+            try { el.focus({ preventScroll: false }); } catch (err) { el.focus(); }
+        }
+    }
+
+    function center(el) {
+        var r = el.getBoundingClientRect();
+        return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    }
+
+    // 2D spatial move: focus the nearest item in the pressed direction, so
+    // "down" goes to the element below rather than the next one in DOM order.
+    function moveFocus(dir) {
+        var items = collectItems();
+        if (items.length === 0) {
+            return;
+        }
+        if (!focusEl || indexOfFocus(items) === -1) {
+            // nothing focused yet (or it was re-rendered away) — land on the first
+            setFocus(items[0]);
+            return;
+        }
+        var f = center(focusEl);
+        var best = null;
+        var bestScore = Infinity;
+        for (var i = 0; i < items.length; i++) {
+            if (items[i] === focusEl) {
+                continue;
+            }
+            var p = center(items[i]);
+            var dx = p.x - f.x;
+            var dy = p.y - f.y;
+            var primary, secondary;
+            if (dir === "right") { if (dx <= 2) { continue; } primary = dx; secondary = Math.abs(dy); }
+            else if (dir === "left") { if (dx >= -2) { continue; } primary = -dx; secondary = Math.abs(dy); }
+            else if (dir === "down") { if (dy <= 2) { continue; } primary = dy; secondary = Math.abs(dx); }
+            else if (dir === "up") { if (dy >= -2) { continue; } primary = -dy; secondary = Math.abs(dx); }
+            else { continue; }
+            var score = primary + secondary * 2;
+            if (score < bestScore) {
+                bestScore = score;
+                best = items[i];
+            }
+        }
+        if (best) {
+            setFocus(best);
+        }
+    }
+
+    function activate() {
+        var items = collectItems();
+        if (indexOfFocus(items) === -1) {
+            setFocus(items[0]);
+            return;
+        }
+        if (!focusEl) {
+            return;
+        }
+        if (focusEl.tagName.toLowerCase() === "input") {
+            // Pop the on-screen keyboard so the field is typeable with a pad;
+            // fall back to a plain focus if the OSK module isn't present.
+            if (typeof oskOpen === "function") {
+                oskOpen(focusEl);
+            } else {
+                focusEl.focus();
+            }
+            return;
+        }
+        focusEl.click();
+    }
+
+    function back() {
+        var path = location.pathname;
+        if (/index\.html$/.test(path) || path === "/" || path === "") {
+            return; // already at the top of the menu tree
+        }
+        location.href = "./index.html";
+    }
+
+    function pressed(pad, idx) {
+        var now = pad.buttons[idx] && pad.buttons[idx].pressed;
+        var was = prevButtons[idx] || false;
+        return !!now && !was;
+    }
+
+    function recordButtons(pad) {
+        prevButtons = [];
+        for (var i = 0; i < pad.buttons.length; i++) {
+            prevButtons[i] = pad.buttons[i].pressed;
+        }
+    }
+
+    // While the on-screen keyboard is open, the d-pad/stick moves between keys
+    // (2D spatial), A presses the key, B closes the keyboard.
+    function handleOskInput(pad) {
+        if (pressed(pad, BTN_A)) {
+            oskActivateFocused();
+        }
+        if (pressed(pad, BTN_B)) {
+            oskClose();
+            return;
+        }
+        var now = Date.now();
+        if (pressed(pad, DPAD_UP)) {
+            oskMoveFocus("up");
+        } else if (pressed(pad, DPAD_DOWN)) {
+            oskMoveFocus("down");
+        } else if (pressed(pad, DPAD_LEFT)) {
+            oskMoveFocus("left");
+        } else if (pressed(pad, DPAD_RIGHT)) {
+            oskMoveFocus("right");
+        } else if (now - lastStepAt > REPEAT_DELAY) {
+            var ly = pad.axes[1] || 0;
+            var lx = pad.axes[0] || 0;
+            if (ly < -MOVE_DEADZONE) { oskMoveFocus("up"); lastStepAt = now; }
+            else if (ly > MOVE_DEADZONE) { oskMoveFocus("down"); lastStepAt = now; }
+            else if (lx < -MOVE_DEADZONE) { oskMoveFocus("left"); lastStepAt = now; }
+            else if (lx > MOVE_DEADZONE) { oskMoveFocus("right"); lastStepAt = now; }
+        }
+    }
+
+    function loop() {
+        rafId = window.requestAnimationFrame(loop);
+        var pad = getPad();
+        if (!pad) {
+            return;
+        }
+
+        if (typeof oskIsOpen === "function" && oskIsOpen()) {
+            handleOskInput(pad);
+            recordButtons(pad);
+            return;
+        }
+
+        // Edge-triggered actions
+        if (pressed(pad, BTN_A)) {
+            activate();
+        }
+        if (pressed(pad, BTN_B)) {
+            back();
+        }
+
+        // Directional focus movement: d-pad (edge) or left stick (with repeat).
+        var now = Date.now();
+        var ly = pad.axes[1] || 0;
+        var lx = pad.axes[0] || 0;
+        var dir = null;
+        if (pressed(pad, DPAD_UP)) { dir = "up"; }
+        else if (pressed(pad, DPAD_DOWN)) { dir = "down"; }
+        else if (pressed(pad, DPAD_LEFT)) { dir = "left"; }
+        else if (pressed(pad, DPAD_RIGHT)) { dir = "right"; }
+        else if (now - lastStepAt > REPEAT_DELAY) {
+            if (ly < -MOVE_DEADZONE) { dir = "up"; }
+            else if (ly > MOVE_DEADZONE) { dir = "down"; }
+            else if (lx < -MOVE_DEADZONE) { dir = "left"; }
+            else if (lx > MOVE_DEADZONE) { dir = "right"; }
+        }
+        if (dir) {
+            moveFocus(dir);
+            lastStepAt = now;
+        }
+
+        recordButtons(pad);
+    }
+
+    // --- prompt overlay (reuses the .gamepad-prompts styles) ---
+    function buildPrompt() {
+        if (promptEl || !document.body) {
+            return;
+        }
+        var el = document.createElement("div");
+        el.id = "gamepadPrompts";
+        el.className = "gamepad-prompts hidden";
+        document.body.appendChild(el);
+        promptEl = el;
+    }
+
+    function showPrompt(on) {
+        if (!promptEl) {
+            buildPrompt();
+        }
+        if (!promptEl) {
+            return;
+        }
+        if (!on) {
+            promptEl.className = "gamepad-prompts hidden";
+            return;
+        }
+        var aGlyph = padType === "playstation" ? "✕" : "A";
+        var bGlyph = padType === "playstation" ? "○" : "B";
+        promptEl.innerHTML =
+            '<span class="gp-toast">🎮 Controller connected</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-dpad">↕</span>Navigate</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-face">' + aGlyph + '</span>Select</span>' +
+            '<span class="gp-hint"><span class="gp-glyph gp-face">' + bGlyph + '</span>Back</span>';
+        promptEl.className = "gamepad-prompts visible";
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/client/scripts/osk.js
+++ b/client/scripts/osk.js
@@ -1,0 +1,147 @@
+// On-screen keyboard (wraps the simple-keyboard library) for controller text
+// entry. Shared by the map editor and the join page.
+//
+// It has NO gamepad poll of its own: the active page poller (menuGamepad.js on
+// join, editorGamepad.js in the editor) routes input here while oskIsOpen() is
+// true — calling oskMoveFocus(dir) / oskActivateFocused() / oskClose(). This
+// keeps a single pad reader per page. If the simple-keyboard CDN failed to
+// load, oskOpen() falls back to just focusing the field (hardware keyboard).
+
+var _osk = null;            // SimpleKeyboard instance (lazily created)
+var _oskActiveInput = null; // the <input> currently being edited
+var _oskFocusEl = null;     // the highlighted key (.hg-button)
+
+function oskIsOpen() {
+    var c = document.getElementById("oskContainer");
+    return !!c && c.classList.contains("visible");
+}
+
+function _oskEnsure() {
+    if (_osk) {
+        return _osk;
+    }
+    var SK = window.SimpleKeyboard && (window.SimpleKeyboard.default || window.SimpleKeyboard);
+    if (!SK) {
+        return null; // library not loaded
+    }
+    var container = document.createElement("div");
+    container.id = "oskContainer";
+    container.className = "osk-container hidden";
+    container.innerHTML = '<div class="osk-keyboard simple-keyboard"></div>';
+    document.body.appendChild(container);
+
+    _osk = new SK(".simple-keyboard", {
+        onChange: function (input) {
+            if (_oskActiveInput) {
+                _oskActiveInput.value = input;
+                _oskActiveInput.dispatchEvent(new Event("input", { bubbles: true }));
+            }
+        },
+        onKeyPress: function (button) {
+            if (button === "{shift}" || button === "{lock}") {
+                var cur = _osk.options.layoutName;
+                _osk.setOptions({ layoutName: cur === "default" ? "shift" : "default" });
+            } else if (button === "{enter}") {
+                oskClose();
+            }
+        }
+    });
+    return _osk;
+}
+
+function oskOpen(input) {
+    var kb = _oskEnsure();
+    if (!kb) {
+        try { input.focus(); } catch (e) { /* ignore */ }
+        return;
+    }
+    _oskActiveInput = input;
+    kb.setInput(input.value || "");
+    var c = document.getElementById("oskContainer");
+    c.className = "osk-container visible";
+    var btns = _oskButtons();
+    _oskSetFocus(btns.length ? btns[0] : null);
+}
+
+function oskClose() {
+    var c = document.getElementById("oskContainer");
+    if (c) {
+        c.className = "osk-container hidden";
+    }
+    if (_oskFocusEl) {
+        _oskFocusEl.classList.remove("osk-focus");
+        _oskFocusEl = null;
+    }
+    if (_oskActiveInput) {
+        try { _oskActiveInput.blur(); } catch (e) { /* ignore */ }
+    }
+    _oskActiveInput = null;
+}
+
+function oskActivateFocused() {
+    if (_oskFocusEl) {
+        _oskFocusEl.click();
+    }
+}
+
+function _oskButtons() {
+    var c = document.getElementById("oskContainer");
+    if (!c) {
+        return [];
+    }
+    return Array.prototype.slice.call(c.querySelectorAll(".hg-button"));
+}
+
+function _oskSetFocus(el) {
+    if (!el) {
+        return;
+    }
+    if (_oskFocusEl) {
+        _oskFocusEl.classList.remove("osk-focus");
+    }
+    _oskFocusEl = el;
+    el.classList.add("osk-focus");
+}
+
+function _oskCenter(el) {
+    var r = el.getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+}
+
+// 2D spatial move: pick the nearest key in the requested direction, preferring
+// alignment on the cross axis so a grid of keys feels natural.
+function oskMoveFocus(dir) {
+    var btns = _oskButtons();
+    if (btns.length === 0) {
+        return;
+    }
+    if (!_oskFocusEl) {
+        _oskSetFocus(btns[0]);
+        return;
+    }
+    var f = _oskCenter(_oskFocusEl);
+    var best = null;
+    var bestScore = Infinity;
+    for (var i = 0; i < btns.length; i++) {
+        if (btns[i] === _oskFocusEl) {
+            continue;
+        }
+        var p = _oskCenter(btns[i]);
+        var dx = p.x - f.x;
+        var dy = p.y - f.y;
+        var primary, secondary;
+        if (dir === "right") { if (dx <= 2) { continue; } primary = dx; secondary = Math.abs(dy); }
+        else if (dir === "left") { if (dx >= -2) { continue; } primary = -dx; secondary = Math.abs(dy); }
+        else if (dir === "down") { if (dy <= 2) { continue; } primary = dy; secondary = Math.abs(dx); }
+        else if (dir === "up") { if (dy >= -2) { continue; } primary = -dy; secondary = Math.abs(dx); }
+        else { continue; }
+        var score = primary + secondary * 2;
+        if (score < bestScore) {
+            bestScore = score;
+            best = btns[i];
+        }
+    }
+    if (best) {
+        _oskSetFocus(best);
+    }
+}

--- a/index.js
+++ b/index.js
@@ -11,16 +11,67 @@ const htmlPath = path.join(__dirname, 'client');
 
 app.use(compression());
 
-// Inject the running server's version into index.html so the landing
-// page always reflects what's actually deployed. Runs in both dev and
-// prod; read once at startup so we don't fs.readFile on every request.
+// Inject the running server's version and the latest release headline into
+// index.html so the landing page always reflects what's actually deployed.
+// Runs in both dev and prod; read once at startup so we don't hit disk on
+// every request.
 const APP_VERSION = require('./package.json').version;
+const APP_NEWS = loadLatestHeadline();
+
+function escapeHtml(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+// The news banner surfaces the most recent CHANGELOG entry: the first bullet
+// under the topmost section that has one (Unreleased first, then the latest
+// versioned release). Returns '' if there are no entries yet.
+function loadLatestHeadline() {
+    try {
+        var md = fs.readFileSync(path.join(__dirname, 'CHANGELOG.md'), 'utf8');
+        var lines = md.split('\n');
+        // Only scan inside the release sections (after the first "## " heading),
+        // so a stray bullet in the intro/guidance prose can't become the headline.
+        var inSections = false;
+        for (var i = 0; i < lines.length; i++) {
+            var line = lines[i].trim();
+            if (line.indexOf('## ') === 0) {
+                inSections = true;
+                continue;
+            }
+            if (inSections && line.indexOf('- ') === 0) {
+                return line.slice(2).trim()
+                    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // [text](url) -> text
+                    .replace(/[*`_]/g, '');                  // strip emphasis/code marks
+            }
+        }
+    } catch (e) {
+        console.log('Could not read CHANGELOG.md for news banner:', e.message);
+    }
+    return '';
+}
+
+function newsBannerHtml() {
+    if (!APP_NEWS) {
+        return '';
+    }
+    return '<a class="news-banner" target="_blank" href="https://github.com/sjdodge123/chaochao/releases/latest">' +
+        '<span class="news-badge">Patch notes</span>' +
+        '<span class="news-headline">' + escapeHtml(APP_NEWS) + '</span>' +
+        '</a>';
+}
+
 app.use(function (req, res, next) {
     var url = req.path === '/' ? '/index.html' : req.path;
     if (url !== '/index.html') return next();
     fs.readFile(path.join(htmlPath, url), 'utf8', function (err, html) {
         if (err) return next();
-        var modified = html.replace(/<!-- VERSION -->/g, 'v' + APP_VERSION);
+        var modified = html
+            .replace(/<!-- VERSION -->/g, 'v' + APP_VERSION)
+            .replace(/<!-- NEWS_BANNER -->/g, newsBannerHtml());
         res.set('Content-Type', 'text/html');
         res.send(modified);
     });


### PR DESCRIPTION
Adds full gamepad support across the client, plus an on-screen keyboard for controller text entry and a landing-page news banner. All client-side (no server/gameplay changes); no game-mechanic tuning touched.

## What's included

**In-game (`gamepad.js`)**
- Left stick → existing 8-way movement; **d-pad** also moves. Right stick → twin-stick aim (via the existing `mousemove` channel). A / RT → attack (also fires the held ability). Start → fullscreen.
- Change-detection + aim throttling so per-frame polling doesn't flood the socket; an idle pad never stomps keyboard/mouse.
- **X** opens the emoji wheel (point-to-pick with the stick, A send / B cancel). **B / Esc** opens a Leave-game confirmation modal (controller- and mouse-navigable).

**Menus (`menuGamepad.js`)** — landing + join pages: d-pad/stick focus ring with 2D spatial navigation, A activates, B goes back; re-scans the dynamically-rendered room cards.

**Map editor (`editorGamepad.js`)** — RB toggles **panel navigation ↔ stick-cursor canvas painting**, reusing the editor's real click/paint code paths. B is a universal back (canvas → map list → home).

**On-screen keyboard (`osk.js`, simple-keyboard via CDN)** — pops when a text field is activated by the pad (editor Author/Name/Email, join-by-ID); 2D spatial key nav, routed by each page's pad poller so there's a single pad reader per page.

**Glyphs & prompts** — one in-game hint bar whose glyphs swap to the **active input method** (keyboard/mouse, controller, touch), pad-type aware (Xbox/PlayStation). Auto-fades after ~60s, **Select / H** to hide, restores on input-scheme change. Touch controls get on-canvas captions.

**Landing page** — a "Patch notes" news banner injected server-side (`index.js`) from the latest `CHANGELOG.md` headline.

## Notes
- The bundler (`build.js`) and the per-page `<script>` tags were updated for the new modules; `osk.js`/simple-keyboard load on the editor and join pages.
- Includes fixes from a multi-angle code review (emoji-wheel cancel-anchor exclusion, editor brush-release on mode-toggle/disconnect, keyboard frozen behind the leave modal, glyph flip-flop guard, CHANGELOG parser anchoring, pad-vanish movement release, canvas-cursor deadzone re-scaling).

## Verification
- All changed scripts + `index.js` pass `node --check`; play/create/join bundles concatenate cleanly.
- Verified live in Chrome: the ~60s auto-fade fires through the real timer (opacity → 0.15) and the Select/H toggle works; the news-banner injects the CHANGELOG headline; the emoji-wheel cancel-anchor exclusion confirmed against the real markup.
- Live controller feel (stick painting, twin-stick aim) still warrants a hands-on pass with a physical pad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)