### PR TITLE
Add light/dark/auto theme toggle

### DIFF
--- a/client/create.html
+++ b/client/create.html
@@ -4,6 +4,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
+  <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-832XFC4F84"></script>
   <script>
@@ -299,6 +301,7 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 
   <script src='socket.io/socket.io.js'></script>
+  <script src="scripts/theme.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/index.js"></script>
   <!-- BUILD: bundle-start -->
   <script src="scripts/rhill-voronoi-core.js"></script>

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -12,7 +12,54 @@
 }
 :root {
     --navbar-height: 60px;
+
+    /* Theme palette — light (default). The dark overrides live in the
+       [data-theme="dark"] block below; theme.js flips the data-theme
+       attribute on <html> based on the saved light/dark/auto preference. */
+    --bg: #ffffff;
+    --surface: #ffffff;        /* cards, panels, modals */
+    --surface-2: #f6f6f6;      /* subtle inset panels (game cards, editor) */
+    --text: #212529;
+    --text-soft: #495057;      /* slightly muted body text (stats, news copy) */
+    --text-muted: #6c757d;
+    --border: #e6e6e6;
+    --card-shadow: var(--card-shadow);     /* drop shadow / glow on cards and banners */
+    --navbar-bg: #000000;
+    --navbar-text: #ffffff;
+    /* navbar control chrome — kept white-based because the navbar stays dark in
+       both themes; change here (not in .theme-toggle) if the navbar ever lightens. */
+    --navbar-control-border: rgba(255, 255, 255, 0.35);
+    --navbar-control-hover: rgba(255, 255, 255, 0.15);
+    --board-bg: #ffffff;       /* letterbox around the game/editor canvas */
+    --overlay-bg: rgba(255, 255, 255, 0.92);  /* floating controller toasts */
+    --overlay-text: #555555;
+
+    /* Colours consumed by the canvas renderer via window.themePalette. */
+    --canvas-surface: #f0f0f0;     /* playfield fill */
+    --canvas-ink: #000000;         /* on-board text/borders */
+    --canvas-ink-outline: #ffffff; /* contrast halo behind that text */
 }
+
+[data-theme="dark"] {
+    --bg: #15171a;
+    --surface: #1e2127;
+    --surface-2: #262a31;
+    --text: #e6e6e6;
+    --text-soft: #b9bfc6;
+    --text-muted: #9aa0a6;
+    --border: #2c2f36;
+    --card-shadow: rgba(0, 0, 0, 0.55);
+    --navbar-bg: #0a0a0a;
+    --navbar-text: #f0f0f0;
+    --board-bg: #15171a;
+    --overlay-bg: rgba(30, 33, 39, 0.94);
+    --overlay-text: #cfd2d6;
+
+    --canvas-surface: #20242b;
+    --canvas-ink: #e6e6e6;
+    --canvas-ink-outline: #000000;
+}
+
 html,body {
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     width: 100vw;
@@ -24,20 +71,49 @@ body {
        on the first child) so the offset doesn't margin-collapse out of
        body and inflate the page height past the viewport. */
     padding-top: var(--navbar-height);
+    background: var(--bg);
+    color: var(--text);
 }
 
 nav {
     height: var(--navbar-height);
     width: 100%;
-    border-bottom: thin solid #e6e6e6;
+    border-bottom: thin solid var(--border);
     box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
     position: fixed;
     z-index: 1005;
     top: 0;
     left: 0;
-    background: #000;
-    color: #fff;
+    background: var(--navbar-bg);
+    color: var(--navbar-text);
   }
