### PR TITLE
Server-authoritative background music sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Releases are cut automatically on merge to `main` by the `Release on merge to ma
 
 ## Unreleased
 
-(none yet)
+### General
+- Everyone in a game now hears the same background music at the same time, and it switches moods together — calm normally, intense when someone's one win away, and ominous on brutal rounds.
+
+### Bug fixes
+- Background music no longer cuts out to silence mid-round when a track finishes; it rolls straight into the next one.
+- Background music now plays continuously through the round-transition and map-load screens instead of restarting at the start of every race.
 
 ## v0.1.4 — 2026-05-23
 

--- a/client/scripts/audio.js
+++ b/client/scripts/audio.js
@@ -13,11 +13,17 @@ function clearFade(sound) {
     }
 }
 
-var calmBackgroundMusicList = [];
-var excitingBackgroundMusicList = [];
-var brutalBackgroundMusicList = [];
+// Playlists are name-keyed maps (trackName -> Audio) so a server-sent track name
+// resolves to the exact same Audio instance that volumeChange() tunes.
+var calmBackgroundMusicList = {};
+var excitingBackgroundMusicList = {};
+var brutalBackgroundMusicList = {};
+var backgroundMusicLists = {};
 var currentBackgroundMusic = null;
 var backgroundBuildTimer = null;
+// Set by client.js once the socket exists; lets the server drive the next track
+// when one finishes so background music stays continuous and in sync.
+var musicTrackEndedHandler = null;
 
 var playerJoinSound = new Audio("./assets/sounds/pleasing-bell.mp3");
 var playerDiedSound = new Audio("./assets/sounds/TailWhip.mp3");
@@ -71,9 +77,6 @@ var gameStart = new Audio("./assets/sounds/gamestart.mp3");
 var slowstride = new Audio("./assets/sounds/slowstride.mp3");
 var slowpipes = new Audio("./assets/sounds/slow-pipes.mp3");
 
-calmBackgroundMusicList.push(slowstride);
-calmBackgroundMusicList.push(slowpipes);
-
 var therush = new Audio("./assets/sounds/the-rush.mp3");
 var beastv2 = new Audio("./assets/sounds/beastv2.mp3");
 var mindInMotion = new Audio("./assets/sounds/mind_in_motion.mp3");
@@ -83,24 +86,37 @@ var bumpinbits3 = new Audio("./assets/sounds/bumpinbits3.mp3");
 var bumpinbits4 = new Audio("./assets/sounds/bumpinbits4.mp3");
 var bumpinbits5 = new Audio("./assets/sounds/bumpinbits5.mp3");
 
-excitingBackgroundMusicList.push(mindInMotion);
-excitingBackgroundMusicList.push(therush);
-excitingBackgroundMusicList.push(beastv2);
-excitingBackgroundMusicList.push(bumpinbits1);
-excitingBackgroundMusicList.push(bumpinbits2);
-excitingBackgroundMusicList.push(bumpinbits3);
-excitingBackgroundMusicList.push(bumpinbits4);
-excitingBackgroundMusicList.push(bumpinbits5);
-
 var heavyfabric = new Audio("./assets/sounds/heavyfabric.mp3");
 var desperationSetsIn = new Audio("./assets/sounds/DesperationSetsIn.mp3");
 var horrorLoop = new Audio("./assets/sounds/HorrorLoop.mp3");
 var depthOfDespair = new Audio("./assets/sounds/depthOfDespair.mp3");
 
-brutalBackgroundMusicList.push(depthOfDespair);
-brutalBackgroundMusicList.push(horrorLoop);
-brutalBackgroundMusicList.push(desperationSetsIn);
-brutalBackgroundMusicList.push(heavyfabric);
+// Register a track under a mood. Keys MUST match the names in config.json "music"
+// so a server-sent {mood, track} resolves here. trackName is stamped on the Audio
+// so the "ended" listener can report which track finished back to the server.
+function registerBackgroundTrack(playlist, mood, name, sound) {
+	sound.trackName = name;
+	playlist[name] = sound;
+	sound.addEventListener("ended", handleBackgroundTrackEnded);
+	backgroundMusicLists[mood] = playlist;
+}
+
+registerBackgroundTrack(calmBackgroundMusicList, "calm", "slowstride", slowstride);
+registerBackgroundTrack(calmBackgroundMusicList, "calm", "slow-pipes", slowpipes);
+
+registerBackgroundTrack(excitingBackgroundMusicList, "exciting", "mind_in_motion", mindInMotion);
+registerBackgroundTrack(excitingBackgroundMusicList, "exciting", "the-rush", therush);
+registerBackgroundTrack(excitingBackgroundMusicList, "exciting", "beastv2", beastv2);
+registerBackgroundTrack(excitingBackgroundMusicList, "exciting", "bumpinbits1", bumpinbits1);
+registerBackgroundTrack(excitingBackgroundMusicList, "exciting", "bumpinbits2", bumpinbits2);
+registerBackgroundTrack(excitingBackgroundMusicList, "exciting", "bumpinbits3", bumpinbits3);
+registerBackgroundTrack(excitingBackgroundMusicList, "exciting", "bumpinbits4", bumpinbits4);
+registerBackgroundTrack(excitingBackgroundMusicList, "exciting", "bumpinbits5", bumpinbits5);
+
+registerBackgroundTrack(brutalBackgroundMusicList, "brutal", "depthOfDespair", depthOfDespair);
+registerBackgroundTrack(brutalBackgroundMusicList, "brutal", "HorrorLoop", horrorLoop);
+registerBackgroundTrack(brutalBackgroundMusicList, "brutal", "DesperationSetsIn", desperationSetsIn);
+registerBackgroundTrack(brutalBackgroundMusicList, "brutal", "heavyfabric", heavyfabric);
 
 
 function volumeChange() {
@@ -218,31 +234,6 @@ function stopAllSounds() {
     playingSounds.clear();
 }
 
-function playBackgroundSound() {
-    //Count all players near victory
-    for (var id in playerList) {
-        if (playerList[id].nearVictory == true) {
-            playersNearVictory.push(id);
-        } else {
-            playersNearVictory.splice(playersNearVictory.indexOf(id), 1);
-        }
-    }
-    //Not a match point, change to calming music
-    if (playersNearVictory.length < 1) {
-        if (brutalRound == false) {
-            changeBackgroundMusic(calmBackgroundMusicList);
-        } else {
-            changeBackgroundMusic(brutalBackgroundMusicList);
-        }
-        return;
-    }
-    //If match point, change to exciting music
-    if (playersNearVictory.length > 0) {
-        changeBackgroundMusic(excitingBackgroundMusicList);
-        return;
-    }
-}
-
 function playSoundAfterFinish(sound) {
     playingSounds.add(sound);
     if (!gameMuted) {
@@ -255,29 +246,45 @@ function playSoundAfterFinish(sound) {
     }
 }
 
-function changeBackgroundMusic(musicList) {
-    //No existing background sounds, set musiclist provided
-    if (currentBackgroundMusic == null || currentBackgroundMusic.ended || currentBackgroundMusic.paused) {
-        currentBackgroundMusic = musicList[getRandomInt(0, musicList.length - 1)];
-        fadeSoundIn(currentBackgroundMusic);
-        playSound(currentBackgroundMusic);
+// Server-authoritative: play the exact mood+track the server told us to. The
+// server decides what everyone hears; the client only obeys.
+function setBackgroundMusic(mood, trackName) {
+    if (mood == null || trackName == null) {
         return;
     }
-    //Existing background music playing from provided musiclist, continue
-    if (musicList === brutalBackgroundMusicList && isBrutalPlaylist(currentBackgroundMusic)) {
+    var playlist = backgroundMusicLists[mood];
+    if (playlist == null) {
+        console.warn("setBackgroundMusic: unknown mood '" + mood + "' from server — no music change");
         return;
     }
-    if (musicList === calmBackgroundMusicList && isCalmingPlaylist(currentBackgroundMusic)) {
+    var track = playlist[trackName];
+    if (track == null) {
+        console.warn("setBackgroundMusic: track '" + trackName + "' not registered for mood '" + mood + "' (config.json/audio.js mismatch?) — no music change");
         return;
     }
-    if (musicList === excitingBackgroundMusicList && isExcitingPlaylist(currentBackgroundMusic)) {
+    //Already playing this exact track — leave it (and its fade) alone.
+    if (currentBackgroundMusic === track && !track.paused && !track.ended) {
         return;
     }
-    //Existing background music does not match playlist, fade out and change playlist
-    fadeSoundOut(currentBackgroundMusic);
-    currentBackgroundMusic = musicList[getRandomInt(0, musicList.length - 1)];
-    fadeSoundIn(currentBackgroundMusic);
-    playSound(currentBackgroundMusic);
+    //Fade out whatever else is playing before switching.
+    if (currentBackgroundMusic != null && currentBackgroundMusic !== track) {
+        fadeSoundOut(currentBackgroundMusic);
+    }
+    currentBackgroundMusic = track;
+    fadeSoundIn(track);
+    playSound(track);
+}
+
+// Background tracks don't loop. When the active one finishes, tell the server so
+// it can pick the next track for everyone — keeps music continuous and in sync.
+function handleBackgroundTrackEnded(event) {
+    var sound = event.target;
+    if (sound !== currentBackgroundMusic) {
+        return;
+    }
+    if (musicTrackEndedHandler != null) {
+        musicTrackEndedHandler(sound.trackName);
+    }
 }
 
 function fadeSoundIn(sound) {
@@ -310,29 +317,3 @@ function fadeSoundOut(sound) {
     fadeTimers.set(sound, timer);
 }
 
-function isExcitingPlaylist(sound) {
-    for (var i = 0; i < excitingBackgroundMusicList.length; i++) {
-        if (sound === excitingBackgroundMusicList[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-function isBrutalPlaylist(sound) {
-    for (var i = 0; i < brutalBackgroundMusicList.length; i++) {
-        if (sound === brutalBackgroundMusicList[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-function isCalmingPlaylist(sound) {
-    for (var i = 0; i < calmBackgroundMusicList.length; i++) {
-        if (sound === calmBackgroundMusicList[i]) {
-            return true;
-        }
-    }
-    return false;
-}

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -11,6 +11,11 @@ var config,
 function clientConnect() {
 	var server = io();
 
+	//Let audio.js report a finished background track so the server picks the next one.
+	musicTrackEndedHandler = function (trackName) {
+		server.emit("musicTrackEnded", trackName);
+	};
+
 	server.on('welcome', function (id) {
 		debugLog("welcome, myID=", id);
 		myID = id;
@@ -56,6 +61,10 @@ function clientConnect() {
 		}
 		if (playerList[myID] != null) {
 			myPlayer = playerList[myID];
+		}
+		//Late joiners: pick up the race already in progress on the right track/mood.
+		if (gameState.music != null) {
+			setBackgroundMusic(gameState.music.mood, gameState.music.track);
 		}
 		setupEmojiWheel();
 	});
@@ -183,11 +192,19 @@ function clientConnect() {
 	});
 	server.on("startRace", function (packet) {
 		playSound(countDownB);
-		playBackgroundSound();
+		if (packet != null && packet.music != null) {
+			setBackgroundMusic(packet.music.mood, packet.music.track);
+		}
 		oldNotches = {};
 		resetTrails();
 		resetPlayerRanks();
 		currentState = config.stateMap.racing;
+	});
+	//Server-driven mood change (near-victory) or next track (previous one ended).
+	server.on("musicMood", function (packet) {
+		if (packet != null) {
+			setBackgroundMusic(packet.mood, packet.track);
+		}
 	});
 	server.on("startOverview", function (packet) {
 		resetRound();

--- a/server/config.json
+++ b/server/config.json
@@ -24,6 +24,12 @@
     "maxTotalBrutals": 3,
     "TESTSingleMap": false,
     "submitViaMail": "chaochaothegame@gmail.com",
+    "music": {
+        "calm": ["slowstride", "slow-pipes"],
+        "exciting": ["mind_in_motion", "the-rush", "beastv2", "bumpinbits1", "bumpinbits2", "bumpinbits3", "bumpinbits4", "bumpinbits5"],
+        "brutal": ["depthOfDespair", "HorrorLoop", "DesperationSetsIn", "heavyfabric"]
+    },
+    "musicFallbackSeconds": 600,
     "tileMap": {
         "slow": {
             "id": 0,

--- a/server/game.js
+++ b/server/game.js
@@ -131,6 +131,10 @@ class Game {
 		//State mgmt
 		this.stateMap = c.stateMap;
 		this.currentState = this.stateMap.waiting;
+		//Server-authoritative background music ({mood, track}); null until a race starts
+		this.currentMusic = null;
+		//When currentMusic.track was last chosen, for the fallback rotation timer
+		this.musicChangedAt = null;
 		this.gameBoard = new GameBoard(world, playerList, projectileList, aimerList, hazardList, engine, roomSig);
 	}
 
@@ -151,6 +155,8 @@ class Game {
 		//In Racing State or Collapse State
 		if (this.currentState == this.stateMap.racing || this.currentState == this.stateMap.collapsing) {
 			this.checkForWinners();
+			this.updateMusicMood();
+			this.checkMusicFallback();
 		}
 		//In Overview State
 		if (this.currentState == this.stateMap.overview) {
@@ -361,6 +367,83 @@ class Game {
 		messenger.messageRoomBySig(this.roomSig, "startWaiting", null);
 		this.currentState = this.stateMap.waiting;
 	}
+	//The mood the room should be hearing right now: exciting overrides everything
+	//when anyone is one notch from winning, otherwise brutal rounds get brutal music.
+	computeMusicMood() {
+		for (var id in this.playerList) {
+			if (this.playerList[id].nearVictory == true) {
+				return "exciting";
+			}
+		}
+		if (this.gameBoard.brutalRound == true) {
+			return "brutal";
+		}
+		return "calm";
+	}
+	//Pick a track name for a mood from the shared config manifest, avoiding an
+	//immediate repeat of avoidTrack when the playlist has alternatives.
+	pickMusicTrack(mood, avoidTrack) {
+		var playlist = c.music[mood];
+		if (playlist == null || playlist.length == 0) {
+			return null;
+		}
+		if (playlist.length == 1) {
+			return playlist[0];
+		}
+		var track = playlist[utils.getRandomInt(0, playlist.length - 1)];
+		var attempts = 0;
+		while (track == avoidTrack && attempts < 5) {
+			track = playlist[utils.getRandomInt(0, playlist.length - 1)];
+			attempts++;
+		}
+		return track;
+	}
+	//Set the room's music and remember when, so the fallback timer can recover
+	//if no client ever reports the track ending.
+	setRoomMusic(mood, track) {
+		this.currentMusic = { mood: mood, track: track };
+		this.musicChangedAt = Date.now();
+	}
+	//Called every racing tick: if the room's mood changed (someone hit/left
+	//near-victory), pick a track for the new mood and tell every client to switch.
+	updateMusicMood() {
+		if (this.currentMusic == null) {
+			return;
+		}
+		var desiredMood = this.computeMusicMood();
+		if (desiredMood == this.currentMusic.mood) {
+			return;
+		}
+		this.setRoomMusic(desiredMood, this.pickMusicTrack(desiredMood, null));
+		messenger.messageRoomBySig(this.roomSig, "musicMood", this.currentMusic);
+	}
+	//A client reported its background track finished. Background tracks don't loop,
+	//so pick the next one for the current mood and broadcast it, keeping music
+	//continuous and in sync. Stale reports for an already-rotated track are ignored.
+	rotateMusicTrack(endedTrack) {
+		if (this.currentMusic == null || this.currentMusic.track != endedTrack) {
+			return;
+		}
+		var mood = this.currentMusic.mood;
+		this.setRoomMusic(mood, this.pickMusicTrack(mood, endedTrack));
+		messenger.messageRoomBySig(this.roomSig, "musicMood", this.currentMusic);
+	}
+	//Safety net: clients normally drive rotation by reporting "ended" (precise,
+	//per-track). But if every client is muted/backgrounded/autoplay-blocked, that
+	//report never comes. If the current track has been playing past the fallback
+	//window (set above the longest track so it never cuts normal playback), advance
+	//it anyway so the room never gets stuck in silence.
+	checkMusicFallback() {
+		if (this.currentMusic == null || this.musicChangedAt == null) {
+			return;
+		}
+		if (Date.now() - this.musicChangedAt < c.musicFallbackSeconds * 1000) {
+			return;
+		}
+		var mood = this.currentMusic.mood;
+		this.setRoomMusic(mood, this.pickMusicTrack(mood, this.currentMusic.track));
+		messenger.messageRoomBySig(this.roomSig, "musicMood", this.currentMusic);
+	}
 	startLobby() {
 		console.log("Start Lobby")
 		debug.log("startLobby: from state=", this.currentState, " playerCount=", this.playerCount);
@@ -412,7 +495,15 @@ class Game {
 		}
 
 
-		messenger.messageRoomBySig(this.roomSig, "startRace", null);
+		//Keep the current track playing across the load/overview screens — only pick
+		//a new one for the first race or when the mood actually changes. The client
+		//re-plays the same track as a no-op, so music continues uninterrupted.
+		var mood = this.computeMusicMood();
+		if (this.currentMusic == null || this.currentMusic.mood != mood) {
+			this.setRoomMusic(mood, this.pickMusicTrack(mood, null));
+		}
+
+		messenger.messageRoomBySig(this.roomSig, "startRace", { music: this.currentMusic });
 	}
 
 	startOverview() {
@@ -444,6 +535,8 @@ class Game {
 		this.locked = false;
 		this.collapseInitated = false;
 		this.notchesToWin = c.baseNotchesToWin;
+		this.currentMusic = null;
+		this.musicChangedAt = null;
 		this.gameBoard.resetGame(this.currentState);
 		messenger.messageRoomBySig(this.roomSig, "resetGame", null);
 	}

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -113,7 +113,8 @@ function checkForMail(client) {
 			config: c,
 			myID: client.id,
 			gameID: roomSig,
-			world: worldData
+			world: worldData,
+			music: room.game.currentMusic
 		};
 		client.emit("gameState", gameState);
 		//Update all existing players with the new player's info
@@ -128,6 +129,14 @@ function checkForMail(client) {
 
 	client.on('playerLeaveRoom', function () {
 		hostess.kickFromRoom(client.id);
+	});
+
+	client.on('musicTrackEnded', function (trackName) {
+		var room = hostess.getRoomBySig(roomMailList[client.id]);
+		if (room == undefined) {
+			return;
+		}
+		room.game.rotateMusicTrack(trackName);
 	});
 
 	client.on('drip', function () {


### PR DESCRIPTION
## What

Background music was chosen client-side and randomized per client, so everyone in a game heard a different track and switched moods at different times. This moves track + mood selection to the server so the whole room stays on the same playlist. Scope is "same track + same mood" — not sample-accurate playback position (intentionally out of scope).

## Changes

- **`server/config.json`** — new `music` manifest keyed by mood (`calm` / `exciting` / `brutal`), already shipped to clients via `gameState.config`. Added `musicFallbackSeconds` (600).
- **`server/game.js`** — `Game` owns `currentMusic = {mood, track}`:
  - `startRace` picks the track, and **keeps it across the load/overview screens** — only re-picking on the first race or a real mood change, so music plays continuously instead of restarting each round.
  - `updateMusicMood` (each racing tick) switches mood when the room-wide near-victory count crosses zero (exciting), else brutal on brutal rounds, else calm.
  - `rotateMusicTrack` advances to the next track when a client reports its track ended (background tracks don't loop), with stale-report dedup.
  - `checkMusicFallback` is a server-side safety net: if no client reports an `ended` track within `musicFallbackSeconds` (above the longest track at 468s), it advances anyway so a fully muted/backgrounded room never stalls in silence.
- **`server/messenger.js`** — late-joiner `gameState` includes the room's current `{mood, track}`; new `musicTrackEnded` handler drives rotation.
- **`client/scripts/audio.js`** — playlists are now name-keyed maps reusing the same `Audio` instances `volumeChange()` tunes; new `setBackgroundMusic(mood, track)` obeys the server (random pick removed; fades kept) and `console.warn`s on an unresolved mood/track.
- **`client/scripts/client.js`** — `startRace`, `musicMood`, and `gameState` handlers all route through `setBackgroundMusic`.

## Player-facing notes

Added to `CHANGELOG.md` under Unreleased (config.json + game.js are game-mechanic files):
- Everyone hears the same track and switches moods together.
- Music no longer goes silent mid-round when a track finishes.
- Music plays continuously through round-transition / map-load screens instead of restarting each race.

## Verification

- `npm run build` succeeds; server boots clean.
- A harness driving the **real `Game` code** confirms: same `{mood, track}` broadcast to the room; mood switches on near-victory; track persists across same-mood rounds and changes on a real mood change; the fallback fires only past the window and resets on a client `ended` report.
- In-browser: config delivered, track selection + mood switching work, and the two `console.warn` paths fire correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)