### PR TITLE
Add site favicon

### DIFF
--- a/client/assets/img/favicon.svg
+++ b/client/assets/img/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- Chao Chao: top-down arena pucks on the site's black tile -->
+  <rect width="64" height="64" rx="14" fill="#0a0a0a"/>
+  <g stroke="#000" stroke-opacity="0.35" stroke-width="1.5">
+    <circle cx="32" cy="23" r="13" fill="#FFD700"/>
+    <circle cx="22" cy="41" r="13" fill="#cf1020"/>
+    <circle cx="42" cy="41" r="13" fill="#90ee90"/>
+  </g>
+  <!-- glossy highlights to read as round pucks -->
+  <g fill="#fff" fill-opacity="0.45">
+    <circle cx="28" cy="19" r="3.2"/>
+    <circle cx="18" cy="37" r="3.2"/>
+    <circle cx="38" cy="37" r="3.2"/>
+  </g>
+</svg>

--- a/client/create.html
+++ b/client/create.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" type="text/css" href="css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/css/index.css">
+  <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
   <title>Chao Chao Map Edit</title>
   <style>
     /* When the editor is visible, lock the page so the canvas can't be

--- a/client/index.html
+++ b/client/index.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="css/styles.css">
     <link rel="stylesheet" type="text/css" href="assets/css/all.css">
+    <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <title>Chao Chao</title>
   </head>
   <body>

--- a/client/join.html
+++ b/client/join.html
@@ -16,6 +16,7 @@
         <link rel="stylesheet" type="text/css" href="css/styles.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/css/index.css">
+        <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
         <title>Chao Chao Join a game</title>
     </head>
 <body>

--- a/client/play.html
+++ b/client/play.html
@@ -17,6 +17,7 @@
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
         <link rel="stylesheet" type="text/css" href="css/styles.css">
         <link rel="stylesheet" type="text/css" href="assets/css/all.css">
+        <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
         <title>Chao Chao</title>
     </head>
     <body style="overflow: hidden;">


### PR DESCRIPTION
## What

Adds a favicon for the site. It depicts three overlapping player pucks — gold, red, and green, using the actual player colors from `server/config.json` — on the black rounded tile that matches the site nav, evoking the top-down arena.

## Changes

- New `client/assets/img/favicon.svg`.
- `<link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">` added to the `<head>` of `index.html`, `play.html`, `join.html`, and `create.html`.

## Notes

- SVG favicon — rendered crisply by all current browsers. No `.ico`/PNG fallback is included; if support for older browsers is wanted, a rasterized `favicon.ico` can be added later.
- No game-mechanic files touched (`config.json` / `game.js` / `engine.js`), so this is exempt from the CHANGELOG release-notes requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)