### PR TITLE
Map editor: Preview / Playtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Map editor
+
+- You can now preview a map you're building straight from the editor and play-test it solo before saving. Hitting Preview drops you right into the race — no lobby to wait through. When you die or reach the goal, you're dropped back into the editor with your map intact so you can keep tweaking and try again. Maps without a goal tile can't be previewed.
 
 ## v0.2.0 — 2026-05-24
 

--- a/client/create.html
+++ b/client/create.html
@@ -272,6 +272,8 @@
               Actions
             </div>
             <hr />
+            <button id="previewButton" class="btn btn-block">Preview / Playtest<i class="fa fa-play ml-2" aria-hidden="true"></i></button>
+            <button id="previewStatus" class="btn btn-block" disabled style="display:none;"><span></span></button>
             <button id="exportButton" class="btn btn-block">Copy to Clipboard<i class="fa fa-clipboard ml-2" aria-hidden="true"></i></button>
             <button id="submitButton" class="btn btn-block">Upload to Github<i class="fa fa-cloud-upload ml-2"></i></button>
             <button id="submitStatus" class="btn btn-block" disabled ><span>Submitting..</span></button>

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -6,6 +6,7 @@ var config,
 	lastTime = null,
 	totalPlayers = 0,
 	serverTimeoutWait = 5,
