### PR TITLE
Consolidate per-PR releases into a weekly digest + single headline

### DIFF
--- a/.github/scripts/build-weekly-digest.mjs
+++ b/.github/scripts/build-weekly-digest.mjs
@@ -1,0 +1,36 @@
+// Build the consolidated weekly release digest from CHANGELOG.md.
+//
+// Reads CHANGELOG.md, groups the calendar week (Mon–Sun, UTC) of the most
+// recent release into one set of notes, writes them to WEEKLY_NOTES.md, and
+// emits the digest's tag/title as step outputs so the workflow can upsert a
+// single "week-YYYY-MM-DD" GitHub Release. Per-PR releases are untouched.
+//
+// Outputs (GITHUB_OUTPUT): week_tag, week_title. Sets built=false (and writes
+// nothing) when there are no releases to digest.
+
+import fs from 'node:fs';
+import { buildWeeklyDigest, renderDigestBody } from './changelog-lib.mjs';
+
+function setOutput(key, value) {
+    if (process.env.GITHUB_OUTPUT) {
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+    }
+}
+
+const md = fs.readFileSync('CHANGELOG.md', 'utf8');
+const digest = buildWeeklyDigest(md);
+
+if (!digest) {
+    console.log('No releases in CHANGELOG.md — nothing to digest.');
+    setOutput('built', 'false');
+    process.exit(0);
+}
+
+fs.writeFileSync('WEEKLY_NOTES.md', renderDigestBody(digest));
+setOutput('built', 'true');
+setOutput('week_tag', digest.weekTag);
+setOutput('week_title', digest.weekTitle);
+
+console.log(`Built ${digest.weekTag} (${digest.weekTitle}).`);
+console.log(`Headline: ${digest.headline ?? '(none)'}`);
+console.log(`Includes: ${digest.versions.join(', ')}`);