+
+/* light/dark/auto toggle injected into the navbar by theme.js */
+.theme-toggle {
+    margin-left: auto;        /* push to the far right of the navbar */
+    width: 34px;
+    height: 34px;
+    padding: 0;
+    border-radius: 50%;
+    border: 1px solid var(--navbar-control-border);
+    background: transparent;
+    color: var(--navbar-text);
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s, border-color 0.2s;
+}
+.theme-toggle:hover {
+    background: var(--navbar-control-hover);
+}
+.theme-toggle:focus {
+    outline: none;
+    border-color: #c87f8a;
+    box-shadow: 0 0 0 3px rgba(200, 127, 138, 0.4);
+}
 
   section {
     /* navbar offset comes from body { padding-top } so margins don't
@@ -80,9 +156,9 @@ canvas {
 }
 #joinMenu {
     border-radius: 6px;
-    box-shadow: 0px 0px 6px #B2B2B2;
+    box-shadow: 0px 0px 6px var(--card-shadow);
     padding: 0.75rem;
-    background: #fff;
+    background: var(--surface);
     min-height: 80px;
 }
 #gameSelection {
@@ -97,8 +173,8 @@ canvas {
     gap: 1rem;
     padding: 0.6rem 0.9rem;
     border-radius: 4px;
-    background-color: #F6F6F6;
-    box-shadow: 0px 0px 3px #B2B2B2;
+    background-color: var(--surface-2);
+    box-shadow: 0px 0px 3px var(--card-shadow);
 }
 .card-info {
     display: flex;
@@ -114,11 +190,11 @@ canvas {
 }
 .card-stat {
     font-size: 0.9rem;
-    color: #495057;
+    color: var(--text-soft);
     white-space: nowrap;
 }
 .card-stat-label {
-    color: #6c757d;
+    color: var(--text-muted);
 }
 .gameCard .join-btn {
     flex: 0 0 auto;
@@ -127,7 +203,7 @@ canvas {
 .empty-state {
     text-align: center;
     padding: 1.5rem 1rem;
-    color: #6c757d;
+    color: var(--text-muted);
 }
 .not-found-banner {
     background-color: #fff3cd;
@@ -157,7 +233,7 @@ canvas {
 }
 
 #gameWindow {
-    background: white;
+    background: var(--board-bg);
     overflow: hidden;
     display: none;
     /* Fill the section and flex-centre the canvas stack inside so the
@@ -174,7 +250,7 @@ canvas {
 }
 
 #createWindow {
-    background: white;
+    background: var(--board-bg);
     overflow: hidden;
     display: none;
     height: 100%;
@@ -324,16 +400,16 @@ div.desc {
 }
 
 .play-container {
-    background-color: white;
+    background-color: var(--surface);
     width: 100%;
     padding: 1.5rem;
     border-radius: 6px;
-    box-shadow: 0px 0px 6px #B2B2B2;
+    box-shadow: 0px 0px 6px var(--card-shadow);
 }
 
 .tagline {
     margin: 0.75rem 0 0;
-    color: #6c757d;
+    color: var(--text-muted);
     font-size: 0.9rem;
     text-align: center;
 }
@@ -346,18 +422,18 @@ div.desc {
     width: 100%;
     margin-top: 0.75rem;
     padding: 0.6rem 0.9rem;
-    background-color: #fff;
+    background-color: var(--surface);
     border: 1px solid #f0d6da;
     border-left: 4px solid #c87f8a;
     border-radius: 6px;
-    box-shadow: 0px 0px 6px #B2B2B2;
+    box-shadow: 0px 0px 6px var(--card-shadow);
     text-decoration: none;
-    color: #444;
+    color: var(--text-soft);
     transition: box-shadow 0.2s, transform 0.2s;
 }
 .news-banner:hover {
     text-decoration: none;
-    color: #444;
+    color: var(--text-soft);
     box-shadow: 0px 2px 10px rgba(200, 127, 138, 0.35);
     transform: translateY(-1px);
 }
@@ -379,12 +455,12 @@ div.desc {
 
 
 .create-container {
-    background-color: white;
+    background-color: var(--surface);
     height: 100px;
     width: 50%;
     padding: 10px;
     border-radius: 5px;
-    box-shadow: 0px 0px 6px #B2B2B2;
+    box-shadow: 0px 0px 6px var(--card-shadow);
 }
 
 #exitIcon {
@@ -489,12 +565,12 @@ div.desc {
     align-items: center;
     gap: 14px;
     padding: 8px 16px;
-    background-color: rgba(255, 255, 255, 0.92);
+    background-color: var(--overlay-bg);
     border-radius: 22px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     font-size: 14px;
-    color: #555;
+    color: var(--overlay-text);
     z-index: 1006;
     pointer-events: none;
     transition: opacity 0.3s;
@@ -619,12 +695,12 @@ div.desc {
     align-items: center;
     gap: 6px;
     padding: 5px 10px;
-    background-color: rgba(255, 255, 255, 0.92);
+    background-color: var(--overlay-bg);
     border-radius: 18px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     font-size: 13px;
-    color: #555;
+    color: var(--overlay-text);
     transition: opacity 0.3s;
 }
 
@@ -699,12 +775,12 @@ div.desc {
     align-items: center;
     gap: 12px;
     padding: 6px 14px;
-    background-color: rgba(255, 255, 255, 0.92);
+    background-color: var(--overlay-bg);
     border-radius: 18px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     font-size: 13px;
-    color: #555;
+    color: var(--overlay-text);
     z-index: 2000;
     pointer-events: none;
 }
@@ -757,7 +833,7 @@ div.desc {
     align-items: center;
     gap: 6px;
     padding: 8px 16px;
-    background-color: rgba(255, 255, 255, 0.92);
+    background-color: var(--overlay-bg);
     border-radius: 22px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
@@ -827,7 +903,7 @@ div.desc {
     display: none;
 }
 .confirm-dialog {
-    background: #fff;
+    background: var(--surface);
     border-radius: 10px;
     padding: 1.5rem 1.75rem;
     box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
@@ -838,7 +914,7 @@ div.desc {
 .confirm-title {
     font-size: 1.25rem;
     font-weight: 600;
-    color: #333;
+    color: var(--text);
     margin-bottom: 1.1rem;
 }
 .confirm-buttons {
@@ -852,13 +928,62 @@ div.desc {
     font-size: 1rem;
     font-weight: 600;
     border-radius: 6px;
-    border: 1px solid #ccc;
-    background: #f6f6f6;
-    color: #333;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--text);
     cursor: pointer;
 }
 .confirm-btn.confirm-leave {
     background: #c87f8a;
     border-color: #c87f8a;
     color: #fff;
+}
+
+/* --- dark-mode overrides for Bootstrap-driven and map-editor surfaces ---
+   These selectors carry extra specificity (or !important) so they win over
+   Bootstrap utilities and the per-page inline styles in create.html. */
+[data-theme="dark"] .bg-light {
+    background-color: var(--surface-2) !important;
+    color: var(--text);
+}
+[data-theme="dark"] .form-control {
+    background-color: var(--surface-2);
+    color: var(--text);
+    border-color: var(--border);
+}
+[data-theme="dark"] .form-control::placeholder {
+    color: var(--text-muted);
+}
+[data-theme="dark"] .form-control:focus {
+    background-color: var(--surface-2);
+    color: var(--text);
+}
+/* map editor (create.html) toolbars are pinned with hardcoded light greys */
+[data-theme="dark"] #editorToolbar,
+[data-theme="dark"] #actionsSection {
+    background: var(--surface-2);
+    border-color: var(--border);
+}
+[data-theme="dark"] #controlPanel {
+    border-right-color: var(--border);
+}
+/* the Actions buttons render with the native button face (light); pull them
+   into the dark theme so they match the rest of the editor panel. */
+[data-theme="dark"] #controlPanel .btn-block {
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+}
+/* the "game not found" warning banner is a hardcoded light amber; give it a
+   dark-amber variant so it doesn't read as a light-mode artifact. */
+[data-theme="dark"] .not-found-banner {
+    background-color: #3a3320;
+    color: #ffe08a;
+    border-color: #5c4a1f;
+}
+/* news banner: its surface/text follow the theme, so soften the hardcoded
+   pink hairline border in dark mode (keeping the brand left accent). */
+[data-theme="dark"] .news-banner {
+    border-color: #43363a;
+    border-left-color: #c87f8a;
 }

