### PR TITLE
Local multiplayer: up to 4 players on one screen (controllers + keyboard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+- [headline] Local multiplayer! Up to 4 people can play on one screen — each on their own controller, plus one on keyboard/mouse — all joining the same game as real players, right alongside anyone online.
+- Plug in controllers and they show up in a header at the top of the screen; press A on one to jump in. The first controller (with no keyboard player) becomes Player 1, and each player gets their own color so you can tell who's who.
+- Each player has their own on-screen controls, emoji wheel, and a "Leave?" prompt (B on a controller, Esc on keyboard) — one player leaving or unplugging never ends everyone else's game.
 
 ## v0.1.6 — 2026-05-23
 

--- a/backlog.md
+++ b/backlog.md
@@ -2,6 +2,12 @@
 
 Tracked work that is known and intentionally deferred. The currently-in-progress changes are not listed here.
 
+## In-game play (`client/scripts/input.js`, `client/play.html`)
+
+### Bugs
+
+- **Touch handlers crash when `virtualButtonList` is null.** The `touchstart`/`touchend`/`touchmove` listeners are registered unconditionally (`input.js:22-24`), but `virtualButtonList` starts as `null` (`input.js:6`) and is only built by `setupVirtualbuttons()` when `isTouchDevice()` is true (`input.js:30-32`). On a hybrid device where `isTouchDevice()` returns false but the browser still dispatches touch events (touchscreen laptop + trackpad, a force-touch trackpad, or Chrome touch emulation), `onTouchStart`/`onTouchEnd` iterate `virtualButtonList.length` and throw `Cannot read properties of null (reading 'length')`. It doesn't break gameplay — the handlers just abort — but it spams the console. Fix: guard the touch handlers with an early `if (!virtualButtonList) return;`, or build the button list unconditionally at init. Pre-existing; surfaced during local-multiplayer controller testing but unrelated to it (touch input is out of scope for local MP).
+
 ## Map editor (`client/scripts/create.js`, `client/create.html`)
 
 ### Bugs

--- a/build.js
+++ b/build.js
@@ -19,12 +19,14 @@ const bundles = {
         'client/scripts/create.js',
         'client/scripts/osk.js',
         'client/scripts/editorGamepad.js',
-        'client/scripts/utils.js'
+        'client/scripts/utils.js',
+        'client/scripts/controllerHeader.js'
     ],
     'join.bundle.min.js': [
         'client/scripts/join.js',
         'client/scripts/osk.js',
-        'client/scripts/menuGamepad.js'
+        'client/scripts/menuGamepad.js',
+        'client/scripts/controllerHeader.js'
     ]
 };
 

--- a/client/create.html
+++ b/client/create.html
@@ -303,6 +303,7 @@
   <script src="scripts/osk.js"></script>
   <script src="scripts/editorGamepad.js"></script>
   <script src="scripts/utils.js"></script>
+  <script src="scripts/controllerHeader.js"></script>
   <!-- BUILD: bundle-end -->
 </body>
 

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -607,6 +607,11 @@ div.desc {
     font-weight: 700;
 }
 
+/* a pad player whose socket is mid-reconnect (transient blip) */
+.pad-player.reconnecting {
+    opacity: 0.45;
+}
+
 /* the controller -> player color link; lights up once the server assigns a color */
 .gp-color-dot {
     width: 14px;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -575,6 +575,108 @@ div.desc {
     font-weight: 600;
 }
 
+/* --- per-pad player overlay (local multiplayer) --- */
+/* One compact block per pad player, top-centre, each with a color dot tinted to
+   that player's assigned color so a controller maps visibly to its player. */
+#padPlayers {
+    position: fixed;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 10px;
+    z-index: 1006;
+    pointer-events: none;
+}
+
+.pad-player {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px;
+    background-color: rgba(255, 255, 255, 0.92);
+    border-radius: 18px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 13px;
+    color: #555;
+    transition: opacity 0.3s;
+}
+
+.pad-player .pp-label {
+    font-weight: 700;
+}
+
+/* the controller -> player color link; lights up once the server assigns a color */
+.gp-color-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background-color: #bbb;
+    border: 2px solid rgba(0, 0, 0, 0.25);
+    box-sizing: border-box;
+}
+
+.pad-player .gp-glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 5px;
+    border-radius: 10px;
+    background-color: #c87f8a;
+    color: white;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.pad-player .gp-glyph.gp-stick {
+    border-radius: 50%;
+    background-color: #555;
+}
+
+/* "controller detected — press A to join" toast, just below the player blocks */
+#padToast {
+    position: fixed;
+    top: 50px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    background-color: rgba(255, 255, 255, 0.92);
+    border-radius: 22px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    color: #c87f8a;
+    z-index: 1007;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+#padToast.visible {
+    opacity: 1;
+}
+
+#padToast .gp-glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 5px;
+    border-radius: 11px;
+    background-color: #c87f8a;
+    color: white;
+    font-size: 12px;
+    font-weight: 600;
+}
+
 /* on-screen keyboard (simple-keyboard) for controller text entry */
 .osk-container {
     position: fixed;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -625,6 +625,17 @@ div.desc {
     opacity: 0.45;
 }
 
+/* a player's inline "Leave?" confirm (B opens it, A confirms, B cancels) */
+.pad-player.confirming {
+    outline: 2px solid #e05a5a;
+    outline-offset: -1px;
+}
+
+.pad-player .pp-confirm {
+    font-weight: 700;
+    color: #e05a5a;
+}
+
 /* the controller -> player color link; lights up once the server assigns a color */
 .gp-color-dot {
     width: 14px;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -674,6 +674,64 @@ div.desc {
     font-weight: 600;
 }
 
+/* informational controller-detection header on the menu/editor pages */
+#controllerHeader {
+    position: fixed;
+    top: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 14px;
+    background-color: rgba(255, 255, 255, 0.92);
+    border-radius: 18px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 13px;
+    color: #555;
+    z-index: 2000;
+    pointer-events: none;
+}
+
+#controllerHeader.visible {
+    display: inline-flex;
+}
+
+#controllerHeader .ch-count {
+    font-weight: 700;
+    color: #c87f8a;
+}
+
+#controllerHeader .ch-pad {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+#controllerHeader .pp-label {
+    font-weight: 700;
+}
+
+#controllerHeader .gp-glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 5px;
+    border-radius: 10px;
+    background-color: #c87f8a;
+    color: white;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+#controllerHeader .ch-join {
+    color: #888;
+    font-size: 11px;
+}
+
 /* "controller detected — press A to join" toast, just below the player blocks */
 #padToast {
     position: fixed;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -602,6 +602,18 @@ div.desc {
     gap: 4px;
 }
 