--- a/.github/scripts/changelog-lib.mjs
+++ b/.github/scripts/changelog-lib.mjs
@@ -1,0 +1,163 @@
+// Shared CHANGELOG parsing for the weekly release digest.
+//
+// The CHANGELOG lists releases newest-first as "## vX.Y.Z — YYYY-MM-DD"
+// sections, each with "### <Heading>" subsections of "- " bullets. Per-PR
+// releases keep cutting their own section/tag; this module groups a calendar
+// week's worth of those sections (Mon–Sun, UTC) into one consolidated digest
+// and picks the week's headline bullet.
+//
+// A bullet may be flagged as the week's headline with a leading "[headline]"
+// marker, e.g. "- [headline] Now with controller support!". The most recent
+// such bullet in the week wins; the marker is stripped for display.
+//
+// NOTE: index.js (CommonJS, at the repo root) reproduces the headline +
+// week-tag subset of this logic for the landing-page banner. The week-Monday
+// computation and the "week-YYYY-MM-DD" tag format MUST stay identical in both
+// places, or the banner link will 404 against the digest release.
+
+const MONTHS = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+const HEADLINE_RE = /^(\s*-\s+)\[headline\]\s*/i;
+
+// Remove a leading "[headline]" marker from a single bullet line (keeps the
+// "- " prefix). Non-bullet lines and unmarked bullets pass through unchanged.
+export function stripHeadlineMarker(line) {
+    return line.replace(HEADLINE_RE, '$1');
+}
+
+// Strip "[headline]" markers from every bullet in a multi-line block.
+export function stripHeadlineMarkers(body) {
+    return body
+        .split('\n')
+        .map((l) => stripHeadlineMarker(l))
+        .join('\n');
+}
+
+// Does this bullet line carry the [headline] marker?
+function isHeadlineBullet(line) {
+    return HEADLINE_RE.test(line);
+}
+
+// Bullet text without the "- " prefix and without any [headline] marker.
+function bulletText(line) {
+    return stripHeadlineMarker(line).replace(/^\s*-\s+/, '').trim();
+}
+
+// Monday (UTC) of the calendar week containing the given YYYY-MM-DD, returned
+// as YYYY-MM-DD. Weeks run Monday–Sunday.
+export function mondayOf(dateStr) {
+    const d = new Date(`${dateStr}T00:00:00Z`);
+    const dow = d.getUTCDay();              // 0=Sun..6=Sat
+    const backToMonday = (dow + 6) % 7;     // Mon->0, Sun->6
+    d.setUTCDate(d.getUTCDate() - backToMonday);
+    return d.toISOString().slice(0, 10);
+}
+
+// "Week of May 18, 2026" for a YYYY-MM-DD Monday.
+export function weekTitle(mondayStr) {
+    const d = new Date(`${mondayStr}T00:00:00Z`);
+    return `Week of ${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
+}
+
+// Parse "## vX.Y.Z — YYYY-MM-DD" sections (newest first, as written). Each
+// section becomes { version, date, groups: [{ heading|null, bullets:[line] }] }.
+// "## Unreleased" and the intro prose are ignored.
+export function parseSections(md) {
+    const lines = md.split('\n');
+    const sections = [];
+    let cur = null;
+    let group = null;
+
+    const pushGroup = () => {
+        if (group && group.bullets.length) cur.groups.push(group);
+        group = null;
+    };
+
+    for (const line of lines) {
+        const ver = line.match(/^##\s+v(\d+\.\d+\.\d+)\s+—\s+(\d{4}-\d{2}-\d{2})/);
+        if (line.startsWith('## ')) {
+            // Any "## " heading closes the current section.
+            if (cur) { pushGroup(); sections.push(cur); cur = null; }
+            if (ver) cur = { version: ver[1], date: ver[2], groups: [] };
+            continue;
+        }
+        if (!cur) continue;
+        const sub = line.match(/^###\s+(.*\S)\s*$/);
+        if (sub) { pushGroup(); group = { heading: sub[1], bullets: [] }; continue; }
+        if (/^\s*-\s+/.test(line)) {
+            if (!group) group = { heading: null, bullets: [] };
+            group.bullets.push(line);
+        }
+    }
+    if (cur) { pushGroup(); sections.push(cur); }
+    return sections;
+}
+
+// Build the consolidated weekly digest from CHANGELOG markdown, or null if
+// there are no releases yet. The "current week" is the calendar week of the
+// most recent (topmost) release section, so the banner is never empty between
+// releases.
+export function buildWeeklyDigest(md) {
+    const sections = parseSections(md);
+    if (!sections.length) return null;
+
+    const monday = mondayOf(sections[0].date);
+    const weekSections = sections.filter((s) => mondayOf(s.date) === monday);
+
+    // Merge groups across the week, preserving heading first-seen order and
+    // dropping duplicate bullets (by stripped text).
+    const order = [];
+    const byHeading = new Map();
+    const seen = new Set();
+    let headline = null;
+
+    for (const s of weekSections) {
+        for (const g of s.groups) {
+            const key = g.heading || '';
+            if (!byHeading.has(key)) { byHeading.set(key, []); order.push(key); }
+            for (const b of g.bullets) {
+                const text = bulletText(b);
+                if (headline === null && isHeadlineBullet(b)) headline = text;
+                if (seen.has(text)) continue;
+                seen.add(text);
+                byHeading.get(key).push(text);
+            }
+        }
+    }
+    // Fallback headline: the first bullet of the week.
+    if (headline === null) {
+        const firstKey = order.find((k) => byHeading.get(k).length);
+        if (firstKey !== undefined) headline = byHeading.get(firstKey)[0];
+    }
+
+    const groups = order
+        .map((k) => ({ heading: k || null, bullets: byHeading.get(k) }))
+        .filter((g) => g.bullets.length);
+
+    return {
+        weekMonday: monday,
+        weekTag: `week-${monday}`,
+        weekTitle: weekTitle(monday),
+        headline,
+        groups,
+        versions: weekSections.map((s) => `v${s.version}`),
+    };
+}
+
+// Render the digest's body as Markdown for the GitHub release notes.
+export function renderDigestBody(digest) {
+    const out = [];
+    if (digest.headline) out.push(`> **${digest.headline}**`, '');
+    for (const g of digest.groups) {
+        if (g.heading) out.push(`### ${g.heading}`);
+        for (const b of g.bullets) out.push(`- ${b}`);
+        out.push('');
+    }
+    if (digest.versions.length) {
+        out.push('---', `Includes ${digest.versions.join(', ')}.`);
+    }
+    return out.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+}