--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
+    <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-832XFC4F84"></script>
     <script>
@@ -54,5 +56,6 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
     <script src="scripts/menuGamepad.js"></script>
     <script src="scripts/controllerHeader.js"></script>
+    <script src="scripts/theme.js"></script>
   </body>
 </html>

--- a/client/join.html
+++ b/client/join.html
@@ -2,6 +2,8 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
+        <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
         <!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-832XFC4F84"></script>
         <script>
@@ -56,6 +58,7 @@
         </div>
     </section>
     <script src='socket.io/socket.io.js'></script>
+    <script src="scripts/theme.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/index.js"></script>
     <!-- BUILD: bundle-start -->
     <script src="scripts/join.js"></script>

--- a/client/play.html
+++ b/client/play.html
@@ -4,6 +4,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-capable" content="yes">
+        <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
+        <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
         <!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-832XFC4F84"></script>
         <script>
@@ -48,6 +50,7 @@
         </section>
         <!-- Load game files -->
         <script src='socket.io/socket.io.js'></script>
+        <script src="scripts/theme.js"></script>
         <!-- BUILD: bundle-start -->
         <script src="scripts/game.js"></script>
         <script src="scripts/client.js"></script>

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3,6 +3,17 @@ var spreadScale = 0.15;
 var bombScale = 0.025;
 var complexPatternScale = 0.1;
 