+	previewReturnScheduled = false,
 	playerWon = null;
 
 function clientConnect() {
@@ -179,6 +180,9 @@ function registerPrimaryHandlers(server) {
 		playerList[id].onFire = 0;
 		playerList[id].deathMessage = '💀';
 		createDownRankSymbol(id);
+		if (id == myID) {
+			previewReturnToEditor();
+		}
 	});
 	server.on("playerInfected", function (id) {
 		playerList[id].alive = true;
@@ -234,6 +238,9 @@ function registerPrimaryHandlers(server) {
 		}
 	});
 	server.on("startOverview", function (packet) {
+		// Round ended (solo death or goal reached) — schedule the editor return
+		// first, so a throw in the rendering calls below can't strand the creator.
+		previewReturnToEditor();
 		resetRound();
 		stopSound(lavaCollapse);
 		resetTrails();
@@ -243,6 +250,9 @@ function registerPrimaryHandlers(server) {
 		currentState = config.stateMap.overview;
 	});
 	server.on("startGameover", function (packet) {
+		// Match over (solo creator hit the winning notch) — schedule the editor
+		// return first so the calls below can't strand the creator if they throw.
+		previewReturnToEditor();
 		playerWon = packet.winner;
 		achievements = packet.achievements;
 		stopAllSounds();
@@ -703,6 +713,20 @@ function clientSendStart(id) {
 	if (id != null) {
 		server.emit('enterGame', id);
 	}
+}
+
+// In a preview session, the round ends when the solo creator dies or reaches
+// the goal (both surface as startOverview, plus startGameover on a win). After
+// a short beat to see the result, navigate back to the editor with the map
+// intact. The flag makes whichever trigger fires first win and dedupes the rest.
+function previewReturnToEditor() {
+	if (!previewMode || previewReturnScheduled) {
+		return;
+	}
+	previewReturnScheduled = true;
+	setTimeout(function () {
+		window.location = './create.html';
+	}, 1500);
 }
 
 function pingServer() {

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -17,6 +17,7 @@ var server,
     brushColor = "black",
     patterns = {},
     currentCell = null,
+    previewPending = false,
     newWidth = 0,
     newHeight = 0,
     world = { x: 0, y: 0, width: 1366, height: 768 },
@@ -72,8 +73,32 @@ window.onload = function () {
     server.emit("getMaps");
     server.emit("getConfig");
     setupPage();
-    rebuild();
-    showLoadWindow();
+
+    // Returning from a play-test? Rehydrate the in-progress map and drop the
+    // creator straight back into the editor, mirroring the "load a saved map"
+    // path. removeItem so a later manual reload doesn't re-restore. mapReady is
+    // forced true so animloop's first-frame rebuild() can't wipe the restored
+    // map (the wipe only matters before the editor is first shown).
+    var saved = sessionStorage.getItem('previewMap');
+    var restored = null;
+    if (saved != null) {
+        sessionStorage.removeItem('previewMap');
+        try {
+            restored = JSON.parse(saved);
+        } catch (e) {
+            restored = null;
+        }
+    }
+    if (restored != null) {
+        vMap = restored;
+        $('#author').val(vMap.author);
+        $('#name').val(vMap.name);
+        mapReady = true;
+        showEditor();
+    } else {
+        rebuild();
+        showLoadWindow();
+    }
 }
 
 function showLoadWindow() {
@@ -113,6 +138,18 @@ function clientConnect() {
         submitStatus.css("color", "white");
         submitStatus.css("background-color", "green");
         submitStatus.text("Success");
+    });
+
+    server.on('previewRoomCreated', function (payload) {
+        // sessionStorage.previewMap was stashed before emitting; navigate the
+        // same tab into the play page, which injects that map and starts a
+        // solo session. preview=1 flags the play page to reroute back here.
+        window.location = 'play.html?gameid=' + payload.gameID + '&preview=1';
+    });
+    server.on('previewRejected', function (payload) {
+        previewPending = false;
+        $("#previewButton").prop("disabled", false);
+        showPreviewError(payload && payload.reason ? payload.reason : "Map could not be previewed.");
     });
 
     server.on("maplisting", function (mapnames) {
@@ -299,6 +336,10 @@ function setupPage() {
         drawBrushAimer = false;
         drawObject = null;
         drawObject = config.hazards.movingBumper.id;
+        return false;
+    });
+    $("#previewButton").on("click", function () {
+        previewMap();
         return false;
     });
     $("#exportButton").on("click", function () {
@@ -786,6 +827,99 @@ function submitToGithub() {
     submitStatus.text("Submitting..");
     server.emit('submitNewMap', JSON.stringify(vMap));
 }
+// Mirror of server/utils.js validateMap — gives fast inline feedback in the
+// editor; the server re-runs it as the trust boundary. Returns { valid, reason }.
+function validateMap(map) {
+    if (map == null) {
+        return { valid: false, reason: "No map data." };
+    }
+    if (!Array.isArray(map.cells) || map.cells.length === 0) {
+        return { valid: false, reason: "Map has no cells." };
+    }
+    var hasGoal = false;
+    for (var i = 0; i < map.cells.length; i++) {
+        var cell = map.cells[i];
+        if (cell == null || cell.site == null) {
+            return { valid: false, reason: "Map has a malformed cell." };
+        }
+        if (typeof cell.site.x !== "number" || typeof cell.site.y !== "number") {
+            return { valid: false, reason: "Map has a cell with an invalid position." };
+        }
+        if (!Array.isArray(cell.halfedges)) {
+            return { valid: false, reason: "Map has a cell with no geometry." };
+        }
+        if (typeof cell.id !== "number") {
+            return { valid: false, reason: "Map has a cell with an invalid tile." };
+        }
+        if (cell.id === config.tileMap.goal.id) {
+            hasGoal = true;
+        }
+    }
+    if (!hasGoal) {
+        return { valid: false, reason: "Add a goal tile before previewing." };
+    }
+    if (map.hazards != null) {
+        if (!Array.isArray(map.hazards)) {
+            return { valid: false, reason: "Map has malformed hazards." };
+        }
+        for (var h = 0; h < map.hazards.length; h++) {
+            var hazard = map.hazards[h];
+            if (hazard == null || hazard.id == null ||
+                typeof hazard.x !== "number" || typeof hazard.y !== "number") {
+                return { valid: false, reason: "Map has a malformed hazard." };
+            }
+            // A moving bumper rides a rail at a given angle; without a numeric
+            // angle the engine's rail math goes NaN.
+            if (hazard.id === config.hazards.movingBumper.id &&
+                typeof hazard.angle !== "number") {
+                return { valid: false, reason: "Map has a moving bumper with no direction." };
+            }
+        }
+    }
+    return { valid: true };
+}
+
+function showPreviewError(message) {
+    var status = $("#previewStatus");
+    status.css("color", "white");
+    status.css("background-color", "red");
+    status.find("span").text(message);
+    status.show();
+}
+
+function previewMap() {
+    // Ignore re-clicks while a launch is in flight: basicSanitize() mints a
+    // fresh id each call, so a double-click would create two rooms whose map
+    // ids no longer match what's stashed/navigated to.
+    if (previewPending) {
+        return;
+    }
+    // config arrives async (the editor can be shown before it lands, e.g. on
+    // the return-from-preview restore). validateMap needs it.
+    if (config == null) {
+        showPreviewError("Still loading — try again in a moment.");
+        return;
+    }
+    // basicSanitize() fills id/author/name/thumbnail. Prefix the id so the
+    // unsaved map can't collide with a real one in the client's maps[] lookup.
+    basicSanitize();
+    vMap.id = "preview-" + vMap.id;
+    var result = validateMap(vMap);
+    if (!result.valid) {
+        showPreviewError(result.reason);
+        return;
+    }
+    $("#previewStatus").hide();
+    previewPending = true;
+    $("#previewButton").prop("disabled", true);
+    // Stash for the editor to rehydrate on the round-trip back, and for the
+    // play page to inject into its maps[] before enterGame. Same serialized
+    // object goes to the server so both sides resolve the same id.
+    var json = JSON.stringify(vMap);
+    sessionStorage.setItem('previewMap', json);
+    server.emit('createPreviewRoom', json);
+}
+
 function basicSanitize() {
     var author = $("#author").val();
     if (author == "") {

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -30,6 +30,7 @@ var server = null,
     currentState = null,
     inLobby = false,
     loading = true,
+    previewMode = false,
     gameRunning = null;
 
 
@@ -230,6 +231,25 @@ function enterLobby() {
     $('#gameWindow').css('display', 'flex');
     resize();
     var playParams = new URLSearchParams(window.location.search);
+    // Preview launch: the editor stashed the unsaved map in sessionStorage.
+    // Inject it into maps[] BEFORE enterGame so the server's newMap (which
+    // carries only the id) resolves via the existing loadNewMap(id) lookup.
+    if (playParams.get("preview") === "1") {
+        var saved = sessionStorage.getItem('previewMap');
+        if (saved != null) {
+            try {
+                var pMap = JSON.parse(saved);
+                var alreadyLoaded = false;
+                for (var i = 0; i < maps.length; i++) {
+                    if (maps[i].id === pMap.id) { alreadyLoaded = true; break; }
+                }
+                if (!alreadyLoaded) maps.push(pMap);
+                previewMode = true;
+            } catch (e) {
+                debugLog("preview map parse failed", e);
+            }
+        }
+    }
     if (playParams.has("gameid")) {
         var paramGameID = playParams.get("gameid");
         clientSendStart(paramGameID);

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -305,6 +305,11 @@ function loadNewMap(id) {
 			break;
 		}
 	}
+	if (currentMap.cells == null) {
+		// id wasn't in maps[] (e.g. an unsynced preview map); bail rather than
+		// dereferencing undefined cells below.
+		return;
+	}
 	if (currentState == config.stateMap.gated) {
 		var goalFound = false;
 		for (var j = 0; j < currentMap.cells.length; j++) {

--- a/server/game.js
+++ b/server/game.js
@@ -22,6 +22,7 @@ class Room {
 		this.hazardList = {};
 		this.clientCount = 0;
 		this.alive = true;
+		this.isPreview = false;
 		this.engine = _engine.getEngine(this.playerList, this.projectileList, this.hazardList);
 		this.world = new World(0, 0, c.worldWidth, c.worldHeight, this.engine, this.playerList, this.hazardList, this.sig);
 		this.game = new Game(this.clientList, this.playerList, this.projectileList, this.aimerList, this.hazardList, this.world, this.engine, this.sig);
@@ -216,6 +217,14 @@ class Game {
 		//Reset back to waiting if someone leaves
 		if (this.playerCount < c.minPlayersToStart) {
 			this.startWaiting();
+			this.resetLobbyTimer();
+			return;
+		}
+		//Preview play-test: the solo creator has no one to rally on the lobby
+		//start button, so skip the lobby and head straight to the race gate.
+		if (this.gameBoard.isPreview) {
+			this.startGated();
+			return;
 		}
 		//If majority of players stand on the gamestart button start the timer
 		var percentPlayers = (this.lobbyButtonPressedCount / this.playerCount) * 100;
@@ -357,6 +366,9 @@ class Game {
 				setTimeout(function (context) {
 					if (context.currentState == c.stateMap.racing || context.currentState == c.stateMap.collapsing) {
 						var goal = context.gameBoard.findRandomGoalTile();
+						if (goal == null) {
+							return;
+						}
 						context.startCollapse(goal.x, goal.y);
 					}
 				}, 15000, this);
@@ -683,6 +695,11 @@ class GameBoard {
 		this.mapsPlayed = [];
 		this.currentMap = {};
 		this.nextMap = {};
+		// Injected-map (preview) mode: when set, every round loads previewMap
+		// instead of a random library map. previewMap is a per-instance copy —
+		// NEVER push it into the shared this.maps array.
+		this.isPreview = false;
+		this.previewMap = null;
 
 		this.allAbilityIDs = this.indexAbilities();
 		this.collapseLoc = {};
@@ -1188,12 +1205,20 @@ class GameBoard {
 		messenger.messageRoomBySig(this.roomSig, 'collapsedCells', collapsedCells);
 	}
 	findRandomGoalTile() {
-		var goalTiles = [];
 		var cells = this.currentMap.cells;
+		if (cells == null) {
+			return null;
+		}
+		var goalTiles = [];
 		for (var i = 0; i < cells.length; i++) {
 			if (cells[i].id == c.tileMap.goal.id) {
 				goalTiles.push({ x: cells[i].site.x, y: cells[i].site.y });
 			}
+		}
+		// No goal tile (or a torn-down room): return null so callers skip the
+		// collapse instead of dereferencing undefined and crashing the engine.
+		if (goalTiles.length === 0) {
+			return null;
 		}
 		return goalTiles[utils.getRandomInt(0, goalTiles.length - 1)];
 	}
@@ -1288,6 +1313,12 @@ class GameBoard {
 		return false;
 	}
 	determineNextMap() {
+		if (this.isPreview && this.previewMap != null) {
+			// Re-select the injected preview map every round (incl. round 2 via
+			// startOverview), never the random library — mirrors TESTSingleMap.
+			this.nextMap = JSON.parse(JSON.stringify(this.previewMap));
+			return this.nextMap.id;
+		}
 		if (c.TESTSingleMap) {
 			this.nextMap = JSON.parse(JSON.stringify(this.maps[0]));
 			return this.nextMap.id;
@@ -1415,6 +1446,9 @@ class GameBoard {
 		if (context.currentState == c.stateMap.racing || context.currentState == c.stateMap.collapsing) {
 			//Find gold tile location to collapse on
 			var loc = context.gameBoard.findRandomGoalTile();
+			if (loc == null) {
+				return;
+			}
 			context.startCollapse(loc.x, loc.y);
 		}
 

--- a/server/hostess.js
+++ b/server/hostess.js
@@ -13,7 +13,7 @@ exports.getRooms = function () {
 		return rooms;
 	}
 	for (var sig in roomList) {
-		if (roomList[sig].hasSpace()) {
+		if (roomList[sig].hasSpace() && !roomList[sig].isPreview) {
 			var room = roomList[sig];
 			rooms[sig] = {
 				state: room.game.currentState,
@@ -51,11 +51,17 @@ exports.kickFromRoom = function (clientID) {
 	}
 }
 exports.joinARoom = function (sig, clientID) {
-	if (roomList[sig] == null) {
+	var room = roomList[sig];
+	if (room == null) {
 		return false;
 	}
-	roomList[sig].join(clientID);
-	return roomList[sig];
+	// A preview room is a private capacity-1 play-test; never let a second
+	// client (e.g. a guessed ?gameid= link) in once the creator has joined.
+	if (room.isPreview && !room.hasSpace()) {
+		return false;
+	}
+	room.join(clientID);
+	return room;
 }
 exports.updateRooms = function (dt) {
 	for (var sig in roomList) {
@@ -78,6 +84,30 @@ exports.updateRooms = function (dt) {
 }
 exports.getRoomBySig = function (sig) {
 	return roomList[sig];
+}
+// Create an isolated, single-player room running an unsaved (injected) map for
+// the editor's play-test. Capacity 1 + isPreview + locked keep matchmaking from
+// ever placing a stranger here (findARoom skips isLocked; getRooms skips
+// isPreview; once the creator joins hasSpace() is false anyway). The map is
+// injected onto this room's gameBoard only — never the shared map library.
+exports.createPreviewRoom = function (previewMap) {
+	var sig = generateRoomSig();
+	var room = game.getRoom(sig, 1);
+	room.isPreview = true;
+	room.game.locked = true;
+	room.game.gameBoard.isPreview = true;
+	room.game.gameBoard.previewMap = previewMap;
+	roomList[sig] = room;
+	// Safety net: if the creator's play page never connects (abandoned launch),
+	// reclaim the empty room so it can't linger. A joined room is left alone.
+	setTimeout(function () {
+		var orphan = roomList[sig];
+		if (orphan != null && orphan.clientCount == 0) {
+			console.log("Reclaiming unjoined preview room: " + sig);
+			delete roomList[sig];
+		}
+	}, 60000);
+	return sig;
 }
 
 function getRoomCount() {
@@ -102,7 +132,7 @@ function generateRoomSig() {
 	if (roomList[sig] == null || roomList[sig] == undefined) {
 		return sig;
 	}
-	sig = generateRoomSig();
+	return generateRoomSig();
 }
 
 function generateNewRoom() {

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -76,6 +76,23 @@ function checkForMail(client) {
 
 	});
 
+	client.on('createPreviewRoom', function (package) {
+		var previewMap;
+		try {
+			previewMap = JSON.parse(package);
+		} catch (e) {
+			client.emit("previewRejected", { reason: "Could not read map data." });
+			return;
+		}
+		var result = utils.validateMap(previewMap, c);
+		if (!result.valid) {
+			client.emit("previewRejected", { reason: result.reason });
+			return;
+		}
+		var sig = hostess.createPreviewRoom(previewMap);
+		client.emit("previewRoomCreated", { gameID: sig });
+	});
+
 	client.on('enterGame', function (id) {
 		debug.log("enterGame: client=", client.id, " requestedId=", id);
 		var roomSig = '';

--- a/server/utils.js
+++ b/server/utils.js
@@ -309,6 +309,59 @@ exports.loadConfig = function () {
 exports.loadMaps = function () {
     return maps;
 }
+// Shared structural validation for a map before it can be play-tested.
+// Mirrored on the client (client/scripts/create.js) so the editor can give
+// fast feedback; re-run here as the trust boundary before a preview room is
+// created. Returns { valid: bool, reason: string }.
+exports.validateMap = function (vMap, config) {
+    if (vMap == null) {
+        return { valid: false, reason: "No map data." };
+    }
+    if (!Array.isArray(vMap.cells) || vMap.cells.length === 0) {
+        return { valid: false, reason: "Map has no cells." };
+    }
+    var hasGoal = false;
+    for (var i = 0; i < vMap.cells.length; i++) {
+        var cell = vMap.cells[i];
+        if (cell == null || cell.site == null) {
+            return { valid: false, reason: "Map has a malformed cell." };
+        }
+        if (typeof cell.site.x !== "number" || typeof cell.site.y !== "number") {
+            return { valid: false, reason: "Map has a cell with an invalid position." };
+        }
+        if (!Array.isArray(cell.halfedges)) {
+            return { valid: false, reason: "Map has a cell with no geometry." };
+        }
+        if (typeof cell.id !== "number") {
+            return { valid: false, reason: "Map has a cell with an invalid tile." };
+        }
+        if (cell.id === config.tileMap.goal.id) {
+            hasGoal = true;
+        }
+    }
+    if (!hasGoal) {
+        return { valid: false, reason: "Add a goal tile before previewing." };
+    }
+    if (vMap.hazards != null) {
+        if (!Array.isArray(vMap.hazards)) {
+            return { valid: false, reason: "Map has malformed hazards." };
+        }
+        for (var h = 0; h < vMap.hazards.length; h++) {
+            var hazard = vMap.hazards[h];
+            if (hazard == null || hazard.id == null ||
+                typeof hazard.x !== "number" || typeof hazard.y !== "number") {
+                return { valid: false, reason: "Map has a malformed hazard." };
+            }
+            // A moving bumper rides a rail at a given angle; without a numeric
+            // angle the engine's rail math goes NaN.
+            if (hazard.id === config.hazards.movingBumper.id &&
+                typeof hazard.angle !== "number") {
+                return { valid: false, reason: "Map has a moving bumper with no direction." };
+            }
+        }
+    }
+    return { valid: true };
+}
 exports.getContentCount = function () {
     return mapListing.length + soundListing.length + imgListing.length;
 }


### PR DESCRIPTION
## What

Adds a **Preview / Playtest** button to the map editor. Clicking it spawns an isolated, solo game running your *in-progress, unsaved* map so you can play-test it. On death or reaching the goal, after ~1.5s the page returns to the editor with the map intact — iterate without saving, repeat.

Same-tab flow: editor → `play.html` → back to editor. To skip lobby friction, a solo preview auto-advances straight into the race.

## How it works

Maps travel over the wire as an **id only**; both sides load geometry from `client/maps/*.json` by id. A preview map is unsaved, so geometry is injected on **both** sides:
- **Server (physics):** onto the room's `gameBoard` instance only — never the shared map library (`utils.loadMaps()`), so it can't leak into live games.
- **Client (rendering):** pushed into the in-memory `maps[]` before `enterGame`, so the existing `loadNewMap(id)` lookup resolves.

Isolation: the preview room is capacity-1, `isPreview`, and locked — hidden from matchmaking (`getRooms`) and `joinARoom` refuses a second client, so no stranger can land in your play-test.

## Bug fixes folded in
- **No-goal-tile crash:** `findRandomGoalTile()` returned `undefined` with zero goal tiles, crashing the engine when the solo slow-collapse timer fires. Now null-safe in three layers: client validation gate, server validation, and null-safe callers. Maps without a goal tile can't be previewed.
- **Round-2 map reset:** `determineNextMap` now re-selects the injected preview map every round (mirrors the `TESTSingleMap` precedent) instead of re-rolling a random library map.
- **`generateRoomSig` missing `return`** on a sig collision (latent; now exercised by the new room path).

## Testing
- In-process logic tests: injected-map mode, round persistence, null-safe goal, room isolation, no library pollution.
- Socket tests against a live server: no-goal/garbage/missing-angle rejection, valid map → isolated room hidden from matchmaking, second-joiner rejected, solo auto-advance to racing with zero input.
- Real-browser end-to-end (rebased onto current `main`, with local multiplayer present): no-goal inline rejection → Preview → play-page injection + `previewMode` → race → death → return to editor with the map, name, and author restored; stash cleared.

## Notes
- Branch was cut from a pre-local-multiplayer point and **rebased cleanly onto current `main`**; verified the client hooks (boot/`enterLobby`, `playerDied`/`startOverview`/`startGameover` reroutes) work alongside the local-MP rewrite, and that a controller can't hijack a solo preview (its join is rejected gracefully).
- Touches `server/game.js`, so a player-facing `CHANGELOG.md` entry under `## Unreleased` is included (CI-enforced).
- v1 scope: transient editor UI state (brush/zoom/scroll) resets on the round-trip; only map geometry + author/name are restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)