--- a/.github/scripts/cut-release.mjs
+++ b/.github/scripts/cut-release.mjs
@@ -12,6 +12,7 @@
 // Inputs (env): VERSION (e.g. "0.1.3"), RELEASE_DATE (e.g. "2026-05-23").
 
 import fs from 'node:fs';
+import { stripHeadlineMarkers } from './changelog-lib.mjs';
 
 const version = process.env.VERSION;
 const date = process.env.RELEASE_DATE;
@@ -73,7 +74,9 @@ const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 pkg.version = version;
 fs.writeFileSync('package.json', JSON.stringify(pkg, null, 4) + '\n');
 
-fs.writeFileSync('RELEASE_NOTES.md', body + '\n');
+// The "[headline]" marker stays in CHANGELOG.md (the weekly digest reads it),
+// but the per-PR GitHub release body shouldn't show it.
+fs.writeFileSync('RELEASE_NOTES.md', stripHeadlineMarkers(body) + '\n');
 
 console.log(`Prepared release v${version} (${date}).`);
 setOutput('released', 'true');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,3 +130,34 @@ jobs:
           gh release create "v$VERSION" \
             --title "v$VERSION" \
             --notes-file RELEASE_NOTES.md
+
+      # Roll every release from the current calendar week (Mon–Sun) into a
+      # single "week-YYYY-MM-DD" digest release. The landing-page banner links
+      # here, so players see one headline + one consolidated set of notes per
+      # week even though every PR still cuts its own vX.Y.Z release above.
+      - name: Build weekly digest
+        id: digest
+        if: steps.cut.outputs.released == 'true'
+        run: node .github/scripts/build-weekly-digest.mjs
+
+      - name: Publish weekly digest release
+        if: steps.cut.outputs.released == 'true' && steps.digest.outputs.built == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          WEEK_TAG: ${{ steps.digest.outputs.week_tag }}
+          WEEK_TITLE: ${{ steps.digest.outputs.week_title }}
+        run: |
+          # Upsert: refresh the week's digest release if it already exists (a
+          # later PR in the same week), otherwise create it (gh anchors the new
+          # week-* tag at the release commit on main). The week-* tag matches no
+          # other workflow trigger, so this publishes nothing downstream.
+          if gh release view "$WEEK_TAG" >/dev/null 2>&1; then
+            gh release edit "$WEEK_TAG" \
+              --title "$WEEK_TITLE" \
+              --notes-file WEEKLY_NOTES.md
+          else
+            gh release create "$WEEK_TAG" \
+              --title "$WEEK_TITLE" \
+              --notes-file WEEKLY_NOTES.md \
+              --latest=false
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Write entries in the same player-friendly style as the GitHub releases: short bu
 
 Releases are cut automatically on merge to `main` by the `Release on merge to main` workflow: when `## Unreleased` has notes, it moves them under a new `## vX.Y.Z — YYYY-MM-DD` heading, resets `Unreleased`, bumps `package.json`, tags `vX.Y.Z`, and publishes the GitHub release using that section as the body. The version bump comes from the merged PR's label — `release:major`, `release:minor`, or `release:patch` (default `patch`). PRs that add no notes don't trigger a release.
 
+After each release the same workflow also rolls every `vX.Y.Z` from the current calendar week (Monday–Sunday, UTC) into a single consolidated `week-YYYY-MM-DD` GitHub release, and the landing-page banner shows **one headline for the week** linking to it. To choose that headline, prefix the bullet you want featured with `[headline]`, e.g. `- [headline] Now with controller support!` — the most recent flagged bullet of the week wins, and the marker is stripped everywhere it's shown (banner, per-PR release notes, weekly digest). If no bullet is flagged, the week's first bullet is used.
+
 ## Unreleased
 
 (none yet)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,18 @@ For any such change, add a bullet under `## Unreleased` in `CHANGELOG.md` in the
 
 The `Game mechanic changes need release notes` GitHub Actions check enforces this on every PR and push to `main`.
 