+// Theme-aware colours for canvas elements that sit on the board surface and
+// must stay readable in dark mode (playfield fill/border + on-board text).
+// theme.js keeps window.themePalette in sync with the active theme; the
+// fallbacks match the original light-mode literals so this degrades safely if
+// theme.js hasn't run yet. Intrinsic colours (player/tile/podium/hazard) are
+// left untouched on purpose.
+function themeColor(key, fallback) {
+    var pal = (typeof window !== 'undefined') ? window.themePalette : null;
+    return (pal && pal[key]) ? pal[key] : fallback;
+}
+
 var patterns = {};
 var brutalPatterns = {};
 var brutalRoundImages = {};
@@ -609,9 +620,9 @@ function drawAimer(aimer) {
 function drawMapTitle() {
     if (currentMap != null) {
         gameContext.save();
-        gameContext.strokeStyle = "white";
+        gameContext.strokeStyle = themeColor('inkOutline', 'white');
         gameContext.lineWidth = 4;
-        gameContext.fillStyle = "black";
+        gameContext.fillStyle = themeColor('ink', 'black');
         gameContext.font = "14px Arial";
         gameContext.strokeText('"' + currentMap.name + '"', 5, gameCanvas.height - 25);
         gameContext.strokeText('~' + currentMap.author, 5, gameCanvas.height - 10);
@@ -709,6 +720,13 @@ function drawDeathMessage(player) {
         gameContext.save();
         gameContext.drawImage(commentIconSolid, player.x, player.y - 40, commentIconSolid.width * 0.07, commentIconSolid.height * 0.07);
         gameContext.font = '20px Times New Roman';
+        // theme-aware so the message stays readable where it overflows the
+        // bubble onto the (now theme-coloured) board; outline gives a contrast
+        // halo in both themes, matching drawMapTitle.
+        gameContext.lineWidth = 3;
+        gameContext.strokeStyle = themeColor('inkOutline', 'white');
+        gameContext.fillStyle = themeColor('ink', 'black');
+        gameContext.strokeText(player.deathMessage, player.x + 8, player.y - 17);
         gameContext.fillText(player.deathMessage, player.x + 8, player.y - 17);
         gameContext.restore();
     }
@@ -937,7 +955,7 @@ function drawWorld() {
     if (world != null) {
         gameContext.save();
         gameContext.beginPath();
-        gameContext.fillStyle = "#F0F0F0";
+        gameContext.fillStyle = themeColor('surface', '#F0F0F0');
         gameContext.rect(world.x + camera.getCameraX(), world.y + camera.getCameraY(), world.width, world.height);
         gameContext.fill();
         gameContext.restore();
@@ -945,7 +963,7 @@ function drawWorld() {
         gameContext.save();
         gameContext.beginPath();
         gameContext.lineWidth = 4;
-        gameContext.strokeStyle = "black";
+        gameContext.strokeStyle = themeColor('ink', 'black');
         gameContext.rect(world.x + camera.getCameraX(), world.y + camera.getCameraY(), world.width, world.height);
         gameContext.stroke();
         gameContext.restore();
@@ -1224,9 +1242,9 @@ function drawGameInfo() {
     var startX = world.width / 2 - 125;
     gameContext.save();
     gameContext.font = "14px Arial";
-    gameContext.strokeStyle = "white";
+    gameContext.strokeStyle = themeColor('inkOutline', 'white');
     gameContext.lineWidth = 4;
-    gameContext.fillStyle = "black";
+    gameContext.fillStyle = themeColor('ink', 'black');
     gameContext.strokeText("GameID: " + gameID, startX + 10, 20);
     gameContext.fillText("GameID: " + gameID, startX + 10, 20);
     gameContext.strokeText("Players: " + totalPlayers, startX + 100, 20);
@@ -1273,7 +1291,7 @@ function drawTouchControls() {
         gameContext.save();
         gameContext.beginPath();
         gameContext.lineWidth = 3;
-        gameContext.strokeStyle = "black ";
+        gameContext.strokeStyle = themeColor('ink', 'black');
         gameContext.arc(joystickMovement.baseX, joystickMovement.baseY, joystickMovement.baseRadius, 0, Math.PI * 2, false);
         gameContext.stroke();
         gameContext.beginPath();
@@ -1294,7 +1312,7 @@ function drawTouchControls() {
 
         gameContext.beginPath();
         gameContext.lineWidth = 3;
-        gameContext.strokeStyle = "black ";
+        gameContext.strokeStyle = themeColor('ink', 'black');
         gameContext.arc(joystickCamera.baseX, joystickCamera.baseY, joystickCamera.baseRadius, 0, Math.PI * 2, false);
         gameContext.stroke();
         gameContext.beginPath();
@@ -1312,7 +1330,7 @@ function drawTouchControls() {
         gameContext.save();
         gameContext.beginPath();
         gameContext.lineWidth = 1;
-        gameContext.strokeStyle = "black";
+        gameContext.strokeStyle = themeColor('ink', 'black');
         gameContext.fillStyle = "rgba(0, 0, 255, 0.2)";
 
         //gameContext.rect(attackButton.baseX, attackButton.baseY, attackButton.width, attackButton.height);
@@ -1395,7 +1413,7 @@ function drawTitle() {
     }
     if (currentState == config.stateMap.waiting && lobbyStartButton == null) {
         gameContext.save();
-        gameContext.fillStyle = "black";;
+        gameContext.fillStyle = themeColor('ink', 'black');
         gameContext.lineWidth = 3;
         gameContext.font = "30px Arial";
         gameContext.fillText('Waiting for more players..', (gameCanvas.width / 2) - 200, (gameCanvas.height / 2) - 25);

--- a/client/scripts/theme.js
+++ b/client/scripts/theme.js
@@ -1,0 +1,105 @@
+// Light / dark / auto theme toggle, shared across every page.
+//
+// The *preference* ('light' | 'dark' | 'auto') is persisted in localStorage.
+// The *resolved* theme ('light' | 'dark') is reflected as data-theme on <html>;
+// a tiny inline script in each page's <head> sets it before first paint so the
+// page never flashes the wrong theme. This file owns the navbar toggle button,
+// persistence, reacting to OS theme changes while in auto mode, and publishing
+// window.themePalette so the canvas renderer (draw.js) can read plain colour
+// strings without touching getComputedStyle every frame.
+(function () {
+    var STORAGE_KEY = 'themePref';
+    var ORDER = ['auto', 'light', 'dark'];
+    // basic Unicode glyphs so this works regardless of which Font Awesome
+    // version a given page happens to load.
+    var GLYPH = { auto: '◐', light: '☀', dark: '☾' };
+    var LABEL = { auto: 'Auto', light: 'Light', dark: 'Dark' };
+
+    var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+    var btn = null;
+    // In-memory source of truth, seeded lazily from storage. This keeps the
+    // toggle cycling correctly even where localStorage writes throw (private
+    // mode / storage disabled) — the choice just won't persist across reloads.
+    var currentPref = null;
+
+    function readStoredPref() {
+        try {
+            var p = localStorage.getItem(STORAGE_KEY);
+            return (p === 'light' || p === 'dark' || p === 'auto') ? p : 'auto';
+        } catch (e) {
+            return 'auto';
+        }
+    }
+    function getPref() {
+        if (currentPref === null) currentPref = readStoredPref();
+        return currentPref;
+    }
+    function setPref(pref) {
+        currentPref = pref;
+        try { localStorage.setItem(STORAGE_KEY, pref); } catch (e) {}
+    }
+    function resolve(pref) {
+        if (pref === 'dark') return 'dark';
+        if (pref === 'light') return 'light';
+        return (media && media.matches) ? 'dark' : 'light';
+    }
+
+    // Pull the canvas colours out of the CSS custom properties so draw.js reads
+    // them as a cheap object lookup. Refreshed whenever the theme changes.
+    function refreshPalette() {
+        var cs = getComputedStyle(document.documentElement);
+        window.themePalette = {
+            surface: (cs.getPropertyValue('--canvas-surface') || '').trim() || '#F0F0F0',
+            ink: (cs.getPropertyValue('--canvas-ink') || '').trim() || '#000000',
+            inkOutline: (cs.getPropertyValue('--canvas-ink-outline') || '').trim() || '#FFFFFF'
+        };
+    }
+
+    function updateButton(pref) {
+        if (!btn) return;
+        btn.textContent = GLYPH[pref] || GLYPH.auto;
+        btn.title = 'Theme: ' + (LABEL[pref] || 'Auto') + ' (click to change)';
+        btn.setAttribute('aria-label', 'Theme: ' + (LABEL[pref] || 'Auto') + '. Click to change.');
+    }
+
+    function apply(pref) {
+        document.documentElement.setAttribute('data-theme', resolve(pref));
+        refreshPalette();
+        updateButton(pref);
+    }
+
+    function cycle() {
+        var next = ORDER[(ORDER.indexOf(getPref()) + 1) % ORDER.length];
+        setPref(next);
+        apply(next);
+    }
+
+    function injectButton() {
+        var nav = document.querySelector('nav');
+        if (!nav || document.getElementById('themeToggle')) return;
+        btn = document.createElement('button');
+        btn.id = 'themeToggle';
+        btn.type = 'button';
+        btn.className = 'theme-toggle';
+        btn.addEventListener('click', cycle);
+        nav.appendChild(btn);
+        updateButton(getPref());
+    }
+
+    // React to OS theme changes, but only when the user is in auto mode.
+    if (media) {
+        var onChange = function () { if (getPref() === 'auto') apply('auto'); };
+        if (media.addEventListener) media.addEventListener('change', onChange);
+        else if (media.addListener) media.addListener(onChange);
+    }
+
+    // data-theme is already set by the inline <head> script, so the stylesheet
+    // values are resolvable now — seed the palette before the canvas renders.
+    refreshPalette();
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', injectButton);
+    } else {
+        injectButton();
+    }
+})();


### PR DESCRIPTION
## Summary

Adds a light/dark/auto theme toggle to the navbar on every page (landing, play, join, create).

- New non-bundled `client/scripts/theme.js` injects the toggle button (◐ auto / ☀ light / ☾ dark), cycles auto→light→dark, persists the choice in `localStorage` (with an in-memory fallback so it still works when storage writes are blocked), and follows the OS while in auto mode.
- A tiny inline `<head>` script on each page sets `data-theme` before first paint to avoid a flash of the wrong theme.
- `client/css/styles.css` gains a color-variable palette with a `[data-theme="dark"]` block; hardcoded colors across the navbars, cards, landing/join surfaces, modals, controller overlays, and the map editor were converted to variables.
- `client/scripts/draw.js` reads a `window.themePalette` so on-board canvas text and surfaces (playfield, HUD, map title, death/waiting messages, touch controls) stay readable in dark mode. Intrinsic game colors — players, tiles, podium, hazards — are deliberately left unchanged.

## Game mechanic impact

- [ ] This change touches `server/config.json`, `server/game.js`, or `server/engine.js` (gameplay tuning, round logic, or physics).
- [ ] If yes, I added a player-facing entry under `## Unreleased` in `CHANGELOG.md`. (CI enforces this.)

**No** — client-only UI/CSS, so it's exempt from the release-notes check.

## Test plan

- `npm run build` succeeds (all three bundles compile; `theme.js` is standalone, not bundled).
- Verified in Chrome: toggle cycles auto→light→dark with the glyph, `data-theme`, and `localStorage` staying in sync; light and dark on the landing page; dark game canvas (HUD/board readable, tile colors unchanged); dark map editor; dark not-found and news banners.
- Ran an extra-high-effort code review; all findings fixed (themed death-message + touch-control canvas colors, `localStorage`-resilient toggle, banner dark variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
