### PR TITLE
Add CI jobs that boot and tick the game to catch gameplay-breaking merges

### DIFF
--- a/.github/scripts/smoke-test.js
+++ b/.github/scripts/smoke-test.js
@@ -1,0 +1,223 @@
+'use strict';
+
+// Runtime smoke test for PRs into main.
+//
+// `node --check` and the bundle build prove the code *parses*; they cannot tell
+// you the game still *runs*. A change to game.js / engine.js / compressor.js can
+// pass both and then throw on the first tick (undefined deref, NaN physics, a
+// compressor/decoder shape change). This script actually boots the server-side
+// game and ticks it, with no network layer and no real browser:
+//
+//   Session A — full stack on one room: drives the REAL messenger socket
+//     handlers (enterGame, movement, mousemove) for 3 fake clients, forces a
+//     race, and ticks hostess.updateRooms(dt) with random input. Exercises
+//     messenger + hostess + game state machine + engine + compressor together.
+//
+//   Session B — engine coverage on EVERY committed map: injects each map via the
+//     play-test (preview) path, forces a race, and ticks the engine so a
+//     structurally-valid-but-engine-breaking map (degenerate geometry, etc.) is
+//     caught here rather than in production.
+//
+// Any throw, or a malformed compressor payload, fails the run (exit 1).
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
+const hostess = require(path.join(repoRoot, 'server', 'hostess.js'));
+const game = require(path.join(repoRoot, 'server', 'game.js'));
+const compressor = require(path.join(repoRoot, 'server', 'compressor.js'));
+const utils = require(path.join(repoRoot, 'server', 'utils.js'));
+const config = require(path.join(repoRoot, 'server', 'config.json'));
+
+const DT = config.serverTickSpeed / 1000; // same fixed step the live loop uses
+const MOVES = ['moveForward', 'moveBackward', 'turnLeft', 'turnRight', 'attack'];
+
+let failures = 0;
+function fail(msg) {
+    failures++;
+    console.log('::error::' + msg);
+}
+
+// A socket.io socket stand-in: records .on() handlers so the test can fire the
+// real messenger handlers, and no-ops every outbound call (emit/join/broadcast).
+function makeFakeSocket(id) {
+    const handlers = {};
+    return {
+        id: id,
+        handlers: handlers,
+        on(event, fn) { handlers[event] = fn; },
+        emit() { },
+        join() { },
+        leave() { },
+        broadcast: { to() { return { emit() { } }; } },
+        fire(event, payload) {
+            if (handlers[event]) handlers[event](payload);
+        }
+    };
+}
+
+// io stand-in so messenger.messageRoomBySig()/messageClientBySig() don't throw.
+const fakeIo = {
+    to() { return { emit() { } }; },
+    sockets: { emit() { } }
+};
+
+function randomInput() {
+    const packet = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+    for (const m of MOVES) {
+        if (Math.random() < 0.5) packet[m] = true;
+    }
+    return packet;
+}
+
+// The four compacted arrays a client decoder expects every tick. If any isn't an
+// array, client.js' update*List() decoders would break — catch it here.
+function assertUpdatesWellFormed(room, label) {
+    const checks = {
+        playerList: compressor.sendPlayerUpdates(room.playerList),
+        projList: compressor.sendProjUpdates(room.projectileList),
+        aimerList: compressor.sendAimerUpdates(room.aimerList),
+        hazardList: compressor.sendHazardUpdates(room.hazardList)
+    };
+    for (const key in checks) {
+        if (!Array.isArray(checks[key])) {
+            fail(label + ': compressor.' + key + ' returned a non-array (' + typeof checks[key] + ')');
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Session A: full stack through the real messenger handlers on one room.
+// ---------------------------------------------------------------------------
+function sessionFullStack() {
+    const sockets = [];
+    for (let i = 0; i < 3; i++) {
+        const s = makeFakeSocket('smoke-player-' + i);
+        sockets.push(s);
+        messenger.addMailBox(s.id, s); // registers handlers + emits welcome/contentDelivery
+        s.fire('enterGame', -1);       // real join + matchmake + player spawn
+    }
+
+    // The players are now in exactly one room; grab it for state forcing/ticks.
+    const sigs = Object.keys(hostess.getRooms());
+    if (sigs.length === 0) {
+        fail('Session A: enterGame created no joinable room');
+        return;
+    }
+    const room = hostess.getRoomBySig(sigs[0]);
+    if (room == null) {
+        fail('Session A: could not resolve the room created by enterGame');
+        return;
+    }
+
+    // Tick a bit in the natural (waiting/lobby) state with random input.
+    for (let f = 0; f < 60; f++) {
+        for (const s of sockets) {
+            s.fire('movement', randomInput());
+            s.fire('mousemove', Math.random() * 360);
+        }
+        hostess.updateRooms(DT);
+        assertUpdatesWellFormed(room, 'Session A (pre-race) frame ' + f);
+        if (failures > 0) return;
+    }
+
+    // Force the race so the engine's collision/physics path actually runs
+    // (the live timers are wall-clock + lobby-button driven; we don't wait).
+    room.game.startGated();
+    room.game.startRace();
+
+    for (let f = 0; f < 400; f++) {
+        for (const s of sockets) {
+            s.fire('movement', randomInput());
+            s.fire('mousemove', Math.random() * 360);
+        }
+        hostess.updateRooms(DT);
+        assertUpdatesWellFormed(room, 'Session A (racing) frame ' + f);
+        if (failures > 0) return;
+    }
+
+    // Drive the collapse path too — that's where the map tears down to lava.
+    room.game.startCollapse(config.worldWidth / 2, config.worldHeight / 2);
+    for (let f = 0; f < 120; f++) {
+        hostess.updateRooms(DT);
+        assertUpdatesWellFormed(room, 'Session A (collapsing) frame ' + f);
+        if (failures > 0) return;
+    }
+
+    // Clean up so Session B starts from an empty room registry.
+    for (const s of sockets) {
+        hostess.kickFromRoom(s.id);
+        messenger.removeMailBox(s.id);
+    }
+    console.log('Session A passed: full-stack room ticked waiting -> racing -> collapsing.');
+}
+
+// ---------------------------------------------------------------------------
+// Session B: run the engine on every committed map via the play-test path.
+// ---------------------------------------------------------------------------
+function sessionEveryMap() {
+    const mapsDir = path.join(repoRoot, 'client', 'maps');
+    const files = fs.readdirSync(mapsDir).filter(f => f.endsWith('.json'));
+    let ran = 0;
+
+    for (const file of files) {
+        const map = JSON.parse(fs.readFileSync(path.join(mapsDir, file), 'utf8'));
+        const sig = 'smoke-map-' + ran;
+        const room = game.getRoom(sig, 4);
+
+        // Pin map selection to this map (determineNextMap honors previewMap),
+        // exactly like the editor's solo play-test does.
+        room.game.gameBoard.isPreview = true;
+        room.game.gameBoard.previewMap = map;
+
+        // Spawn a couple of players directly (no socket needed for this path).
+        for (let i = 0; i < 2; i++) {
+            const id = sig + '-p' + i;
+            const player = room.world.createNewPlayer(id);
+            room.playerList[id] = player;
+            room.game.determineGameState(player);
+        }
+
+        try {
+            room.game.startLobby(); // world.resize() here builds the engine quadTree
+            room.game.startGated();
+            room.game.startRace();
+            for (let f = 0; f < 60; f++) {
+                for (const id in room.playerList) {
+                    const p = room.playerList[id];
+                    const packet = randomInput();
+                    p.moveForward = packet.moveForward;
+                    p.moveBackward = packet.moveBackward;
+                    p.turnLeft = packet.turnLeft;
+                    p.turnRight = packet.turnRight;
+                    p.attack = packet.attack;
+                    p.angle = Math.random() * 360;
+                }
+                room.update(DT);
+            }
+            assertUpdatesWellFormed(room, 'map ' + file);
+        } catch (e) {
+            fail('map ' + file + ' broke the engine: ' + e.message + '\n' + e.stack);
+        }
+        ran++;
+        if (failures > 0) return;
+    }
+    console.log('Session B passed: engine ran on ' + ran + ' map(s).');
+}
+
+messenger.build(fakeIo);
+try {
+    sessionFullStack();
+    if (failures === 0) sessionEveryMap();
+} catch (e) {
+    fail('Unhandled exception during smoke test: ' + e.message + '\n' + e.stack);
+}
+
+if (failures > 0) {
+    console.log('\nSmoke test FAILED with ' + failures + ' error(s).');
+    process.exit(1);
+}
+console.log('\nSmoke test passed: game booted and ticked without crashing.');
+process.exit(0);

--- a/.github/scripts/validate-content.js
+++ b/.github/scripts/validate-content.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// Content validation gate for PRs into main.
+//
+// Catches broken game *data* that a JavaScript syntax check and bundle build
+// cannot see: a malformed map JSON (the in-browser editor opens PRs that add
+// these), or a config.json that no longer has the keys the engine reads. Both
+// would pass `node --check` yet crash the server at boot or mid-game.
+//
+// Structural map validation reuses the server's own utils.validateMap() so this
+// stays in lockstep with the trust-boundary check the live editor runs before a
+// play-test — one source of truth, not a re-implementation that can drift.
+//
+// Note on ordering: server/utils.js require()s every map at module load, so a
+// malformed map JSON would crash this script with an ugly stack trace before any
+// of our checks run. We therefore JSON-parse config.json and all maps OURSELVES
+// first (clean per-file ::error:: messages — these failures come from non-dev
+// map submissions), and only require utils.js once we know everything parses.
+//
+// Exits 0 when everything is valid, 1 (with ::error:: annotations) otherwise.
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const mapsDir = path.join(repoRoot, 'client', 'maps');
+const configPath = path.join(repoRoot, 'server', 'config.json');
+
+const errors = [];
+function fail(msg) {
+    errors.push(msg);
+    console.log('::error::' + msg);
+}
+
+function done() {
+    if (errors.length > 0) {
+        console.log('\nContent validation FAILED with ' + errors.length + ' error(s).');
+        process.exit(1);
+    }
+}
+
+// --- Phase 1: parse everything ourselves (no utils.js require yet) ----------
+let config = null;
+try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+} catch (e) {
+    fail('server/config.json: invalid JSON — ' + e.message);
+}
+
+const parsedMaps = []; // { file, map }
+const mapFiles = fs.readdirSync(mapsDir).filter(f => f.endsWith('.json'));
+if (mapFiles.length === 0) {
+    fail('client/maps contains no .json maps');
+}
+for (const file of mapFiles) {
+    try {
+        parsedMaps.push({ file, map: JSON.parse(fs.readFileSync(path.join(mapsDir, file), 'utf8')) });
+    } catch (e) {
+        fail('client/maps/' + file + ': invalid JSON — ' + e.message);
+    }
+}
+
+// A parse failure (or unreadable config) means requiring utils.js below would
+// itself crash. Bail now with the clean messages we already have.
+done();
+
+// --- Phase 2: structural checks (safe to load the server's own validator) ---
+const utils = require(path.join(repoRoot, 'server', 'utils.js'));
+
+// config.json keys read unconditionally in game.js / engine.js / validateMap;
+// if any go missing or change type, the server breaks on the first tick.
+const numericKeys = [
+    'port', 'serverTickSpeed', 'worldWidth', 'worldHeight',
+    'worldCollapseSpeed', 'minPlayersToStart', 'maxPlayersInRoom',
+    'forceConstant', 'baseNotchesToWin', 'minimumNotchesToWin'
+];
+for (const key of numericKeys) {
+    if (typeof config[key] !== 'number') {
+        fail('config.json: "' + key + '" must be a number, got ' + typeof config[key]);
+    }
+}
+
+// The state machine indexes config.stateMap by name throughout game.js.
+const requiredStates = ['waiting', 'lobby', 'overview', 'gated', 'racing', 'collapsing', 'gameOver'];
+if (config.stateMap == null || typeof config.stateMap !== 'object') {
+    fail('config.json: "stateMap" is missing or not an object');
+} else {
+    for (const s of requiredStates) {
+        if (!(s in config.stateMap)) {
+            fail('config.json: stateMap is missing state "' + s + '"');
+        }
+    }
+}
+
+// tileMap.goal.id is what utils.validateMap looks for to confirm a map is
+// playable; the other tile types are referenced across engine.js.
+const requiredTiles = ['slow', 'normal', 'fast', 'lava', 'ice', 'ability', 'goal', 'bumper', 'random'];
+if (config.tileMap == null || typeof config.tileMap !== 'object') {
+    fail('config.json: "tileMap" is missing or not an object');
+} else {
+    for (const t of requiredTiles) {
+        if (config.tileMap[t] == null) {
+            fail('config.json: tileMap is missing tile "' + t + '"');
+        }
+    }
+    if (config.tileMap.goal != null && typeof config.tileMap.goal.id !== 'number') {
+        fail('config.json: tileMap.goal.id must be a number');
+    }
+}
+
+// utils.validateMap dereferences config.hazards.movingBumper.id.
+if (config.hazards == null || config.hazards.movingBumper == null ||
+    typeof config.hazards.movingBumper.id !== 'number') {
+    fail('config.json: hazards.movingBumper.id must be a number');
+}
+
+for (const { file, map } of parsedMaps) {
+    const result = utils.validateMap(map, config);
+    if (!result.valid) {
+        fail('client/maps/' + file + ': ' + result.reason);
+    }
+}
+
+done();
+console.log('Content validation passed: config.json OK, ' + parsedMaps.length + ' map(s) valid.');

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,10 +1,13 @@
 name: PR validation
 
-# Basic standards gate for pull requests into main:
-#   1. dependencies install cleanly against the committed lockfile,
-#   2. every JavaScript file parses (no syntax errors), and
-#   3. the client bundles build.
-# Keep this fast and dependency-light so it stays a low-friction check.
+# Standards gate for pull requests into main. Three independent jobs so a red
+# check tells you *what* broke at a glance:
+#   validate         — deps install cleanly, every .js parses, the bundles build.
+#   validate-content — every map JSON and config.json is structurally valid.
+#   smoke-test       — the server boots and the game actually ticks without
+#                      crashing (the part a parse/build check can't see).
+# Keep this fast and dependency-light so it stays a low-friction check — the
+# runtime checks reuse the server's own modules and add no new npm dependency.
 
 on:
   pull_request:
@@ -43,3 +46,71 @@ jobs:
 
       - name: Build client bundles
         run: npm run build
+
+  validate-content:
+    # Catches broken game data — a malformed map JSON (the in-browser editor
+    # opens PRs that add these) or a config.json missing keys the engine reads.
+    # Both pass `node --check` yet break the server, so they need their own gate.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        # Needed because the validator reuses server/utils.js (which requires deps).
+        run: npm ci
+
+      - name: Validate maps and config
+        run: node .github/scripts/validate-content.js
+
+  smoke-test:
+    # Boots the server and ticks the game — proves it still *runs*, not just that
+    # it parses and builds. Catches runtime breakage in game.js / engine.js /
+    # compressor.js / messenger.js that the other jobs cannot see.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Boot check (server starts and stays up)
+        # Start the server on an ephemeral port; require it to log "listening"
+        # within the timeout and not exit early. Catches module-load/boot crashes.
+        run: |
+          PORT=28734 node index.js > boot.log 2>&1 &
+          server_pid=$!
+          ok=0
+          for i in $(seq 1 30); do
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              echo "::error::Server exited before it finished booting:"
+              cat boot.log
+              exit 1
+            fi
+            if grep -q "listening on" boot.log; then ok=1; break; fi
+            sleep 0.5
+          done
+          kill "$server_pid" 2>/dev/null || true
+          wait "$server_pid" 2>/dev/null || true
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::Server did not report 'listening' within the timeout:"
+            cat boot.log
+            exit 1
+          fi
+          echo "Server booted and is listening."
+
+      - name: Headless game-loop smoke test
+        run: node .github/scripts/smoke-test.js


### PR DESCRIPTION
## What

Adds two runtime CI jobs to `.github/workflows/pr-validation.yml` so a PR merge can't silently break gameplay. The existing `validate` job only proves the code *parses* and *bundles* — nothing actually ran the game. These reuse the server's own modules and add **no new npm dependency** (the workflow's stated "fast and dependency-light" rule).

### `validate-content` → `.github/scripts/validate-content.js`
Catches broken game *data* that `node --check` can't see:
- JSON-parses `config.json` and every `client/maps/*.json`,
- runs the server's own `utils.validateMap()` on each map (one source of truth, no drift),
- checks config structural keys the engine reads (stateMap states, tile ids incl. `goal`, `hazards.movingBumper.id`, numeric tuning fields).

It parses everything itself *before* requiring `utils.js` (which loads all maps at import), so a malformed map submission — the in-browser editor opens these PRs — fails with a clean `client/maps/X.json: ...` message instead of a stack trace.

### `smoke-test`
Proves the game still *runs*:
- **Boot check:** spawn `node index.js` on an ephemeral port, require it to log `listening`, fail on early exit.
- **Headless game-loop driver** (`.github/scripts/smoke-test.js`):
  - *Session A* drives the real `messenger` handlers (`enterGame`/`movement`) for 3 fake clients, forces lobby→gated→racing→collapsing, ticks `hostess.updateRooms(dt)` — exercising messenger + hostess + state machine + engine + compressor together.
  - *Session B* runs the engine on **all 49 maps** via the editor's preview-map injection path, catching maps that are structurally valid but break the physics/QuadTree.

## Verification
Ran every gate locally — all pass. Negative tests confirm the gates bite: an injected engine throw, a malformed-JSON map, and a no-goal map each exit 1 with clean messages.

Not a game-mechanic change (no `config.json`/`game.js`/`engine.js` edits), so no CHANGELOG entry required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)