+### Weekly digest and the front-page headline
+
+Every PR still cuts its own `vX.Y.Z` release, but the landing-page banner shows **one headline per calendar week** (Mon–Sun, UTC) linking to a consolidated `week-YYYY-MM-DD` GitHub release that the release workflow builds automatically. To pick the bullet featured as that week's headline, prefix it with `[headline]`:
+
+```
+### General
+- [headline] Now with controller support!
+- Smaller polish that won't be the headline
+```
+
+The most recent `[headline]` bullet in the week wins; if none is flagged, the week's first bullet is used. The marker is stripped wherever the line is shown (banner, per-PR release notes, and the weekly digest), so it only affects which line gets promoted.
+
 ### Cutting a release
 
 1. Move the `## Unreleased` block under a new `## vX.Y.Z — YYYY-MM-DD` heading in `CHANGELOG.md`. Leave a fresh empty `## Unreleased` at the top.

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ app.use(compression());
 // Runs in both dev and prod; read once at startup so we don't hit disk on
 // every request.
 const APP_VERSION = require('./package.json').version;
-const APP_NEWS = loadLatestHeadline();
+const APP_NEWS = loadWeeklyNews();
+const RELEASES_REPO = 'sjdodge123/chaochao';
 
 function escapeHtml(s) {
     return String(s)
@@ -26,41 +27,68 @@ function escapeHtml(s) {
         .replace(/"/g, '&quot;');
 }
 
-// The news banner surfaces the most recent CHANGELOG entry: the first bullet
-// under the topmost section that has one (Unreleased first, then the latest
-// versioned release). Returns '' if there are no entries yet.
-function loadLatestHeadline() {
+// Monday (UTC, YYYY-MM-DD) of the calendar week containing a YYYY-MM-DD date.
+// MUST match mondayOf() in .github/scripts/changelog-lib.mjs, which names the
+// "week-YYYY-MM-DD" digest release this banner links to.
+function mondayOf(dateStr) {
+    var d = new Date(dateStr + 'T00:00:00Z');
+    d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+    return d.toISOString().slice(0, 10);
+}
+
+// The news banner surfaces ONE headline for the latest week of releases and
+// links to that week's consolidated digest release. The headline is the most
+// recent bullet flagged "[headline]" within the week of the topmost release
+// section, falling back to that week's first bullet. Returns null when there
+// are no releases yet. Kept in lockstep with the digest built in
+// .github/scripts/changelog-lib.mjs.
+function loadWeeklyNews() {
     try {
         var md = fs.readFileSync(path.join(__dirname, 'CHANGELOG.md'), 'utf8');
         var lines = md.split('\n');
-        // Only scan inside the release sections (after the first "## " heading),
-        // so a stray bullet in the intro/guidance prose can't become the headline.
-        var inSections = false;
+        var weekMonday = null;     // week of the topmost release section
+        var inWeek = false;        // currently scanning a section in that week
+        var headline = null;       // [headline]-marked bullet (first wins)
+        var firstBullet = null;    // fallback: first bullet of the week
+        var headlineRe = /^-\s+\[headline\]\s*/i;
         for (var i = 0; i < lines.length; i++) {
             var line = lines[i].trim();
-            if (line.indexOf('## ') === 0) {
-                inSections = true;
+            var ver = line.match(/^##\s+v\d+\.\d+\.\d+\s+—\s+(\d{4}-\d{2}-\d{2})/);
+            if (ver) {
+                var monday = mondayOf(ver[1]);
+                if (weekMonday === null) weekMonday = monday;
+                inWeek = monday === weekMonday;
                 continue;
             }
-            if (inSections && line.indexOf('- ') === 0) {
-                return line.slice(2).trim()
-                    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // [text](url) -> text
-                    .replace(/[*`_]/g, '');                  // strip emphasis/code marks
+            if (line.indexOf('## ') === 0) { inWeek = false; continue; }
+            if (!inWeek || line.indexOf('- ') !== 0) continue;
+            var clean = function (t) {
+                return t.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // [text](url) -> text
+                    .replace(/[*`_]/g, '').trim();              // strip emphasis/code
+            };
+            if (firstBullet === null) firstBullet = clean(line.slice(2));
+            if (headline === null && headlineRe.test(line)) {
+                headline = clean(line.replace(headlineRe, ''));
             }
         }
+        var text = headline || firstBullet;
+        if (!text || !weekMonday) return null;
+        return { headline: text, weekTag: 'week-' + weekMonday };
     } catch (e) {
         console.log('Could not read CHANGELOG.md for news banner:', e.message);
+        return null;
     }
-    return '';
 }
 
 function newsBannerHtml() {
     if (!APP_NEWS) {
         return '';
     }
-    return '<a class="news-banner" target="_blank" href="https://github.com/sjdodge123/chaochao/releases/latest">' +
-        '<span class="news-badge">Patch notes</span>' +
-        '<span class="news-headline">' + escapeHtml(APP_NEWS) + '</span>' +
+    var href = 'https://github.com/' + RELEASES_REPO +
+        '/releases/tag/' + encodeURIComponent(APP_NEWS.weekTag);
+    return '<a class="news-banner" target="_blank" href="' + escapeHtml(href) + '">' +
+        '<span class="news-badge">This week</span>' +
+        '<span class="news-headline">' + escapeHtml(APP_NEWS.headline) + '</span>' +
         '</a>';
 }
 


### PR DESCRIPTION
## What

Keeps per-PR releases exactly as they are (each merge still cuts its own `vX.Y.Z` tag + GitHub release), but consolidates the **player-facing** view: the landing-page banner now shows **one headline per calendar week** (Mon–Sun, UTC) linking to a single consolidated `week-YYYY-MM-DD` digest release, instead of changing on every PR.

## How it works

- After each per-PR release, `release.yml` builds the digest and **upserts** a `week-YYYY-MM-DD` GitHub release (creates it for the first release of the week, edits it for later ones). Reuses the existing `RELEASE_TOKEN` — no new secret. The digest is `--latest=false`, so the semver `vX.Y.Z` releases remain "latest".
- The banner derives "the week" from the most recent release's date (not today's), so it's never blank between weeks.

## Choosing the headline

Prefix the bullet you want featured with `[headline]`:

```
### General
- [headline] Now with controller support!
- Smaller polish that won't be the headline
```

Most recent flagged bullet in the week wins; if none is flagged, the week's first bullet is used. The marker is stripped everywhere it's shown (banner, per-PR release notes, weekly digest).

## Files

- `.github/scripts/changelog-lib.mjs` (new) — parse sections, week math, consolidation, headline pick.
- `.github/scripts/build-weekly-digest.mjs` (new) — writes `WEEKLY_NOTES.md` + emits `week_tag`/`week_title`.
- `.github/workflows/release.yml` — upsert the weekly digest release after the per-PR publish.
- `.github/scripts/cut-release.mjs` — strip `[headline]` from per-PR notes (kept in CHANGELOG).
- `index.js` — banner shows the week's headline, links to the `week-*` tag.
- `CHANGELOG.md` / `CONTRIBUTING.md` — document the convention.

## Testing

- Library unit tests: week-boundary math, marker-wins selection, cross-week exclusion, heading grouping + dedup, fallback, empty-changelog → null.
- Ran `build-weekly-digest.mjs` and `cut-release.mjs` on temp data — digest groups correctly and strips the marker; per-PR notes strip it while CHANGELOG keeps it.
- Booted `index.js` over HTTP against the real CHANGELOG: banner links to `releases/tag/week-2026-05-18` with badge "This week" — server and CI agree on the week tag.
- `node --check` on all touched JS, `npm run build` (all three bundles), and `release.yml` YAML all pass.

> Note: the live `gh release` upsert can't be dry-run; it first runs for real on the next post-merge release, which will create the inaugural `week-*` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)