### PR TITLE
Fix moving bumpers jittering/sticking off the end of their rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- Sliding bumpers no longer jitter or get stuck off the end of their track. After a hitch they now snap back onto their rail and keep moving smoothly.
 
 ## v0.3.0 — 2026-05-24
 

--- a/server/engine.js
+++ b/server/engine.js
@@ -165,10 +165,14 @@ class Engine {
 			var newVelY = 0;
 			if (hazard.rail != null) {
 				var currentDist = utils.getMagSq(hazard.rail.x, hazard.rail.y, hazard.x, hazard.y);
-				if (currentDist > hazard.rail.lengthSq) {
+				var movingOutward = (hazard.angle == hazard.rail.angle);
+				// Reverse at the far end only while heading outward, and at the
+				// near end only while heading back. Guarding both ends keeps a
+				// single overshoot (e.g. from a long tick) from flipping the
+				// angle every frame and trapping the bumper jittering in place.
+				if (movingOutward && currentDist > hazard.rail.lengthSq) {
 					hazard.angle -= 180;
-				}
-				if (hazard.angle != hazard.rail.angle && currentDist < hazard.lengthSq) {
+				} else if (!movingOutward && currentDist < hazard.lengthSq) {
 					hazard.angle += 180;
 				}
 
@@ -179,6 +183,16 @@ class Engine {
 			hazard.velY = newVelY;
 			hazard.newX += hazard.velX * this.dt;
 			hazard.newY += hazard.velY * this.dt;
+			// Keep the bumper on its rail: if a long tick overshot the far end,
+			// snap it back onto the segment instead of letting it drift away.
+			if (hazard.rail != null) {
+				var overshootSq = utils.getMagSq(hazard.rail.x, hazard.rail.y, hazard.newX, hazard.newY);
+				if (overshootSq > hazard.rail.lengthSq) {
+					var scale = Math.sqrt(hazard.rail.lengthSq / overshootSq);
+					hazard.newX = hazard.rail.x + (hazard.newX - hazard.rail.x) * scale;
+					hazard.newY = hazard.rail.y + (hazard.newY - hazard.rail.y) * scale;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

Moving bumpers (the ones that slide back and forth along a fixed track) would sometimes **jitter** and/or **get stuck** off the end of their rail.

## Root cause

In `server/engine.js` `updateHazards`, the rail-reversal logic flips the bumper's travel angle by 180° at each end of the rail. The **far-end** reversal had no direction guard:

```js
if (currentDist > hazard.rail.lengthSq) {   // fires every tick while past the end
    hazard.angle -= 180;
}
```

(The near-end reversal *was* guarded by `hazard.angle != hazard.rail.angle`.)

So whenever a bumper sat past the far boundary for more than one tick, it subtracted 180° **every tick** — the travel direction flipped each frame, net movement ≈ 0, and the bumper vibrated in place off the rail.

This only triggered intermittently because the per-tick step is `speed * dt²`. A single long tick — GC pause, a heavy frame, or the server **sleep/wake loop** re-arming after a room was empty — overshoots the boundary by a large amount in one jump, which then trips the unguarded reversal and traps the bumper.

Simulating the exact logic: one 0.5s hitch flings the bumper ~566px off a 100px rail, where it locks into a ±2px-per-tick jitter indefinitely.

## Fix

1. **Direction-guard both reversals** — far end only fires while heading outward, near end only while heading back. This stops the every-frame angle flip.
2. **Clamp the position back onto the rail** if it overshoots the far end, so a single hitch can't fling the bumper away.

## Verification

- `node --check server/engine.js` passes.
- Ran the exact edited block through a harness injecting two 0.5s hitches: the bumper never leaves its 100px rail (max dist 100.00), oscillates cleanly between the near (~9) and far (100) ends, and the angle stays bounded with no runaway.

CHANGELOG updated under `## Unreleased` (required — `engine.js` is a game-mechanic file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)