### PR TITLE
Feature controller support as this week's headline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 ## v0.1.4 — 2026-05-23
 
 ### General
-- Now with controller support! Plug in a controller and play
+- [headline] Now with controller support! Plug in a controller and play
 
 ## v0.1.3 — 2026-05-23
 


### PR DESCRIPTION
Promotes the controller-support bullet to the landing-page banner headline for the week of 2026-05-18.

## Why

The weekly-digest banner shows the most recent `[headline]`-flagged bullet of the week, falling back to the week's first bullet. With no marker, it was showing the `v0.1.5` crash-fix bullet ("Fixed a crash…"). Adding `[headline]` to the `v0.1.4` controller-support bullet makes the banner read **"Now with controller support! Plug in a controller and play"** and link to the `week-2026-05-18` digest release.

## Scope

- One-line change: adds the `[headline]` marker to an already-released CHANGELOG bullet.
- Touches no game-mechanic files (`config.json`/`game.js`/`engine.js`), so `check-release-notes` skips.
- Unreleased is empty, so merging cuts **no** new release and triggers no digest rebuild — it only redeploys so `index.js` re-reads the marked CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)