### PR TITLE
Return to menu when a controller leaves and no real player remains

### DIFF
--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -650,9 +650,37 @@ function dropLocalPlayer(slot) {
 	}
 	try { lp.socket.disconnect(); } catch (e) { /* already gone */ }
 	localPlayers[slot] = null;
+	// A controller player who just left was effectively the only player if all that
+	// remains is the primary slot with no one actually driving it — no pad bound and
+	// the keyboard/mouse was never used to play (a phantom P1 that only exists to
+	// hold the tab). In that case fall through to the same teardown the primary leave
+	// uses, so leaving returns to the menu instead of stranding the tab on a player
+	// nobody is controlling. A real keyboard/mouse player (kbmClaimedPrimary) or
+	// another controller still in the game keeps the session alive.
+	if (onlyPhantomPrimaryRemains()) {
+		// No real player left — tear the tab down and go back to the menu, same as
+		// the last-player-leaving path in handlePrimaryLost().
+		try { server.disconnect(); } catch (e) { /* ignore */ }
+		window.location.href = "./index.html";
+		return;
+	}
 	if (typeof onLocalPlayersChanged === "function") {
 		onLocalPlayersChanged(); // restore the bottom bar if back to 1 player
 	}
+}
+
+// True when the sole surviving local player is the primary slot and nobody is
+// actually driving it: no controller bound and the keyboard/mouse never claimed P1.
+function onlyPhantomPrimaryRemains() {
+	var remaining = null, count = 0;
+	for (var s = 0; s < localPlayers.length; s++) {
+		if (localPlayers[s]) {
+			count++;
+			remaining = localPlayers[s];
+		}
+	}
+	return count === 1 && remaining.isPrimary &&
+		remaining.padIndex == null && !kbmClaimedPrimary;
 }
 
 // The primary (rendering/audio) connection was lost. If pad players are still in


### PR DESCRIPTION
## Problem

When a controller is a **secondary** local player sitting behind a primary connection that nobody is actually driving (a "phantom P1" — no controller bound and the keyboard/mouse never used to play), pressing **B → A** to leave dropped *just the controller* and left the tab stranded in the lobby on that phantom connection. From the player's view: "it drops my controller but doesn't bring me back to the menu."

This phantom state is reachable in normal play — e.g. two controllers join (one takes P1), then the P1 controller unplugs, leaving a phantom P1 behind the surviving controller.

## Fix

`client/scripts/client.js` — in `dropLocalPlayer()`, after a non-primary player leaves, if the only survivor is a phantom primary (`isPrimary && padIndex == null && !kbmClaimedPrimary`), tear the tab down and return to the menu instead of stranding it. A **real keyboard/mouse player** (`kbmClaimedPrimary`) or **another controller** still in the game keeps the session alive — a genuine couch-co-op partner is never kicked.

## Verification

Reproduced and verified all three cases in a browser with a mocked Gamepad API:

- Phantom primary + controller leaves → returns to menu ✅
- Real keyboard player + controller leaves → controller dropped, keyboard player stays in lobby ✅
- Solo controller (bound to primary) leaves → still returns to menu, unchanged path ✅

`npm run build` passes.

## Notes

- Client-only change (no `server/config.json`, `game.js`, or `engine.js` touched), so no CHANGELOG entry per the release-notes rule.
- The phantom-primary → menu path also now activates on non-"Leave"-button drops of the lone controller (unplug, reconnect-grace expiry, server kick of that slot). In all of those there is no real player rendering, so exiting to the menu is consistent — but it is a behavior change beyond the deliberate B→A leave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)