+/* a connected controller that hasn't joined yet: "press A to join" */
+.pad-player.join-prompt {
+    opacity: 0.8;
+    border: 1px dashed #c87f8a;
+}
+
+.pad-player .pp-join {
+    color: #888;
+    font-size: 11px;
+    font-style: italic;
+}
+
 .pad-player {
     display: inline-flex;
     align-items: center;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -587,6 +587,19 @@ div.desc {
     gap: 10px;
     z-index: 1006;
     pointer-events: none;
+    transition: opacity 0.3s;
+}
+
+/* inherit the bottom bar's fade behaviour: dim after ~60s idle / on toggle */
+#padPlayers.faded {
+    opacity: 0.15;
+    transition: opacity 0.8s;
+}
+
+.pad-player .pp-hints {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .pad-player {
@@ -639,6 +652,15 @@ div.desc {
 .pad-player .gp-glyph.gp-stick {
     border-radius: 50%;
     background-color: #555;
+}
+
+/* keyboard player's chips look like keycaps (matches the bottom-bar gp-key) */
+.pad-player .gp-glyph.gp-key {
+    background-color: #fff;
+    color: #333;
+    border: 1px solid #bbb;
+    border-radius: 4px;
+    font-weight: 600;
 }
 
 /* "controller detected — press A to join" toast, just below the player blocks */

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -637,10 +637,13 @@ div.desc {
     opacity: 0.45;
 }
 
-/* a player's inline "Leave?" confirm (B opens it, A confirms, B cancels) */
+/* a player's inline "Leave?" confirm (B opens it, A confirms, B cancels):
+   highlight the whole block so it stands out while the prompt is up */
 .pad-player.confirming {
     outline: 2px solid #e05a5a;
     outline-offset: -1px;
+    background-color: rgba(224, 90, 90, 0.18);
+    box-shadow: 0 0 10px rgba(224, 90, 90, 0.55);
 }
 
 .pad-player .pp-confirm {

--- a/client/index.html
+++ b/client/index.html
@@ -52,5 +52,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
     <script src="scripts/menuGamepad.js"></script>
+    <script src="scripts/controllerHeader.js"></script>
   </body>
 </html>

--- a/client/join.html
+++ b/client/join.html
@@ -60,6 +60,7 @@
     <script src="scripts/join.js"></script>
     <script src="scripts/osk.js"></script>
     <script src="scripts/menuGamepad.js"></script>
+    <script src="scripts/controllerHeader.js"></script>
     <!-- BUILD: bundle-end -->
 
 </body>

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -80,6 +80,11 @@ function registerPrimaryHandlers(server) {
 			myPlayer = playerList[myID];
 		}
 		setupEmojiWheel();
+		// In local multiplayer P1 also gets a top hint block (the bottom bar is
+		// suppressed); created once the primary has joined.
+		if (localMultiplayerEnabled() && typeof onLocalPlayerJoined === "function" && localPlayers[primarySlot]) {
+			onLocalPlayerJoined(localPlayers[primarySlot]);
+		}
 	});
 
 	server.on("playerJoin", function (appendPlayerList) {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -673,6 +673,15 @@ function sendEmoji(emoji) {
 	server.emit('sendEmoji', emoji);
 }
 
+// Emit an emoji on a specific local player's socket so the server attributes it
+// (ownerId = emitting socket id) to the player who actually picked it. Falls back
+// to the primary socket if the slot is gone.
+function sendEmojiForSlot(emoji, slot) {
+	var lp = (slot != null && localPlayers[slot]) ? localPlayers[slot] : null;
+	var sock = (lp && lp.socket) ? lp.socket : server;
+	sock.emit('sendEmoji', emoji);
+}
+
 function calcPing() {
 	ping = new Date() - lastTime;
 	pingTimeout = setTimeout(pingServer, 1000);

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -602,6 +602,10 @@ function dropLocalPlayer(slot) {
 		clearTimeout(lp.reconnectTimer);
 		lp.reconnectTimer = null;
 	}
+	if (lp.leaveConfirmTimer) {
+		clearTimeout(lp.leaveConfirmTimer);
+		lp.leaveConfirmTimer = null;
+	}
 	// If this player had the shared emoji wheel open, close it — otherwise it
 	// soft-locks open (no surviving player owns it, so none can dismiss it).
 	if (typeof emojiOwnerSlot !== "undefined" && emojiOwnerSlot === slot &&

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -498,11 +498,33 @@ function registerSecondaryHandlers(sock, slot) {
 		}
 	});
 	sock.on('gameState', function (gs) {
-		if (localPlayers[slot]) {
-			localPlayers[slot].myID = gs.myID;
-			localPlayers[slot].joined = true;
+		var lp = localPlayers[slot];
+		if (lp) {
+			lp.myID = gs.myID;
+			lp.joined = true;
+			lp.everJoined = true;
+			if (lp.reconnectTimer) {
+				clearTimeout(lp.reconnectTimer);
+				lp.reconnectTimer = null;
+			}
+		}
+		if (typeof onLocalPlayerReconnecting === "function") {
+			onLocalPlayerReconnecting(slot, false); // recovered — un-grey its block
 		}
 		debugLog("[localmp] slot", slot, "joined room", gs.gameID, "as", gs.myID);
+	});
+	sock.on('connect', function () {
+		var lp = localPlayers[slot];
+		// socket.io fires 'connect' on the initial connect AND on each reconnect.
+		// The initial join is already buffered by addLocalPlayer; on a RECONNECT
+		// (everJoined) re-join the same room so the pad player pops back in
+		// without having to press to rejoin. The reconnect gets a fresh server id
+		// (no server-side session recovery here), so this spawns a new player and
+		// the gameState handler updates the slot's myID.
+		if (lp && lp.everJoined && gameID != null) {
+			debugLog("[localmp] slot", slot, "reconnected — re-joining room", gameID);
+			sock.emit('enterGame', gameID);
+		}
 	});
 	sock.on('roomNotFound', function () {
 		debugLog("[localmp] slot", slot, "roomNotFound — dropping slot, tab kept alive");
@@ -512,13 +534,29 @@ function registerSecondaryHandlers(sock, slot) {
 		debugLog("[localmp] slot", slot, "serverKick — dropping slot, tab kept alive");
 		dropLocalPlayer(slot);
 	});
-	sock.on('disconnect', function () {
-		// An unintended drop of a pad player's socket: free the slot so the pad
-		// can re-press to rejoin. (No-op if we already tore it down.)
-		if (localPlayers[slot] && localPlayers[slot].socket === sock) {
-			debugLog("[localmp] slot", slot, "socket disconnected — dropping slot");
-			dropLocalPlayer(slot);
+	sock.on('disconnect', function (reason) {
+		// We tore it down on purpose (kick / leave / unplug call sock.disconnect()).
+		if (reason === 'io client disconnect') {
+			return;
 		}
+		var lp = localPlayers[slot];
+		if (!lp || lp.socket !== sock) {
+			return;
+		}
+		// Transient blip: keep the slot, grey its block, and let socket.io
+		// auto-reconnect (the 'connect' handler re-joins). Drop only if it can't
+		// recover within the grace window (§6.10).
+		debugLog("[localmp] slot", slot, "disconnected (", reason, ") — awaiting reconnect");
+		if (typeof onLocalPlayerReconnecting === "function") {
+			onLocalPlayerReconnecting(slot, true);
+		}
+		if (lp.reconnectTimer) {
+			clearTimeout(lp.reconnectTimer);
+		}
+		lp.reconnectTimer = setTimeout(function () {
+			debugLog("[localmp] slot", slot, "reconnect grace expired — dropping");
+			dropLocalPlayer(slot);
+		}, RECONNECT_GRACE_MS);
 	});
 }
 
@@ -554,6 +592,10 @@ function dropLocalPlayer(slot) {
 	var lp = localPlayers[slot];
 	if (!lp) {
 		return;
+	}
+	if (lp.reconnectTimer) {
+		clearTimeout(lp.reconnectTimer);
+		lp.reconnectTimer = null;
 	}
 	if (lp.isPrimary) {
 		handlePrimaryLost();

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -58,6 +58,12 @@ function clientConnect() {
 			myPlayer = playerList[myID];
 		}
 		setupEmojiWheel();
+		// PHASE 1 SPIKE: once the primary player has confirmed its room, open the
+		// second local player into the SAME gameID (sequential join, §5.4). The
+		// guard makes this fire exactly once.
+		if (spikeTwoPlayers() && spikePlayer2.socket == null && gameID != null) {
+			openSpikeSecondPlayer(gameID);
+		}
 	});
 
 	server.on("playerJoin", function (appendPlayerList) {
@@ -468,6 +474,53 @@ function clientSendStart(id) {
 	if (id != null) {
 		server.emit('enterGame', id);
 	}
+}
+
+// PHASE 1 SPIKE: open a second, independent connection from this same tab and
+// join it into `gameId` (the room the primary already confirmed). The critical
+// detail (§6.7): `forceNew` — without it, io() reuses the cached Manager and you
+// get the SAME socket.id, i.e. one server player. This socket is an
+// input/identity channel only: it deliberately registers NO render/audio
+// handlers (the primary owns those, §5.1/§6.8a) and NO navigation handlers, so a
+// kick/notfound on player #2 drops only player #2 and never tears down the tab
+// (previews the per-slot teardown of §6.17).
+function openSpikeSecondPlayer(gameId) {
+	if (spikePlayer2.socket != null) {
+		return;
+	}
+	debugLog("[spike] opening 2nd player socket -> gameId=", gameId);
+	var sock = io({ forceNew: true });
+	spikePlayer2.socket = sock;
+
+	sock.on('welcome', function (id) {
+		spikePlayer2.myID = id;
+		debugLog("[spike] P2 welcome, myID=", id);
+	});
+
+	sock.on('gameState', function (gs) {
+		spikePlayer2.joined = true;
+		// Proof line: two distinct ids, same room.
+		console.log("[spike] P2 joined room", gs.gameID, "as", gs.myID,
+			"| P1 is", myID, "in room", gameID,
+			"| distinct?", gs.myID !== myID, "| same room?", String(gs.gameID) === String(gameID));
+		// Route the gamepad to player #2 (keyboard/mouse still drive player #1).
+		gpEmitSocket = sock;
+		gpEmitID = spikePlayer2.myID;
+	});
+
+	// Per-slot teardown preview: log, do NOT navigate the tab.
+	sock.on('roomNotFound', function () {
+		console.warn("[spike] P2 roomNotFound — could not join", gameId, "(tab kept alive)");
+		gpEmitSocket = null;
+		gpEmitID = null;
+	});
+	sock.on('serverKick', function () {
+		console.warn("[spike] P2 serverKick — dropping P2 only (tab kept alive)");
+		gpEmitSocket = null;
+		gpEmitID = null;
+	});
+
+	sock.emit('enterGame', gameId);
 }
 
 function pingServer() {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -9,11 +9,26 @@ var config,
 	playerWon = null;
 
 function clientConnect() {
-	var server = io();
+	// The primary connection (slot 0): the keyboard/mouse player and the sole
+	// owner of rendering, audio, UI and one-shot/timer handlers. The globals
+	// `server`/`myID`/`myPlayer` alias this slot (see game.js localPlayers).
+	var sock = io();
+	server = sock;
+	localPlayers[primarySlot] = makeLocalPlayer(primarySlot, sock, true);
+	registerPrimaryHandlers(sock);
+	return sock;
+}
+
+// Registers the FULL handler set on the primary connection. The bodies use the
+// `server`/`myID`/`playerList`/`myPlayer` globals, which alias the primary slot.
+function registerPrimaryHandlers(server) {
 
 	server.on('welcome', function (id) {
 		debugLog("welcome, myID=", id);
 		myID = id;
+		if (localPlayers[primarySlot]) {
+			localPlayers[primarySlot].myID = id;
+		}
 	});
 
 	server.on("drop", function () {
@@ -30,8 +45,11 @@ function clientConnect() {
 
 	server.on("serverKick", function () {
 		debugLog("serverKick received -- being booted");
-		server.disconnect();
-		window.location.href = "./index.html";
+		// Per-slot teardown (§6.17): drop the primary slot. With no other local
+		// players this disconnects and navigates exactly as before (N=1); with pad
+		// players still in the game it fails over to one of them instead of ending
+		// everyone's session.
+		dropLocalPlayer(primarySlot);
 	});
 
 
@@ -54,16 +72,14 @@ function clientConnect() {
 		if (gameState.myID != null) {
 			myID = gameState.myID;
 		}
+		if (localPlayers[primarySlot]) {
+			localPlayers[primarySlot].myID = myID;
+			localPlayers[primarySlot].joined = true;
+		}
 		if (playerList[myID] != null) {
 			myPlayer = playerList[myID];
 		}
 		setupEmojiWheel();
-		// PHASE 1 SPIKE: once the primary player has confirmed its room, open the
-		// second local player into the SAME gameID (sequential join, §5.4). The
-		// guard makes this fire exactly once.
-		if (spikeTwoPlayers() && spikePlayer2.socket == null && gameID != null) {
-			openSpikeSecondPlayer(gameID);
-		}
 	});
 
 	server.on("playerJoin", function (appendPlayerList) {
@@ -466,61 +482,144 @@ function clientConnect() {
 			lobbyStartButton.startSpin = false;
 		}
 	});
+}
 
-	return server;
+// Minimal handler set for a NON-primary connection (a pad player). It is an
+// input/identity channel only: it captures its own server id and handles its own
+// teardown, but does NOT run rendering/audio/UI/timer handlers (the primary owns
+// those — running them per socket would fire every room broadcast N times,
+// §6.8a). Teardown is per-slot: a kick/notfound on this slot drops only this
+// slot and never navigates the tab (§6.17).
+function registerSecondaryHandlers(sock, slot) {
+	sock.on('welcome', function (id) {
+		debugLog("[localmp] slot", slot, "welcome, myID=", id);
+		if (localPlayers[slot]) {
+			localPlayers[slot].myID = id;
+		}
+	});
+	sock.on('gameState', function (gs) {
+		if (localPlayers[slot]) {
+			localPlayers[slot].myID = gs.myID;
+			localPlayers[slot].joined = true;
+		}
+		debugLog("[localmp] slot", slot, "joined room", gs.gameID, "as", gs.myID);
+	});
+	sock.on('roomNotFound', function () {
+		debugLog("[localmp] slot", slot, "roomNotFound — dropping slot, tab kept alive");
+		dropLocalPlayer(slot);
+	});
+	sock.on('serverKick', function () {
+		debugLog("[localmp] slot", slot, "serverKick — dropping slot, tab kept alive");
+		dropLocalPlayer(slot);
+	});
+	sock.on('disconnect', function () {
+		// An unintended drop of a pad player's socket: free the slot so the pad
+		// can re-press to rejoin. (No-op if we already tore it down.)
+		if (localPlayers[slot] && localPlayers[slot].socket === sock) {
+			debugLog("[localmp] slot", slot, "socket disconnected — dropping slot");
+			dropLocalPlayer(slot);
+		}
+	});
+}
+
+// Open a new local player on `slot`, driven by gamepad `padIndex`, and join it
+// into the SAME room as the primary (`gameID`). `forceNew` is load-bearing
+// (§6.7): without it io() reuses the cached Manager and the new "player" would
+// share the primary's socket id.
+function addLocalPlayer(slot, padIndex) {
+	if (localPlayers[slot]) {
+		return localPlayers[slot];
+	}
+	if (gameID == null) {
+		return null; // primary hasn't confirmed a room yet
+	}
+	debugLog("[localmp] opening slot", slot, "pad", padIndex, "-> gameID", gameID);
+	var sock = io({ forceNew: true });
+	var lp = makeLocalPlayer(slot, sock, false);
+	lp.padIndex = padIndex;
+	localPlayers[slot] = lp;
+	registerSecondaryHandlers(sock, slot);
+	sock.emit('enterGame', gameID);
+	if (typeof onLocalPlayerJoined === "function") {
+		onLocalPlayerJoined(lp); // hook for the glyph overlay (Phase 5)
+	}
+	return lp;
+}
+
+// Drop one local player. Non-primary: close its socket and free its slot, leaving
+// everyone else running. Primary: if other locals remain, fail over to one of
+// them rather than tearing down the whole tab (§6.17 — only navigate when the
+// LAST local player is gone).
+function dropLocalPlayer(slot) {
+	var lp = localPlayers[slot];
+	if (!lp) {
+		return;
+	}
+	if (lp.isPrimary) {
+		handlePrimaryLost();
+		return;
+	}
+	try { lp.socket.disconnect(); } catch (e) { /* already gone */ }
+	localPlayers[slot] = null;
+	if (typeof onLocalPlayerDropped === "function") {
+		onLocalPlayerDropped(slot); // hook for the glyph overlay (Phase 5)
+	}
+}
+
+// The primary (rendering/audio) connection was lost. If pad players are still in
+// the game, promote the lowest surviving slot to primary so the couch session and
+// its rendering continue; only when no local players remain do we leave the page.
+function handlePrimaryLost() {
+	var survivor = null;
+	for (var s = 0; s < localPlayers.length; s++) {
+		if (localPlayers[s] && !localPlayers[s].isPrimary) {
+			survivor = localPlayers[s];
+			break;
+		}
+	}
+	if (survivor == null) {
+		// Last local player gone — behave as today and leave.
+		try { server.disconnect(); } catch (e) { /* ignore */ }
+		window.location.href = "./index.html";
+		return;
+	}
+	promoteToPrimary(survivor);
+}
+
+// Best-effort failover: re-point the primary aliases at `lp`'s socket and attach
+// the full handler set so rendering/audio resume on it. The keyboard then drives
+// this player too (acceptable until the lobby formalises slot ownership).
+function promoteToPrimary(lp) {
+	debugLog("[localmp] promoting slot", lp.slot, "to primary");
+	var old = localPlayers[primarySlot];
+	if (old) {
+		localPlayers[primarySlot] = null;
+		try { old.socket.disconnect(); } catch (e) { /* ignore */ }
+	}
+	lp.isPrimary = true;
+	lp.padIndex = null; // keyboard owns the primary slot
+	primarySlot = lp.slot;
+	server = lp.socket;
+	myID = lp.myID;
+	if (playerList && myID != null && playerList[myID]) {
+		myPlayer = playerList[myID];
+	}
+	// Drop the secondary-only listeners before attaching the full set, so the
+	// promoted socket doesn't run both handler sets for the same event.
+	try {
+		lp.socket.off('welcome');
+		lp.socket.off('gameState');
+		lp.socket.off('roomNotFound');
+		lp.socket.off('serverKick');
+		lp.socket.off('disconnect');
+	} catch (e) { /* ignore */ }
+	registerPrimaryHandlers(lp.socket); // resume render/audio/state handlers
 }
 
 function clientSendStart(id) {
 	if (id != null) {
 		server.emit('enterGame', id);
 	}
-}
-
-// PHASE 1 SPIKE: open a second, independent connection from this same tab and
-// join it into `gameId` (the room the primary already confirmed). The critical
-// detail (§6.7): `forceNew` — without it, io() reuses the cached Manager and you
-// get the SAME socket.id, i.e. one server player. This socket is an
-// input/identity channel only: it deliberately registers NO render/audio
-// handlers (the primary owns those, §5.1/§6.8a) and NO navigation handlers, so a
-// kick/notfound on player #2 drops only player #2 and never tears down the tab
-// (previews the per-slot teardown of §6.17).
-function openSpikeSecondPlayer(gameId) {
-	if (spikePlayer2.socket != null) {
-		return;
-	}
-	debugLog("[spike] opening 2nd player socket -> gameId=", gameId);
-	var sock = io({ forceNew: true });
-	spikePlayer2.socket = sock;
-
-	sock.on('welcome', function (id) {
-		spikePlayer2.myID = id;
-		debugLog("[spike] P2 welcome, myID=", id);
-	});
-
-	sock.on('gameState', function (gs) {
-		spikePlayer2.joined = true;
-		// Proof line: two distinct ids, same room.
-		console.log("[spike] P2 joined room", gs.gameID, "as", gs.myID,
-			"| P1 is", myID, "in room", gameID,
-			"| distinct?", gs.myID !== myID, "| same room?", String(gs.gameID) === String(gameID));
-		// Route the gamepad to player #2 (keyboard/mouse still drive player #1).
-		gpEmitSocket = sock;
-		gpEmitID = spikePlayer2.myID;
-	});
-
-	// Per-slot teardown preview: log, do NOT navigate the tab.
-	sock.on('roomNotFound', function () {
-		console.warn("[spike] P2 roomNotFound — could not join", gameId, "(tab kept alive)");
-		gpEmitSocket = null;
-		gpEmitID = null;
-	});
-	sock.on('serverKick', function () {
-		console.warn("[spike] P2 serverKick — dropping P2 only (tab kept alive)");
-		gpEmitSocket = null;
-		gpEmitID = null;
-	});
-
-	sock.emit('enterGame', gameId);
 }
 
 function pingServer() {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -602,6 +602,11 @@ function dropLocalPlayer(slot) {
 		clearTimeout(lp.reconnectTimer);
 		lp.reconnectTimer = null;
 	}
+	// The controller that drove this player must release its buttons before it can
+	// (re)join, so the press that confirmed leaving doesn't instantly re-join them.
+	if (lp.padIndex != null && typeof markPadNeedsRelease === "function") {
+		markPadNeedsRelease(lp.padIndex);
+	}
 	if (lp.isPrimary) {
 		handlePrimaryLost();
 		return;

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -639,8 +639,9 @@ function handlePrimaryLost() {
 }
 
 // Best-effort failover: re-point the primary aliases at `lp`'s socket and attach
-// the full handler set so rendering/audio resume on it. The keyboard then drives
-// this player too (acceptable until the lobby formalises slot ownership).
+// the full handler set so rendering/audio resume on it. `lp` KEEPS its gamepad
+// binding (padIndex) so a promoted controller player keeps controlling the game;
+// the keyboard/mouse also drives the primary if used.
 function promoteToPrimary(lp) {
 	debugLog("[localmp] promoting slot", lp.slot, "to primary");
 	var old = localPlayers[primarySlot];
@@ -649,7 +650,6 @@ function promoteToPrimary(lp) {
 		try { old.socket.disconnect(); } catch (e) { /* ignore */ }
 	}
 	lp.isPrimary = true;
-	lp.padIndex = null; // keyboard owns the primary slot
 	primarySlot = lp.slot;
 	server = lp.socket;
 	myID = lp.myID;

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -602,6 +602,12 @@ function dropLocalPlayer(slot) {
 		clearTimeout(lp.reconnectTimer);
 		lp.reconnectTimer = null;
 	}
+	// If this player had the shared emoji wheel open, close it — otherwise it
+	// soft-locks open (no surviving player owns it, so none can dismiss it).
+	if (typeof emojiOwnerSlot !== "undefined" && emojiOwnerSlot === slot &&
+		typeof closeEmojiWindow === "function") {
+		closeEmojiWindow("cancel");
+	}
 	// The controller that drove this player must release its buttons before it can
 	// (re)join, so the press that confirmed leaving doesn't instantly re-join them.
 	if (lp.padIndex != null && typeof markPadNeedsRelease === "function") {
@@ -664,6 +670,7 @@ function promoteToPrimary(lp) {
 		lp.socket.off('roomNotFound');
 		lp.socket.off('serverKick');
 		lp.socket.off('disconnect');
+		lp.socket.off('connect'); // drop the secondary reconnect-rejoin handler too
 	} catch (e) { /* ignore */ }
 	registerPrimaryHandlers(lp.socket); // resume render/audio/state handlers
 	if (typeof onLocalPlayersChanged === "function") {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -80,10 +80,10 @@ function registerPrimaryHandlers(server) {
 			myPlayer = playerList[myID];
 		}
 		setupEmojiWheel();
-		// In local multiplayer P1 also gets a top hint block (the bottom bar is
-		// suppressed); created once the primary has joined.
-		if (localMultiplayerEnabled() && typeof onLocalPlayerJoined === "function" && localPlayers[primarySlot]) {
-			onLocalPlayerJoined(localPlayers[primarySlot]);
+		// Refresh the hint UI now the primary has joined (solo bottom bar by
+		// default; switches to per-player blocks once a 2nd local player joins).
+		if (typeof onLocalPlayersChanged === "function") {
+			onLocalPlayersChanged();
 		}
 	});
 
@@ -583,8 +583,8 @@ function addLocalPlayer(slot, padIndex) {
 	localPlayers[slot] = lp;
 	registerSecondaryHandlers(sock, slot);
 	sock.emit('enterGame', gameID);
-	if (typeof onLocalPlayerJoined === "function") {
-		onLocalPlayerJoined(lp); // hook for the glyph overlay (Phase 5)
+	if (typeof onLocalPlayersChanged === "function") {
+		onLocalPlayersChanged(); // switch to per-player blocks if now >= 2 players
 	}
 	return lp;
 }
@@ -608,8 +608,8 @@ function dropLocalPlayer(slot) {
 	}
 	try { lp.socket.disconnect(); } catch (e) { /* already gone */ }
 	localPlayers[slot] = null;
-	if (typeof onLocalPlayerDropped === "function") {
-		onLocalPlayerDropped(slot); // hook for the glyph overlay (Phase 5)
+	if (typeof onLocalPlayersChanged === "function") {
+		onLocalPlayersChanged(); // restore the bottom bar if back to 1 player
 	}
 }
 
@@ -661,6 +661,9 @@ function promoteToPrimary(lp) {
 		lp.socket.off('disconnect');
 	} catch (e) { /* ignore */ }
 	registerPrimaryHandlers(lp.socket); // resume render/audio/state handlers
+	if (typeof onLocalPlayersChanged === "function") {
+		onLocalPlayersChanged(); // reconcile the hint UI for the new player count
+	}
 }
 
 function clientSendStart(id) {

--- a/client/scripts/controllerHeader.js
+++ b/client/scripts/controllerHeader.js
@@ -1,0 +1,95 @@
+"use strict";
+
+// Lightweight, self-contained controller-detection header for the pages that
+// don't have an in-game player header (index / join / create). It shows how many
+// controllers the browser is detecting and a "press A to join" hint per pad, so
+// you can glance at the header on any page to see what's plugged in. It is purely
+// informational here — there is no game/socket on these pages, so actual joining
+// happens in-game (play.html has its own real per-player header).
+//
+// Note: browsers only surface a gamepad after its first button press, so a pad
+// appears here once it's been pressed (same as in-game).
+
+(function () {
+    if (typeof document === "undefined" || typeof navigator === "undefined") {
+        return;
+    }
+
+    function detectType(id) {
+        var s = (id || "").toLowerCase();
+        if (s.indexOf("xbox") !== -1 || s.indexOf("xinput") !== -1) {
+            return "xbox";
+        }
+        if (s.indexOf("playstation") !== -1 || s.indexOf("dualshock") !== -1 ||
+            s.indexOf("dualsense") !== -1 || s.indexOf("054c") !== -1) {
+            return "playstation";
+        }
+        return "generic";
+    }
+    function attackGlyph(type) {
+        return type === "playstation" ? "✕" : "A";
+    }
+
+    var el = null;
+    function ensureEl() {
+        if (el || !document.body) {
+            return el;
+        }
+        el = document.createElement("div");
+        el.id = "controllerHeader";
+        document.body.appendChild(el);
+        return el;
+    }
+
+    var lastSig = "";
+    function render() {
+        var box = ensureEl();
+        if (!box) {
+            return;
+        }
+        var pads = navigator.getGamepads ? navigator.getGamepads() : [];
+        var present = [];
+        for (var i = 0; i < pads.length; i++) {
+            if (pads[i]) {
+                present.push(detectType(pads[i].id));
+            }
+        }
+        // Only touch the DOM when the set of controllers changes.
+        var sig = present.join(",");
+        if (sig === lastSig) {
+            return;
+        }
+        lastSig = sig;
+        if (present.length === 0) {
+            box.innerHTML = "";
+            box.classList.remove("visible");
+            return;
+        }
+        var html = '<span class="ch-count">🎮 ' + present.length + " " +
+            (present.length === 1 ? "controller" : "controllers") + "</span>";
+        for (var j = 0; j < present.length; j++) {
+            html += '<span class="ch-pad">' +
+                '<span class="pp-label">P' + (j + 1) + '</span>' +
+                '<span class="gp-glyph gp-face">' + attackGlyph(present[j]) + '</span>' +
+                '<span class="ch-join">press to join</span>' +
+                '</span>';
+        }
+        box.innerHTML = html;
+        box.classList.add("visible");
+    }
+
+    function start() {
+        ensureEl();
+        render();
+        // A detection indicator doesn't need 60fps; poll a few times a second.
+        setInterval(render, 250);
+        window.addEventListener("gamepadconnected", render, false);
+        window.addEventListener("gamepaddisconnected", render, false);
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start);
+    } else {
+        start();
+    }
+})();

--- a/client/scripts/controllerHeader.js
+++ b/client/scripts/controllerHeader.js
@@ -79,13 +79,26 @@
         box.classList.add("visible");
     }
 
+    var started = false;
+    var pollTimer = null;
     function start() {
+        if (started) {
+            return; // guard against stacking intervals/listeners on a double init
+        }
+        started = true;
         ensureEl();
         render();
         // A detection indicator doesn't need 60fps; poll a few times a second.
-        setInterval(render, 250);
+        pollTimer = setInterval(render, 250);
         window.addEventListener("gamepadconnected", render, false);
         window.addEventListener("gamepaddisconnected", render, false);
+        // Stop polling when the page goes away (keeps it tidy on bfcache/unload).
+        window.addEventListener("pagehide", function () {
+            if (pollTimer) {
+                clearInterval(pollTimer);
+                pollTimer = null;
+            }
+        }, false);
     }
 
     if (document.readyState === "loading") {

--- a/client/scripts/controllerHeader.js
+++ b/client/scripts/controllerHeader.js
@@ -66,12 +66,13 @@
             return;
         }
         var html = '<span class="ch-count">🎮 ' + present.length + " " +
-            (present.length === 1 ? "controller" : "controllers") + "</span>";
+            (present.length === 1 ? "controller" : "controllers detected") + "</span>";
         for (var j = 0; j < present.length; j++) {
+            // Informational only on the menu pages: a label + the pad's glyph, no
+            // "press to join" (you can only actually join in-game).
             html += '<span class="ch-pad">' +
                 '<span class="pp-label">P' + (j + 1) + '</span>' +
                 '<span class="gp-glyph gp-face">' + attackGlyph(present[j]) + '</span>' +
-                '<span class="ch-join">press to join</span>' +
                 '</span>';
         }
         box.innerHTML = html;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -524,8 +524,37 @@ function drawAbilties() {
     }
 }
 
+// The player objects for every LOCAL player (slot) that is currently alive. On a
+// shared couch screen there can be several, so blackout cuts a vision hole around
+// each (not just the primary). At N=1 this is just [myPlayer] when alive, so the
+// behaviour is identical to before.
+function livingLocalPlayers() {
+    var out = [];
+    if (typeof localPlayers === "undefined" || typeof playerList === "undefined" || !playerList) {
+        return out;
+    }
+    for (var s = 0; s < localPlayers.length; s++) {
+        var lp = localPlayers[s];
+        if (!lp || lp.myID == null) {
+            continue;
+        }
+        var p = playerList[lp.myID];
+        if (p != null && p.alive) {
+            out.push(p);
+        }
+    }
+    return out;
+}
+
 function drawOverlay() {
-    if (brutalRound == true && blackout == true && myPlayer != null && myPlayer.alive) {
+    if (brutalRound == true && blackout == true) {
+        // Cut a vision hole around each living local player. If none are alive
+        // (everyone local is dead/spectating) we draw no overlay, so spectators
+        // see the whole map — same as the single-player behaviour when dead.
+        var living = livingLocalPlayers();
+        if (living.length === 0) {
+            return;
+        }
         overlayContext.save();
         overlayContext.fillStyle = "black";
         overlayContext.fillRect(0, 0, overlayCanvas.width, overlayCanvas.height);
@@ -534,7 +563,10 @@ function drawOverlay() {
         overlayContext.save();
         overlayContext.globalCompositeOperation = 'destination-out';
         var sprite = getBlackoutHoleSprite();
-        overlayContext.drawImage(sprite, myPlayer.x - sprite.width / 2, myPlayer.y - sprite.height / 2);
+        for (var i = 0; i < living.length; i++) {
+            var p = living[i];
+            overlayContext.drawImage(sprite, p.x - sprite.width / 2, p.y - sprite.height / 2);
+        }
         overlayContext.restore();
     }
 }

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -105,6 +105,7 @@ function makeLocalPlayer(slot, socket, isPrimary) {
         everJoined: false,        // has this slot ever confirmed a room? (drives auto-rejoin)
         reconnectTimer: null,     // grace timer started on a transient disconnect
         leaveConfirm: false,      // showing the inline "leave?" confirm in this player's block
+        leaveConfirmTimer: null,  // auto-cancel timer for the inline leave confirm
         // pad mapping (null for the keyboard/primary slot)
         padIndex: null,
         padType: "generic",

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -149,6 +149,7 @@ $(function () {
 function setupPage() {
 
     window.addEventListener('blur', cancelAllLocalMovement);
+    window.addEventListener('focus', onTabRefocus);
     window.addEventListener('resize', resize, false);
     window.requestAnimFrame = (function () {
         return window.requestAnimationFrame ||

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -75,6 +75,10 @@ var LOCAL_PLAYER_CAP = 4;   // ship default; raise toward 8 once hardware + the
                             // server color-palette fix (getUniqueColorR) land.
 var localPlayers = [];      // slot index -> local player entry (slot 0 = primary)
 var primarySlot = 0;        // index in localPlayers of the render/audio owner
+// Set once a movement key is pressed. While false, the FIRST controller to press
+// claims the primary slot (P1) so the game is playable with controllers only; if
+// the keyboard is in use it owns P1 and pads start at P2.
+var keyboardClaimedPrimary = false;
 
 // Gated for now (the lobby in a later phase replaces this with a real claim flow).
 // When absent, only the primary slot ever exists => identical to today. Memoised

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -77,10 +77,11 @@ var RECONNECT_GRACE_MS = 12000; // keep a pad slot alive this long across a
                                 // transient disconnect before dropping it.
 var localPlayers = [];      // slot index -> local player entry (slot 0 = primary)
 var primarySlot = 0;        // index in localPlayers of the render/audio owner
-// Set once a movement key is pressed. While false, the FIRST controller to press
-// claims the primary slot (P1) so the game is playable with controllers only; if
-// the keyboard is in use it owns P1 and pads start at P2.
-var keyboardClaimedPrimary = false;
+// Set once the keyboard OR mouse drives P1 (a movement key, a click, or
+// mouse-move play). While false, the FIRST controller to give input claims the
+// primary slot (P1) so the game is playable with controllers only; once kb/m is
+// in use it owns P1 and controllers join as P2+.
+var kbmClaimedPrimary = false;
 // The emoji wheel is a single shared element; this is the slot that currently has
 // it open (null = closed). Only that player navigates it (others keep playing),
 // and the chosen emoji is emitted on that player's own socket so it's attributed

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -81,6 +81,11 @@ var primarySlot = 0;        // index in localPlayers of the render/audio owner
 // claims the primary slot (P1) so the game is playable with controllers only; if
 // the keyboard is in use it owns P1 and pads start at P2.
 var keyboardClaimedPrimary = false;
+// The emoji wheel is a single shared element; this is the slot that currently has
+// it open (null = closed). Only that player navigates it (others keep playing),
+// and the chosen emoji is emitted on that player's own socket so it's attributed
+// to the right player.
+var emojiOwnerSlot = null;
 
 // Gated for now (the lobby in a later phase replaces this with a real claim flow).
 // When absent, only the primary slot ever exists => identical to today. Memoised

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -73,6 +73,8 @@ var attack = false,
 // lives in `lp.input` and emits on `lp.socket`.
 var LOCAL_PLAYER_CAP = 4;   // ship default; raise toward 8 once hardware + the
                             // server color-palette fix (getUniqueColorR) land.
+var RECONNECT_GRACE_MS = 12000; // keep a pad slot alive this long across a
+                                // transient disconnect before dropping it.
 var localPlayers = [];      // slot index -> local player entry (slot 0 = primary)
 var primarySlot = 0;        // index in localPlayers of the render/audio owner
 // Set once a movement key is pressed. While false, the FIRST controller to press
@@ -100,6 +102,8 @@ function makeLocalPlayer(slot, socket, isPrimary) {
         myID: null,
         isPrimary: !!isPrimary,
         joined: false,
+        everJoined: false,        // has this slot ever confirmed a room? (drives auto-rejoin)
+        reconnectTimer: null,     // grace timer started on a transient disconnect
         // pad mapping (null for the keyboard/primary slot)
         padIndex: null,
         padType: "generic",

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -54,6 +54,18 @@ var attack = false,
     mousex = null,
     mousey = null;
 
+// --- PHASE 1 SPIKE: local two-player proof (gated behind ?spike2p=1) ---
+// Opens a SECOND, independent Socket.IO connection from this one tab and joins
+// it into the same room as the primary player, to prove Approach A end-to-end:
+// two forceNew sockets => two distinct server players in one room, with a
+// gamepad routed to player #2. Throwaway scaffolding; Phase 2 generalises it
+// into a per-slot localPlayers[0..N-1] table. When the flag is absent, none of
+// this runs and behaviour is identical to today (N=1).
+function spikeTwoPlayers() {
+    return new URLSearchParams(window.location.search).has('spike2p');
+}
+var spikePlayer2 = { socket: null, myID: null, joined: false };
+
 var then = Date.now(),
     dt;
 

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -87,16 +87,10 @@ var keyboardClaimedPrimary = false;
 // to the right player.
 var emojiOwnerSlot = null;
 
-// Gated for now (the lobby in a later phase replaces this with a real claim flow).
-// When absent, only the primary slot ever exists => identical to today. Memoised
-// because pollGamepad calls this every frame.
-var _localMpFlag = null;
-function localMultiplayerEnabled() {
-    if (_localMpFlag === null) {
-        _localMpFlag = new URLSearchParams(window.location.search).has('localmp');
-    }
-    return _localMpFlag;
-}
+// Local multiplayer is always on: there is no URL flag. A solo player is simply
+// the primary slot (P1); additional controllers join as their own players when
+// they press a button. The hint UI is per-player top blocks (no single bottom
+// bar to flip-flop between schemes).
 
 // One local player's state. For the primary slot, `input` is unused (the keyboard
 // writes the movement globals instead); for pad slots it is the per-slot input.
@@ -109,6 +103,7 @@ function makeLocalPlayer(slot, socket, isPrimary) {
         joined: false,
         everJoined: false,        // has this slot ever confirmed a room? (drives auto-rejoin)
         reconnectTimer: null,     // grace timer started on a transient disconnect
+        leaveConfirm: false,      // showing the inline "leave?" confirm in this player's block
         // pad mapping (null for the keyboard/primary slot)
         padIndex: null,
         padType: "generic",

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -54,17 +54,90 @@ var attack = false,
     mousex = null,
     mousey = null;
 
-// --- PHASE 1 SPIKE: local two-player proof (gated behind ?spike2p=1) ---
-// Opens a SECOND, independent Socket.IO connection from this one tab and joins
-// it into the same room as the primary player, to prove Approach A end-to-end:
-// two forceNew sockets => two distinct server players in one room, with a
-// gamepad routed to player #2. Throwaway scaffolding; Phase 2 generalises it
-// into a per-slot localPlayers[0..N-1] table. When the flag is absent, none of
-// this runs and behaviour is identical to today (N=1).
-function spikeTwoPlayers() {
-    return new URLSearchParams(window.location.search).has('spike2p');
+// --- Local multiplayer (Approach A): one Socket.IO connection per local player ---
+//
+// Each local player ("slot") owns its OWN socket + server identity, and — for pad
+// players — its own input state and gamepad mapping. To the server these are just
+// N independent players, so no server changes are needed.
+//
+// Slot 0 is the PRIMARY: it is the page's original connection and the
+// keyboard/mouse player, and it alone owns ALL rendering, audio, UI and one-shot/
+// timer handling (every socket receives every room broadcast, so running those on
+// each socket would fire them N times). The globals `server`, `myID`, `myPlayer`,
+// the movement booleans and `menuOpen` are ALIASES for the primary slot, so every
+// existing render/input path keeps driving the primary player unchanged. This is
+// also why N=1 behaves exactly as before: there is only the primary slot.
+//
+// Non-primary slots (pad players, slot >= 1) are pure input/identity channels:
+// their sockets handle only welcome/gameState(identity)/lifecycle, and their input
+// lives in `lp.input` and emits on `lp.socket`.
+var LOCAL_PLAYER_CAP = 4;   // ship default; raise toward 8 once hardware + the
+                            // server color-palette fix (getUniqueColorR) land.
+var localPlayers = [];      // slot index -> local player entry (slot 0 = primary)
+var primarySlot = 0;        // index in localPlayers of the render/audio owner
+
+// Gated for now (the lobby in a later phase replaces this with a real claim flow).
+// When absent, only the primary slot ever exists => identical to today. Memoised
+// because pollGamepad calls this every frame.
+var _localMpFlag = null;
+function localMultiplayerEnabled() {
+    if (_localMpFlag === null) {
+        _localMpFlag = new URLSearchParams(window.location.search).has('localmp');
+    }
+    return _localMpFlag;
 }
-var spikePlayer2 = { socket: null, myID: null, joined: false };
+
+// One local player's state. For the primary slot, `input` is unused (the keyboard
+// writes the movement globals instead); for pad slots it is the per-slot input.
+function makeLocalPlayer(slot, socket, isPrimary) {
+    return {
+        slot: slot,
+        socket: socket,
+        myID: null,
+        isPrimary: !!isPrimary,
+        joined: false,
+        // pad mapping (null for the keyboard/primary slot)
+        padIndex: null,
+        padType: "generic",
+        // per-slot input (pad slots only)
+        input: { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false },
+        // per-pad poll edge state (must be per-slot so pads don't clobber each other)
+        gp: {
+            prevMove: { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false },
+            hadMoveInput: false,
+            aimActive: false,
+            prevAimAngle: null,
+            lastAimEmit: 0,
+            prevButtons: []
+        }
+    };
+}
+function localPlayerForPadIndex(idx) {
+    for (var i = 0; i < localPlayers.length; i++) {
+        if (localPlayers[i] && localPlayers[i].padIndex === idx) {
+            return localPlayers[i];
+        }
+    }
+    return null;
+}
+function nextFreeSlot() {
+    // Pads claim slots starting at 1 (slot 0 is the keyboard/primary player).
+    for (var s = 1; s < LOCAL_PLAYER_CAP; s++) {
+        if (!localPlayers[s]) {
+            return s;
+        }
+    }
+    return null;
+}
+function liveLocalPlayerCount() {
+    var n = 0;
+    for (var i = 0; i < localPlayers.length; i++) {
+        if (localPlayers[i]) {
+            n++;
+        }
+    }
+    return n;
+}
 
 var then = Date.now(),
     dt;
@@ -75,7 +148,7 @@ $(function () {
 
 function setupPage() {
 
-    window.addEventListener('blur', cancelMovement);
+    window.addEventListener('blur', cancelAllLocalMovement);
     window.addEventListener('resize', resize, false);
     window.requestAnimFrame = (function () {
         return window.requestAnimationFrame ||

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -130,8 +130,13 @@ function localPlayerForPadIndex(idx) {
     return null;
 }
 function nextFreeSlot() {
-    // Pads claim slots starting at 1 (slot 0 is the keyboard/primary player).
-    for (var s = 1; s < LOCAL_PLAYER_CAP; s++) {
+    // Any free slot except the current primary's (which always holds a player).
+    // Scanning from 0 — rather than hard-coding slot 0 as primary — so a slot
+    // freed by a primary failover (where primarySlot is no longer 0) is reusable.
+    for (var s = 0; s < LOCAL_PLAYER_CAP; s++) {
+        if (s === primarySlot) {
+            continue;
+        }
         if (!localPlayers[s]) {
             return s;
         }

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -104,12 +104,28 @@ function markTouchUsed() {
 
 function onGamepadKeyDown(e) {
     setInputMethod("kbm"); // a key press means keyboard/mouse is in use
-    if (e.key === "Escape" || e.keyCode === 27) {
-        if (leaveModalIsOpen()) {
+    if (leaveModalIsOpen()) {
+        // The leave modal owns the keyboard while it's up: arrows / A-D move
+        // between Leave and Cancel, Enter or Space confirms, Esc closes.
+        if (e.key === "Escape" || e.keyCode === 27) {
             closeLeaveModal();
-        } else {
-            openLeaveModal();
+        } else if (e.keyCode === 37 || e.keyCode === 65 || e.key === "ArrowLeft") {
+            setLeaveFocus(0); // Leave
+            e.preventDefault();
+        } else if (e.keyCode === 39 || e.keyCode === 68 || e.key === "ArrowRight") {
+            setLeaveFocus(1); // Cancel
+            e.preventDefault();
+        } else if (e.keyCode === 13 || e.keyCode === 32 || e.key === "Enter" || e.key === " ") {
+            var btns = leaveButtons();
+            if (btns[leaveFocusIdx]) {
+                btns[leaveFocusIdx].click();
+            }
+            e.preventDefault();
         }
+        return;
+    }
+    if (e.key === "Escape" || e.keyCode === 27) {
+        openLeaveModal();
     } else if (e.key === "h" || e.key === "H" || e.keyCode === 72) {
         toggleHintFade(); // hide/show the control hints
     }

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -118,73 +118,33 @@ function onGamepadKeyDown(e) {
 function onGamepadConnected(e) {
     var type = detectGamepadType(e.gamepad.id);
     debugLog("gamepad connected:", e.gamepad.id, "->", type, "idx", e.gamepad.index);
-    if (!localMultiplayerEnabled()) {
-        // Single-player: adopt this pad onto the primary slot (today's behavior).
-        gamepadConnected = true;
-        gamepadIndex = e.gamepad.index;
-        gamepadType = type;
-        var p = localPlayers[primarySlot];
-        if (p) {
-            p.padIndex = e.gamepad.index;
-            p.padType = type;
-            p.gp.prevButtons = [];
-        }
-        // Don't swap the glyphs yet — wait until the pad is actually used, so a
-        // connected-but-idle pad doesn't override a player still on keyboard.
-        return;
-    }
-    // Local multiplayer: the pad hot-joins as a NEW local player on its first
-    // button press (pollGamepad). Browsers only reliably surface an idle pad
-    // after a press anyway, so we wait for that rather than joining on connect.
-    debugLog("[localmp] controller detected — press a button to join");
+    // The pad hot-joins as a local player on its first button press (pollGamepad);
+    // browsers only reliably surface an idle pad after a press anyway. Prompt for it.
     showJoinToast(type);
 }
 
 function onGamepadDisconnected(e) {
-    if (!localMultiplayerEnabled()) {
-        var p = localPlayers[primarySlot];
-        if (!p || e.gamepad.index !== p.padIndex) {
-            return;
-        }
-        gamepadConnected = false;
-        gamepadIndex = null;
-        p.padIndex = null;
-        if (p.gp.hadMoveInput) {
-            cancelMovement();
-            p.gp.hadMoveInput = false;
-        }
-        p.gp.prevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
-        if (activeInputMethod === "pad") {
-            setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
-        }
-        debugLog("gamepad disconnected");
+    var lp = localPlayerForPadIndex(e.gamepad.index);
+    if (!lp) {
         return;
     }
-    // Local multiplayer: a pad's controller was unplugged.
-    var lp = localPlayerForPadIndex(e.gamepad.index);
-    if (lp && !lp.isPrimary) {
-        // A pad player (P2+) unplugged — stop and drop just that slot.
-        debugLog("[localmp] pad", e.gamepad.index, "unplugged — dropping slot", lp.slot);
-        cancelMovementForSlot(lp);
-        dropLocalPlayer(lp.slot);
-    } else if (lp && lp.isPrimary) {
-        // The pad driving P1 (pad-only) unplugged — keep the primary player alive
-        // (keyboard, or a re-pressed pad, can drive it) but release the binding
-        // and clear its block.
+    cancelMovementForSlot(lp);
+    lp.gp.hadMoveInput = false;
+    if (lp.isPrimary) {
+        // The pad driving P1 unplugged — keep the player (keyboard, or a re-pressed
+        // pad, can drive it); just release the binding. Its block hints (if in
+        // multiplayer) revert to keyboard on the next refresh.
         debugLog("[localmp] P1 pad", e.gamepad.index, "unplugged — releasing binding");
-        cancelMovementForSlot(lp);
         lp.padIndex = null;
-        lp.gp.hadMoveInput = false;
         gamepadConnected = false;
         gamepadIndex = null;
         if (activeInputMethod === "pad") {
             setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
         }
-        // P1 persists (keyboard can drive it) — revert its block hints to keyboard
-        // rather than removing the block.
-        if (typeof setBlockHints === "function") {
-            setBlockHints(lp);
-        }
+    } else {
+        // A pad player (P2+) unplugged — drop just that slot.
+        debugLog("[localmp] pad", e.gamepad.index, "unplugged — dropping slot", lp.slot);
+        dropLocalPlayer(lp.slot);
     }
 }
 
@@ -198,45 +158,6 @@ function detectGamepadType(id) {
         return "playstation";
     }
     return "generic";
-}
-
-// Chrome only surfaces a pad after the first button press, and a pad held at
-// page load never fires 'gamepadconnected'. So in single-player we adopt the
-// first live pad onto the primary slot while polling.
-function adoptFirstPadToPrimary(pads) {
-    var p = localPlayers[primarySlot];
-    if (!p) {
-        return null;
-    }
-    if (p.padIndex != null && pads[p.padIndex]) {
-        return pads[p.padIndex];
-    }
-    for (var i = 0; i < pads.length; i++) {
-        if (pads[i]) {
-            p.padIndex = i;
-            p.padType = detectGamepadType(pads[i].id);
-            gamepadConnected = true;
-            gamepadIndex = i;
-            gamepadType = p.padType;
-            return pads[i];
-        }
-    }
-    // No pad present. If we thought one was connected, it vanished without a
-    // 'gamepaddisconnected' event — release any held movement so the player
-    // doesn't keep drifting, and fall back to keyboard/touch hints.
-    if (p.padIndex != null) {
-        p.padIndex = null;
-        gamepadConnected = false;
-        gamepadIndex = null;
-        if (p.gp.hadMoveInput && typeof cancelMovement === "function") {
-            cancelMovement();
-            p.gp.hadMoveInput = false;
-        }
-        if (activeInputMethod === "pad") {
-            setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
-        }
-    }
-    return null;
 }
 
 function anyButtonPressed(pad) {
@@ -320,13 +241,9 @@ function bindPadToPrimary(padIndex, pad) {
     primary.padIndex = padIndex;
     primary.padType = detectGamepadType(pad.id);
     primary.gp.prevButtons = snapshotButtons(pad);
-    gamepadType = primary.padType; // the bottom hint bar's attack glyph
-    if (typeof onLocalPlayerJoined === "function") {
-        onLocalPlayerJoined(primary); // ensure P1 has a block
-    }
-    if (typeof setBlockHints === "function") {
-        setBlockHints(primary); // P1 now drives by pad — switch its hints to pad glyphs
-    }
+    gamepadType = primary.padType; // the (solo) bottom hint bar's attack glyph
+    // Solo: the bottom bar will show the pad scheme on first input. In multiplayer
+    // P1's block hints refresh to pad glyphs automatically (refreshPadBlocks).
 }
 
 // True when the room already holds its max players. Counts the live playerList
@@ -366,19 +283,21 @@ function pollGamepad(dt) {
         padEdgeResetPending = false;
         return;
     }
-    if (!localMultiplayerEnabled()) {
-        // Single-player: one pad drives the primary slot, exactly as before.
-        var pad = adoptFirstPadToPrimary(pads);
-        if (pad) {
-            pollPadForSlot(pad, localPlayers[primarySlot]);
+    // Release any bound pad that vanished without a 'gamepaddisconnected' event so
+    // the player doesn't keep drifting (a browser quirk the old single-pad path
+    // guarded against).
+    for (var v = 0; v < localPlayers.length; v++) {
+        var lpv = localPlayers[v];
+        if (lpv && lpv.padIndex != null && !pads[lpv.padIndex] && lpv.gp.hadMoveInput) {
+            cancelMovementForSlot(lpv);
+            lpv.gp.hadMoveInput = false;
         }
-        return;
     }
-    // Keep each pad player's color dot in sync with their server-assigned color.
+    // Keep the top blocks (color dots + per-player hints) in sync.
     refreshPadBlocks();
-    // Local multiplayer: keyboard owns the primary slot; each connected pad drives
-    // its own claimed slot, and an unclaimed pad hot-joins as a new local player
-    // on its first button press.
+    // Each connected pad drives its claimed slot; the first pad (with no keyboard
+    // in use) takes P1, and any other unclaimed pad hot-joins as a new local
+    // player on its first button press.
     for (var i = 0; i < pads.length; i++) {
         var pad = pads[i];
         if (!pad) {
@@ -401,51 +320,47 @@ function pollGamepad(dt) {
     }
 }
 
-// Poll one pad and apply it to its local player `lp`. The emoji wheel is a single
-// shared element owned by one slot at a time: only the OWNER navigates it; every
-// other player keeps playing, so one player's wheel never freezes the others
-// (§6.16). The leave modal stays primary-only.
+// Poll one pad and apply it to its local player `lp`.
+// - Emoji wheel: a single shared element owned by one slot at a time; only the
+//   owner navigates it, everyone else keeps playing (§6.16).
+// - Leave (B): in multiplayer it's an inline "Leave?" confirm in this player's own
+//   block (per-slot); when solo it's the existing centre modal.
 function pollPadForSlot(pad, lp) {
+    var blocks = (hintUiMode === "blocks");
     var wheelOpen = (typeof menuOpen !== "undefined" && menuOpen);
     var iOwnWheel = wheelOpen && emojiOwnerSlot === lp.slot;
 
-    if (lp.isPrimary) {
-        // Using the pad swaps the glyphs to the controller scheme.
-        if (padHasInput(pad)) {
-            lastPadInputAt = Date.now();
-            setInputMethod("pad");
+    // Any pad can toggle the hints; only the primary's pad swaps the (solo) bar.
+    if (buttonPressedThisFrame(pad, GP_BTN_SELECT, lp)) {
+        toggleHintFade();
+    }
+    if (lp.isPrimary && padHasInput(pad)) {
+        lastPadInputAt = Date.now();
+        setInputMethod("pad");
+    }
+
+    if (lp.leaveConfirm) {
+        // This player is confirming leave inline in their block.
+        pollLeaveConfirm(pad, lp);
+    } else if (!blocks && lp.isPrimary && leaveModalIsOpen()) {
+        // Solo: navigate the centre leave modal.
+        pollLeaveModal(pad, lp);
+    } else if (iOwnWheel) {
+        pollEmojiWheel(pad, lp);
+    } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
+        if (blocks) {
+            openLeaveConfirm(lp);  // inline confirm in this player's block
+        } else if (lp.isPrimary) {
+            openLeaveModal();      // solo: the centre modal
         }
-        // Select toggles the hint bar between hidden (transparent) and shown.
-        if (buttonPressedThisFrame(pad, GP_BTN_SELECT, lp)) {
-            toggleHintFade();
-        }
-        if (leaveModalIsOpen()) {
-            pollLeaveModal(pad, lp);
-        } else if (iOwnWheel) {
-            pollEmojiWheel(pad, lp);
-        } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
-            openLeaveModal();
-        } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_EMOJI, lp)) {
-            openEmojiFromPad(lp);
-        } else {
-            // Normal play (also the case when another player owns the wheel).
-            pollAim(pad, lp);
-            pollMovementAndAttack(pad, lp);
-            if (buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
-                goFullScreen();
-            }
-        }
+    } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_EMOJI, lp)) {
+        openEmojiFromPad(lp);
     } else {
-        if (iOwnWheel) {
-            pollEmojiWheel(pad, lp);
-        } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_EMOJI, lp)) {
-            openEmojiFromPad(lp);
-        } else {
-            pollAim(pad, lp);
-            pollMovementAndAttack(pad, lp);
-            if (buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
-                goFullScreen();
-            }
+        // Normal play (also when another player owns the wheel).
+        pollAim(pad, lp);
+        pollMovementAndAttack(pad, lp);
+        if (buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
+            goFullScreen();
         }
     }
     rememberButtons(pad, lp);
@@ -915,10 +830,9 @@ function setInputMethod(method) {
         return;
     }
     activeInputMethod = method;
-    // In local multiplayer the single bottom bar can't represent several players'
-    // schemes at once (it would flip-flop), so each player carries their own
-    // compact hints in their top block instead — don't show the bottom bar.
-    if (localMultiplayerEnabled()) {
+    // With 2+ local players the single bottom bar can't represent everyone's
+    // scheme at once, so it's replaced by per-player top blocks — don't show it.
+    if (hintUiMode === "blocks") {
         return;
     }
     if (!hintBarEl) {
@@ -988,21 +902,22 @@ function scheduleHintFade() {
     }, HINT_FADE_MS);
 }
 
-// --- per-pad player overlay (local multiplayer, §5.3) ---
+// --- per-player hint overlay ---
 //
-// One compact block per pad player, each carrying a color dot tinted with that
-// player's server-assigned color — the readable link "this controller = the red
-// player" — plus the player's slot label and that pad's own attack glyph (A on
-// Xbox, ✕ on PlayStation, so mixed-brand pads show their real button). Built
-// lazily; populated by the onLocalPlayerJoined/Dropped hooks (client.js) and kept
-// in color-sync by refreshPadBlocks() each frame (the color arrives a beat after
-// join via playerJoin/gameUpdates). The keyboard/primary player keeps the bottom
-// hint bar; these blocks are for the pad players only.
+// SOLO (one local player) keeps the single bottom hint bar, which adapts to the
+// player's input (keyboard / pad / touch) — the behaviour people are used to.
+// As soon as a SECOND local player joins we switch to per-player top blocks:
+// each block carries a color dot tinted with that player's server-assigned color
+// (the readable "this controller = the red player" link), the slot label, and
+// that player's OWN compact hints (their pad's glyphs, or keyboard chips) — so a
+// keyboard P1 + pad players don't fight over one bar. Dropping back to one local
+// player restores the bottom bar. The blocks inherit the bar's fade/hide.
 
-var padPlayersEl = null;     // container element
-var padBlocks = {};          // slot -> { el, dot, lastColor }
+var padPlayersEl = null;     // container element for the top blocks
+var padBlocks = {};          // slot -> { el, dot, hints, lastColor, lastMethod }
 var padToastEl = null;
 var padToastTimer = null;
+var hintUiMode = "bar";      // "bar" (solo) | "blocks" (>= 2 local players)
 
 function buildPadPlayersUI() {
     if (padPlayersEl || typeof document === "undefined" || !document.body) {
@@ -1012,6 +927,40 @@ function buildPadPlayersUI() {
     el.id = "padPlayers";
     document.body.appendChild(el);
     padPlayersEl = el;
+}
+
+// Called whenever the set of local players changes (join/drop). Switches the hint
+// UI between the solo bottom bar and the per-player top blocks, and reconciles
+// which blocks exist.
+function onLocalPlayersChanged() {
+    var multi = (typeof liveLocalPlayerCount === "function") && liveLocalPlayerCount() >= 2;
+    if (multi) {
+        if (hintUiMode !== "blocks") {
+            hintUiMode = "blocks";
+            if (hintBarEl) {
+                hintBarEl.className = "gamepad-prompts hidden"; // bottom bar off in multiplayer
+            }
+        }
+        for (var s = 0; s < localPlayers.length; s++) {
+            if (localPlayers[s]) {
+                ensureBlock(localPlayers[s]);
+            }
+        }
+        // Remove blocks for slots that no longer exist.
+        for (var slot in padBlocks) {
+            if (!localPlayers[slot]) {
+                removeBlock(slot);
+            }
+        }
+        scheduleHintFade();
+    } else if (hintUiMode === "blocks") {
+        // Back down to one local player — restore the bottom bar.
+        hintUiMode = "bar";
+        removeAllBlocks();
+        var method = activeInputMethod || "kbm";
+        activeInputMethod = null; // force setInputMethod to rebuild + show the bar
+        setInputMethod(method);
+    }
 }
 
 function attackGlyphFor(type) {
@@ -1049,8 +998,8 @@ function showJoinToast(type) {
         '<span class="gp-glyph gp-face">' + attackGlyphFor(type) + '</span> to join', 4000);
 }
 
-// Hook (client.js addLocalPlayer): a pad player joined — create its block.
-function onLocalPlayerJoined(lp) {
+// Create a block for a local player if it doesn't already have one.
+function ensureBlock(lp) {
     if (!padPlayersEl) {
         buildPadPlayersUI();
     }
@@ -1075,7 +1024,6 @@ function onLocalPlayerJoined(lp) {
     padPlayersEl.appendChild(block);
     padBlocks[lp.slot] = { el: block, dot: dot, hints: hints, lastColor: null, lastMethod: null };
     setBlockHints(lp);
-    scheduleHintFade(); // a player joined — show the hints, restart the auto-fade
 
     // A join just happened — drop the connect toast.
     if (padToastEl) {
@@ -1083,23 +1031,36 @@ function onLocalPlayerJoined(lp) {
     }
 }
 
-// The compact control hints for a player's CURRENT input method (keyboard vs
-// their own pad brand) — baked into each top block so every player sees their own
-// scheme without the single bottom bar flip-flopping.
+// The compact control hints for a player's CURRENT input method (keyboard, touch,
+// or their own pad brand) — baked into each top block so every player sees their
+// own scheme without the single bottom bar flip-flopping.
 function blockMethodFor(lp) {
-    return (lp.padIndex != null) ? "pad" : "kbm";
+    if (lp.padIndex != null) {
+        return "pad";
+    }
+    if (typeof isTouchScreen !== "undefined" && isTouchScreen) {
+        return "touch";
+    }
+    return "kbm";
 }
 
 function miniHintsFor(method, padType) {
     if (method === "pad") {
         return '<span class="gp-glyph gp-stick">L</span>' +
             '<span class="gp-glyph gp-face">' + attackGlyphFor(padType) + '</span>' +
-            '<span class="gp-glyph gp-face">' + emojiGlyphFor(padType) + '</span>';
+            '<span class="gp-glyph gp-face">' + emojiGlyphFor(padType) + '</span>' +
+            '<span class="gp-glyph gp-face">' + leaveGlyphFor(padType) + '</span>';
+    }
+    if (method === "touch") {
+        return '<span class="gp-glyph gp-key">🕹️</span>' +
+            '<span class="gp-glyph gp-key">👆</span>' +
+            '<span class="gp-glyph gp-key">💬</span>';
     }
     // keyboard / mouse
     return '<span class="gp-glyph gp-key">WASD</span>' +
         '<span class="gp-glyph gp-key">🖱</span>' +
-        '<span class="gp-glyph gp-key">RMB</span>';
+        '<span class="gp-glyph gp-key">RMB</span>' +
+        '<span class="gp-glyph gp-key">Esc</span>';
 }
 
 // (Re)set a block's hint glyphs to match the player's current method. No-op when
@@ -1133,8 +1094,7 @@ function onLocalPlayerReconnecting(slot, isReconnecting) {
     }
 }
 
-// Hook (client.js dropLocalPlayer): a pad player left — remove its block.
-function onLocalPlayerDropped(slot) {
+function removeBlock(slot) {
     var b = padBlocks[slot];
     if (!b) {
         return;
@@ -1145,8 +1105,16 @@ function onLocalPlayerDropped(slot) {
     delete padBlocks[slot];
 }
 
-// Tint each pad player's dot with their current server-assigned color (which only
-// arrives a moment after join). Cheap; only writes the DOM when the color changes.
+function removeAllBlocks() {
+    for (var slot in padBlocks) {
+        removeBlock(slot);
+    }
+}
+
+// Keep each block in sync each frame: tint its dot with the player's current
+// server-assigned color (arrives a beat after join) and update its hint glyphs if
+// the player's input method changed (e.g. a pad bound to / unbound from P1). Both
+// only touch the DOM on an actual change.
 function refreshPadBlocks() {
     if (typeof playerList === "undefined" || !playerList) {
         return;
@@ -1157,11 +1125,65 @@ function refreshPadBlocks() {
         if (!lp || !b) {
             continue;
         }
+        if (!lp.leaveConfirm) {
+            setBlockHints(lp);
+        }
         var p = (lp.myID != null) ? playerList[lp.myID] : null;
         var color = (p && p.color) ? p.color : null;
         if (color && color !== b.lastColor) {
             b.dot.style.backgroundColor = color;
             b.lastColor = color;
+        }
+    }
+}
+
+// --- per-player "leave game" confirm, inline in the block (controllers) ---
+
+function leaveGlyphFor(type) {
+    return type === "playstation" ? "○" : "B";
+}
+
+// B opens an inline "Leave?" confirm in this player's block; A confirms (drops
+// the player / disconnects), B cancels. Per-slot, so it never freezes the others.
+function openLeaveConfirm(lp) {
+    if (lp.gp.hadMoveInput) {
+        cancelMovementForSlot(lp);
+        lp.gp.hadMoveInput = false;
+    }
+    lp.gp.prevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+    lp.leaveConfirm = true;
+    setBlockLeaveConfirm(lp.slot, true);
+}
+
+function pollLeaveConfirm(pad, lp) {
+    if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
+        lp.leaveConfirm = false;
+        dropLocalPlayer(lp.slot); // confirmed — disconnect this player
+        return;
+    }
+    if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
+        lp.leaveConfirm = false;
+        setBlockLeaveConfirm(lp.slot, false); // cancelled
+    }
+}
+
+function setBlockLeaveConfirm(slot, confirming) {
+    var b = padBlocks[slot];
+    if (!b) {
+        return;
+    }
+    if (confirming) {
+        b.el.classList.add("confirming");
+        var lp = localPlayers[slot];
+        var type = (lp && lp.padType) ? lp.padType : "generic";
+        b.hints.innerHTML = '<span class="pp-confirm">Leave?</span>' +
+            '<span class="gp-glyph gp-face">' + attackGlyphFor(type) + '</span>' +
+            '<span class="gp-glyph gp-face">' + leaveGlyphFor(type) + '</span>';
+    } else {
+        b.el.classList.remove("confirming");
+        b.lastMethod = null; // force a hint rebuild on the next refresh
+        if (localPlayers[slot]) {
+            setBlockHints(localPlayers[slot]);
         }
     }
 }

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -160,6 +160,17 @@ function detectGamepadType(id) {
     return "generic";
 }
 
+// Pad indices that must release all buttons before they can (re)join. Set when a
+// player leaves, so the button they held to confirm the leave doesn't instantly
+// re-join them — they have to release and press again. A brand-new pad isn't in
+// this set, so its very first press still joins immediately.
+var padNeedsRelease = {};
+function markPadNeedsRelease(idx) {
+    if (idx != null) {
+        padNeedsRelease[idx] = true;
+    }
+}
+
 function anyButtonPressed(pad) {
     for (var i = 0; i < pad.buttons.length; i++) {
         if (pad.buttons[i] && (pad.buttons[i].pressed || pad.buttons[i].value > GP_TRIGGER_THRESHOLD)) {
@@ -305,7 +316,14 @@ function pollGamepad(dt) {
         }
         var lp = localPlayerForPadIndex(i);
         if (!lp) {
-            if (anyButtonPressed(pad)) {
+            var pressed = anyButtonPressed(pad);
+            if (padNeedsRelease[i]) {
+                // Just-left pad: wait until its buttons are released before it can
+                // join again (so the leave-confirm press can't re-join it).
+                if (!pressed) {
+                    delete padNeedsRelease[i];
+                }
+            } else if (pressed) {
                 tryClaimPadSlot(i, pad);
             }
             continue; // wait until the slot has joined (myID set) before polling

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -1104,9 +1104,19 @@ function onLocalPlayersChanged() {
     }
     // A block per joined local player; drop blocks for slots that are gone.
     for (var s = 0; s < localPlayers.length; s++) {
-        if (localPlayers[s]) {
-            ensureBlock(localPlayers[s]);
+        var lp = localPlayers[s];
+        if (!lp) {
+            continue;
         }
+        // Don't show a phantom kb/m "P1" block when no one is actually using the
+        // keyboard/mouse — so a controller-only player just sees their controller
+        // (which becomes P1 when they press A). Once kb/m is used (kbmClaimedPrimary)
+        // or a controller binds to P1, the block appears.
+        if (lp.isPrimary && lp.padIndex == null && !kbmClaimedPrimary) {
+            removeBlock(s);
+            continue;
+        }
+        ensureBlock(lp);
     }
     for (var slot in padBlocks) {
         if (!localPlayers[slot]) {

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -160,13 +160,29 @@ function onGamepadDisconnected(e) {
         debugLog("gamepad disconnected");
         return;
     }
-    // Local multiplayer: a pad player's controller was unplugged. Stop their
-    // movement and drop just that slot (everyone else keeps playing).
+    // Local multiplayer: a pad's controller was unplugged.
     var lp = localPlayerForPadIndex(e.gamepad.index);
     if (lp && !lp.isPrimary) {
+        // A pad player (P2+) unplugged — stop and drop just that slot.
         debugLog("[localmp] pad", e.gamepad.index, "unplugged — dropping slot", lp.slot);
         cancelMovementForSlot(lp);
         dropLocalPlayer(lp.slot);
+    } else if (lp && lp.isPrimary) {
+        // The pad driving P1 (pad-only) unplugged — keep the primary player alive
+        // (keyboard, or a re-pressed pad, can drive it) but release the binding
+        // and clear its block.
+        debugLog("[localmp] P1 pad", e.gamepad.index, "unplugged — releasing binding");
+        cancelMovementForSlot(lp);
+        lp.padIndex = null;
+        lp.gp.hadMoveInput = false;
+        gamepadConnected = false;
+        gamepadIndex = null;
+        if (activeInputMethod === "pad") {
+            setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
+        }
+        if (typeof onLocalPlayerDropped === "function") {
+            onLocalPlayerDropped(lp.slot);
+        }
     }
 }
 
@@ -258,6 +274,83 @@ function rebaselinePadEdges(pads) {
     }
 }
 
+// An unclaimed pad pressed a button — claim a slot for it.
+function tryClaimPadSlot(padIndex, pad) {
+    var primary = localPlayers[primarySlot];
+    // Pad-only P1: if no keyboard is being used to play and the primary slot has
+    // no pad yet, the FIRST controller drives P1 (the existing primary
+    // connection) so no keyboard is required. This reuses the existing player, so
+    // there's no new join and no capacity check.
+    if (primary && primary.padIndex == null && !keyboardClaimedPrimary) {
+        bindPadToPrimary(padIndex, pad);
+        return;
+    }
+    // Otherwise the pad becomes a new local player (P2+). Joining by gameId
+    // bypasses the server's hasSpace()/isLocked() checks (§5.4), so guard here.
+    var slot = nextFreeSlot();
+    if (slot == null) {
+        showPadToast("All " + LOCAL_PLAYER_CAP + " local player slots are full", 3000);
+        return;
+    }
+    if (typeof gameID === "undefined" || gameID == null) {
+        return; // primary hasn't confirmed a room yet
+    }
+    if (roomIsFull()) {
+        showPadToast("Room is full — can't add another player", 3000);
+        return;
+    }
+    var lp = addLocalPlayer(slot, padIndex);
+    if (lp) {
+        lp.gp.prevButtons = snapshotButtons(pad); // don't let the join press = attack
+        if (joinWouldSpectate()) {
+            showPadToast("P" + (slot + 1) + " joining — spectator until next round", 3500);
+        }
+    }
+}
+
+// Bind a pad to the existing primary slot (pad-only P1). Drives the primary
+// player via the same path the single-player pad uses.
+function bindPadToPrimary(padIndex, pad) {
+    var primary = localPlayers[primarySlot];
+    if (!primary) {
+        return;
+    }
+    primary.padIndex = padIndex;
+    primary.padType = detectGamepadType(pad.id);
+    primary.gp.prevButtons = snapshotButtons(pad);
+    gamepadType = primary.padType; // the bottom hint bar's attack glyph
+    if (typeof onLocalPlayerJoined === "function") {
+        onLocalPlayerJoined(primary); // give P1 a color-dot block too
+    }
+}
+
+// True when the room already holds its max players. Counts the live playerList
+// plus any local players that have joined but whose playerJoin hasn't reflected
+// on the primary yet, so two quick joins can't both slip past.
+function roomIsFull() {
+    if (typeof config === "undefined" || !config || !config.maxPlayersInRoom) {
+        return false;
+    }
+    if (typeof playerList === "undefined" || !playerList) {
+        return false;
+    }
+    var count = Object.keys(playerList).length;
+    for (var s = 0; s < localPlayers.length; s++) {
+        var lp = localPlayers[s];
+        if (lp && lp.myID != null && !playerList[lp.myID]) {
+            count++;
+        }
+    }
+    return count >= config.maxPlayersInRoom;
+}
+
+// True if a join right now would land mid-race (server makes them a spectator
+// until the next round, §6.15).
+function joinWouldSpectate() {
+    return typeof config !== "undefined" && config && typeof currentState !== "undefined" &&
+        (currentState === config.stateMap.racing || currentState === config.stateMap.collapsing);
+}
+
 // Called once per frame from gameLoop().
 function pollGamepad(dt) {
     var pads = navigator.getGamepads ? navigator.getGamepads() : [];
@@ -289,14 +382,7 @@ function pollGamepad(dt) {
         var lp = localPlayerForPadIndex(i);
         if (!lp) {
             if (anyButtonPressed(pad)) {
-                var slot = nextFreeSlot();
-                if (slot != null && typeof gameID !== "undefined" && gameID != null) {
-                    lp = addLocalPlayer(slot, i);
-                    if (lp) {
-                        // Don't let the join press also register as an attack next frame.
-                        lp.gp.prevButtons = snapshotButtons(pad);
-                    }
-                }
+                tryClaimPadSlot(i, pad);
             }
             continue; // wait until the slot has joined (myID set) before polling
         }
@@ -888,8 +974,9 @@ function attackGlyphFor(type) {
     return type === "playstation" ? "✕" : "A";
 }
 
-// Brief "controller detected — press A to join" toast when a pad connects.
-function showJoinToast(type) {
+// Brief transient toast at the top of the screen (controller join prompts,
+// room-full / spectator notices).
+function showPadToast(html, ms) {
     if (typeof document === "undefined" || !document.body) {
         return;
     }
@@ -898,15 +985,20 @@ function showJoinToast(type) {
         padToastEl.id = "padToast";
         document.body.appendChild(padToastEl);
     }
-    padToastEl.innerHTML = '🎮 Controller detected — press ' +
-        '<span class="gp-glyph gp-face">' + attackGlyphFor(type) + '</span> to join';
+    padToastEl.innerHTML = html;
     padToastEl.classList.add("visible");
     clearTimeout(padToastTimer);
     padToastTimer = setTimeout(function () {
         if (padToastEl) {
             padToastEl.classList.remove("visible");
         }
-    }, 4000);
+    }, ms || 4000);
+}
+
+// "Controller detected — press A to join" toast when a pad connects.
+function showJoinToast(type) {
+    showPadToast('🎮 Controller detected — press ' +
+        '<span class="gp-glyph gp-face">' + attackGlyphFor(type) + '</span> to join', 4000);
 }
 
 // Hook (client.js addLocalPlayer): a pad player joined — create its block.

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -396,10 +396,14 @@ function pollGamepad(dt) {
     }
 }
 
-// Poll one pad and apply it to its local player `lp`. The primary slot also owns
-// the emoji wheel / leave modal / hint bar; non-primary pads do movement only, so
-// the primary opening a modal never freezes pad players (§6.16).
+// Poll one pad and apply it to its local player `lp`. The emoji wheel is a single
+// shared element owned by one slot at a time: only the OWNER navigates it; every
+// other player keeps playing, so one player's wheel never freezes the others
+// (§6.16). The leave modal stays primary-only.
 function pollPadForSlot(pad, lp) {
+    var wheelOpen = (typeof menuOpen !== "undefined" && menuOpen);
+    var iOwnWheel = wheelOpen && emojiOwnerSlot === lp.slot;
+
     if (lp.isPrimary) {
         // Using the pad swaps the glyphs to the controller scheme.
         if (padHasInput(pad)) {
@@ -412,13 +416,14 @@ function pollPadForSlot(pad, lp) {
         }
         if (leaveModalIsOpen()) {
             pollLeaveModal(pad, lp);
-        } else if (typeof menuOpen !== "undefined" && menuOpen) {
+        } else if (iOwnWheel) {
             pollEmojiWheel(pad, lp);
-        } else if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
+        } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
             openLeaveModal();
-        } else if (buttonPressedThisFrame(pad, GP_BTN_EMOJI, lp)) {
+        } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_EMOJI, lp)) {
             openEmojiFromPad(lp);
         } else {
+            // Normal play (also the case when another player owns the wheel).
             pollAim(pad, lp);
             pollMovementAndAttack(pad, lp);
             if (buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
@@ -426,10 +431,16 @@ function pollPadForSlot(pad, lp) {
             }
         }
     } else {
-        pollAim(pad, lp);
-        pollMovementAndAttack(pad, lp);
-        if (buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
-            goFullScreen();
+        if (iOwnWheel) {
+            pollEmojiWheel(pad, lp);
+        } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_EMOJI, lp)) {
+            openEmojiFromPad(lp);
+        } else {
+            pollAim(pad, lp);
+            pollMovementAndAttack(pad, lp);
+            if (buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
+                goFullScreen();
+            }
         }
     }
     rememberButtons(pad, lp);
@@ -647,8 +658,7 @@ function nearestEmojiToDir(items, lx, ly) {
     return best;
 }
 
-// The emoji wheel is owned by the PRIMARY slot only (§6.16 MVP), so `lp` here is
-// always the primary; passing it keeps the per-pad edge state consistent.
+// Any pad player can open the shared emoji wheel; that slot becomes its owner.
 function openEmojiFromPad(lp) {
     // Stop driving the player while the wheel is up.
     if (lp.gp.hadMoveInput) {
@@ -659,7 +669,13 @@ function openEmojiFromPad(lp) {
     gpEmojiIndex = 0;
     var w = window.innerWidth || 800;
     var h = window.innerHeight || 600;
-    openEmojiWindow(w / 2 - 50, h / 2 - 50);
+    openEmojiWindow(w / 2 - 50, h / 2 - 50); // sets menuOpen + a default (primary) owner
+    // This pad owns the wheel; tint its border with this player's color.
+    emojiOwnerSlot = lp.slot;
+    if (typeof emojiMenu !== "undefined" && emojiMenu && typeof playerList !== "undefined" &&
+        playerList && lp.myID != null && playerList[lp.myID]) {
+        emojiMenu.style.borderColor = playerList[lp.myID].color;
+    }
 }
 
 function pollEmojiWheel(pad, lp) {
@@ -977,6 +993,10 @@ function attackGlyphFor(type) {
     return type === "playstation" ? "✕" : "A";
 }
 
+function emojiGlyphFor(type) {
+    return type === "playstation" ? "□" : "X";
+}
+
 // Brief transient toast at the top of the screen (controller join prompts,
 // room-full / spectator notices).
 function showPadToast(html, ms) {
@@ -1027,11 +1047,15 @@ function onLocalPlayerJoined(lp) {
     var atk = document.createElement("span");
     atk.className = "gp-glyph gp-face";
     atk.textContent = attackGlyphFor(lp.padType);
+    var emoji = document.createElement("span");
+    emoji.className = "gp-glyph gp-face";
+    emoji.textContent = emojiGlyphFor(lp.padType);
 
     block.appendChild(dot);
     block.appendChild(label);
     block.appendChild(move);
     block.appendChild(atk);
+    block.appendChild(emoji);
     padPlayersEl.appendChild(block);
     padBlocks[lp.slot] = { el: block, dot: dot, lastColor: null };
 

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -1371,6 +1371,7 @@ function leaveGlyphFor(type) {
 function openLeaveConfirm(lp) {
     lp.leaveConfirm = true;
     setBlockLeaveConfirm(lp.slot, true);
+    scheduleHintFade(); // un-fade the header so the "Leave?" prompt is readable
     if (lp.leaveConfirmTimer) {
         clearTimeout(lp.leaveConfirmTimer);
     }

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -215,7 +215,7 @@ function tryClaimPadSlot(padIndex, pad) {
     // no pad yet, the FIRST controller drives P1 (the existing primary
     // connection) so no keyboard is required. This reuses the existing player, so
     // there's no new join and no capacity check.
-    if (primary && primary.padIndex == null && !keyboardClaimedPrimary) {
+    if (primary && primary.padIndex == null && !kbmClaimedPrimary) {
         bindPadToPrimary(padIndex, pad);
         return;
     }
@@ -316,22 +316,18 @@ function pollGamepad(dt) {
         }
         var lp = localPlayerForPadIndex(i);
         if (!lp) {
-            // A pad that just left must release its buttons before (re)joining, so
-            // the press that confirmed leaving can't instantly re-join it.
+            // A pad that just left must go idle before (re)joining, so the input
+            // that confirmed leaving can't instantly re-join it.
             if (padNeedsRelease[i]) {
-                if (!anyButtonPressed(pad)) {
+                if (!padHasInput(pad)) {
                     delete padNeedsRelease[i];
                 }
                 continue;
             }
-            var primary = localPlayers[primarySlot];
-            if (primary && primary.padIndex == null && !keyboardClaimedPrimary) {
-                // First controller, no keyboard in use → it drives P1. Adopt it as
-                // soon as it's present (no button required) so stick/d-pad menu and
-                // lobby navigation work immediately, matching the old single-pad UX.
-                bindPadToPrimary(i, pad);
-            } else if (anyButtonPressed(pad)) {
-                // An additional controller joins as a new player (P2+) on a press.
+            // Claim on ANY input — stick OR button — so navigating with the stick
+            // works without first pressing a button. tryClaimPadSlot decides
+            // whether this pad takes P1 (no kb/m player yet) or joins as P2+.
+            if (padHasInput(pad)) {
                 tryClaimPadSlot(i, pad);
             }
             continue; // wait until the slot has joined (myID set) before polling

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -180,8 +180,10 @@ function onGamepadDisconnected(e) {
         if (activeInputMethod === "pad") {
             setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
         }
-        if (typeof onLocalPlayerDropped === "function") {
-            onLocalPlayerDropped(lp.slot);
+        // P1 persists (keyboard can drive it) — revert its block hints to keyboard
+        // rather than removing the block.
+        if (typeof setBlockHints === "function") {
+            setBlockHints(lp);
         }
     }
 }
@@ -320,7 +322,10 @@ function bindPadToPrimary(padIndex, pad) {
     primary.gp.prevButtons = snapshotButtons(pad);
     gamepadType = primary.padType; // the bottom hint bar's attack glyph
     if (typeof onLocalPlayerJoined === "function") {
-        onLocalPlayerJoined(primary); // give P1 a color-dot block too
+        onLocalPlayerJoined(primary); // ensure P1 has a block
+    }
+    if (typeof setBlockHints === "function") {
+        setBlockHints(primary); // P1 now drives by pad — switch its hints to pad glyphs
     }
 }
 
@@ -910,6 +915,12 @@ function setInputMethod(method) {
         return;
     }
     activeInputMethod = method;
+    // In local multiplayer the single bottom bar can't represent several players'
+    // schemes at once (it would flip-flop), so each player carries their own
+    // compact hints in their top block instead — don't show the bottom bar.
+    if (localMultiplayerEnabled()) {
+        return;
+    }
     if (!hintBarEl) {
         buildHintBar();
     }
@@ -950,15 +961,29 @@ function padHasInput(pad) {
 }
 
 // Show the hint bar at full opacity and (re)start the ~60s countdown to fade.
-function scheduleHintFade() {
-    if (!hintBarEl) {
-        return;
+// The hint UI is the bottom bar (single-player) and/or the per-player top blocks
+// (local MP). Fade/hide apply to whichever exist.
+function hintFadeEls() {
+    var els = [];
+    if (hintBarEl) {
+        els.push(hintBarEl);
     }
-    hintBarEl.classList.remove("faded");
+    if (padPlayersEl) {
+        els.push(padPlayersEl);
+    }
+    return els;
+}
+
+function scheduleHintFade() {
+    var els = hintFadeEls();
+    for (var i = 0; i < els.length; i++) {
+        els[i].classList.remove("faded");
+    }
     clearTimeout(gpFadeTimer);
     gpFadeTimer = setTimeout(function () {
-        if (hintBarEl && hintBarEl.classList.contains("visible")) {
-            hintBarEl.classList.add("faded");
+        var e = hintFadeEls();
+        for (var j = 0; j < e.length; j++) {
+            e[j].classList.add("faded");
         }
     }, HINT_FADE_MS);
 }
@@ -1041,28 +1066,56 @@ function onLocalPlayerJoined(lp) {
     var label = document.createElement("span");
     label.className = "pp-label";
     label.textContent = "P" + (lp.slot + 1);
-    var move = document.createElement("span");
-    move.className = "gp-glyph gp-stick";
-    move.textContent = "L";
-    var atk = document.createElement("span");
-    atk.className = "gp-glyph gp-face";
-    atk.textContent = attackGlyphFor(lp.padType);
-    var emoji = document.createElement("span");
-    emoji.className = "gp-glyph gp-face";
-    emoji.textContent = emojiGlyphFor(lp.padType);
+    var hints = document.createElement("span");
+    hints.className = "pp-hints";
 
     block.appendChild(dot);
     block.appendChild(label);
-    block.appendChild(move);
-    block.appendChild(atk);
-    block.appendChild(emoji);
+    block.appendChild(hints);
     padPlayersEl.appendChild(block);
-    padBlocks[lp.slot] = { el: block, dot: dot, lastColor: null };
+    padBlocks[lp.slot] = { el: block, dot: dot, hints: hints, lastColor: null, lastMethod: null };
+    setBlockHints(lp);
+    scheduleHintFade(); // a player joined — show the hints, restart the auto-fade
 
     // A join just happened — drop the connect toast.
     if (padToastEl) {
         padToastEl.classList.remove("visible");
     }
+}
+
+// The compact control hints for a player's CURRENT input method (keyboard vs
+// their own pad brand) — baked into each top block so every player sees their own
+// scheme without the single bottom bar flip-flopping.
+function blockMethodFor(lp) {
+    return (lp.padIndex != null) ? "pad" : "kbm";
+}
+
+function miniHintsFor(method, padType) {
+    if (method === "pad") {
+        return '<span class="gp-glyph gp-stick">L</span>' +
+            '<span class="gp-glyph gp-face">' + attackGlyphFor(padType) + '</span>' +
+            '<span class="gp-glyph gp-face">' + emojiGlyphFor(padType) + '</span>';
+    }
+    // keyboard / mouse
+    return '<span class="gp-glyph gp-key">WASD</span>' +
+        '<span class="gp-glyph gp-key">🖱</span>' +
+        '<span class="gp-glyph gp-key">RMB</span>';
+}
+
+// (Re)set a block's hint glyphs to match the player's current method. No-op when
+// unchanged, so a pad binding/unbinding only rewrites the DOM when needed.
+function setBlockHints(lp) {
+    var b = padBlocks[lp.slot];
+    if (!b) {
+        return;
+    }
+    var method = blockMethodFor(lp);
+    var key = method + "|" + lp.padType;
+    if (key === b.lastMethod) {
+        return;
+    }
+    b.hints.innerHTML = miniHintsFor(method, lp.padType);
+    b.lastMethod = key;
 }
 
 // Hook (client.js): grey a pad player's block while their socket is reconnecting,
@@ -1115,13 +1168,22 @@ function refreshPadBlocks() {
 
 // Manual toggle (Select button / H key): hide the bar now, or restore it.
 function toggleHintFade() {
-    if (!hintBarEl) {
+    var els = hintFadeEls();
+    if (els.length === 0) {
         return;
     }
-    if (hintBarEl.classList.contains("faded")) {
+    var anyFaded = false;
+    for (var i = 0; i < els.length; i++) {
+        if (els[i].classList.contains("faded")) {
+            anyFaded = true;
+        }
+    }
+    if (anyFaded) {
         scheduleHintFade(); // restore to full opacity + restart the auto-fade
     } else {
         clearTimeout(gpFadeTimer);
-        hintBarEl.classList.add("faded"); // hide on demand
+        for (var j = 0; j < els.length; j++) {
+            els[j].classList.add("faded"); // hide on demand
+        }
     }
 }

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -257,6 +257,36 @@ function bindPadToPrimary(padIndex, pad) {
     // P1's block hints refresh to pad glyphs automatically (refreshPadBlocks).
 }
 
+// The keyboard/mouse started driving P1. Mark it claimed; and if a controller had
+// grabbed P1 first (no kb/m yet), bump that controller to its own player (P2+) and
+// give P1 back to kb/m — so "kb/m + controllers" works no matter who moved first.
+function claimPrimaryForKbm() {
+    if (kbmClaimedPrimary) {
+        return;
+    }
+    kbmClaimedPrimary = true;
+    var primary = localPlayers[primarySlot];
+    if (!primary || primary.padIndex == null) {
+        return; // no controller on P1 — nothing to bump
+    }
+    var padIdx = primary.padIndex;
+    var padType = primary.padType;
+    // kb/m takes over P1.
+    primary.padIndex = null;
+    if (typeof cancelMovementForSlot === "function") {
+        cancelMovementForSlot(primary);
+    }
+    primary.gp.hadMoveInput = false;
+    // Re-add the controller as its own player (P2+), if there's room.
+    var slot = nextFreeSlot();
+    if (slot != null && typeof gameID !== "undefined" && gameID != null && !roomIsFull()) {
+        var lp = addLocalPlayer(slot, padIdx);
+        if (lp) {
+            lp.padType = padType;
+        }
+    }
+}
+
 // True when the room already holds its max players. Counts the live playerList
 // plus any local players that have joined but whose playerJoin hasn't reflected
 // on the primary yet, so two quick joins can't both slip past.

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -25,6 +25,7 @@ var GP_AIM_DEADZONE = 0.35;      // right stick: only re-aim when pushed past th
 var GP_TRIGGER_THRESHOLD = 0.5;  // analog trigger counts as "pressed" past this
 var GP_AIM_MIN_DELTA = 2;        // deg; skip aim emits smaller than this
 var GP_AIM_MIN_INTERVAL = 50;    // ms; cap aim emits at ~20 Hz
+var LEAVE_CONFIRM_TIMEOUT_MS = 5000; // auto-cancel the inline "Leave?" confirm
 
 // --- standard-mapping button indices ---
 var GP_BTN_A = 0;     // attack / confirm
@@ -135,12 +136,15 @@ function onGamepadKeyDown(e) {
     if (hintUiMode === "blocks" && primary && padBlocks[primarySlot]) {
         if (primary.leaveConfirm) {
             if (e.keyCode === 13 || e.key === "Enter") {
+                if (primary.leaveConfirmTimer) {
+                    clearTimeout(primary.leaveConfirmTimer);
+                    primary.leaveConfirmTimer = null;
+                }
                 primary.leaveConfirm = false;
                 dropLocalPlayer(primarySlot);
                 e.preventDefault();
             } else if (e.key === "Escape" || e.keyCode === 27) {
-                primary.leaveConfirm = false;
-                setBlockLeaveConfirm(primarySlot, false);
+                cancelLeaveConfirm(primary);
                 e.preventDefault();
             }
             return;
@@ -458,7 +462,10 @@ function pollPadForSlot(pad, lp) {
     }
 
     if (lp.leaveConfirm) {
-        // This player is confirming leave inline in their block.
+        // Confirming leave inline: keep steering (movement isn't halted), but A
+        // confirms and B cancels, so attack is suppressed while the prompt is up.
+        pollAim(pad, lp);
+        pollMovementAndAttack(pad, lp, true);
         pollLeaveConfirm(pad, lp);
     } else if (!blocks && lp.isPrimary && leaveModalIsOpen()) {
         // Solo: navigate the centre leave modal.
@@ -527,7 +534,7 @@ function pollAim(pad, lp) {
     gp.lastAimEmit = now;
 }
 
-function pollMovementAndAttack(pad, lp) {
+function pollMovementAndAttack(pad, lp, ignoreAttack) {
     var mf = false, mb = false, tl = false, tr = false;
     var moveActive = false;
 
@@ -570,7 +577,9 @@ function pollMovementAndAttack(pad, lp) {
         }
     }
 
-    var atk = readAttack(pad);
+    // During the leave-confirm A is the confirm button, so attack is suppressed
+    // (the player can still steer with the stick/d-pad).
+    var atk = ignoreAttack ? false : readAttack(pad);
     applyInputState(lp, mf, mb, tl, tr, atk, moveActive);
 }
 
@@ -1102,10 +1111,14 @@ function onLocalPlayersChanged() {
         if (hintUiMode === "blocks") {
             // No controllers and solo — restore the bottom bar.
             hintUiMode = "bar";
-            // Clear any in-progress inline leave-confirm flags before their blocks
-            // are removed, so a flag can't linger with no visible UI.
+            // Clear any in-progress inline leave-confirm (flag + timer) before
+            // their blocks are removed, so nothing lingers with no visible UI.
             for (var c = 0; c < localPlayers.length; c++) {
                 if (localPlayers[c]) {
+                    if (localPlayers[c].leaveConfirmTimer) {
+                        clearTimeout(localPlayers[c].leaveConfirmTimer);
+                        localPlayers[c].leaveConfirmTimer = null;
+                    }
                     localPlayers[c].leaveConfirm = false;
                 }
             }
@@ -1287,15 +1300,14 @@ function setBlockHints(lp) {
 function onLocalPlayerReconnecting(slot, isReconnecting) {
     // Cancel any in-progress leave-confirm: while mid-reconnect the slot isn't
     // polled, so its A/B can't resolve the confirm — don't leave it frozen.
-    if (isReconnecting && localPlayers[slot]) {
-        localPlayers[slot].leaveConfirm = false;
+    if (isReconnecting) {
+        cancelLeaveConfirm(localPlayers[slot]);
     }
     var b = padBlocks[slot];
     if (!b || !b.el) {
         return;
     }
     if (isReconnecting) {
-        setBlockLeaveConfirm(slot, false); // restore normal hints if it was confirming
         b.el.classList.add("reconnecting");
     } else {
         b.el.classList.remove("reconnecting");
@@ -1353,25 +1365,45 @@ function leaveGlyphFor(type) {
 
 // B opens an inline "Leave?" confirm in this player's block; A confirms (drops
 // the player / disconnects), B cancels. Per-slot, so it never freezes the others.
+// Opening the confirm does NOT halt movement (the player keeps steering while
+// deciding, matching the keyboard Esc behavior). The block is highlighted, and
+// the prompt auto-cancels after LEAVE_CONFIRM_TIMEOUT_MS with no confirm.
 function openLeaveConfirm(lp) {
-    if (lp.gp.hadMoveInput) {
-        cancelMovementForSlot(lp);
-        lp.gp.hadMoveInput = false;
-    }
-    lp.gp.prevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
     lp.leaveConfirm = true;
     setBlockLeaveConfirm(lp.slot, true);
+    if (lp.leaveConfirmTimer) {
+        clearTimeout(lp.leaveConfirmTimer);
+    }
+    lp.leaveConfirmTimer = setTimeout(function () {
+        cancelLeaveConfirm(lp);
+    }, LEAVE_CONFIRM_TIMEOUT_MS);
+}
+
+// Cancel the inline confirm: clear the timeout, drop the flag, and un-highlight.
+function cancelLeaveConfirm(lp) {
+    if (!lp) {
+        return;
+    }
+    if (lp.leaveConfirmTimer) {
+        clearTimeout(lp.leaveConfirmTimer);
+        lp.leaveConfirmTimer = null;
+    }
+    lp.leaveConfirm = false;
+    setBlockLeaveConfirm(lp.slot, false);
 }
 
 function pollLeaveConfirm(pad, lp) {
     if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
+        if (lp.leaveConfirmTimer) {
+            clearTimeout(lp.leaveConfirmTimer);
+            lp.leaveConfirmTimer = null;
+        }
         lp.leaveConfirm = false;
         dropLocalPlayer(lp.slot); // confirmed — disconnect this player
         return;
     }
     if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
-        lp.leaveConfirm = false;
-        setBlockLeaveConfirm(lp.slot, false); // cancelled
+        cancelLeaveConfirm(lp); // cancelled
     }
 }
 

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -104,12 +104,35 @@ function markTouchUsed() {
 
 function onGamepadKeyDown(e) {
     setInputMethod("kbm"); // a key press means keyboard/mouse is in use
-    var primary = localPlayers[primarySlot];
 
-    // Multiplayer: the keyboard player leaves via the SAME inline "Leave?" confirm
-    // in their own block that controllers use (not the centre modal). Esc opens it,
-    // Enter confirms (leave), Esc cancels.
-    if (hintUiMode === "blocks" && primary) {
+    // The centre leave modal (used when solo, or when the primary has no inline
+    // block) owns the keyboard while open, in any mode: arrows / A-D move between
+    // Leave and Cancel, Enter or Space confirms, Esc closes.
+    if (leaveModalIsOpen()) {
+        if (e.key === "Escape" || e.keyCode === 27) {
+            closeLeaveModal();
+        } else if (e.keyCode === 37 || e.keyCode === 65 || e.key === "ArrowLeft") {
+            setLeaveFocus(0); // Leave
+            e.preventDefault();
+        } else if (e.keyCode === 39 || e.keyCode === 68 || e.key === "ArrowRight") {
+            setLeaveFocus(1); // Cancel
+            e.preventDefault();
+        } else if (e.keyCode === 13 || e.keyCode === 32 || e.key === "Enter" || e.key === " ") {
+            var btns = leaveButtons();
+            if (btns[leaveFocusIdx]) {
+                btns[leaveFocusIdx].click();
+            }
+            e.preventDefault();
+        }
+        return;
+    }
+
+    var primary = localPlayers[primarySlot];
+    // Multiplayer WITH a visible P1 block: the keyboard player leaves via the same
+    // inline "Leave?" confirm in their block that controllers use. (Only when the
+    // block actually exists — otherwise fall through to the visible centre modal,
+    // so we never arm an invisible confirm.)
+    if (hintUiMode === "blocks" && primary && padBlocks[primarySlot]) {
         if (primary.leaveConfirm) {
             if (e.keyCode === 13 || e.key === "Enter") {
                 primary.leaveConfirm = false;
@@ -133,26 +156,7 @@ function onGamepadKeyDown(e) {
         return;
     }
 
-    // Solo: the centre leave modal. While it's up, arrows / A-D move between Leave
-    // and Cancel, Enter or Space confirms, Esc closes.
-    if (leaveModalIsOpen()) {
-        if (e.key === "Escape" || e.keyCode === 27) {
-            closeLeaveModal();
-        } else if (e.keyCode === 37 || e.keyCode === 65 || e.key === "ArrowLeft") {
-            setLeaveFocus(0); // Leave
-            e.preventDefault();
-        } else if (e.keyCode === 39 || e.keyCode === 68 || e.key === "ArrowRight") {
-            setLeaveFocus(1); // Cancel
-            e.preventDefault();
-        } else if (e.keyCode === 13 || e.keyCode === 32 || e.key === "Enter" || e.key === " ") {
-            var btns = leaveButtons();
-            if (btns[leaveFocusIdx]) {
-                btns[leaveFocusIdx].click();
-            }
-            e.preventDefault();
-        }
-        return;
-    }
+    // Solo, or multiplayer with no visible P1 block: the centre modal (visible).
     if (e.key === "Escape" || e.keyCode === 27) {
         openLeaveModal();
     } else if (e.key === "h" || e.key === "H" || e.keyCode === 72) {
@@ -331,7 +335,17 @@ function claimPrimaryForKbm() {
         var lp = addLocalPlayer(slot, padIdx);
         if (lp) {
             lp.padType = padType;
+            // Seed the new slot's button state from the live pad so a button held
+            // during the bump isn't seen as a fresh press (phantom attack/menu).
+            var pads = (typeof navigator !== "undefined" && navigator.getGamepads) ? navigator.getGamepads() : [];
+            if (pads[padIdx]) {
+                lp.gp.prevButtons = snapshotButtons(pads[padIdx]);
+            }
         }
+    } else {
+        // No room to re-home the controller — require a release before it can
+        // re-join, so a held button doesn't spam join attempts / room-full toasts.
+        markPadNeedsRelease(padIdx);
     }
 }
 
@@ -433,8 +447,9 @@ function pollPadForSlot(pad, lp) {
     var wheelOpen = (typeof menuOpen !== "undefined" && menuOpen);
     var iOwnWheel = wheelOpen && emojiOwnerSlot === lp.slot;
 
-    // Any pad can toggle the hints; only the primary's pad swaps the (solo) bar.
-    if (buttonPressedThisFrame(pad, GP_BTN_SELECT, lp)) {
+    // System/shared actions (hint show/hide) belong to the primary pad only, so
+    // multiple players don't fight over the one shared overlay (§6.15).
+    if (lp.isPrimary && buttonPressedThisFrame(pad, GP_BTN_SELECT, lp)) {
         toggleHintFade();
     }
     if (lp.isPrimary && padHasInput(pad)) {
@@ -462,7 +477,8 @@ function pollPadForSlot(pad, lp) {
         // Normal play (also when another player owns the wheel).
         pollAim(pad, lp);
         pollMovementAndAttack(pad, lp);
-        if (buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
+        // Fullscreen is a shared-screen action — primary pad only.
+        if (lp.isPrimary && buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
             goFullScreen();
         }
     }
@@ -1086,6 +1102,13 @@ function onLocalPlayersChanged() {
         if (hintUiMode === "blocks") {
             // No controllers and solo — restore the bottom bar.
             hintUiMode = "bar";
+            // Clear any in-progress inline leave-confirm flags before their blocks
+            // are removed, so a flag can't linger with no visible UI.
+            for (var c = 0; c < localPlayers.length; c++) {
+                if (localPlayers[c]) {
+                    localPlayers[c].leaveConfirm = false;
+                }
+            }
             removeAllBlocks();
             removeAllJoinPrompts();
             var method = activeInputMethod || "kbm";
@@ -1262,11 +1285,17 @@ function setBlockHints(lp) {
 // and restore it on recovery — so a transient blip shows as "reconnecting" rather
 // than vanishing.
 function onLocalPlayerReconnecting(slot, isReconnecting) {
+    // Cancel any in-progress leave-confirm: while mid-reconnect the slot isn't
+    // polled, so its A/B can't resolve the confirm — don't leave it frozen.
+    if (isReconnecting && localPlayers[slot]) {
+        localPlayers[slot].leaveConfirm = false;
+    }
     var b = padBlocks[slot];
     if (!b || !b.el) {
         return;
     }
     if (isReconnecting) {
+        setBlockLeaveConfirm(slot, false); // restore normal hints if it was confirming
         b.el.classList.add("reconnecting");
     } else {
         b.el.classList.remove("reconnecting");

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -215,6 +215,9 @@ function markPadNeedsRelease(idx) {
         padNeedsRelease[idx] = true;
     }
 }
+// Per-pad-index "was A pressed last frame" for UNCLAIMED pads, so a controller
+// joins on an A-press edge (not a held A).
+var unclaimedAPrev = {};
 
 function anyButtonPressed(pad) {
     for (var i = 0; i < pad.buttons.length; i++) {
@@ -379,11 +382,13 @@ function pollGamepad(dt) {
             lpv.gp.hadMoveInput = false;
         }
     }
-    // Keep the top blocks (color dots + per-player hints) in sync.
+    // Reconcile the header (player blocks + "press A to join" prompts) and keep
+    // the color dots / hints in sync.
+    onLocalPlayersChanged();
     refreshPadBlocks();
-    // Each connected pad drives its claimed slot; the first pad (with no keyboard
-    // in use) takes P1, and any other unclaimed pad hot-joins as a new local
-    // player on its first button press.
+    // Each connected pad drives its claimed slot; an unclaimed controller shows a
+    // "press A to join" prompt and joins on its A button (tryClaimPadSlot decides
+    // whether it takes P1 — no kb/m player yet — or joins as P2+).
     for (var i = 0; i < pads.length; i++) {
         var pad = pads[i];
         if (!pad) {
@@ -391,22 +396,23 @@ function pollGamepad(dt) {
         }
         var lp = localPlayerForPadIndex(i);
         if (!lp) {
-            // A pad that just left must go idle before (re)joining, so the input
-            // that confirmed leaving can't instantly re-join it.
+            var aDown = !!(pad.buttons[GP_BTN_A] && pad.buttons[GP_BTN_A].pressed);
+            // A pad that just left must go idle before it can (re)join.
             if (padNeedsRelease[i]) {
-                if (!padHasInput(pad)) {
+                if (!anyButtonPressed(pad)) {
                     delete padNeedsRelease[i];
                 }
+                unclaimedAPrev[i] = aDown;
                 continue;
             }
-            // Claim on ANY input — stick OR button — so navigating with the stick
-            // works without first pressing a button. tryClaimPadSlot decides
-            // whether this pad takes P1 (no kb/m player yet) or joins as P2+.
-            if (padHasInput(pad)) {
+            // Join on the A button (an edge, so a held A doesn't double-join).
+            if (aDown && !unclaimedAPrev[i]) {
                 tryClaimPadSlot(i, pad);
             }
+            unclaimedAPrev[i] = aDown;
             continue; // wait until the slot has joined (myID set) before polling
         }
+        delete unclaimedAPrev[i];
         if (lp.myID == null) {
             continue;
         }
@@ -1014,9 +1020,41 @@ function scheduleHintFade() {
 
 var padPlayersEl = null;     // container element for the top blocks
 var padBlocks = {};          // slot -> { el, dot, hints, lastColor, lastMethod }
+var joinPromptBlocks = {};   // pad index -> "press A to join" block element
 var padToastEl = null;
 var padToastTimer = null;
-var hintUiMode = "bar";      // "bar" (solo) | "blocks" (>= 2 local players)
+var hintUiMode = "bar";      // "bar" (solo, no controllers) | "blocks" (header up)
+
+// A "press A to join" block for a connected controller that hasn't joined yet.
+function ensureJoinPrompt(idx, type) {
+    if (!padPlayersEl) {
+        buildPadPlayersUI();
+    }
+    if (!padPlayersEl || joinPromptBlocks[idx]) {
+        return;
+    }
+    var el = document.createElement("div");
+    el.className = "pad-player join-prompt";
+    el.innerHTML = '<span class="gp-glyph gp-face">' + attackGlyphFor(type) + '</span>' +
+        '<span class="pp-join">press to join</span>';
+    padPlayersEl.appendChild(el);
+    joinPromptBlocks[idx] = el;
+}
+function removeJoinPrompt(idx) {
+    var el = joinPromptBlocks[idx];
+    if (!el) {
+        return;
+    }
+    if (el.parentNode) {
+        el.parentNode.removeChild(el);
+    }
+    delete joinPromptBlocks[idx];
+}
+function removeAllJoinPrompts() {
+    for (var k in joinPromptBlocks) {
+        removeJoinPrompt(k);
+    }
+}
 
 function buildPadPlayersUI() {
     if (padPlayersEl || typeof document === "undefined" || !document.body) {
@@ -1028,37 +1066,69 @@ function buildPadPlayersUI() {
     padPlayersEl = el;
 }
 
-// Called whenever the set of local players changes (join/drop). Switches the hint
-// UI between the solo bottom bar and the per-player top blocks, and reconciles
-// which blocks exist.
+// Reconciles the in-game header each frame (and on join/drop). The per-controller
+// header is shown whenever a controller is connected OR 2+ local players are in;
+// otherwise the solo bottom bar. In header mode it renders: a block per joined
+// local player (mini controls), and a "press A to join" prompt per connected
+// controller that hasn't joined yet (the prompt becomes a mini-controls block
+// when that controller joins).
 function onLocalPlayersChanged() {
-    var multi = (typeof liveLocalPlayerCount === "function") && liveLocalPlayerCount() >= 2;
-    if (multi) {
-        if (hintUiMode !== "blocks") {
-            hintUiMode = "blocks";
-            if (hintBarEl) {
-                hintBarEl.className = "gamepad-prompts hidden"; // bottom bar off in multiplayer
-            }
+    var pads = (typeof navigator !== "undefined" && navigator.getGamepads) ? navigator.getGamepads() : [];
+    var nControllers = 0;
+    for (var i = 0; i < pads.length; i++) {
+        if (pads[i]) {
+            nControllers++;
         }
-        for (var s = 0; s < localPlayers.length; s++) {
-            if (localPlayers[s]) {
-                ensureBlock(localPlayers[s]);
-            }
+    }
+    var showBlocks = (typeof liveLocalPlayerCount === "function" && liveLocalPlayerCount() >= 2) || nControllers >= 1;
+
+    if (!showBlocks) {
+        if (hintUiMode === "blocks") {
+            // No controllers and solo — restore the bottom bar.
+            hintUiMode = "bar";
+            removeAllBlocks();
+            removeAllJoinPrompts();
+            var method = activeInputMethod || "kbm";
+            activeInputMethod = null; // force setInputMethod to rebuild + show the bar
+            setInputMethod(method);
         }
-        // Remove blocks for slots that no longer exist.
-        for (var slot in padBlocks) {
-            if (!localPlayers[slot]) {
-                removeBlock(slot);
-            }
+        return;
+    }
+
+    if (hintUiMode !== "blocks") {
+        hintUiMode = "blocks";
+        if (hintBarEl) {
+            hintBarEl.className = "gamepad-prompts hidden"; // bottom bar off when the header is up
         }
         scheduleHintFade();
-    } else if (hintUiMode === "blocks") {
-        // Back down to one local player — restore the bottom bar.
-        hintUiMode = "bar";
-        removeAllBlocks();
-        var method = activeInputMethod || "kbm";
-        activeInputMethod = null; // force setInputMethod to rebuild + show the bar
-        setInputMethod(method);
+    }
+    // A block per joined local player; drop blocks for slots that are gone.
+    for (var s = 0; s < localPlayers.length; s++) {
+        if (localPlayers[s]) {
+            ensureBlock(localPlayers[s]);
+        }
+    }
+    for (var slot in padBlocks) {
+        if (!localPlayers[slot]) {
+            removeBlock(slot);
+        }
+    }
+    // A "press A to join" prompt per connected controller that hasn't joined.
+    for (var j = 0; j < pads.length; j++) {
+        if (!pads[j]) {
+            continue;
+        }
+        if (localPlayerForPadIndex(j)) {
+            removeJoinPrompt(j); // joined now — its mini-controls block takes over
+        } else {
+            ensureJoinPrompt(j, detectGamepadType(pads[j].id));
+        }
+    }
+    for (var key in joinPromptBlocks) {
+        var idx = parseInt(key, 10);
+        if (!pads[idx] || localPlayerForPadIndex(idx)) {
+            removeJoinPrompt(idx);
+        }
     }
 }
 

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -19,6 +19,17 @@ var gamepadConnected = false;
 var gamepadIndex = null;
 var gamepadType = "generic"; // "xbox" | "playstation" | "generic"
 
+// --- PHASE 1 SPIKE: per-pad emit routing ---
+// When set, this pad's input is emitted on `gpEmitSocket` and attributed to the
+// player `gpEmitID`, instead of the primary `server` / global `myID`. When both
+// are null (the default, flag off), behaviour is identical to today (N=1). This
+// is the throwaway proof that one tab can drive a second, independent server
+// player; Phase 2 replaces it with the per-slot localPlayers table.
+var gpEmitSocket = null;
+var gpEmitID = null;
+function gpSocket() { return gpEmitSocket || server; }
+function gpID() { return gpEmitID != null ? gpEmitID : myID; }
+
 // --- tuning ---
 var GP_MOVE_DEADZONE = 0.30;     // left stick: ignore drift below this
 var GP_AIM_DEADZONE = 0.35;      // right stick: only re-aim when pushed past this
@@ -241,7 +252,7 @@ function pollAim(pad) {
     if (!gpAimActive) {
         return;
     }
-    if (typeof playerList === "undefined" || !playerList || myID == null || !playerList[myID]) {
+    if (typeof playerList === "undefined" || !playerList || gpID() == null || !playerList[gpID()]) {
         return;
     }
 
@@ -266,9 +277,9 @@ function pollAim(pad) {
         return;
     }
 
-    playerList[myID].angle = deg;
-    if (server) {
-        server.emit('mousemove', deg);
+    playerList[gpID()].angle = deg;
+    if (gpSocket()) {
+        gpSocket().emit('mousemove', deg);
     }
     gpPrevAimAngle = deg;
     gpLastAimEmit = now;
@@ -347,10 +358,10 @@ function applyInputState(mf, mb, tl, tr, atk, moveActive) {
             attack = atk;
             // When the right stick isn't aiming, face the movement direction
             // (mirrors the keyboard behaviour).
-            if (!gpAimActive && typeof playerList !== "undefined" && playerList && myID != null && playerList[myID]) {
-                calcAngleFromKeys(playerList[myID]);
-                if (server) {
-                    server.emit('mousemove', playerList[myID].angle);
+            if (!gpAimActive && typeof playerList !== "undefined" && playerList && gpID() != null && playerList[gpID()]) {
+                calcAngleFromKeys(playerList[gpID()]);
+                if (gpSocket()) {
+                    gpSocket().emit('mousemove', playerList[gpID()].angle);
                 }
             }
             emitMovement();
@@ -361,8 +372,8 @@ function applyInputState(mf, mb, tl, tr, atk, moveActive) {
 }
 
 function emitMovement() {
-    if (server) {
-        server.emit('movement', {
+    if (gpSocket()) {
+        gpSocket().emit('movement', {
             turnLeft: turnLeft,
             moveForward: moveForward,
             turnRight: turnRight,

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -14,21 +14,10 @@
 // poll loop here is careful to do the same: it diffs against the pad's own
 // previous reading and only touches the socket when something actually changed.
 
-// --- connection state ---
+// --- connection state (the PRIMARY slot's pad, single-player path) ---
 var gamepadConnected = false;
 var gamepadIndex = null;
 var gamepadType = "generic"; // "xbox" | "playstation" | "generic"
-
-// --- PHASE 1 SPIKE: per-pad emit routing ---
-// When set, this pad's input is emitted on `gpEmitSocket` and attributed to the
-// player `gpEmitID`, instead of the primary `server` / global `myID`. When both
-// are null (the default, flag off), behaviour is identical to today (N=1). This
-// is the throwaway proof that one tab can drive a second, independent server
-// player; Phase 2 replaces it with the per-slot localPlayers table.
-var gpEmitSocket = null;
-var gpEmitID = null;
-function gpSocket() { return gpEmitSocket || server; }
-function gpID() { return gpEmitID != null ? gpEmitID : myID; }
 
 // --- tuning ---
 var GP_MOVE_DEADZONE = 0.30;     // left stick: ignore drift below this
@@ -49,13 +38,11 @@ var GP_DPAD_DOWN = 13;
 var GP_DPAD_LEFT = 14;
 var GP_DPAD_RIGHT = 15;
 
-// --- per-frame remembered state (so we only emit on change) ---
-var gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
-var gpHadMoveInput = false; // did the pad drive movement on the previous frame?
-var gpAimActive = false;    // is the right stick currently aiming?
-var gpPrevAimAngle = null;
-var gpLastAimEmit = 0;
-var gpPrevButtons = [];     // pressed-state per button, for edge detection
+// --- per-frame remembered state ---
+// The per-pad edge/aim/move state that used to be single globals now lives in
+// each local player's `lp.gp` (game.js makeLocalPlayer), so multiple pads don't
+// clobber each other. These two remain global because the emoji wheel is a
+// single shared DOM element owned by the PRIMARY slot only (§6.16 MVP).
 var gpEmojiIndex = 0;       // highlighted slot while the emoji wheel is open
 var gpEmojiStepAt = 0;      // last d-pad step time (for repeat throttling)
 
@@ -128,33 +115,57 @@ function onGamepadKeyDown(e) {
 }
 
 function onGamepadConnected(e) {
-    gamepadConnected = true;
-    gamepadIndex = e.gamepad.index;
-    gamepadType = detectGamepadType(e.gamepad.id);
-    gpPrevButtons = [];
-    // Don't swap the glyphs yet — wait until the pad is actually used (see
-    // padHasInput in pollGamepad), so a connected-but-idle pad doesn't override
-    // a player still on keyboard/mouse.
-    debugLog("gamepad connected:", e.gamepad.id, "->", gamepadType);
+    var type = detectGamepadType(e.gamepad.id);
+    debugLog("gamepad connected:", e.gamepad.id, "->", type, "idx", e.gamepad.index);
+    if (!localMultiplayerEnabled()) {
+        // Single-player: adopt this pad onto the primary slot (today's behavior).
+        gamepadConnected = true;
+        gamepadIndex = e.gamepad.index;
+        gamepadType = type;
+        var p = localPlayers[primarySlot];
+        if (p) {
+            p.padIndex = e.gamepad.index;
+            p.padType = type;
+            p.gp.prevButtons = [];
+        }
+        // Don't swap the glyphs yet — wait until the pad is actually used, so a
+        // connected-but-idle pad doesn't override a player still on keyboard.
+        return;
+    }
+    // Local multiplayer: the pad hot-joins as a NEW local player on its first
+    // button press (pollGamepad). Browsers only reliably surface an idle pad
+    // after a press anyway, so we wait for that rather than joining on connect.
+    debugLog("[localmp] controller detected — press a button to join");
 }
 
 function onGamepadDisconnected(e) {
-    if (e.gamepad.index !== gamepadIndex) {
+    if (!localMultiplayerEnabled()) {
+        var p = localPlayers[primarySlot];
+        if (!p || e.gamepad.index !== p.padIndex) {
+            return;
+        }
+        gamepadConnected = false;
+        gamepadIndex = null;
+        p.padIndex = null;
+        if (p.gp.hadMoveInput) {
+            cancelMovement();
+            p.gp.hadMoveInput = false;
+        }
+        p.gp.prevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+        if (activeInputMethod === "pad") {
+            setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
+        }
+        debugLog("gamepad disconnected");
         return;
     }
-    gamepadConnected = false;
-    gamepadIndex = null;
-    // Release anything the pad was holding so the player doesn't keep moving.
-    if (gpHadMoveInput) {
-        cancelMovement();
-        gpHadMoveInput = false;
+    // Local multiplayer: a pad player's controller was unplugged. Stop their
+    // movement and drop just that slot (everyone else keeps playing).
+    var lp = localPlayerForPadIndex(e.gamepad.index);
+    if (lp && !lp.isPrimary) {
+        debugLog("[localmp] pad", e.gamepad.index, "unplugged — dropping slot", lp.slot);
+        cancelMovementForSlot(lp);
+        dropLocalPlayer(lp.slot);
     }
-    gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
-    // The pad is gone — fall back to the device's other input method.
-    if (activeInputMethod === "pad") {
-        setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
-    }
-    debugLog("gamepad disconnected");
 }
 
 function detectGamepadType(id) {
@@ -170,32 +181,36 @@ function detectGamepadType(id) {
 }
 
 // Chrome only surfaces a pad after the first button press, and a pad held at
-// page load never fires 'gamepadconnected'. So we also adopt the first live
-// pad we see while polling.
-function getActiveGamepad() {
-    var pads = navigator.getGamepads ? navigator.getGamepads() : [];
-    if (gamepadIndex != null && pads[gamepadIndex]) {
-        return pads[gamepadIndex];
+// page load never fires 'gamepadconnected'. So in single-player we adopt the
+// first live pad onto the primary slot while polling.
+function adoptFirstPadToPrimary(pads) {
+    var p = localPlayers[primarySlot];
+    if (!p) {
+        return null;
+    }
+    if (p.padIndex != null && pads[p.padIndex]) {
+        return pads[p.padIndex];
     }
     for (var i = 0; i < pads.length; i++) {
         if (pads[i]) {
+            p.padIndex = i;
+            p.padType = detectGamepadType(pads[i].id);
+            gamepadConnected = true;
             gamepadIndex = i;
-            if (!gamepadConnected) {
-                gamepadConnected = true;
-                gamepadType = detectGamepadType(pads[i].id);
-            }
+            gamepadType = p.padType;
             return pads[i];
         }
     }
     // No pad present. If we thought one was connected, it vanished without a
     // 'gamepaddisconnected' event — release any held movement so the player
     // doesn't keep drifting, and fall back to keyboard/touch hints.
-    if (gamepadConnected) {
+    if (p.padIndex != null) {
+        p.padIndex = null;
         gamepadConnected = false;
         gamepadIndex = null;
-        if (gpHadMoveInput && typeof cancelMovement === "function") {
+        if (p.gp.hadMoveInput && typeof cancelMovement === "function") {
             cancelMovement();
-            gpHadMoveInput = false;
+            p.gp.hadMoveInput = false;
         }
         if (activeInputMethod === "pad") {
             setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
@@ -204,55 +219,112 @@ function getActiveGamepad() {
     return null;
 }
 
+function anyButtonPressed(pad) {
+    for (var i = 0; i < pad.buttons.length; i++) {
+        if (pad.buttons[i] && (pad.buttons[i].pressed || pad.buttons[i].value > GP_TRIGGER_THRESHOLD)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function snapshotButtons(pad) {
+    var out = [];
+    for (var i = 0; i < pad.buttons.length; i++) {
+        out[i] = pad.buttons[i].pressed;
+    }
+    return out;
+}
+
 // Called once per frame from gameLoop().
 function pollGamepad(dt) {
-    var pad = getActiveGamepad();
-    if (!pad) {
+    var pads = navigator.getGamepads ? navigator.getGamepads() : [];
+    if (!localMultiplayerEnabled()) {
+        // Single-player: one pad drives the primary slot, exactly as before.
+        var pad = adoptFirstPadToPrimary(pads);
+        if (pad) {
+            pollPadForSlot(pad, localPlayers[primarySlot]);
+        }
         return;
     }
-
-    // Using the pad swaps the glyphs to the controller scheme.
-    if (padHasInput(pad)) {
-        lastPadInputAt = Date.now();
-        setInputMethod("pad");
+    // Local multiplayer: keyboard owns the primary slot; each connected pad drives
+    // its own claimed slot, and an unclaimed pad hot-joins as a new local player
+    // on its first button press.
+    for (var i = 0; i < pads.length; i++) {
+        var pad = pads[i];
+        if (!pad) {
+            continue;
+        }
+        var lp = localPlayerForPadIndex(i);
+        if (!lp) {
+            if (anyButtonPressed(pad)) {
+                var slot = nextFreeSlot();
+                if (slot != null && typeof gameID !== "undefined" && gameID != null) {
+                    lp = addLocalPlayer(slot, i);
+                    if (lp) {
+                        // Don't let the join press also register as an attack next frame.
+                        lp.gp.prevButtons = snapshotButtons(pad);
+                    }
+                }
+            }
+            continue; // wait until the slot has joined (myID set) before polling
+        }
+        if (lp.myID == null) {
+            continue;
+        }
+        pollPadForSlot(pad, lp);
     }
+}
 
-    // Select toggles the hint bar between hidden (transparent) and shown.
-    if (buttonPressedThisFrame(pad, GP_BTN_SELECT)) {
-        toggleHintFade();
-    }
-
-    if (leaveModalIsOpen()) {
-        // The confirm modal owns input while it's up.
-        pollLeaveModal(pad);
-    } else if (typeof menuOpen !== "undefined" && menuOpen) {
-        // The emoji wheel owns input while it's up.
-        pollEmojiWheel(pad);
-    } else if (buttonPressedThisFrame(pad, GP_BTN_B)) {
-        openLeaveModal();
-    } else if (buttonPressedThisFrame(pad, GP_BTN_EMOJI)) {
-        openEmojiFromPad();
+// Poll one pad and apply it to its local player `lp`. The primary slot also owns
+// the emoji wheel / leave modal / hint bar; non-primary pads do movement only, so
+// the primary opening a modal never freezes pad players (§6.16).
+function pollPadForSlot(pad, lp) {
+    if (lp.isPrimary) {
+        // Using the pad swaps the glyphs to the controller scheme.
+        if (padHasInput(pad)) {
+            lastPadInputAt = Date.now();
+            setInputMethod("pad");
+        }
+        // Select toggles the hint bar between hidden (transparent) and shown.
+        if (buttonPressedThisFrame(pad, GP_BTN_SELECT, lp)) {
+            toggleHintFade();
+        }
+        if (leaveModalIsOpen()) {
+            pollLeaveModal(pad, lp);
+        } else if (typeof menuOpen !== "undefined" && menuOpen) {
+            pollEmojiWheel(pad, lp);
+        } else if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
+            openLeaveModal();
+        } else if (buttonPressedThisFrame(pad, GP_BTN_EMOJI, lp)) {
+            openEmojiFromPad(lp);
+        } else {
+            pollAim(pad, lp);
+            pollMovementAndAttack(pad, lp);
+            if (buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
+                goFullScreen();
+            }
+        }
     } else {
-        // Aim first so movement knows whether the right stick owns the facing.
-        pollAim(pad);
-        pollMovementAndAttack(pad);
-        if (buttonPressedThisFrame(pad, GP_BTN_START)) {
+        pollAim(pad, lp);
+        pollMovementAndAttack(pad, lp);
+        if (buttonPressedThisFrame(pad, GP_BTN_START, lp)) {
             goFullScreen();
         }
     }
-
-    rememberButtons(pad);
+    rememberButtons(pad, lp);
 }
 
-function pollAim(pad) {
+function pollAim(pad, lp) {
+    var gp = lp.gp;
     var rx = pad.axes[2] || 0;
     var ry = pad.axes[3] || 0;
     var mag = Math.sqrt(rx * rx + ry * ry);
-    gpAimActive = mag >= GP_AIM_DEADZONE;
-    if (!gpAimActive) {
+    gp.aimActive = mag >= GP_AIM_DEADZONE;
+    if (!gp.aimActive) {
         return;
     }
-    if (typeof playerList === "undefined" || !playerList || gpID() == null || !playerList[gpID()]) {
+    if (typeof playerList === "undefined" || !playerList || lp.myID == null || !playerList[lp.myID]) {
         return;
     }
 
@@ -263,8 +335,8 @@ function pollAim(pad) {
     }
 
     // Throttle: skip tiny changes and cap the emit rate so we don't flood the socket.
-    if (gpPrevAimAngle != null) {
-        var delta = Math.abs(deg - gpPrevAimAngle);
+    if (gp.prevAimAngle != null) {
+        var delta = Math.abs(deg - gp.prevAimAngle);
         if (delta > 180) {
             delta = 360 - delta;
         }
@@ -273,19 +345,19 @@ function pollAim(pad) {
         }
     }
     var now = Date.now();
-    if (now - gpLastAimEmit < GP_AIM_MIN_INTERVAL) {
+    if (now - gp.lastAimEmit < GP_AIM_MIN_INTERVAL) {
         return;
     }
 
-    playerList[gpID()].angle = deg;
-    if (gpSocket()) {
-        gpSocket().emit('mousemove', deg);
+    playerList[lp.myID].angle = deg;
+    if (lp.socket) {
+        lp.socket.emit('mousemove', deg);
     }
-    gpPrevAimAngle = deg;
-    gpLastAimEmit = now;
+    gp.prevAimAngle = deg;
+    gp.lastAimEmit = now;
 }
 
-function pollMovementAndAttack(pad) {
+function pollMovementAndAttack(pad, lp) {
     var mf = false, mb = false, tl = false, tr = false;
     var moveActive = false;
 
@@ -329,7 +401,7 @@ function pollMovementAndAttack(pad) {
     }
 
     var atk = readAttack(pad);
-    applyInputState(mf, mb, tl, tr, atk, moveActive);
+    applyInputState(lp, mf, mb, tl, tr, atk, moveActive);
 }
 
 function readAttack(pad) {
@@ -338,61 +410,73 @@ function readAttack(pad) {
     return !!(a || rt);
 }
 
-function applyInputState(mf, mb, tl, tr, atk, moveActive) {
+function applyInputState(lp, mf, mb, tl, tr, atk, moveActive) {
+    var gp = lp.gp;
     // Only let the pad drive when it is actually providing input, or when it is
     // releasing input it held last frame. This keeps keyboard/mouse usable while
-    // the pad sits idle.
-    var padDriving = moveActive || atk || gpHadMoveInput;
+    // the (primary) pad sits idle.
+    var padDriving = moveActive || atk || gp.hadMoveInput;
     if (padDriving) {
-        var changed = (mf !== gpPrevMove.moveForward) ||
-            (mb !== gpPrevMove.moveBackward) ||
-            (tl !== gpPrevMove.turnLeft) ||
-            (tr !== gpPrevMove.turnRight) ||
-            (atk !== gpPrevMove.attack);
+        var prev = gp.prevMove;
+        var changed = (mf !== prev.moveForward) ||
+            (mb !== prev.moveBackward) ||
+            (tl !== prev.turnLeft) ||
+            (tr !== prev.turnRight) ||
+            (atk !== prev.attack);
 
         if (changed) {
-            moveForward = mf;
-            moveBackward = mb;
-            turnLeft = tl;
-            turnRight = tr;
-            attack = atk;
+            // Primary slot writes the movement globals (shared with keyboard);
+            // pad slots write their own per-slot input.
+            if (lp.isPrimary) {
+                moveForward = mf;
+                moveBackward = mb;
+                turnLeft = tl;
+                turnRight = tr;
+                attack = atk;
+            } else {
+                lp.input.moveForward = mf;
+                lp.input.moveBackward = mb;
+                lp.input.turnLeft = tl;
+                lp.input.turnRight = tr;
+                lp.input.attack = atk;
+            }
             // When the right stick isn't aiming, face the movement direction
-            // (mirrors the keyboard behaviour).
-            if (!gpAimActive && typeof playerList !== "undefined" && playerList && gpID() != null && playerList[gpID()]) {
-                calcAngleFromKeys(playerList[gpID()]);
-                if (gpSocket()) {
-                    gpSocket().emit('mousemove', playerList[gpID()].angle);
+            // (mirrors the keyboard behaviour), per this slot's own input.
+            if (!gp.aimActive && typeof playerList !== "undefined" && playerList && lp.myID != null && playerList[lp.myID]) {
+                var ang = calcAngleFromInput(mf, mb, tl, tr, playerList[lp.myID].angle);
+                playerList[lp.myID].angle = ang;
+                if (lp.socket) {
+                    lp.socket.emit('mousemove', ang);
                 }
             }
-            emitMovement();
-            gpPrevMove = { moveForward: mf, moveBackward: mb, turnLeft: tl, turnRight: tr, attack: atk };
+            emitMovement(lp);
+            gp.prevMove = { moveForward: mf, moveBackward: mb, turnLeft: tl, turnRight: tr, attack: atk };
         }
     }
-    gpHadMoveInput = moveActive || atk;
+    gp.hadMoveInput = moveActive || atk;
 }
 
-function emitMovement() {
-    if (gpSocket()) {
-        gpSocket().emit('movement', {
-            turnLeft: turnLeft,
-            moveForward: moveForward,
-            turnRight: turnRight,
-            moveBackward: moveBackward,
-            attack: attack
-        });
+function emitMovement(lp) {
+    if (!lp.socket) {
+        return;
     }
+    var inp = lp.isPrimary
+        ? { turnLeft: turnLeft, moveForward: moveForward, turnRight: turnRight, moveBackward: moveBackward, attack: attack }
+        : { turnLeft: lp.input.turnLeft, moveForward: lp.input.moveForward, turnRight: lp.input.turnRight, moveBackward: lp.input.moveBackward, attack: lp.input.attack };
+    lp.socket.emit('movement', inp);
 }
 
-function rememberButtons(pad) {
-    gpPrevButtons = [];
+function rememberButtons(pad, lp) {
+    var buttons = [];
     for (var i = 0; i < pad.buttons.length; i++) {
-        gpPrevButtons[i] = pad.buttons[i].pressed;
+        buttons[i] = pad.buttons[i].pressed;
     }
+    lp.gp.prevButtons = buttons;
 }
 
-function buttonPressedThisFrame(pad, idx) {
+function buttonPressedThisFrame(pad, idx, lp) {
     var now = pad.buttons[idx] && pad.buttons[idx].pressed;
-    var was = gpPrevButtons[idx] || false;
+    var was = (lp.gp.prevButtons[idx]) || false;
     return !!now && !was;
 }
 
@@ -443,20 +527,22 @@ function nearestEmojiToDir(items, lx, ly) {
     return best;
 }
 
-function openEmojiFromPad() {
+// The emoji wheel is owned by the PRIMARY slot only (§6.16 MVP), so `lp` here is
+// always the primary; passing it keeps the per-pad edge state consistent.
+function openEmojiFromPad(lp) {
     // Stop driving the player while the wheel is up.
-    if (gpHadMoveInput) {
-        cancelMovement();
-        gpHadMoveInput = false;
+    if (lp.gp.hadMoveInput) {
+        cancelMovementForSlot(lp);
+        lp.gp.hadMoveInput = false;
     }
-    gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+    lp.gp.prevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
     gpEmojiIndex = 0;
     var w = window.innerWidth || 800;
     var h = window.innerHeight || 600;
     openEmojiWindow(w / 2 - 50, h / 2 - 50);
 }
 
-function pollEmojiWheel(pad) {
+function pollEmojiWheel(pad, lp) {
     var items = emojiItems();
     if (items.length === 0) {
         return;
@@ -466,13 +552,13 @@ function pollEmojiWheel(pad) {
     }
 
     // Confirm sends the highlighted emoji; B / X cancels.
-    if (buttonPressedThisFrame(pad, GP_BTN_A)) {
+    if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
         var chosen = items[gpEmojiIndex].innerHTML;
         clearEmojiHighlight(items);
         closeEmojiWindow(chosen);
         return;
     }
-    if (buttonPressedThisFrame(pad, GP_BTN_B) || buttonPressedThisFrame(pad, GP_BTN_EMOJI)) {
+    if (buttonPressedThisFrame(pad, GP_BTN_B, lp) || buttonPressedThisFrame(pad, GP_BTN_EMOJI, lp)) {
         clearEmojiHighlight(items);
         closeEmojiWindow("cancel");
         return;
@@ -486,10 +572,10 @@ function pollEmojiWheel(pad) {
         gpEmojiIndex = nearestEmojiToDir(items, lx, ly);
     }
     var now = Date.now();
-    if (buttonPressedThisFrame(pad, GP_DPAD_RIGHT) || buttonPressedThisFrame(pad, GP_DPAD_DOWN)) {
+    if (buttonPressedThisFrame(pad, GP_DPAD_RIGHT, lp) || buttonPressedThisFrame(pad, GP_DPAD_DOWN, lp)) {
         gpEmojiIndex = (gpEmojiIndex + 1) % items.length;
         gpEmojiStepAt = now;
-    } else if (buttonPressedThisFrame(pad, GP_DPAD_LEFT) || buttonPressedThisFrame(pad, GP_DPAD_UP)) {
+    } else if (buttonPressedThisFrame(pad, GP_DPAD_LEFT, lp) || buttonPressedThisFrame(pad, GP_DPAD_UP, lp)) {
         gpEmojiIndex = (gpEmojiIndex - 1 + items.length) % items.length;
         gpEmojiStepAt = now;
     }
@@ -552,8 +638,11 @@ function openLeaveModal() {
     if (typeof cancelMovement === "function") {
         cancelMovement();
     }
-    gpHadMoveInput = false;
-    gpPrevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+    var primary = localPlayers[primarySlot];
+    if (primary) {
+        primary.gp.hadMoveInput = false;
+        primary.gp.prevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+    }
     leaveModalEl.className = "confirm-modal visible";
     setLeaveFocus(1); // default to Cancel
 }
@@ -565,8 +654,15 @@ function closeLeaveModal() {
 }
 
 function doLeaveGame() {
-    // Navigating away drops the socket; the server kicks us from the room.
-    window.location.href = "./index.html";
+    // The leave modal is owned by the primary slot. Drop just that slot: with no
+    // other local players this disconnects and navigates away as before (N=1);
+    // with pad players still in the game it fails over to one of them instead of
+    // ending the whole couch session (§6.17).
+    if (typeof dropLocalPlayer === "function") {
+        dropLocalPlayer(primarySlot);
+    } else {
+        window.location.href = "./index.html";
+    }
 }
 
 function leaveButtons() {
@@ -592,21 +688,21 @@ function setLeaveFocus(idx) {
     }
 }
 
-function pollLeaveModal(pad) {
-    if (buttonPressedThisFrame(pad, GP_BTN_B)) {
+function pollLeaveModal(pad, lp) {
+    if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
         closeLeaveModal();
         return;
     }
-    if (buttonPressedThisFrame(pad, GP_BTN_A)) {
+    if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
         var btns = leaveButtons();
         if (btns[leaveFocusIdx]) {
             btns[leaveFocusIdx].click();
         }
         return;
     }
-    if (buttonPressedThisFrame(pad, GP_DPAD_LEFT)) {
+    if (buttonPressedThisFrame(pad, GP_DPAD_LEFT, lp)) {
         setLeaveFocus(0);
-    } else if (buttonPressedThisFrame(pad, GP_DPAD_RIGHT)) {
+    } else if (buttonPressedThisFrame(pad, GP_DPAD_RIGHT, lp)) {
         setLeaveFocus(1);
     } else {
         var lx = pad.axes[0] || 0;

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -73,6 +73,7 @@ function initGamepad() {
     window.addEventListener("touchstart", markTouchUsed, false);
     buildHintBar();
     buildLeaveModalUI();
+    buildPadPlayersUI();
     // Start on the device's most likely method; live usage swaps it.
     setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
 }
@@ -136,6 +137,7 @@ function onGamepadConnected(e) {
     // button press (pollGamepad). Browsers only reliably surface an idle pad
     // after a press anyway, so we wait for that rather than joining on connect.
     debugLog("[localmp] controller detected — press a button to join");
+    showJoinToast(type);
 }
 
 function onGamepadDisconnected(e) {
@@ -274,6 +276,8 @@ function pollGamepad(dt) {
         }
         return;
     }
+    // Keep each pad player's color dot in sync with their server-assigned color.
+    refreshPadBlocks();
     // Local multiplayer: keyboard owns the primary slot; each connected pad drives
     // its own claimed slot, and an unclaimed pad hot-joins as a new local player
     // on its first button press.
@@ -852,6 +856,127 @@ function scheduleHintFade() {
             hintBarEl.classList.add("faded");
         }
     }, HINT_FADE_MS);
+}
+
+// --- per-pad player overlay (local multiplayer, §5.3) ---
+//
+// One compact block per pad player, each carrying a color dot tinted with that
+// player's server-assigned color — the readable link "this controller = the red
+// player" — plus the player's slot label and that pad's own attack glyph (A on
+// Xbox, ✕ on PlayStation, so mixed-brand pads show their real button). Built
+// lazily; populated by the onLocalPlayerJoined/Dropped hooks (client.js) and kept
+// in color-sync by refreshPadBlocks() each frame (the color arrives a beat after
+// join via playerJoin/gameUpdates). The keyboard/primary player keeps the bottom
+// hint bar; these blocks are for the pad players only.
+
+var padPlayersEl = null;     // container element
+var padBlocks = {};          // slot -> { el, dot, lastColor }
+var padToastEl = null;
+var padToastTimer = null;
+
+function buildPadPlayersUI() {
+    if (padPlayersEl || typeof document === "undefined" || !document.body) {
+        return;
+    }
+    var el = document.createElement("div");
+    el.id = "padPlayers";
+    document.body.appendChild(el);
+    padPlayersEl = el;
+}
+
+function attackGlyphFor(type) {
+    return type === "playstation" ? "✕" : "A";
+}
+
+// Brief "controller detected — press A to join" toast when a pad connects.
+function showJoinToast(type) {
+    if (typeof document === "undefined" || !document.body) {
+        return;
+    }
+    if (!padToastEl) {
+        padToastEl = document.createElement("div");
+        padToastEl.id = "padToast";
+        document.body.appendChild(padToastEl);
+    }
+    padToastEl.innerHTML = '🎮 Controller detected — press ' +
+        '<span class="gp-glyph gp-face">' + attackGlyphFor(type) + '</span> to join';
+    padToastEl.classList.add("visible");
+    clearTimeout(padToastTimer);
+    padToastTimer = setTimeout(function () {
+        if (padToastEl) {
+            padToastEl.classList.remove("visible");
+        }
+    }, 4000);
+}
+
+// Hook (client.js addLocalPlayer): a pad player joined — create its block.
+function onLocalPlayerJoined(lp) {
+    if (!padPlayersEl) {
+        buildPadPlayersUI();
+    }
+    if (!padPlayersEl || padBlocks[lp.slot]) {
+        return;
+    }
+    var block = document.createElement("div");
+    block.className = "pad-player";
+    block.id = "padPlayer-" + lp.slot;
+
+    var dot = document.createElement("span");
+    dot.className = "gp-color-dot";
+    var label = document.createElement("span");
+    label.className = "pp-label";
+    label.textContent = "P" + (lp.slot + 1);
+    var move = document.createElement("span");
+    move.className = "gp-glyph gp-stick";
+    move.textContent = "L";
+    var atk = document.createElement("span");
+    atk.className = "gp-glyph gp-face";
+    atk.textContent = attackGlyphFor(lp.padType);
+
+    block.appendChild(dot);
+    block.appendChild(label);
+    block.appendChild(move);
+    block.appendChild(atk);
+    padPlayersEl.appendChild(block);
+    padBlocks[lp.slot] = { el: block, dot: dot, lastColor: null };
+
+    // A join just happened — drop the connect toast.
+    if (padToastEl) {
+        padToastEl.classList.remove("visible");
+    }
+}
+
+// Hook (client.js dropLocalPlayer): a pad player left — remove its block.
+function onLocalPlayerDropped(slot) {
+    var b = padBlocks[slot];
+    if (!b) {
+        return;
+    }
+    if (b.el && b.el.parentNode) {
+        b.el.parentNode.removeChild(b.el);
+    }
+    delete padBlocks[slot];
+}
+
+// Tint each pad player's dot with their current server-assigned color (which only
+// arrives a moment after join). Cheap; only writes the DOM when the color changes.
+function refreshPadBlocks() {
+    if (typeof playerList === "undefined" || !playerList) {
+        return;
+    }
+    for (var slot in padBlocks) {
+        var lp = localPlayers[slot];
+        var b = padBlocks[slot];
+        if (!lp || !b) {
+            continue;
+        }
+        var p = (lp.myID != null) ? playerList[lp.myID] : null;
+        var color = (p && p.color) ? p.color : null;
+        if (color && color !== b.lastColor) {
+            b.dot.style.backgroundColor = color;
+            b.lastColor = color;
+        }
+    }
 }
 
 // Manual toggle (Select button / H key): hide the bar now, or restore it.

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -389,6 +389,9 @@ function pollGamepad(dt) {
         if (lp.myID == null) {
             continue;
         }
+        if (lp.socket && lp.socket.connected === false) {
+            continue; // mid-reconnect — don't emit into a dropped socket
+        }
         pollPadForSlot(pad, lp);
     }
 }
@@ -1035,6 +1038,21 @@ function onLocalPlayerJoined(lp) {
     // A join just happened — drop the connect toast.
     if (padToastEl) {
         padToastEl.classList.remove("visible");
+    }
+}
+
+// Hook (client.js): grey a pad player's block while their socket is reconnecting,
+// and restore it on recovery — so a transient blip shows as "reconnecting" rather
+// than vanishing.
+function onLocalPlayerReconnecting(slot, isReconnecting) {
+    var b = padBlocks[slot];
+    if (!b || !b.el) {
+        return;
+    }
+    if (isReconnecting) {
+        b.el.classList.add("reconnecting");
+    } else {
+        b.el.classList.remove("reconnecting");
     }
 }
 

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -236,9 +236,36 @@ function snapshotButtons(pad) {
     return out;
 }
 
+// Browsers pause rAF/gamepad polling while the tab is hidden and may zero gamepad
+// state across a focus change. On refocus, re-baseline each pad's button
+// edge-state from the live reading so a button held across the focus change isn't
+// seen as a fresh press (no phantom attacks/menu-opens, §6.18). Set on `focus`,
+// consumed on the next poll.
+var padEdgeResetPending = false;
+function onTabRefocus() {
+    padEdgeResetPending = true;
+}
+function rebaselinePadEdges(pads) {
+    for (var s = 0; s < localPlayers.length; s++) {
+        var lp = localPlayers[s];
+        if (lp && lp.padIndex != null && pads[lp.padIndex]) {
+            lp.gp.prevButtons = snapshotButtons(pads[lp.padIndex]);
+            lp.gp.prevMove = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+            lp.gp.hadMoveInput = false;
+        }
+    }
+}
+
 // Called once per frame from gameLoop().
 function pollGamepad(dt) {
     var pads = navigator.getGamepads ? navigator.getGamepads() : [];
+    if (padEdgeResetPending) {
+        // First poll after refocus: establish a clean edge baseline and skip
+        // edge-triggered actions for this frame (movement resumes next frame).
+        rebaselinePadEdges(pads);
+        padEdgeResetPending = false;
+        return;
+    }
     if (!localMultiplayerEnabled()) {
         // Single-player: one pad drives the primary slot, exactly as before.
         var pad = adoptFirstPadToPrimary(pads);

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -104,9 +104,38 @@ function markTouchUsed() {
 
 function onGamepadKeyDown(e) {
     setInputMethod("kbm"); // a key press means keyboard/mouse is in use
+    var primary = localPlayers[primarySlot];
+
+    // Multiplayer: the keyboard player leaves via the SAME inline "Leave?" confirm
+    // in their own block that controllers use (not the centre modal). Esc opens it,
+    // Enter confirms (leave), Esc cancels.
+    if (hintUiMode === "blocks" && primary) {
+        if (primary.leaveConfirm) {
+            if (e.keyCode === 13 || e.key === "Enter") {
+                primary.leaveConfirm = false;
+                dropLocalPlayer(primarySlot);
+                e.preventDefault();
+            } else if (e.key === "Escape" || e.keyCode === 27) {
+                primary.leaveConfirm = false;
+                setBlockLeaveConfirm(primarySlot, false);
+                e.preventDefault();
+            }
+            return;
+        }
+        if (e.key === "Escape" || e.keyCode === 27) {
+            openLeaveConfirm(primary);
+            e.preventDefault();
+            return;
+        }
+        if (e.key === "h" || e.key === "H" || e.keyCode === 72) {
+            toggleHintFade();
+        }
+        return;
+    }
+
+    // Solo: the centre leave modal. While it's up, arrows / A-D move between Leave
+    // and Cancel, Enter or Space confirms, Esc closes.
     if (leaveModalIsOpen()) {
-        // The leave modal owns the keyboard while it's up: arrows / A-D move
-        // between Leave and Cancel, Enter or Space confirms, Esc closes.
         if (e.key === "Escape" || e.keyCode === 27) {
             closeLeaveModal();
         } else if (e.keyCode === 37 || e.keyCode === 65 || e.key === "ArrowLeft") {
@@ -778,10 +807,12 @@ function closeLeaveModal() {
 }
 
 function doLeaveGame() {
-    // The leave modal is owned by the primary slot. Drop just that slot: with no
-    // other local players this disconnects and navigates away as before (N=1);
-    // with pad players still in the game it fails over to one of them instead of
-    // ending the whole couch session (§6.17).
+    // Always close the modal first so it can't linger if we fail over instead of
+    // navigating away (a primary leave with surviving pad players promotes one).
+    closeLeaveModal();
+    // Drop the primary slot: with no other local players this disconnects and
+    // navigates away as before (N=1); with pad players still in the game it fails
+    // over to one of them instead of ending the whole couch session (§6.17).
     if (typeof dropLocalPlayer === "function") {
         dropLocalPlayer(primarySlot);
     } else {
@@ -1243,10 +1274,17 @@ function setBlockLeaveConfirm(slot, confirming) {
     if (confirming) {
         b.el.classList.add("confirming");
         var lp = localPlayers[slot];
-        var type = (lp && lp.padType) ? lp.padType : "generic";
-        b.hints.innerHTML = '<span class="pp-confirm">Leave?</span>' +
-            '<span class="gp-glyph gp-face">' + attackGlyphFor(type) + '</span>' +
-            '<span class="gp-glyph gp-face">' + leaveGlyphFor(type) + '</span>';
+        var confirmHints;
+        if (lp && lp.padIndex != null) {
+            // controller: A confirms, B cancels
+            confirmHints = '<span class="gp-glyph gp-face">' + attackGlyphFor(lp.padType) + '</span>' +
+                '<span class="gp-glyph gp-face">' + leaveGlyphFor(lp.padType) + '</span>';
+        } else {
+            // keyboard: Enter confirms, Esc cancels
+            confirmHints = '<span class="gp-glyph gp-key">Enter</span>' +
+                '<span class="gp-glyph gp-key">Esc</span>';
+        }
+        b.hints.innerHTML = '<span class="pp-confirm">Leave?</span>' + confirmHints;
     } else {
         b.el.classList.remove("confirming");
         b.lastMethod = null; // force a hint rebuild on the next refresh

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -316,14 +316,22 @@ function pollGamepad(dt) {
         }
         var lp = localPlayerForPadIndex(i);
         if (!lp) {
-            var pressed = anyButtonPressed(pad);
+            // A pad that just left must release its buttons before (re)joining, so
+            // the press that confirmed leaving can't instantly re-join it.
             if (padNeedsRelease[i]) {
-                // Just-left pad: wait until its buttons are released before it can
-                // join again (so the leave-confirm press can't re-join it).
-                if (!pressed) {
+                if (!anyButtonPressed(pad)) {
                     delete padNeedsRelease[i];
                 }
-            } else if (pressed) {
+                continue;
+            }
+            var primary = localPlayers[primarySlot];
+            if (primary && primary.padIndex == null && !keyboardClaimedPrimary) {
+                // First controller, no keyboard in use → it drives P1. Adopt it as
+                // soon as it's present (no button required) so stick/d-pad menu and
+                // lobby navigation work immediately, matching the old single-pad UX.
+                bindPadToPrimary(i, pad);
+            } else if (anyButtonPressed(pad)) {
+                // An additional controller joins as a new player (P2+) on a press.
                 tryClaimPadSlot(i, pad);
             }
             continue; // wait until the slot has joined (myID set) before polling

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -330,12 +330,64 @@ function touchMovement() {
 }
 
 function cancelMovement(evt) {
+    // Cancels the PRIMARY (keyboard/mouse) player's movement via the globals.
     turnLeft = false;
     turnRight = false;
     moveForward = false;
     moveBackward = false;
     attack = false;
     server.emit('movement', { turnLeft: false, moveForward: false, turnRight: false, moveBackward: false, attack: false });
+}
+
+// Stop one local player's movement on its own socket. Primary -> the globals;
+// pad slot -> its own input struct.
+function cancelMovementForSlot(lp) {
+    if (!lp) {
+        return;
+    }
+    if (lp.isPrimary) {
+        cancelMovement();
+        return;
+    }
+    lp.input.turnLeft = false;
+    lp.input.turnRight = false;
+    lp.input.moveForward = false;
+    lp.input.moveBackward = false;
+    lp.input.attack = false;
+    if (lp.socket) {
+        lp.socket.emit('movement', { turnLeft: false, moveForward: false, turnRight: false, moveBackward: false, attack: false });
+    }
+}
+
+// On tab blur, stop EVERY local player (not just the primary) so no one drifts
+// while the tab is backgrounded, emitting a stop on each player's own socket
+// (§6.18).
+function cancelAllLocalMovement(evt) {
+    if (typeof localPlayers === "undefined" || !localPlayers.length) {
+        cancelMovement(evt); // bootstrap / nothing set up yet
+        return;
+    }
+    for (var i = 0; i < localPlayers.length; i++) {
+        if (localPlayers[i]) {
+            cancelMovementForSlot(localPlayers[i]);
+        }
+    }
+}
+
+// Pure version of calcAngleFromKeys: derive the facing angle from explicit
+// movement booleans instead of the keyboard globals, so a pad slot can compute
+// its own facing without reading the primary player's input. Returns `fallback`
+// (the player's current angle) when no direction is held.
+function calcAngleFromInput(mf, mb, tl, tr, fallback) {
+    if (tl && mf) { return 225; }
+    if (tr && mf) { return 315; }
+    if (tr && mb) { return 45; }
+    if (tl && mb) { return 135; }
+    if (mf) { return 270; }
+    if (mb) { return 90; }
+    if (tl) { return 180; }
+    if (tr) { return 0; }
+    return fallback;
 }
 
 function calcAngleFromKeys(player) {

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -59,7 +59,10 @@ function handleClick(event) {
     switch (event.which) {
         case 1: {
             if (menuOpen == false) {
-                claimPrimaryForKbm(); // mouse is playing P1 -> controllers are P2+
+                // NOTE: a single click is NOT treated as "kb/m is P1" — it's too
+                // ambiguous (could be clicking to start/focus). Only actually
+                // moving the player via keyboard or mouse-move claims P1 (so a
+                // controller-only player keeps P1). See keyDown / handleDblClick.
                 attack = true;
                 server.emit('movement', { turnLeft: turnLeft, moveForward: moveForward, turnRight: turnRight, moveBackward: moveBackward, attack: attack });
             }

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -59,6 +59,7 @@ function handleClick(event) {
     switch (event.which) {
         case 1: {
             if (menuOpen == false) {
+                kbmClaimedPrimary = true; // mouse is playing P1 -> controllers are P2+
                 attack = true;
                 server.emit('movement', { turnLeft: turnLeft, moveForward: moveForward, turnRight: turnRight, moveBackward: moveBackward, attack: attack });
             }
@@ -91,6 +92,7 @@ function handleUnClick(event) {
     }
 }
 function handleDblClick(event) {
+    kbmClaimedPrimary = true; // mouse-move play claims P1 -> controllers are P2+
     if (movingByMouse) {
         cancelMovement(event);
     }
@@ -121,7 +123,7 @@ function keyDown(evt) {
     // The keyboard is being used to play -> it owns the primary slot (P1), so
     // controllers hot-join as P2+. (When this stays false, the first pad takes P1.)
     if (gameKey) {
-        keyboardClaimedPrimary = true;
+        kbmClaimedPrimary = true;
     }
     if (playerList[myID] != null) {
         calcAngleFromKeys(playerList[myID]);

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -59,7 +59,7 @@ function handleClick(event) {
     switch (event.which) {
         case 1: {
             if (menuOpen == false) {
-                kbmClaimedPrimary = true; // mouse is playing P1 -> controllers are P2+
+                claimPrimaryForKbm(); // mouse is playing P1 -> controllers are P2+
                 attack = true;
                 server.emit('movement', { turnLeft: turnLeft, moveForward: moveForward, turnRight: turnRight, moveBackward: moveBackward, attack: attack });
             }
@@ -92,7 +92,7 @@ function handleUnClick(event) {
     }
 }
 function handleDblClick(event) {
-    kbmClaimedPrimary = true; // mouse-move play claims P1 -> controllers are P2+
+    claimPrimaryForKbm(); // mouse-move play claims P1 -> controllers are P2+
     if (movingByMouse) {
         cancelMovement(event);
     }
@@ -123,7 +123,7 @@ function keyDown(evt) {
     // The keyboard is being used to play -> it owns the primary slot (P1), so
     // controllers hot-join as P2+. (When this stays false, the first pad takes P1.)
     if (gameKey) {
-        kbmClaimedPrimary = true;
+        claimPrimaryForKbm();
     }
     if (playerList[myID] != null) {
         calcAngleFromKeys(playerList[myID]);

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -436,20 +436,29 @@ function openEmojiWindow(x, y) {
     if (menuOpen == false) {
         emojiMenu.style.transform = "scale(2)";
         menuOpen = true;
+        // Mouse/touch/keyboard opens belong to the primary; a pad open overrides
+        // this in openEmojiFromPad. Tint the wheel border with the opener's color.
+        emojiOwnerSlot = primarySlot;
+        if (typeof playerList !== "undefined" && playerList && myID != null && playerList[myID]) {
+            emojiMenu.style.borderColor = playerList[myID].color;
+        }
         moveEmojiMenu(x, y);
     }
 
 }
 function closeEmojiWindow(source) {
+    var owner = emojiOwnerSlot;
     if (menuOpen) {
         emojiMenu.style.transform = "scale(0)";
         menuOpen = false;
     }
+    emojiOwnerSlot = null;
     if (source == "cancel") {
         return;
     }
     var emoji = String(source).trim();
-    sendEmoji(emoji);
+    // Attribute the emoji to the player who opened the wheel (their socket).
+    sendEmojiForSlot(emoji, owner);
 }
 
 function moveEmojiMenu(x, y) {

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -55,10 +55,18 @@ function setMousePos(x, y) {
     */
 }
 
+// True only when the emoji wheel is open AND owned by the primary (mouse) player.
+// The mouse must keep working when ANOTHER local player has the wheel open.
+function primaryOwnsWheel() {
+    return (typeof menuOpen !== "undefined" && menuOpen) &&
+        (typeof emojiOwnerSlot === "undefined" || emojiOwnerSlot === primarySlot);
+}
 function handleClick(event) {
     switch (event.which) {
         case 1: {
-            if (menuOpen == false) {
+            // Suppress attack only while the PRIMARY's own wheel is up — a pad
+            // player's wheel must not freeze the mouse player's attack.
+            if (!primaryOwnsWheel()) {
                 // NOTE: a single click is NOT treated as "kb/m is P1" — it's too
                 // ambiguous (could be clicking to start/focus). Only actually
                 // moving the player via keyboard or mouse-move claims P1 (so a
@@ -69,8 +77,12 @@ function handleClick(event) {
             break;
         }
         case 3: {
-            if (menuOpen) {
-                closeEmojiWindow();
+            if (typeof menuOpen !== "undefined" && menuOpen) {
+                // Only close the wheel if it's the primary's own — don't hijack a
+                // pad player's open wheel.
+                if (primaryOwnsWheel()) {
+                    closeEmojiWindow();
+                }
             } else {
                 openEmojiWindow(mousex, mousey);
             }
@@ -83,7 +95,7 @@ function handleClick(event) {
 function handleUnClick(event) {
     switch (event.which) {
         case 1: {
-            if (menuOpen == false) {
+            if (!primaryOwnsWheel()) {
                 attack = false;
                 server.emit('movement', { turnLeft: turnLeft, moveForward: moveForward, turnRight: turnRight, moveBackward: moveBackward, attack: attack });
             }

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -105,6 +105,7 @@ function keyDown(evt) {
     if (movingByMouse) {
         movingByMouse = false;
     }
+    var gameKey = true;
     switch (evt.keyCode) {
         case 65: { turnLeft = true; break; } //Left key
         case 37: { turnLeft = true; break; } //Left key
@@ -115,6 +116,12 @@ function keyDown(evt) {
         case 83: { moveBackward = true; break; } //Down key
         case 40: { moveBackward = true; break; } //Down key
         case 32: { attack = true; break; } // Spacebar
+        default: { gameKey = false; }
+    }
+    // The keyboard is being used to play -> it owns the primary slot (P1), so
+    // controllers hot-join as P2+. (When this stays false, the first pad takes P1.)
+    if (gameKey) {
+        keyboardClaimedPrimary = true;
     }
     if (playerList[myID] != null) {
         calcAngleFromKeys(playerList[myID]);


### PR DESCRIPTION
## What

Adds **local multiplayer**: up to 4 people play one game of chaochao on a single screen — each on their own controller, plus one on keyboard/mouse. Every local player is a real, independent server player, so online players join the same room naturally. Implements the design in `LOCAL_MULTIPLAYER_ANALYSIS.md` (Approach A — one Socket.IO connection per local player).

## How

**≈100% client-side** — the server already treats one socket as one player, so N `forceNew` sockets from one tab are N players with no server changes.

- **Per-slot `localPlayers` table** — each local player owns its own `io({ forceNew: true })` socket, identity, input state, and gamepad mapping. Slot 0 (primary) owns rendering/audio/UI; the `server`/`myID`/`myPlayer`/movement globals alias it, so single-player behavior is unchanged.
- **Multi-pad input** — `gamepad.js` polls every pad and emits on each pad's own socket; per-pad button/edge state and per-pad modal ownership (emoji wheel / leave confirm) so one player's menu never freezes the others.
- **Always-on, no flag** — keyboard/mouse is P1; controllers join on **A** (the first controller becomes P1 if no kb/m is in use). kb/m can reclaim P1 from a controller.
- **Per-controller header** — connected controllers show "press A to join"; on join the block becomes that player's mini-controls with a color dot matching their sprite. Solo keeps the bottom hint bar; 2+ players switch to per-player blocks.
- **Per-slot teardown** — a kick / unplug / leave / timeout drops only that slot; the tab navigates only when the last local player is gone, with primary failover. Plus reconnect guards, per-pad blur/refocus handling, and the `blackout` brutal-round vision-hole now loops every local player.
- **Menu/editor pages** get an informational controller-detection header.

Merged latest `main` (v0.1.6); the music-sync feature integrates cleanly.

## Testing

- Headless: N `forceNew` sockets → N distinct players in one room (passes).
- Manual QA matrix (single-player regression, kb/m + controllers, hot-join, per-slot teardown, blackout, reconnect, mixed-brand pads).
- Multi-angle code-review pass; findings fixed (see commits).

## Notes

- No game-mechanic files touched (`config.json` / `game.js` / `engine.js`) — no rules changes.
- 8-player is parameterized but capped at 4 pending hardware validation (Windows XInput caps Xbox pads at 4).
- Recommend **squash-merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
