### PR TITLE
Mobile input polish + dynamic camera

### DIFF
--- a/MOBILE_INPUT_POLISH_ANALYSIS.md
+++ b/MOBILE_INPUT_POLISH_ANALYSIS.md
@@ -1,0 +1,509 @@
+# Mobile / Gamepad / Keyboard+Mouse HTML Polish Analysis
+
+How to polish the ChaoChao client HTML & front-end for the four input modes it
+supports: **touch (mobile)**, **gamepad**, **keyboard+mouse (desktop)**, and the
+display concerns that cut across all of them (**button sizing, DPI/text
+scaling, page navigation**).
+
+This is an analysis + recommendations doc, not a set of applied changes. Every
+finding cites the file/line it came from so the work can be picked up directly.
+Items are tagged **[P1]** (high impact / broken on a platform), **[P2]**
+(noticeable polish), **[P3]** (nice-to-have). Each item carries a **DoD**
+(definition of done / acceptance criteria) and an **Effort** estimate
+(**S** ≈ <½ day · **M** ≈ 1–2 days · **L** ≈ multi-day / needs a spike), and §11
+groups everything into PR-sized chunks with a suggested sequence.
+
+---
+
+## Verification pass — what was confirmed in code
+
+A second read resolved the open questions from the first draft. Three first-draft
+findings were **corrected** after checking the code:
+
+- **§2.2 coordinate space is NOT a mismatch.** No map JSON overrides world size
+  (`grep` of `client/maps/*.json` found no `worldWidth`/`worldHeight`), and
+  `world` is populated from the server using `config.worldWidth/worldHeight =
+  1366×768` (`server/config.json:5-6`, `worldResize` `gameboard.js:246-253`) —
+  identical to the canvas backing store. Touch coords map into that same
+  1366×768 space (`input.js:238`). So the virtual-button bound rects and the
+  touch coordinates share **one** coordinate space; the §2.2 fix needs no
+  coordinate reconciliation. (If a future map ever ships a non-1366×768 world,
+  this assumption breaks — see §2.2.)
+- **§4.5 controller focus styling is already covered.** `menuGamepad.js:14` uses
+  `NAV_SELECTOR = "a.btn, button.btn, input.form-control"` and toggles `gp-focus`
+  (`menuGamepad.js:116-120`); the landing CTAs, join cards (`a.join-btn` is also
+  `a.btn`), refresh button, and join-by-id input all match. Only the plain
+  keyboard-`Tab` `:focus-visible` case (non-gamepad) is still worth a glance.
+- **§7 PlayStation glyph detection is already implemented.** `gamepad.js:624-632`
+  (`detectGamepadType`, `gamepadType === "playstation"`) already swaps ✕/□/○ vs
+  A/X/B. The first draft's P3 suggestion to add this was wrong and has been
+  removed.
+
+---
+
+## 0. The single biggest structural gap: there are no responsive breakpoints
+
+`client/css/styles.css` (650 lines) contains **zero `@media` queries**. Every
+size is fixed: the navbar is `60px` tall (`:root --navbar-height`,
+`styles.css:14`), the landing title is `4em` (`#game-title`, `styles.css:312`),
+the emoji wheel is a hard-coded `100px` circle (`.emojiMenu`,
+`styles.css:397`), and all the create-editor panels use fixed percentages
+(`#mapEditor` 80%, `#controlPanel` 9%, `styles.css:183`/`212`).
+
+Nothing adapts to viewport width, orientation, or pointer type. The pages
+"work" on mobile only because Bootstrap 4.1.3's grid does some of the lifting on
+the landing/join pages — the game canvas and overlay UI do their own scaling in
+JS. This means most of the recommendations below reduce to: **introduce a small
+set of breakpoints and a `(pointer: coarse)` / `(hover: none)` query**, then
+hang the per-mode tweaks off them.
+
+---
+
+## 1. Display & DPI / text scaling
+
+### 1.1 [P1] The game canvas never accounts for `devicePixelRatio` → blurry on every phone & Retina display
+
+The canvas backing store is fixed at `1366×768`:
+
+```html
+<!-- client/play.html:38-39 -->
+<canvas id="gameCanvas"  width="1366" height="768"></canvas>
+<canvas id="overlayCanvas" width="1366" height="768"></canvas>
+```
+
+`resize()` (`game.js:185`) only ever sets the **CSS** size
+(`gameCanvas.style.width/height`, `game.js:206-209`) — it scales the 1366×768
+bitmap up or down with CSS but never changes the backing-store resolution.
+There is no `devicePixelRatio` reference anywhere in `game.js`, `draw.js`,
+`input.js`, or `client.js` (verified by grep).
+
+Consequences:
+- On a 3× phone or a Retina laptop the whole game is rendered at ~1/3 the native
+  resolution and upscaled → soft edges on sprites and, most visibly, **fuzzy
+  text**. Every canvas-drawn label goes through this: `drawTouchLabel`
+  ("Move"/"Attack"/"Fullscreen"/"Emoji", `draw.js:1320`) and all the score/state
+  HUD text in `draw.js`.
+- This is the actual root cause of the "text DPI scaling" symptom — it is not a
+  font/CSS problem, it's a canvas-resolution problem.
+
+**Recommendation:** make the canvas DPR-aware. Set
+`canvas.width = cssWidth * dpr; canvas.height = cssHeight * dpr;` inside
+`resize()`, keep the CSS size as the layout size, and `ctx.scale(dpr, dpr)` once
+per frame (or bake the ratio into the camera transform). Because all game logic
+currently assumes a 1366×768 coordinate space (`camera` in `game.js:211`, touch
+mapping in `input.js:238`), the cleanest approach is to keep the **logical**
+coordinate space at 1366×768 and apply the DPR as an extra transform, so no
+gameplay math changes. Cap `dpr` at ~2 to avoid over-rendering on 3× phones.
+
+### 1.2 [P2] No `-webkit-text-size-adjust`; fixed `4em` title can overflow narrow phones
+
+`#game-title { font-size: 4em }` (`styles.css:312`) on a 320px-wide device is
+~64px and competes with the `.play-container` padding (`styles.css:329`). Add a
+`clamp()` (e.g. `clamp(2.2rem, 12vw, 4em)`) and set
+`html { -webkit-text-size-adjust: 100% }` so iOS doesn't auto-inflate text in
+landscape.
+
+### 1.3 [P3] Canvas-drawn HUD/label font sizes are constant px
+
+`drawTouchLabel` uses `"bold 16px Arial"` (`draw.js:1322`) in the logical
+coordinate space. Once 1.1 is fixed these will be crisp, but on very small
+phones they're still 16/1366 of the width. Consider scaling label/HUD font with
+the fitted canvas size so captions stay legible on small screens and don't
+dominate on large ones.
+
+---
+
+## 2. Fullscreen controls
+
+### 2.1 [P1] `requestFullscreen()` on a `<div>` is a no-op on iOS Safari
+
+`goFullScreen()` calls `gameWindow.requestFullscreen()` (`game.js:317`) and
+`initEventHandlers()` auto-invokes it on touch devices (`input.js:33`). **iOS
+Safari does not support the Fullscreen API on arbitrary elements** (only
+`<video>`), so on iPhone this silently rejects — the `.catch` at `game.js:319`
+swallows it. Net effect: the prominent on-canvas "Fullscreen" button
+(`draw.js:1302`, `drawTouchLabel("Fullscreen", …)` `draw.js:1307`) does nothing
+on the single most common mobile platform.
+
+**Recommendations:**
+- Feature-detect (`if (el.requestFullscreen)`) and **hide the fullscreen
+  touch button on platforms where it's unavailable** instead of drawing a
+  dead control (gate `exitButton.isVisible()` / `drawTouchControls`
+  `draw.js:1293`).
+- For iOS, lean on the existing PWA meta tags — `apple-mobile-web-app-capable`
+  is already set (`play.html:6`). Document "Add to Home Screen" as the
+  fullscreen path on iOS, since launched-from-home-screen runs chromeless.
+- Don't auto-request fullscreen on load (`input.js:33`) — browsers require a
+  user gesture, so the first call frequently fails anyway; trigger it only from
+  the explicit button tap (which already exists at `input.js:253-255`).
+
+### 2.2 [P1] The fullscreen/emoji touch targets are thin top-corner strips that don't match the drawn icon
+
+The fullscreen and emoji buttons are hit-tested against their **bounding
+rectangle**, not the button's own radius:
+
+```js
+// input.js:206-207  (the bound rects)
+upperLeftRect  = new VirtualButton(0, 10, world.width/16, 50, false);
+upperRightRect = new VirtualButton(world.width - world.width/16, 10, world.width/16, 50, false);
+// input.js:216-217  (radius 12.5 is set but unused for hit-testing)
+exitButton = new Button(world.width - 50, 0, 0, 0, 12.5, false);
+chatButton = new Button(50, 0, 0, 0, 12.5, false);
+// input.js:241  hit test uses the bound rect, not the radius:
+if (virtualButtonList[i].bound.pointInRect(touchX, touchY)) { ... }
+```
+
+So the **effective tap zone** for both fullscreen (top-right) and emoji
+(top-left) is a strip only `world.width/16` wide and `50` tall pinned to the
+very top edge — exactly where the mobile browser's URL bar, the notch, and the
+status bar live. Meanwhile the **icon is drawn at ~57px** (`fullScreenToUse.width
+* 0.1` on a 576-px source, `draw.js:1302`) centered in that strip, so the
+visible target and the touchable target disagree, and the radius `12.5` set on
+the button object is dead.
+
+**Recommendations:**
+- Make the tap zone match (or slightly exceed) the rendered icon — at least a
+  44×44 CSS-px square once converted through the canvas scale. Either widen the
+  bound rects or switch hit-testing to `button.pointInCircle` with a radius sized
+  to the icon.
+- Move both controls **down out of the top safe-area strip** (e.g. `y` below the
+  status bar / notch) so they aren't competing with browser chrome.
+- Reconcile the dead `radius` (12.5) vs. bound-rect logic so there's one source
+  of truth for the target size.
+
+> **Confirmed:** the bound rects (`world.*`) and touch coords (canvas `1366×768`)
+> are the same space today (see Verification pass), so this is a straight
+> resize/reposition — no coordinate conversion needed. Add a guard/comment so it
+> stays true if a map ever ships a non-1366×768 world.
+
+**DoD:** the fullscreen and emoji controls each have a tap zone ≥44×44 CSS-px that
+visually matches the rendered icon, sit below the top safe-area strip, and
+hit-testing uses a single source of truth (no dead `radius`). Verified by tapping
+on a real phone with the URL bar visible. · **Effort: M**
+
+### 2.3 [P2] Fullscreen state and `resize()` coupling
+
+`resize()` special-cases `fullscreenElement` to use the raw viewport
+(`game.js:191-193`) vs. the fitted 16:9 box otherwise. When the iOS path fails
+(2.1) the game stays in the letterboxed branch, which is correct — but combined
+with the dead button it's confusing UX. Hiding the button (2.1) resolves this.
+
+---
+
+## 3. Emoji button / wheel on mobile
+
+### 3.1 [P2] The emoji wheel is a hard-coded 100px circle with point-sized slots
+
+`.emojiMenu` is `100px × 100px` (`styles.css:397-411`) and opened by setting
+`transform: scale(2)` (`input.js:378`) → a 200px wheel. The twelve emoji slots
+are absolutely positioned at hard-coded pixel offsets for the *unscaled* 100px
+circle (`#emojiMenu a:nth-child(n)`, `styles.css:421-473`) at `font-size: 12px`
+(`styles.css:417`). After the 2× scale each emoji is ~24px.
+
+Problems on mobile:
+- 24px is **below the ~44px minimum touch target**; the slots sit close together
+  on the 200px ring, so mis-taps are likely.
+- The layout is brittle: it only looks right at exactly `scale(2)`. There's no
+  responsive sizing for small vs. large phones.
+- Slot positions are authored in raw px, so adding/removing emojis means
+  re-doing the trig by hand.
+
+**Recommendations:**
+- Rebuild the wheel sizing with CSS custom properties / `calc()` driven by a
+  single `--wheel-radius`, and size the wheel from viewport (`min(60vw, 320px)`)
+  so it scales with the device instead of a fixed 100px×2.
+- Bump per-slot hit area to ≥44px (pad the anchors, not just the glyph).
+- Consider generating slot positions from JS (`setupEmojiWheel`,
+  `client.js:60`) using `cos/sin` over the count, instead of 12 hard-coded
+  `nth-child` rules — this also future-proofs the gamepad wheel navigation that
+  reads these same anchors (`gamepad.js:390-409`, `emojiItems()`).
+
+### 3.2 [P2] Open position can clip off-screen
+
+On touch, the wheel opens at `rect.width/2 - 50, rect.height/2 - 50`
+(`input.js:260`) and `moveEmojiMenu` sets `style.left/top` (`input.js:396-398`).
+With mouse/keyboard it opens at the cursor (`input.js:71`,
+`openEmojiWindow(mousex, mousey)`). Near a screen edge (cursor case) the 200px
+wheel can clip. Clamp the open position to keep the full wheel within the
+viewport.
+
+### 3.3 [P3] Emoji control is consistent across modes — keep it that way
+
+Good baseline already exists: right-click opens it on desktop (`input.js:67`),
+the on-canvas chat button opens it on touch (`input.js:256`), and the gamepad
+`X`/`Square` opens it with d-pad navigation (`gamepad.js:222`, `GP_BTN_EMOJI`).
+Any redesign in 3.1 should preserve all three entry points and the gamepad
+`emojiItems()` DOM contract (first `<a>` is the close button — see the comment at
+`gamepad.js:391`).
+
+---
+
+## 4. Page navigation & the navbar
+
+### 4.1 [P2] Navbar audio/gamepad toggles are tiny, label-less icon links
+
+The top nav has `#masterControl` and `#musicControl` as bare `<a>` tags wrapping
+Font Awesome glyphs with only `margin-left: 5px` (`.music-btn`, `styles.css:291`;
+markup `play.html:28-31`). On a phone these are small, closely-spaced tap
+targets with no visible hit area and no text label.
+
+**Recommendations:**
+- Give them a real padded hit box (≥44px), `cursor:pointer` is set but there's
+  no padding. Add `aria-label`s (currently only `aria-hidden` icons).
+- Consider collapsing them into the navbar with proper spacing at narrow
+  widths, or a small settings popover.
+
+### 4.2 [P2] The navbar isn't a real responsive Bootstrap navbar
+
+Markup uses `<nav class="d-flex align-items-center px-3">` with a manual
+`navbar-brand` (`play.html:23`, `index.html:25`, `join.html:22`) but none of
+Bootstrap's `navbar`/`navbar-expand`/`collapse` machinery. It's fine because
+there's little in it, but if nav grows, adopt the Bootstrap navbar pattern (or a
+custom flex/`gap` layout) so it degrades on small screens.
+
+### 4.3 [P2] Fixed 60px navbar eats vertical space in landscape mobile
+
+`--navbar-height: 60px` is constant (`styles.css:14`) and the section height is
+`calc(100vh - var(--navbar-height))` (`styles.css:45`). In landscape on a phone
+(the natural orientation for this game) 60px + browser chrome is a big chunk of a
+~375px-tall viewport. Consider a shorter navbar under `(orientation: landscape)
+and (max-height: 480px)`, or hiding it during active gameplay (it's already
+`position: fixed; z-index: 1005`).
+
+### 4.4 [P2] `100vh` will be wrong on mobile browsers
+
+`html, body { height: 100vh }` (`styles.css:19`) and
+`section { height: calc(100vh - var(--navbar-height)) }` (`styles.css:45`) use
+`vh`, which on mobile Safari/Chrome includes the area behind the dynamic URL
+bar — causing the canvas to be slightly too tall and content to shift when the
+bar collapses. Move to `100dvh` (dynamic viewport height) with a `vh` fallback.
+
+### 4.5 [P3] Controller focus styling is covered — only plain `Tab` focus left to check
+
+`menuGamepad.js` is loaded on landing and join (`index.html:54`, `join.html:62`),
+uses `NAV_SELECTOR = "a.btn, button.btn, input.form-control"` (`menuGamepad.js:14`)
+and toggles the `.gp-focus` ring (`styles.css:556`, applied at
+`menuGamepad.js:116-120`). **Confirmed:** the landing CTAs
+(`#playButton/#joinButton/#createButton`, all `a.btn`, `index.html:39-41`), the
+join cards' button (`a.join-btn` is also `a.btn`, `styles.css:123`), the refresh
+button (`button.btn`), and the join-by-id input (`input.form-control`) all match
+the selector, so controller focus already reaches them.
+
+The only remaining gap is **non-gamepad keyboard `Tab` focus**: confirm a visible
+`:focus-visible` outline exists (Bootstrap 4's default may be suppressed) so
+keyboard-only desktop users can see where they are.
+
+**DoD:** tabbing through landing and join with a keyboard (no gamepad) shows a
+clear focus indicator on every interactive element. · **Effort: S**
+
+---
+
+## 5. Button sizing & touch targets (cross-cutting)
+
+### 5.1 [P2] Default Bootstrap `.btn` is below the 44px touch minimum
+
+`.btn { font-size: 0.95rem }` (`styles.css:288`) with Bootstrap 4's default
+padding yields ~38px-tall buttons. The landing CTAs are full-width
+(`w-100`, `index.html:39`) so width is fine, but height and the join page's
+inline buttons (`#refreshButton .btn-sm` `join.html:32`, `#joinByIdButton`
+`join.html:50`, `.join-btn` `styles.css:123`) are small for touch.
+
+**Recommendation:** under `(pointer: coarse)`, bump `.btn` min-height to 44px and
+increase vertical padding; avoid `.btn-sm` on touch.
+
+### 5.2 [P1/P2] On-canvas controls live in logical 1366×768 space — they shrink with the canvas, not with the finger
+
+The joystick (`baseRadius: 200`, `stickRadius: 120`, `maxPullRadius: 100`,
+`joystick.js:12-16`) and buttons are all sized in the logical coordinate space.
+When the canvas is fitted to a narrow phone, everything is multiplied by the
+fit ratio (`optimalRatio`, `game.js:189`), so a 200px joystick on a 375px-wide
+screen renders at ~55px radius regardless of the player's hand. There's no
+minimum physical size and no per-device tuning.
+
+**Recommendations:**
+- Define touch-control sizes in **CSS pixels** (or a physical target) and convert
+  *into* logical space, rather than authoring in logical px — so a thumb-sized
+  joystick stays thumb-sized on every screen.
+- Reconsider the joystick `deadzone: 10` (`joystick.js:19`) and `maxPullRadius`
+  relative to the rendered size on small screens.
+
+### 5.3 [P3] `onMove` has an assignment-as-condition bug
+
+`Joystick.onMove` and `Button.onMove` both do `if (this.pressed = true)`
+(`joystick.js:130`, `joystick.js:238`) — assignment, not comparison. It happens
+to work because the body always runs, but it silently forces `pressed = true` on
+every move and is a latent bug. Fix to `==`/`===` or restructure.
+
+---
+
+## 6. Touch event handling & viewport meta
+
+### 6.1 [P1] Viewport meta lacks `viewport-fit=cover` → no safe-area inset support
+
+All pages use:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+```
+
+(`play.html:4`, `index.html:5`, `join.html:4`). Without `viewport-fit=cover`,
+`env(safe-area-inset-*)` is unavailable, so on notched/home-indicator phones:
+- The fixed navbar (`styles.css:29`) can sit under the notch in landscape.
+- The gamepad prompt bar (`.gamepad-prompts { bottom: 12px }`, `styles.css:484`)
+  and the on-screen keyboard (`.osk-container { bottom: 16px }`, `styles.css:583`)
+  can sit under the home indicator.
+
+**Recommendation:** add `viewport-fit=cover` and pad fixed UI with
+`env(safe-area-inset-bottom/top)`.
+
+### 6.2 [P2] Touch listeners are `passive:false` but `touchmove` never calls `preventDefault` → page can scroll/rubber-band during a joystick drag
+
+`touchstart/end/move` are registered `{ passive: false }` (`input.js:22-24`),
+and `onTouchStart` calls `preventDefault` only for the right-click/context path,
+not in `onTouchMove` (`input.js:287-314`). `body { overflow: hidden }` on
+play.html (`play.html:22`) limits scrolling, but iOS pinch-zoom and rubber-band
+overscroll can still fire mid-drag, making the joystick feel slippery.
+
+**Recommendations:**
+- Call `evt.preventDefault()` in `onTouchMove` when a control owns the touch
+  (you already pay the `passive:false` cost, so you might as well use it).
+- Add `touch-action: none` to the canvas/`#gameWindow` and
+  `overscroll-behavior: none` to `body` to stop pull-to-refresh and zoom on the
+  play page.
+- Consider `user-scalable=no` **only on the play page** (keep pinch-zoom on
+  landing/join for accessibility).
+
+### 6.3 [P3] `isTouchDevice()` relies solely on `(hover: none)`
+
+`isTouchDevice = () => window.matchMedia('(hover: none)').matches`
+(`input.js:316`). Touch laptops and hybrid devices can report `hover: none` (or
+the inverse), mis-classifying the input mode and showing/hiding the whole touch
+UI incorrectly. Consider combining `(pointer: coarse)`, `'ontouchstart' in
+window`, and `navigator.maxTouchPoints`, and/or switching control schemes
+dynamically on first touch/mouse/gamepad event rather than once at init.
+
+---
+
+## 7. Gamepad (already strong — polish only)
+
+The gamepad story is the most mature: in-game pad support (`gamepad.js`), menu
+navigation (`menuGamepad.js`), editor support (`editorGamepad.js`), an on-screen
+keyboard for text entry (`osk.js` + simple-keyboard, `join.html:18,58`), a
+prompt/hint bar (`.gamepad-prompts`, `styles.css:483`), focus rings
+(`.gp-focus`), and a leave-game confirm modal (`.confirm-modal`,
+`styles.css:601`). Remaining polish:
+
+- **[P3]** The prompt bar dims after ~60s (`.faded`, `styles.css:514`) and — by
+  design — only un-dims on a scheme change or the Select/`H` toggle
+  (`gamepad.js:664`, `714-732`), *not* on arbitrary input. That's a reasonable
+  choice; the only action item is to make it respect safe-area (see §6.1) so the
+  faded bar doesn't sit under the home indicator. · **DoD:** bar clears the home
+  indicator on a notched phone. · **Effort: S**
+- **[P3]** OSK width is `min(720px, 96vw)` (`styles.css:584`) — good; just verify
+  it doesn't overlap the prompt bar on short landscape screens. · **Effort: S**
+- *(PlayStation glyphs: already implemented — `gamepad.js:624-632`. No action.)*
+
+---
+
+## 8. Keyboard + mouse (desktop)
+
+Largely fine. Notes:
+
+- **[P2]** Right-click opens the emoji wheel (`input.js:67`) and `contextmenu` is
+  globally suppressed (`input.js:26`). That's intentional, but document it —
+  users may expect a context menu. Provide an on-screen hint.
+- **[P2]** `dblclick` toggles `movingByMouse` (`input.js:93-98`) — a hidden
+  mode-toggle with no on-screen indication. Surface the current mode somewhere.
+- **[P3]** `calcMousePos` calls `preventDefault` on every `mousemove`
+  (`input.js:39`) — usually harmless but can interfere with text selection
+  outside the canvas; scope it to the canvas element instead of `window`.
+- **[P3]** Movement keys are handled via `keyCode` (`input.js:108-110`, deprecated)
+  — fine functionally; migrate to `event.code` if touched.
+
+---
+
+## 9. The map editor (`create.html`) is desktop-only by construction
+
+Out of scope for the main ask but worth flagging: `create.html` uses fixed
+percentage panels (`#mapEditor` 80%/`#controlPanel` 9%, `styles.css:183/212`)
+and `.mapEditorBtn { font-size: 24px; width: 50%; float:left }`
+(`styles.css:262`). It has gamepad support (`editorGamepad.js`) but no responsive
+/ touch layout. If mobile map-editing is ever a goal it needs its own pass;
+otherwise consider gating it behind a "desktop recommended" notice on small
+screens.
+
+---
+
+## 10. Backlog — every item with priority, effort, PR group & DoD
+
+Effort: **S** ≈ <½ day · **M** ≈ 1–2 days · **L** ≈ multi-day / needs a spike.
+PR column maps to the chunks defined in §11.
+
+| ID | Item | Pri | Effort | PR | Definition of done |
+| --- | --- | --- | --- | --- | --- |
+| 6.1 | `viewport-fit=cover` + `env(safe-area-inset-*)` padding | P1 | S | A | Fixed UI (navbar, prompt bar, OSK) clears notch & home indicator on a notched phone in both orientations. |
+| 4.4 | `100vh` → `100dvh` (with `vh` fallback) | P2 | S | A | Canvas/section height doesn't shift when the mobile URL bar collapses. |
+| 1.2 | `clamp()` title + `-webkit-text-size-adjust:100%` | P2 | S | A | `#game-title` never overflows at 320px wide; iOS doesn't auto-inflate text in landscape. |
+| 4.5 | Visible `:focus-visible` for keyboard-only `Tab` | P3 | S | A | Tabbing landing+join with a keyboard (no pad) shows focus on every control. |
+| 1.1 | DPR-aware canvas (backing store × `dpr`, capped ~2) | P1 | L | B | Game + canvas text render sharp on a 2×/3× device; gameplay coords unchanged; no perf regression. |
+| 1.3 | Scale canvas HUD/label fonts to fitted size | P3 | S | B | `drawTouchLabel`/HUD text legible on a 320px phone and not oversized on desktop. |
+| 2.1 | Fullscreen: feature-detect, hide button where unsupported, drop on-load auto-request | P1 | M | C | No fullscreen button shown on iOS Safari; button works via tap where supported; no failed auto-request on load. |
+| 2.3 | Fullscreen ↔ `resize()` branch coupling | P2 | S | C | Falls out of 2.1; no letterbox/again-fullscreen confusion. |
+| 2.2 | Fullscreen/emoji tap targets match icon, leave top strip, single hit source | P1 | M | D | Each control has a ≥44×44 zone matching its icon, below the safe-area strip; dead `radius` removed. |
+| 5.2 | On-canvas controls sized in CSS px, converted into logical space | P1/P2 | M | D | Joystick/buttons keep a thumb-sized physical size across phone widths. |
+| 5.3 | `if (this.pressed = true)` → comparison | P3 | S | D | `onMove` no longer force-sets `pressed`; behavior unchanged. |
+| 3.1 | Rebuild emoji wheel: viewport-sized radius, ≥44px slots, JS-generated positions | P2 | M | E | Wheel scales with device; each slot ≥44px; adding/removing emojis needs no hand-authored CSS. |
+| 3.2 | Clamp emoji-wheel open position on-screen | P2 | S | E | Full wheel stays in viewport when opened near an edge (cursor case). |
+| 3.3 | Preserve all 3 entry points + `emojiItems()` contract | P3 | — | E | Constraint on 3.1, not separate work. |
+| 4.1 | Navbar audio/gamepad toggles: ≥44px hit box + `aria-label` | P2 | S | F | Toggles are easily tappable on mobile and labelled for screen readers. |
+| 4.3 | Shorter navbar under landscape/short-height media query | P2 | S | F | Navbar reclaims vertical space in landscape phone play. |
+| 5.1 | `.btn` min-height 44px under `(pointer: coarse)`; avoid `.btn-sm` on touch | P2 | S | F | All buttons ≥44px tall on touch devices. |
+| 4.2 | Adopt real responsive Bootstrap navbar (optional) | P2 | M | F | Navbar degrades gracefully if nav content grows; no regressions. |
+| 6.2 | `preventDefault` in `onTouchMove`; `touch-action:none`; `overscroll-behavior:none` | P2 | S | G | Joystick drags don't scroll/zoom/rubber-band the play page on iOS. |
+| 6.3 | Broaden `isTouchDevice()` / switch scheme on first input | P3 | M | G | Hybrid/touch-laptop devices classify correctly; control UI follows actual input. |
+| 7a | Prompt bar respects safe-area | P3 | S | A/G | Faded bar clears home indicator. |
+| 7b | OSK doesn't overlap prompt bar in short landscape | P3 | S | G | No overlap at ~480px height. |
+| 8 | KB+M polish: right-click hint, dblclick-mode indicator, scope `mousemove` preventDefault, `keyCode`→`code` | P3 | S | H | Hidden modes are discoverable; no text-selection interference outside canvas. |
+
+---
+
+## 11. PR-sized grouping & suggested sequence
+
+- **PR A — Viewport & text quick wins** *(S, P1+P2)* — `6.1, 4.4, 1.2, 4.5, 7a`.
+  Pure CSS/HTML, low risk, unblocks safe-area for everything else. **Do first.**
+- **PR B — DPR-aware canvas** *(L, P1)* — `1.1, 1.3`. The headline fix; isolated
+  to `resize()` + the draw transform. Spike the camera-transform interaction
+  first.
+- **PR C — Fullscreen correctness** *(M, P1)* — `2.1, 2.3`. Removes the dead iOS
+  control.
+- **PR D — Touch targets & feel** *(M, P1/P2)* — `2.2, 5.2, 5.3`. The core
+  "controls feel right on mobile" PR.
+- **PR E — Emoji wheel rebuild** *(M, P2)* — `3.1, 3.2` (`3.3` as a constraint).
+- **PR F — Responsive navbar & buttons** *(M, P2)* — `4.1, 4.3, 5.1, 4.2`.
+  Establishes the §0 breakpoints + `(pointer: coarse)` query the rest reuse.
+- **PR G — Touch event hardening** *(S/M, P2/P3)* — `6.2, 6.3, 7b`.
+- **PR H — Desktop KB+M polish** *(S, P3)* — `8`.
+
+**Sequence:** A → B → C → D, then E / F / G in parallel, then H. PRs A and F can
+start in parallel since F introduces the breakpoint scaffolding that A's
+`(pointer: coarse)` tweaks slot into.
+
+**Still needs a decision (not blocking):** 6.3's static-vs-dynamic input-scheme
+strategy, and whether 4.2 (full Bootstrap navbar) is worth it given how little
+the navbar holds today.
+
+---
+
+### Appendix — files referenced
+
+| Area | File(s) |
+| --- | --- |
+| Page markup / viewport meta | `client/play.html`, `client/index.html`, `client/join.html`, `client/create.html` |
+| All styling (no media queries) | `client/css/styles.css` |
+| Canvas sizing / fullscreen / resize | `client/scripts/game.js` (`resize` 185, `goFullScreen` 311) |
+| Touch input, virtual buttons, emoji open | `client/scripts/input.js` |
+| Joystick / button classes | `client/scripts/joystick.js` |
+| On-canvas touch controls & labels | `client/scripts/draw.js` (`drawTouchControls` 1224, `drawTouchLabel` 1320) |
+| Gamepad (in-game / menu / editor) | `client/scripts/gamepad.js`, `menuGamepad.js`, `editorGamepad.js` |
+| On-screen keyboard | `client/scripts/osk.js` |
+| Emoji wheel setup / send | `client/scripts/client.js` (`setupEmojiWheel` 60, `sendEmoji` 478) |

--- a/client/create.html
+++ b/client/create.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
   <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
   <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
   <!-- Google tag (gtag.js) -->

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -13,6 +13,14 @@
 :root {
     --navbar-height: 60px;
 
+    /* Safe-area insets (notch / home indicator). Resolve to 0px on devices
+       and browsers that don't expose them, so the layout is unchanged there.
+       Requires `viewport-fit=cover` on the viewport meta to be non-zero. */
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+
     /* Theme palette — light (default). The dark overrides live in the
        [data-theme="dark"] block below; theme.js flips the data-theme
        attribute on <html> based on the saved light/dark/auto preference. */
@@ -62,21 +70,40 @@
 
 html,body {
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    /* Stop iOS from auto-inflating text in landscape (it ignores our sizing
+       otherwise) while still allowing user zoom. */
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
     width: 100vw;
+    /* `dvh` tracks the *dynamic* viewport so the canvas/section don't shift
+       when the mobile URL bar collapses. `vh` stays as the fallback for
+       browsers without `dvh`. */
     height: 100vh;
+    height: 100dvh;
+    /* Stop pull-to-refresh / overscroll bounce so a touch drag near an edge
+       doesn't yank the page (6.2). */
+    overscroll-behavior: none;
 }
 
 body {
     /* Push body content below the fixed navbar with padding (not margin
        on the first child) so the offset doesn't margin-collapse out of
-       body and inflate the page height past the viewport. */
-    padding-top: var(--navbar-height);
+       body and inflate the page height past the viewport. Include the top
+       safe-area so content clears the notch/status bar. */
+    padding-top: calc(var(--navbar-height) + var(--safe-top));
     background: var(--bg);
     color: var(--text);
 }
 
 nav {
-    height: var(--navbar-height);
+    /* Grow by the top inset and pad it inward so the brand/toggles clear the
+       notch & status bar; pad the sides for the landscape notch. */
+    height: calc(var(--navbar-height) + var(--safe-top));
+    padding-top: var(--safe-top);
+    /* `!important` beats Bootstrap's `.px-3` utility on the same element so
+       the landscape-notch side padding is actually applied. */
+    padding-left: calc(1rem + var(--safe-left)) !important;
+    padding-right: calc(1rem + var(--safe-right)) !important;
     width: 100%;
     border-bottom: thin solid var(--border);
     box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
@@ -117,8 +144,9 @@ nav {
 
   section {
     /* navbar offset comes from body { padding-top } so margins don't
-       collapse out and inflate the page height. */
-    height: calc(100vh - var(--navbar-height));
+       collapse out and inflate the page height. `dvh` mirrors html/body. */
+    height: calc(100vh - var(--navbar-height) - var(--safe-top));
+    height: calc(100dvh - var(--navbar-height) - var(--safe-top));
     position: relative;
   }
 
@@ -138,6 +166,10 @@ canvas {
 #main {
     height: 100%;
     position: relative;
+    /* Let the landing menu scroll instead of being clipped when the viewport is
+       too short (e.g. landscape phones); pairs with the short-viewport rule
+       below that stops vertically centering it. */
+    overflow-y: auto;
 }
 
 .join-container {
@@ -235,6 +267,10 @@ canvas {
 #gameWindow {
     background: var(--board-bg);
     overflow: hidden;
+    /* The game owns all touch gestures inside the play area; disabling native
+       touch-action stops the browser scrolling/zooming during joystick or
+       attack drags (6.2). */
+    touch-action: none;
     display: none;
     /* Fill the section and flex-centre the canvas stack inside so the
        game canvas uses all the space the page has, not 90% with
@@ -387,7 +423,9 @@ div.desc {
 
 #game-title {
     font-family: "San Francisco";
-    font-size: 4em;
+    /* Fluid size: never overflows a 320px phone, never larger than the old 4em
+       on desktop. */
+    font-size: clamp(2.2rem, 12vw, 4em);
 }
 
 .landing-stack {
@@ -470,82 +508,39 @@ div.desc {
     z-index: 99;
 }
 
+/* Emoji wheel: a viewport-sized circle whose slots are positioned by JS
+   (positionEmojiSlots) around a ring, so it scales with the device and adding/
+   removing emojis needs no per-slot CSS. position:fixed so it overlays the
+   viewport and moveEmojiMenu can clamp the whole wheel on-screen. */
 .emojiMenu {
+    --wheel-size: min(72vw, 320px);
+    --slot-size: 46px;
     background-color: white;
-    height: 100px;
-    width: 100px;
+    width: var(--wheel-size);
+    height: var(--wheel-size);
     transform: scale(0);
+    transform-origin: center center;
     border-radius: 50%;
     border-style: solid;
-    position: absolute;
-    top: 0px;
-    bottom: 0px;
-    left: 0px;
-    right: 0px;
-    z-index: 99;
-    transition: 0.3s;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 2001;
+    transition: transform 0.3s;
 }
 
 #emojiMenu a {
     text-decoration: none;
-    display: inline-block;
     position: absolute;
-    font-size: 12px;
+    /* >=44px tap target; centred on its JS-set left/top point */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--slot-size);
+    min-height: var(--slot-size);
+    font-size: 24px;
     color: #BBBBBB;
-}
-
-#emojiMenu a:nth-child(1) {
-    top: 0px;
-    left: 41px;
-}
-
-#emojiMenu a:nth-child(2) {
-    top: 5px;
-    left: 60px;
-}
-
-#emojiMenu a:nth-child(3) {
-    top: 20px;
-    left: 72px;
-}
-
-#emojiMenu a:nth-child(4) {
-    top: 38px;
-    left: 80px;
-}
-
-#emojiMenu a:nth-child(5) {
-    top: 56px;
-    left: 72px;
-}
-
-#emojiMenu a:nth-child(6) {
-    top: 74px;
-    left: 60px;
-}
-#emojiMenu a:nth-child(7) {
-    top: 78px;
-    left: 41px;
-}
-#emojiMenu a:nth-child(8) {
-    top: 74px;
-    left: 22px;
-}
-#emojiMenu a:nth-child(9) {
-    top: 56px;
-    left: 10px;
-}
-#emojiMenu a:nth-child(10) {
-    top: 38px;
-    left: 2px;
-}
-#emojiMenu a:nth-child(11) {
-    top: 20px;
-    left: 10px;
-}
-#emojiMenu a:nth-child(12) {
-    top: 5px;
-    left: 22px;
+    transform: translate(-50%, -50%);
 }
 
 #emojiMenu a:hover {
@@ -558,7 +553,8 @@ div.desc {
 /* --- gamepad / controller prompts --- */
 .gamepad-prompts {
     position: fixed;
-    bottom: 12px;
+    /* clear the home indicator on notched phones */
+    bottom: calc(12px + var(--safe-bottom));
     left: 50%;
     transform: translateX(-50%);
     display: flex;
@@ -628,6 +624,23 @@ div.desc {
     display: none;
 }
 
+/* --- keyboard-only (Tab) focus indicator --- */
+/* Bootstrap 4 swaps the default focus outline for a subtle box-shadow that's
+   easy to miss. `:focus-visible` matches only keyboard/AT focus (never a mouse
+   click), so keyboard-only desktop users get a clear ring on every control
+   without affecting pointer users. */
+a:focus-visible,
+button:focus-visible,
+.btn:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[tabindex]:focus-visible {
+    outline: 3px solid #c87f8a;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(200, 127, 138, 0.25);
+}
+
 /* focus ring for controller navigation of DOM menus (landing + join) */
 .gp-focus {
     outline: 3px solid #c87f8a !important;
@@ -635,10 +648,12 @@ div.desc {
     box-shadow: 0 0 0 4px rgba(200, 127, 138, 0.25);
 }
 
-/* highlighted slot while navigating the in-game emoji wheel */
+/* highlighted slot while navigating the in-game emoji wheel.
+   Keep the translate(-50%,-50%) centering and add the scale on top, or the
+   focused slot would jump off its computed position. */
 #emojiMenu a.gp-emoji-focus {
     color: #c87f8a;
-    transform: scale(1.6);
+    transform: translate(-50%, -50%) scale(1.6);
     font-weight: 700;
 }
 
@@ -656,7 +671,7 @@ div.desc {
    that player's assigned color so a controller maps visibly to its player. */
 #padPlayers {
     position: fixed;
-    top: 12px;
+    top: calc(12px + var(--safe-top));
     left: 50%;
     transform: translateX(-50%);
     display: flex;
@@ -768,7 +783,7 @@ div.desc {
 /* informational controller-detection header on the menu/editor pages */
 #controllerHeader {
     position: fixed;
-    top: 8px;
+    top: calc(8px + var(--safe-top));
     left: 50%;
     transform: translateX(-50%);
     display: none;
@@ -826,7 +841,7 @@ div.desc {
 /* "controller detected — press A to join" toast, just below the player blocks */
 #padToast {
     position: fixed;
-    top: 50px;
+    top: calc(50px + var(--safe-top));
     left: 50%;
     transform: translateX(-50%);
     display: inline-flex;
@@ -868,7 +883,8 @@ div.desc {
 .osk-container {
     position: fixed;
     left: 50%;
-    bottom: 16px;
+    /* clear the home indicator on notched phones */
+    bottom: calc(16px + var(--safe-bottom));
     transform: translateX(-50%);
     width: min(720px, 96vw);
     z-index: 2000;
@@ -877,6 +893,11 @@ div.desc {
     background: #ececec;
 }
 .osk-container.hidden {
+    display: none;
+}
+/* 7b: while the on-screen keyboard is up, hide the bottom gamepad prompt bar so
+   the two never overlap on short landscape screens. */
+body.osk-open .gamepad-prompts {
     display: none;
 }
 .osk-container .hg-button.osk-focus {
@@ -986,4 +1007,82 @@ div.desc {
 [data-theme="dark"] .news-banner {
     border-color: #43363a;
     border-left-color: #c87f8a;
+}
+
+/* ===========================================================================
+   Responsive scaffolding (PR F)
+   The breakpoints + pointer/orientation queries the touch-facing tweaks hang
+   off. Kept in one place so the four input modes share one source of truth.
+   =========================================================================== */
+
+/* 4.1 — navbar audio/gamepad toggles get a real, labelled hit box instead of
+   being bare icon links with only a 5px margin. */
+.nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    min-height: 36px;
+    padding: 0 8px;
+    border-radius: 6px;
+}
+
+/* Touch / coarse pointer: enforce the 44px minimum tap target everywhere. */
+@media (pointer: coarse) {
+    /* 5.1 — Bootstrap .btn (~38px) and .btn-sm are below the 44px minimum. */
+    .btn {
+        min-height: 44px;
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
+    }
+    .btn-sm {
+        min-height: 44px;
+    }
+    /* 4.1 — toggles need the full 44x44 target on touch. */
+    .nav-toggle {
+        min-height: 44px;
+        min-width: 44px;
+        justify-content: center;
+    }
+    /* join-page inline controls share the bump */
+    .join-by-id input,
+    .gameCard .join-btn {
+        min-height: 44px;
+    }
+}
+
+/* 4.3 — landscape phones (the game's natural orientation) have very little
+   vertical room; shrink the fixed navbar so the canvas gets it back. The
+   navbar height, body offset and section height all key off this var. */
+@media (orientation: landscape) and (max-height: 480px) {
+    :root {
+        --navbar-height: 44px;
+    }
+    #game-title {
+        font-size: clamp(1.8rem, 9vw, 3rem);
+    }
+}
+
+/* Short viewports (landscape phones / small windows): the landing menu is
+   vertically centred, which clips the title under the fixed navbar when the
+   content is taller than the viewport. Top-align it and let #main scroll so the
+   whole menu is reachable, and tighten the title/card so it usually fits. */
+@media (max-height: 720px) {
+    #main .container {
+        align-items: flex-start !important;
+        height: auto !important;
+        min-height: 100%;
+        padding-top: 0.75rem;
+        padding-bottom: 0.75rem;
+    }
+    #game-title {
+        font-size: clamp(1.6rem, 7vw, 2.6rem);
+    }
+    .play-container {
+        padding: 1rem;
+    }
+    .news-banner {
+        margin-top: 0.5rem;
+    }
+    .tagline {
+        margin-top: 0.5rem;
+    }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->

--- a/client/join.html
+++ b/client/join.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
         <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
         <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
         <!-- Google tag (gtag.js) -->

--- a/client/play.html
+++ b/client/play.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover, user-scalable=no">
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
@@ -28,10 +28,12 @@
                 <a style="text-decoration: inherit;
                 color: inherit;" href="./index.html">ChaoChao</a>
             </div>
-            <a id="masterControl" style="cursor:pointer; text-decoration: inherit;
+            <a id="masterControl" class="nav-toggle" role="button" tabindex="0" aria-label="Toggle sound effects" style="cursor:pointer; text-decoration: inherit;
             color: inherit;"><i class="music-btn fa fa-gamepad" aria-hidden="true"></i> [<i class="music-btn fa fa-volume-up" aria-hidden="true"></i>]</a>
-            <a id="musicControl" style="cursor:pointer; text-decoration: inherit;
+            <a id="musicControl" class="nav-toggle" role="button" tabindex="0" aria-label="Toggle music" style="cursor:pointer; text-decoration: inherit;
             color: inherit;"><i class="music-btn fas fa-music"></i> [<i class="music-btn fa fa-volume-up" aria-hidden="true"></i>]</a>
+            <a id="cameraControl" class="nav-toggle" role="button" tabindex="0" aria-label="Toggle dynamic camera zoom" style="cursor:pointer; text-decoration: inherit;
+            color: inherit;"><i class="music-btn fas fa-video" aria-hidden="true"></i> [<i class="music-btn fa fa-check" aria-hidden="true"></i>]</a>
           </nav>
         <section>
             <!-- Game enclosed here -->

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1713,7 +1713,8 @@ function drawMouseDriveIndicator() {
     gameContext.font = "bold 15px Arial";
     gameContext.textAlign = "center";
     gameContext.lineWidth = 4;
-    gameContext.strokeStyle = "white";
+    // Theme-aware halo so the pink label reads on the dark board too.
+    gameContext.strokeStyle = themeColor('inkOutline', 'white');
     gameContext.fillStyle = "#c87f8a";
     var label = "Mouse-drive ON — double-click to toggle";
     gameContext.strokeText(label, LOGICAL_WIDTH / 2, 44);
@@ -1732,8 +1733,10 @@ function drawTouchLabel(text, x, y) {
     gameContext.font = "bold " + fontPx + "px Arial";
     gameContext.textAlign = "center";
     gameContext.lineWidth = 4;
-    gameContext.strokeStyle = "white";
-    gameContext.fillStyle = "black";
+    // Theme-aware so the captions read correctly on the dark board too (matches
+    // the rest of the renderer + the adjacent touch-control rings).
+    gameContext.strokeStyle = themeColor('inkOutline', 'white');
+    gameContext.fillStyle = themeColor('ink', 'black');
     gameContext.strokeText(text, x, y);
     gameContext.fillText(text, x, y);
     gameContext.restore();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -582,7 +582,13 @@ function computeWorldViewTarget(dt) {
         var scale = 1 + (focusedView.scale - 1) * e;
         return clampViewToWorld(focusedView.cx, focusedView.cy, scale);
     }
-    return clampViewToWorld(focusedView.cx, focusedView.cy, focusedView.scale);
+    // Back the camera off while aiming/throwing an aimed ability (bomb/ice) so
+    // it's easier to aim and follow the shot; the smoothing eases it out and back.
+    var racingScale = focusedView.scale;
+    if (localAimedAbilityActive()) {
+        racingScale = Math.max(1, racingScale * AIM_ZOOM_OUT_FACTOR);
+    }
+    return clampViewToWorld(focusedView.cx, focusedView.cy, racingScale);
 }
 
 function updateWorldCamera(dt) {
@@ -602,6 +608,45 @@ function updateWorldCamera(dt) {
     worldView.cx += (target.cx - worldView.cx) * a;
     worldView.cy += (target.cy - worldView.cy) * a;
     worldView.scale += (target.scale - worldView.scale) * a;
+}
+
+// True while a local player is dealing with an aimed ability — holding a bomb /
+// ice cannon (lining up the throw), or with its projectile/explosion aimer still
+// live after firing (until it detonates). Drives a sustained camera back-off so
+// the wider view makes aiming and tracking the shot easier.
+function localAimedAbilityActive() {
+    if (typeof config === "undefined" || !config || !config.tileMap || !config.tileMap.abilities) {
+        return false;
+    }
+    if (typeof localPlayers === "undefined" || !localPlayers) {
+        return false;
+    }
+    var bombId = config.tileMap.abilities.bomb.id;
+    var iceId = config.tileMap.abilities.iceCannon.id;
+    for (var i = 0; i < localPlayers.length; i++) {
+        var lp = localPlayers[i];
+        if (!lp || lp.myID == null) {
+            continue;
+        }
+        var id = lp.myID;
+        var p = (typeof playerList !== "undefined" && playerList) ? playerList[id] : null;
+        if (p && (p.ability === bombId || p.ability === iceId)) {
+            return true; // holding / aiming
+        }
+        // fired and in flight: only the bomb/snowFlake projectile (NOT a hockey
+        // puck or cloud, which are also owner/round-keyed in projectileList).
+        var proj = (typeof projectileList !== "undefined" && projectileList) ? projectileList[id] : null;
+        if (proj && (proj.type === "bomb" || proj.type === "snowFlake")) {
+            return true;
+        }
+        // detonating: the bomb's explosion telegraph (NOT the swap aimer, which is
+        // also keyed by owner and uses startSwapCountDown instead).
+        var aim = (typeof aimerList !== "undefined" && aimerList) ? aimerList[id] : null;
+        if (aim && aim.startExplosionCountDown) {
+            return true;
+        }
+    }
+    return false;
 }
 
 function applyWorldTransform() {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -370,12 +370,18 @@ function drawObjects(dt) {
         return;
     }
 
+    updateWorldCamera(dt);
+    applyCanvasTransform();
     drawBackground(dt);
     if (currentState == config.stateMap.overview) {
         screenShake = false;
         drawOverviewBoard();
         return;
     }
+
+    // ---- WORLD PASS: zoomed/panned by the dynamic camera (touch); identity
+    // elsewhere. Everything positioned in world coords goes here. ----
+    applyWorldTransform();
     preShake();
     drawWorld(dt);
     cameraOnMyPlayer();
@@ -391,12 +397,10 @@ function drawObjects(dt) {
         drawGate();
         drawMap();
         drawPingCircles();
-        drawMapTitle();
     }
     if (currentState == config.stateMap.gated) {
         drawGateLine();
     }
-    drawHUD();
     drawPlayers(dt);
     drawPunches();
     drawProjectiles();
@@ -404,15 +408,188 @@ function drawObjects(dt) {
     drawOverlay();
     postShake();
 
+    // ---- HUD PASS: screen space, never zoomed (score, map title, touch
+    // controls, mode indicators, game-over). ----
+    applyCanvasTransform();
+    if (currentState == config.stateMap.gated ||
+        currentState == config.stateMap.racing ||
+        currentState == config.stateMap.collapsing) {
+        drawMapTitle();
+    }
+    drawHUD();
+    drawMouseDriveIndicator();
+
     if (currentState == config.stateMap.gameOver) {
         drawGameOverScreen();
     }
 
 }
 
+// Scale the device-resolution backing store back onto the fixed 1366x768
+// logical drawing space, so every game/HUD/touch coordinate stays in logical
+// units yet renders at full device resolution. setTransform is absolute, so
+// calling it once per frame also resets any stray transform from a prior frame.
+function applyCanvasTransform() {
+    if (gameContext) {
+        gameContext.setTransform(canvasScaleX, 0, 0, canvasScaleY, 0, 0);
+    }
+    if (overlayContext) {
+        overlayContext.setTransform(canvasScaleX, 0, 0, canvasScaleY, 0, 0);
+    }
+}
+
+// --- dynamic touch camera (world zoom) ---------------------------------------
+// World coordinates are the logical 1366x768 space (drawn 1:1 today), so the
+// "whole map" view is identity: centre at LOGICAL/2, scale 1. While racing we
+// frame a tight box on the player (high resolution on a phone) and grow it to
+// include the nearest goal as the player approaches it. The view is smoothed
+// toward its target each frame; applyWorldTransform composes it with the DPR
+// scale so the world zooms but the HUD/touch controls (drawn under the base
+// transform) stay put. Enabled via cameraZoomEnabled (the navbar camera toggle;
+// defaults on for touch, off but toggleable otherwise). Mouse aiming is
+// inverse-mapped through this transform in calcMousePos, so it stays correct
+// when the camera is enabled on desktop.
+
+function worldGoalPoints() {
+    var pts = [];
+    if (typeof currentMap !== "undefined" && currentMap && currentMap.cells &&
+        config && config.tileMap && config.tileMap.goal) {
+        var gid = config.tileMap.goal.id;
+        for (var i = 0; i < currentMap.cells.length; i++) {
+            var c = currentMap.cells[i];
+            if (c && c.id === gid && c.site) {
+                pts.push({ x: c.site.x, y: c.site.y });
+            }
+        }
+    }
+    return pts;
+}
+
+// Clamp a view centre so the visible window never reveals outside the world
+// bounds (at scale 1 the whole world fits, so it locks to the world centre).
+function clampViewToWorld(cx, cy, scale) {
+    var visHalfW = LOGICAL_WIDTH / (2 * scale), visHalfH = LOGICAL_HEIGHT / (2 * scale);
+    cx = (world.width <= visHalfW * 2) ? (world.x + world.width / 2)
+        : Math.max(world.x + visHalfW, Math.min(world.x + world.width - visHalfW, cx));
+    cy = (world.height <= visHalfH * 2) ? (world.y + world.height / 2)
+        : Math.max(world.y + visHalfH, Math.min(world.y + world.height - visHalfH, cy));
+    return { cx: cx, cy: cy, scale: scale };
+}
+
+// The fully-focused view: the DESIRED (unclamped) centre — the player, growing
+// toward the nearest goal as it's approached — plus the focused zoom. The centre
+// is kept separate from the zoom so a transition can ramp the zoom while always
+// anchoring on the player (so the player can never slide out of frame).
+function computeFocusedView() {
+    var halfX = LOGICAL_WIDTH / (2 * WORLD_ZOOM_MAX);
+    var halfY = LOGICAL_HEIGHT / (2 * WORLD_ZOOM_MAX);
+    var minX = myPlayer.x - halfX, maxX = myPlayer.x + halfX;
+    var minY = myPlayer.y - halfY, maxY = myPlayer.y + halfY;
+    // Pull the nearest goal into frame as we get close to it -> the view zooms
+    // back out to keep both the player and the goal visible.
+    var goals = worldGoalPoints();
+    var ng = null, nd = Infinity;
+    for (var i = 0; i < goals.length; i++) {
+        var dx = goals[i].x - myPlayer.x, dy = goals[i].y - myPlayer.y;
+        var d = Math.sqrt(dx * dx + dy * dy);
+        if (d < nd) { nd = d; ng = goals[i]; }
+    }
+    if (ng && nd <= WORLD_ZOOM_ENGAGE) {
+        minX = Math.min(minX, ng.x - WORLD_ZOOM_PAD);
+        maxX = Math.max(maxX, ng.x + WORLD_ZOOM_PAD);
+        minY = Math.min(minY, ng.y - WORLD_ZOOM_PAD);
+        maxY = Math.max(maxY, ng.y + WORLD_ZOOM_PAD);
+    }
+    var boxW = Math.max(1, maxX - minX), boxH = Math.max(1, maxY - minY);
+    var scale = Math.min(LOGICAL_WIDTH / boxW, LOGICAL_HEIGHT / boxH);
+    scale = Math.max(1, Math.min(WORLD_ZOOM_MAX, scale)); // never zoom out past the whole map
+    return { cx: (minX + maxX) / 2, cy: (minY + maxY) / 2, scale: scale };
+}
+
+function computeWorldViewTarget(dt) {
+    // Whole-map (identity) baseline — exactly today's view.
+    var wholeMap = { cx: LOGICAL_WIDTH / 2, cy: LOGICAL_HEIGHT / 2, scale: 1 };
+    if (!cameraZoomEnabled || myPlayer == null || typeof world === "undefined" || world == null) {
+        worldViewFocusedElapsed = 0;
+        return wholeMap;
+    }
+    // Local multiplayer: 2-4 players share one screen, so focusing on the
+    // primary would crop the others out — keep the whole map in that case.
+    if (typeof liveLocalPlayerCount === "function" && liveLocalPlayerCount() > 1) {
+        worldViewFocusedElapsed = 0;
+        return wholeMap;
+    }
+    // Focus on the player only once the round is live (gate countdown + race);
+    // lobby / overview / game-over keep the whole map so the goal + player and
+    // the arena are all visible at the start.
+    var focused = (currentState === config.stateMap.gated ||
+        currentState === config.stateMap.racing ||
+        currentState === config.stateMap.collapsing);
+    if (!focused) {
+        worldViewFocusedElapsed = 0;
+        return wholeMap;
+    }
+    // Advance the focus-phase clock by the (already-clamped) frame dt rather than
+    // wall-clock, so backgrounding the tab pauses the ramp (rAF stops) and the
+    // catch-up frame on refocus can't snap the zoom to the end.
+    worldViewFocusedElapsed += (dt || 16);
+    var focusedView = computeFocusedView();
+
+    // During the gate countdown, run a slow, eased zoom timed to the countdown:
+    // whole-map at the start (take in the arena + goal), arriving at the focused
+    // zoom right as the gate opens. Crucially we ONLY ramp the zoom and keep the
+    // centre anchored on the player (clamped to the world) the whole time — at
+    // scale 1 the clamp shows the whole map, and it homes in on the player as it
+    // zooms, so the player can never slide out of frame mid-transition.
+    if (currentState === config.stateMap.gated) {
+        var dur = ((config.gatedWaitTime || 9) * 1000) - WORLD_ZOOM_HOLD_MS;
+        var elapsed = worldViewFocusedElapsed - WORLD_ZOOM_HOLD_MS;
+        var p = (dur > 0) ? Math.max(0, Math.min(1, elapsed / dur)) : 1;
+        var e = p * p * (3 - 2 * p); // smoothstep: gentle in (see the map) and out (settle)
+        var scale = 1 + (focusedView.scale - 1) * e;
+        return clampViewToWorld(focusedView.cx, focusedView.cy, scale);
+    }
+    return clampViewToWorld(focusedView.cx, focusedView.cy, focusedView.scale);
+}
+
+function updateWorldCamera(dt) {
+    // Clamp the frame delta so a long stall / tab-refocus catch-up frame can't
+    // snap the camera (drives both the gate ramp and the exponential smoothing).
+    var cdt = Math.min(dt || 16, 100);
+    var target = computeWorldViewTarget(cdt);
+    if (worldView == null) {
+        worldView = { cx: target.cx, cy: target.cy, scale: target.scale };
+        return;
+    }
+    // During the gate countdown the target is already a precise, eased time-ramp,
+    // so follow it directly (a=1) for the arc to finish exactly as the gate opens.
+    // Everywhere else, smooth exponentially for natural player/goal tracking.
+    var gatedNow = (cameraZoomEnabled && typeof config !== "undefined" && config && currentState === config.stateMap.gated);
+    var a = gatedNow ? 1 : (1 - Math.exp(-cdt / WORLD_ZOOM_TAU));
+    worldView.cx += (target.cx - worldView.cx) * a;
+    worldView.cy += (target.cy - worldView.cy) * a;
+    worldView.scale += (target.scale - worldView.scale) * a;
+}
+
+function applyWorldTransform() {
+    if (!worldView || !LOGICAL_WIDTH) {
+        applyCanvasTransform();
+        return;
+    }
+    var s = worldView.scale;
+    var ex = LOGICAL_WIDTH / 2 - worldView.cx * s;
+    var ey = LOGICAL_HEIGHT / 2 - worldView.cy * s;
+    if (gameContext) {
+        gameContext.setTransform(s * canvasScaleX, 0, 0, s * canvasScaleY, ex * canvasScaleX, ey * canvasScaleY);
+    }
+    if (overlayContext) {
+        overlayContext.setTransform(s * canvasScaleX, 0, 0, s * canvasScaleY, ex * canvasScaleX, ey * canvasScaleY);
+    }
+}
+
 function drawBackground() {
-    gameContext.clearRect(0, 0, gameCanvas.width, gameCanvas.height);
-    overlayContext.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height);
+    gameContext.clearRect(0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT);
+    overlayContext.clearRect(0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT);
 }
 function drawGameOverScreen() {
     if (playerWon == null) {
@@ -420,7 +597,7 @@ function drawGameOverScreen() {
     }
     gameContext.save();
     gameContext.fillStyle = playerList[playerWon].color;
-    gameContext.rect(0, 0, gameCanvas.width, gameCanvas.height);
+    gameContext.rect(0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT);
     gameContext.fill();
     gameContext.restore();
 
@@ -428,17 +605,17 @@ function drawGameOverScreen() {
     gameContext.fillStyle = "black";
     gameContext.font = '48px serif';
     var winString = decodedColorName + " won the game.";
-    gameContext.fillText(winString, gameCanvas.width / 2 - 400, (gameCanvas.height + 48) / 2);
+    gameContext.fillText(winString, LOGICAL_WIDTH / 2 - 400, (LOGICAL_HEIGHT + 48) / 2);
     gameContext.restore();
 
     if (achievements != null) {
         var xOffset = 200;
         var yOffset = -200;
-        var startingHeight = (gameCanvas.height + 48) / 2;
+        var startingHeight = (LOGICAL_HEIGHT + 48) / 2;
         gameContext.save();
         gameContext.fillStyle = "black";
         gameContext.font = '28px serif';
-        gameContext.fillText("-- Medals -- ", (gameCanvas.width / 2) + xOffset, startingHeight + yOffset);
+        gameContext.fillText("-- Medals -- ", (LOGICAL_WIDTH / 2) + xOffset, startingHeight + yOffset);
 
 
         var lineHeight = 40;
@@ -448,13 +625,13 @@ function drawGameOverScreen() {
                 continue;
             }
             gameContext.fillStyle = "black";
-            gameContext.fillText(achievements[medal].title, (gameCanvas.width / 2) + xOffset, startingHeight + (lineHeight * count) + yOffset);
+            gameContext.fillText(achievements[medal].title, (LOGICAL_WIDTH / 2) + xOffset, startingHeight + (lineHeight * count) + yOffset);
             count++;
             for (var i = 0; i < achievements[medal].ids.length; i++) {
                 var player = playerList[achievements[medal].ids[i]];
 
                 gameContext.beginPath();
-                gameContext.arc((gameCanvas.width / 2) + (xOffset + (35 * (i + 1))), startingHeight + (lineHeight * count) - 15 + yOffset, 15, 0, 2 * Math.PI);
+                gameContext.arc((LOGICAL_WIDTH / 2) + (xOffset + (35 * (i + 1))), startingHeight + (lineHeight * count) - 15 + yOffset, 15, 0, 2 * Math.PI);
                 if (player != null) {
                     gameContext.fillStyle = player.color;
                     gameContext.strokeStyle = "black";
@@ -478,8 +655,11 @@ function preShake() {
     }
     if (screenShake == true) {
         gameContext.save();
-        var dx = Math.random() * 15;
-        var dy = Math.random() * 15;
+        // This translate runs under the world transform; divide by the camera
+        // zoom so the shake is a constant on-screen magnitude at any zoom level.
+        var s = (worldView && worldView.scale) ? worldView.scale : 1;
+        var dx = Math.random() * 15 / s;
+        var dy = Math.random() * 15 / s;
         gameContext.translate(dx, dy);
     }
 }
@@ -571,7 +751,7 @@ function drawOverlay() {
         }
         overlayContext.save();
         overlayContext.fillStyle = "black";
-        overlayContext.fillRect(0, 0, overlayCanvas.width, overlayCanvas.height);
+        overlayContext.fillRect(0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT);
         overlayContext.restore();
 
         overlayContext.save();
@@ -627,10 +807,10 @@ function drawMapTitle() {
         gameContext.lineWidth = 4;
         gameContext.fillStyle = themeColor('ink', 'black');
         gameContext.font = "14px Arial";
-        gameContext.strokeText('"' + currentMap.name + '"', 5, gameCanvas.height - 25);
-        gameContext.strokeText('~' + currentMap.author, 5, gameCanvas.height - 10);
-        gameContext.fillText('"' + currentMap.name + '"', 5, gameCanvas.height - 25);
-        gameContext.fillText('~' + currentMap.author, 5, gameCanvas.height - 10);
+        gameContext.strokeText('"' + currentMap.name + '"', 5, LOGICAL_HEIGHT - 25);
+        gameContext.strokeText('~' + currentMap.author, 5, LOGICAL_HEIGHT - 10);
+        gameContext.fillText('"' + currentMap.name + '"', 5, LOGICAL_HEIGHT - 25);
+        gameContext.fillText('~' + currentMap.author, 5, LOGICAL_HEIGHT - 10);
         gameContext.restore();
     }
 }
@@ -1397,7 +1577,10 @@ function drawHUD() {
 }
 
 function drawGameInfo() {
-    var startX = world.width / 2 - 125;
+    // Drawn in the HUD pass (logical screen space), so centre on the logical
+    // width, not the world width (they're equal today, but the HUD shouldn't
+    // depend on world dims).
+    var startX = LOGICAL_WIDTH / 2 - 125;
     gameContext.save();
     gameContext.font = "14px Arial";
     gameContext.strokeStyle = themeColor('inkOutline', 'white');
@@ -1498,36 +1681,55 @@ function drawTouchControls() {
         gameContext.restore();
         drawTouchLabel("Attack", attackButton.baseX, attackButton.baseY + attackButton.radius + 20);
     }
-    if (exitButton != null && exitButton.isVisible()) {
+    if (exitButton != null && exitButton.isVisible() && fullscreenSupported()) {
+        var exitSize = exitButton.iconSize || 34;
         if (window.document.fullscreenElement) {
             gameContext.save();
-            var iconWidth = exitToUse.width * 0.1;
-            var iconHeight = exitToUse.height * 0.1;
-            gameContext.drawImage(exitToUse, exitButton.baseX - iconWidth / 2, exitButton.baseY - iconHeight / 2, iconWidth, iconHeight);
+            gameContext.drawImage(exitToUse, exitButton.baseX - exitSize / 2, exitButton.baseY - exitSize / 2, exitSize, exitSize);
             gameContext.restore();
         } else {
             gameContext.save();
-            var iconWidth = fullScreenToUse.width * 0.1;
-            var iconHeight = fullScreenToUse.height * 0.1;
-            gameContext.drawImage(fullScreenToUse, exitButton.baseX - iconWidth / 2, exitButton.baseY - iconHeight / 2, iconWidth, iconHeight);
+            gameContext.drawImage(fullScreenToUse, exitButton.baseX - exitSize / 2, exitButton.baseY - exitSize / 2, exitSize, exitSize);
             gameContext.restore();
         }
-        drawTouchLabel(window.document.fullscreenElement ? "Exit" : "Fullscreen", exitButton.baseX, exitButton.baseY + 28);
+        drawTouchLabel(window.document.fullscreenElement ? "Exit" : "Fullscreen", exitButton.baseX, exitButton.baseY + exitSize / 2 + 16);
     }
     if (chatButton != null && chatButton.isVisible()) {
+        var chatSize = chatButton.iconSize || 34;
         gameContext.save();
-        var iconWidth = chatToUse.width * 0.1;
-        var iconHeight = chatToUse.height * 0.1;
-        gameContext.drawImage(chatToUse, chatButton.baseX - iconWidth / 2, chatButton.baseY - iconHeight / 2, iconWidth, iconHeight);
+        gameContext.drawImage(chatToUse, chatButton.baseX - chatSize / 2, chatButton.baseY - chatSize / 2, chatSize, chatSize);
         gameContext.restore();
-        drawTouchLabel("Emoji", chatButton.baseX, chatButton.baseY + 28);
+        drawTouchLabel("Emoji", chatButton.baseX, chatButton.baseY + chatSize / 2 + 16);
     }
+}
+
+// Surface the otherwise-invisible double-click "mouse-drive" mode so players can
+// tell it's on (and how to toggle it). Desktop/mouse only (item 8).
+function drawMouseDriveIndicator() {
+    if (typeof movingByMouse === "undefined" || !movingByMouse || isTouchScreen) {
+        return;
+    }
+    gameContext.save();
+    gameContext.font = "bold 15px Arial";
+    gameContext.textAlign = "center";
+    gameContext.lineWidth = 4;
+    gameContext.strokeStyle = "white";
+    gameContext.fillStyle = "#c87f8a";
+    var label = "Mouse-drive ON — double-click to toggle";
+    gameContext.strokeText(label, LOGICAL_WIDTH / 2, 44);
+    gameContext.fillText(label, LOGICAL_WIDTH / 2, 44);
+    gameContext.restore();
 }
 
 // Small caption under a touch control so mobile players know what it does.
 function drawTouchLabel(text, x, y) {
     gameContext.save();
-    gameContext.font = "bold 16px Arial";
+    // The 1366x768 logical space is scaled down a lot on a phone, so a fixed
+    // 16px label would render only a few CSS px tall. Size up as the fit ratio
+    // shrinks to hold a roughly constant physical size (~15 CSS px), clamped so
+    // it never goes below the original 16px or balloons on large displays.
+    var fontPx = Math.round(Math.max(16, Math.min(40, 15 / (fitRatio || 1))));
+    gameContext.font = "bold " + fontPx + "px Arial";
     gameContext.textAlign = "center";
     gameContext.lineWidth = 4;
     gameContext.strokeStyle = "white";
@@ -1551,8 +1753,8 @@ function drawTitle() {
         gameContext.lineWidth = 10;
         gameContext.fillStyle = "rgba(255, 0, 0, " + brutalRoundConfig.drawTitleAlpha + ")";
         gameContext.font = "50px Arial";
-        gameContext.strokeText('Brutal Round', (gameCanvas.width / 2) - 120, (gameCanvas.height / 2) - 25);
-        gameContext.fillText('Brutal Round', (gameCanvas.width / 2) - 120, (gameCanvas.height / 2) - 25);
+        gameContext.strokeText('Brutal Round', (LOGICAL_WIDTH / 2) - 120, (LOGICAL_HEIGHT / 2) - 25);
+        gameContext.fillText('Brutal Round', (LOGICAL_WIDTH / 2) - 120, (LOGICAL_HEIGHT / 2) - 25);
         var titles = [];
         for (var i = 0; i < brutalRoundConfig.brutalTypes.length; i++) {
             for (var prop in config.brutalRounds) {
@@ -1563,8 +1765,8 @@ function drawTitle() {
         }
         gameContext.font = "30px Arial";
         for (var j = 0; j < titles.length; j++) {
-            gameContext.strokeText(titles[j], (gameCanvas.width / 2) - 120, (gameCanvas.height / 2) + 15 + (35 * j));
-            gameContext.fillText(titles[j], (gameCanvas.width / 2) - 120, (gameCanvas.height / 2) + 15 + (35 * j));
+            gameContext.strokeText(titles[j], (LOGICAL_WIDTH / 2) - 120, (LOGICAL_HEIGHT / 2) + 15 + (35 * j));
+            gameContext.fillText(titles[j], (LOGICAL_WIDTH / 2) - 120, (LOGICAL_HEIGHT / 2) + 15 + (35 * j));
         }
         gameContext.restore();
         brutalRoundConfig.drawTitleAlpha -= .0025;
@@ -1574,7 +1776,7 @@ function drawTitle() {
         gameContext.fillStyle = themeColor('ink', 'black');
         gameContext.lineWidth = 3;
         gameContext.font = "30px Arial";
-        gameContext.fillText('Waiting for more players..', (gameCanvas.width / 2) - 200, (gameCanvas.height / 2) - 25);
+        gameContext.fillText('Waiting for more players..', (LOGICAL_WIDTH / 2) - 200, (LOGICAL_HEIGHT / 2) - 25);
         gameContext.restore();
     }
 }
@@ -1588,7 +1790,7 @@ function drawOverviewBoard() {
 
 function drawNextMap() {
     if (nextMapPreview != null) {
-        var previewWindow = { x: gameCanvas.width / 2 + 100, y: (gameCanvas.height / 2 - (world.height / 10)) - 100 };
+        var previewWindow = { x: LOGICAL_WIDTH / 2 + 100, y: (LOGICAL_HEIGHT / 2 - (world.height / 10)) - 100 };
         gameContext.save();
         gameContext.beginPath();
         gameContext.fillStyle = "white";
@@ -1619,7 +1821,7 @@ function drawOldNotches() {
     }
     var distanceApart = 7;
     var offSetX = 80;
-    var offSetY = gameCanvas.height / 2 - (count * config.playerBaseRadius * distanceApart * .5);
+    var offSetY = LOGICAL_HEIGHT / 2 - (count * config.playerBaseRadius * distanceApart * .5);
 
 
     gameContext.save();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -476,23 +476,53 @@ function clampViewToWorld(cx, cy, scale) {
     return { cx: cx, cy: cy, scale: scale };
 }
 
-// The fully-focused view: the DESIRED (unclamped) centre — the player, growing
-// toward the nearest goal as it's approached — plus the focused zoom. The centre
-// is kept separate from the zoom so a transition can ramp the zoom while always
-// anchoring on the player (so the player can never slide out of frame).
+// World positions of every LIVE local player (so split-on-one-screen co-op keeps
+// everyone framed). Only local players — remote/online players live elsewhere on
+// the map and aren't followed. Falls back to the primary myPlayer.
+function focusWorldPoints() {
+    var pts = [];
+    if (typeof localPlayers !== "undefined" && localPlayers) {
+        for (var i = 0; i < localPlayers.length; i++) {
+            var lp = localPlayers[i];
+            if (lp && lp.myID != null && typeof playerList !== "undefined" &&
+                playerList && playerList[lp.myID]) {
+                pts.push({ x: playerList[lp.myID].x, y: playerList[lp.myID].y });
+            }
+        }
+    }
+    if (pts.length === 0 && myPlayer) {
+        pts.push({ x: myPlayer.x, y: myPlayer.y });
+    }
+    return pts;
+}
+
+// The fully-focused view: the DESIRED (unclamped) centre + zoom that frames every
+// live local player (local co-op widens the zoom as players spread, tightens as
+// they cluster), growing toward the nearest goal as the group approaches it. A
+// single player gets a tight WORLD_ZOOM_MAX framing exactly as before, since each
+// player contributes a max-zoom half-box. Centre is kept separate from the zoom
+// so a transition can ramp only the zoom (players can't slide out of frame).
 function computeFocusedView() {
+    var pts = focusWorldPoints();
     var halfX = LOGICAL_WIDTH / (2 * WORLD_ZOOM_MAX);
     var halfY = LOGICAL_HEIGHT / (2 * WORLD_ZOOM_MAX);
-    var minX = myPlayer.x - halfX, maxX = myPlayer.x + halfX;
-    var minY = myPlayer.y - halfY, maxY = myPlayer.y + halfY;
-    // Pull the nearest goal into frame as we get close to it -> the view zooms
-    // back out to keep both the player and the goal visible.
+    var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (var i = 0; i < pts.length; i++) {
+        minX = Math.min(minX, pts[i].x - halfX);
+        maxX = Math.max(maxX, pts[i].x + halfX);
+        minY = Math.min(minY, pts[i].y - halfY);
+        maxY = Math.max(maxY, pts[i].y + halfY);
+    }
+    // Pull the nearest goal (to any framed player) into frame as the group gets
+    // close to it -> the view zooms out to keep players and the goal visible.
     var goals = worldGoalPoints();
     var ng = null, nd = Infinity;
-    for (var i = 0; i < goals.length; i++) {
-        var dx = goals[i].x - myPlayer.x, dy = goals[i].y - myPlayer.y;
-        var d = Math.sqrt(dx * dx + dy * dy);
-        if (d < nd) { nd = d; ng = goals[i]; }
+    for (var g = 0; g < goals.length; g++) {
+        for (var p = 0; p < pts.length; p++) {
+            var dx = goals[g].x - pts[p].x, dy = goals[g].y - pts[p].y;
+            var d = Math.sqrt(dx * dx + dy * dy);
+            if (d < nd) { nd = d; ng = goals[g]; }
+        }
     }
     if (ng && nd <= WORLD_ZOOM_ENGAGE) {
         minX = Math.min(minX, ng.x - WORLD_ZOOM_PAD);
@@ -513,13 +543,7 @@ function computeWorldViewTarget(dt) {
         worldViewFocusedElapsed = 0;
         return wholeMap;
     }
-    // Local multiplayer: 2-4 players share one screen, so focusing on the
-    // primary would crop the others out — keep the whole map in that case.
-    if (typeof liveLocalPlayerCount === "function" && liveLocalPlayerCount() > 1) {
-        worldViewFocusedElapsed = 0;
-        return wholeMap;
-    }
-    // Focus on the player only once the round is live (gate countdown + race);
+    // Focus once the round is live (gate countdown + race);
     // lobby / overview / game-over keep the whole map so the goal + player and
     // the arena are all visible at the start.
     var focused = (currentState === config.stateMap.gated ||

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -476,21 +476,20 @@ function clampViewToWorld(cx, cy, scale) {
     return { cx: cx, cy: cy, scale: scale };
 }
 
-// World positions of every LIVE local player (so split-on-one-screen co-op keeps
-// everyone framed). Only local players — remote/online players live elsewhere on
-// the map and aren't followed. Falls back to the primary myPlayer.
+// World positions of every LIVING local player (so split-on-one-screen co-op
+// keeps everyone framed). Reuses livingLocalPlayers() so dead / mid-round
+// spectating local players — parked off-arena at (-100,-100) by the server —
+// don't drag the camera. Only local players are followed (remote/online players
+// live elsewhere on the map). Falls back to the primary myPlayer only when it's
+// alive; if nobody local is alive, returns empty (computeFocusedView -> whole map
+// so a dead/spectating cohort can watch the action).
 function focusWorldPoints() {
     var pts = [];
-    if (typeof localPlayers !== "undefined" && localPlayers) {
-        for (var i = 0; i < localPlayers.length; i++) {
-            var lp = localPlayers[i];
-            if (lp && lp.myID != null && typeof playerList !== "undefined" &&
-                playerList && playerList[lp.myID]) {
-                pts.push({ x: playerList[lp.myID].x, y: playerList[lp.myID].y });
-            }
-        }
+    var living = livingLocalPlayers();
+    for (var i = 0; i < living.length; i++) {
+        pts.push({ x: living[i].x, y: living[i].y });
     }
-    if (pts.length === 0 && myPlayer) {
+    if (pts.length === 0 && myPlayer && myPlayer.alive) {
         pts.push({ x: myPlayer.x, y: myPlayer.y });
     }
     return pts;
@@ -503,7 +502,12 @@ function focusWorldPoints() {
 // player contributes a max-zoom half-box. Centre is kept separate from the zoom
 // so a transition can ramp only the zoom (players can't slide out of frame).
 function computeFocusedView() {
+    var wholeMap = { cx: LOGICAL_WIDTH / 2, cy: LOGICAL_HEIGHT / 2, scale: 1 };
     var pts = focusWorldPoints();
+    if (pts.length === 0) {
+        // Nobody local alive to follow -> whole map (watch the action).
+        return wholeMap;
+    }
     var halfX = LOGICAL_WIDTH / (2 * WORLD_ZOOM_MAX);
     var halfY = LOGICAL_HEIGHT / (2 * WORLD_ZOOM_MAX);
     var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
@@ -533,7 +537,12 @@ function computeFocusedView() {
     var boxW = Math.max(1, maxX - minX), boxH = Math.max(1, maxY - minY);
     var scale = Math.min(LOGICAL_WIDTH / boxW, LOGICAL_HEIGHT / boxH);
     scale = Math.max(1, Math.min(WORLD_ZOOM_MAX, scale)); // never zoom out past the whole map
-    return { cx: (minX + maxX) / 2, cy: (minY + maxY) / 2, scale: scale };
+    var cx = (minX + maxX) / 2, cy = (minY + maxY) / 2;
+    // Defensive: a NaN coordinate would poison setTransform and blank the canvas.
+    if (!isFinite(cx) || !isFinite(cy) || !isFinite(scale)) {
+        return wholeMap;
+    }
+    return { cx: cx, cy: cy, scale: scale };
 }
 
 function computeWorldViewTarget(dt) {

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -20,6 +20,30 @@ var server = null,
     overlayContext = null,
     newWidth = 0,
     newHeight = 0,
+    // The fixed logical drawing space (the canvas' initial backing-store size,
+    // 1366x768). All gameplay/HUD/touch coords live in this space; the canvas
+    // backing store is sized to device pixels and scaled back to it each frame
+    // (see resize() + applyCanvasTransform), so high-DPR displays render crisp.
+    LOGICAL_WIDTH = 0,
+    LOGICAL_HEIGHT = 0,
+    fitRatio = 1,   // logical->CSS px scale, for stable physical label sizes
+    canvasScaleX = 1,  // logical->backing-store scale applied per frame (DPR-aware)
+    canvasScaleY = 1,
+    // --- dynamic touch camera (world zoom) ---
+    // Smoothed view {cx, cy, scale} in world coords; null until the first frame.
+    // Whole-map = identity (centre LOGICAL/2, scale 1); racing focuses on the
+    // player and pulls the nearest goal into frame as it's approached.
+    worldView = null,
+    // Dynamic camera on/off. Defaults ON for every input method (set true in
+    // initEventHandlers), toggleable by anyone via the navbar camera button.
+    // Auto-falls back to whole-map when >1 local player shares the screen.
+    cameraZoomEnabled = false,
+    worldViewFocusedElapsed = 0,  // ms accumulated in the focus phase (frame-dt based, not wall-clock)
+    WORLD_ZOOM_MAX = 1.8,      // tightest focus on the player while racing (shows some surroundings)
+    WORLD_ZOOM_ENGAGE = 460,   // world-units: nearest goal pulls into frame within this
+    WORLD_ZOOM_PAD = 120,      // world-units padding around framed points
+    WORLD_ZOOM_TAU = 620,      // smoothing time-constant (ms); higher = slower, gentler glide
+    WORLD_ZOOM_HOLD_MS = 1100, // hold the whole-map view this long when a round starts, before easing in
     maps = [],
     oldNotches = {},
     camera,
@@ -198,11 +222,35 @@ function setupPage() {
             $("#masterControl").html('<i class="music-btn fa fa-gamepad" aria-hidden="true"></i>  [<i class="music-btn fa fa-volume-up" aria-hidden="true"></i>]');
         }
     });
+    // Keyboard activation for the navbar toggles (role="button" tabindex="0"):
+    // Enter/Space fires the click. stopPropagation keeps Space from also
+    // reaching the global gameplay keydown (Space = attack) while a toggle has
+    // focus.
+    function activateToggleOnKey(e) {
+        if (e.key === "Enter" || e.key === " " || e.keyCode === 13 || e.keyCode === 32) {
+            e.preventDefault();
+            e.stopPropagation();
+            $(e.currentTarget).click();
+        }
+    }
+    musicControl.on("keydown", activateToggleOnKey);
+    masterControl.on("keydown", activateToggleOnKey);
+    $("#cameraControl").on("click", function () {
+        cameraZoomEnabled = !cameraZoomEnabled;
+        updateCameraToggleUI();
+    });
+    $("#cameraControl").on("keydown", activateToggleOnKey);
+    updateCameraToggleUI();
     volumeChange();
     gameCanvas = document.getElementById('gameCanvas');
     overlayCanvas = document.getElementById('overlayCanvas');
     gameContext = gameCanvas.getContext('2d');
     overlayContext = overlayCanvas.getContext('2d');
+    // Capture the logical drawing size from the initial backing store (the
+    // 1366x768 width/height HTML attrs) BEFORE resize() repurposes the backing
+    // store for device-pixel rendering.
+    LOGICAL_WIDTH = gameCanvas.width;
+    LOGICAL_HEIGHT = gameCanvas.height;
     init();
     // Use .always() (not .then()) so a single 404 / CORS error in the
     // preload list doesn't leave the lobby never being entered. Once
@@ -307,7 +355,7 @@ function resize() {
     var gameWindowRect = canvasWindow.getBoundingClientRect();
     if (gameWindowRect.width === 0 || gameWindowRect.height === 0) return;
     var viewport = { width: gameWindowRect.width, height: gameWindowRect.height };
-    var optimalRatio = Math.min(viewport.width / gameCanvas.width, viewport.height / gameCanvas.height);
+    var optimalRatio = Math.min(viewport.width / LOGICAL_WIDTH, viewport.height / LOGICAL_HEIGHT);
 
     if (window.document.fullscreenElement) {
         newWidth = viewport.width;
@@ -316,25 +364,53 @@ function resize() {
         // Fit the canvas to the available space at its native 16:9
         // aspect ratio (no padding shrink — the gameWindow flex
         // container provides any breathing room).
-        newWidth = gameCanvas.width * optimalRatio;
-        newHeight = gameCanvas.height * optimalRatio;
+        newWidth = LOGICAL_WIDTH * optimalRatio;
+        newHeight = LOGICAL_HEIGHT * optimalRatio;
     }
+
+    // Logical->CSS scale; used to keep canvas-drawn labels a stable physical
+    // size across phone/desktop widths (see drawTouchLabel).
+    fitRatio = newWidth / LOGICAL_WIDTH;
 
     if (mapContainer != null) {
         mapContainer.style.width = newWidth + "px";
         mapContainer.style.height = newHeight + "px";
     }
+    // CSS (layout) size: the fitted 16:9 box.
     gameCanvas.style.width = newWidth + "px";
     gameCanvas.style.height = newHeight + "px";
     overlayCanvas.style.width = newWidth + "px";
     overlayCanvas.style.height = newHeight + "px";
 
+    // Backing store: render at device resolution so the game (and its text) is
+    // sharp on Retina/phone displays. Cap dpr at 2 to avoid over-rendering on
+    // 3x phones. The logical 1366x768 space is unchanged; applyCanvasTransform()
+    // scales drawing into the backing store each frame, so no gameplay math
+    // moves to device pixels.
+    var dpr = Math.min(window.devicePixelRatio || 1, 2);
+    gameCanvas.width = Math.round(newWidth * dpr);
+    gameCanvas.height = Math.round(newHeight * dpr);
+    overlayCanvas.width = Math.round(newWidth * dpr);
+    overlayCanvas.height = Math.round(newHeight * dpr);
+
+    // Per-frame logical->backing-store transform (set here so applyCanvasTransform
+    // doesn't have to re-read the backing-store size every frame).
+    canvasScaleX = gameCanvas.width / LOGICAL_WIDTH;
+    canvasScaleY = gameCanvas.height / LOGICAL_HEIGHT;
+
+    // Re-flow the on-canvas touch controls to the new fit ratio so they keep a
+    // constant physical size across resizes / orientation changes (no-op until
+    // the controls exist on a touch device).
+    if (typeof layoutTouchControls === "function") {
+        layoutTouchControls();
+    }
+
     camera = {
         active: false,
-        x: gameCanvas.width / 2,
-        y: gameCanvas.height / 2,
-        width: gameCanvas.width,
-        height: gameCanvas.height,
+        x: LOGICAL_WIDTH / 2,
+        y: LOGICAL_HEIGHT / 2,
+        width: LOGICAL_WIDTH,
+        height: LOGICAL_HEIGHT,
         target: null,
         color: 'yellow',
         padding: 150,
@@ -342,8 +418,8 @@ function resize() {
         right: 0,
         top: 0,
         bottom: 0,
-        xOffset: gameCanvas.width / 2,
-        yOffset: gameCanvas.height / 2,
+        xOffset: LOGICAL_WIDTH / 2,
+        yOffset: LOGICAL_HEIGHT / 2,
 
         centerOnObject: function (object) {
             if (!this.active) {
@@ -429,7 +505,33 @@ function resize() {
     }
 }
 
+// Reflect the dynamic-camera on/off state in the navbar toggle (matches the
+// music/master pattern: an icon plus a bracketed status glyph).
+function updateCameraToggleUI() {
+    var el = document.getElementById("cameraControl");
+    if (!el) {
+        return;
+    }
+    var status = cameraZoomEnabled
+        ? '[<i class="music-btn fa fa-check" aria-hidden="true"></i>]'
+        : '[<i class="music-btn fa fa-ban" aria-hidden="true"></i>]';
+    el.innerHTML = '<i class="music-btn fas fa-video" aria-hidden="true"></i> ' + status;
+}
+
+// iOS Safari does NOT implement the Fullscreen API on arbitrary elements (only
+// <video>), so requestFullscreen on #gameWindow silently rejects there. Detect
+// support so we can hide the dead control and skip a doomed request rather than
+// drawing a button that does nothing.
+function fullscreenSupported() {
+    return !!(document.fullscreenEnabled &&
+        typeof gameWindow !== "undefined" && gameWindow &&
+        gameWindow.requestFullscreen);
+}
+
 function goFullScreen() {
+    if (!fullscreenSupported()) {
+        return;
+    }
     if (window.document.fullscreenElement) {
         window.document.exitFullscreen().then(function () {
             resize();

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -44,6 +44,10 @@ var server = null,
     WORLD_ZOOM_PAD = 120,      // world-units padding around framed points
     WORLD_ZOOM_TAU = 620,      // smoothing time-constant (ms); higher = slower, gentler glide
     WORLD_ZOOM_HOLD_MS = 1100, // hold the whole-map view this long when a round starts, before easing in
+    // Sustained camera back-off while holding/throwing an aimed ability (bomb/ice)
+    // until it detonates, so it's easier to aim. Multiplies the focused scale
+    // (0.62 => ~38% wider); the smoothing eases it out and back.
+    AIM_ZOOM_OUT_FACTOR = 0.62,
     maps = [],
     oldNotches = {},
     camera,

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -656,10 +656,38 @@ function rumbleScreen(time) {
 
 function setupEmojiWheel() {
 	var menu = $("#emojiMenu");
+	// Remove any emoji anchors a previous run added (gameState can re-fire on a
+	// socket reconnect), keeping the static close button — otherwise the wheel
+	// accumulates duplicate emojis and positionEmojiSlots spreads them.
+	menu.find("a").filter(function () {
+		return (this.getAttribute("onclick") || "").indexOf("cancel") === -1;
+	}).remove();
 	for (var i = 0; i < config.emojis.length; i++) {
 		menu.append('<a onclick="closeEmojiWindow(this.innerHTML)" href="#">' + config.emojis[i] + '</a>');
 	}
 	emojiMenu.style.borderColor = playerList[myID].color;
+	positionEmojiSlots();
+}
+
+// Lay the emoji anchors out on a ring with JS-computed positions, expressed in
+// percentages so they scale with the viewport-sized wheel and work for any
+// emoji count (no hand-authored per-slot CSS). The first <a> is the static
+// close button (kept at the centre); the rest are the emojis -- this matches
+// emojiItems(), which skips the close button.
+function positionEmojiSlots() {
+	var items = document.querySelectorAll('#emojiMenu a');
+	if (items.length === 0) {
+		return;
+	}
+	items[0].style.left = '50%';
+	items[0].style.top = '50%';
+	var count = items.length - 1;
+	var radiusPct = 38;
+	for (var i = 1; i <= count; i++) {
+		var ang = (-Math.PI / 2) + (2 * Math.PI * (i - 1) / count);
+		items[i].style.left = (50 + radiusPct * Math.cos(ang)) + '%';
+		items[i].style.top = (50 + radiusPct * Math.sin(ang)) + '%';
+	}
 }
 
 

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -723,7 +723,7 @@ function openEmojiFromPad(lp) {
     gpEmojiIndex = 0;
     var w = window.innerWidth || 800;
     var h = window.innerHeight || 600;
-    openEmojiWindow(w / 2 - 50, h / 2 - 50); // sets menuOpen + a default (primary) owner
+    openEmojiWindow(w / 2, h / 2); // centred on the viewport; sets menuOpen + default owner
     // This pad owns the wheel; tint its border with this player's color.
     emojiOwnerSlot = lp.slot;
     if (typeof emojiMenu !== "undefined" && emojiMenu && typeof playerList !== "undefined" &&
@@ -954,6 +954,7 @@ function hintsForMethod(method) {
         '<span class="gp-hint"><span class="gp-glyph gp-key">🖱</span>Aim</span>' +
         '<span class="gp-hint"><span class="gp-glyph gp-key">Click</span>/<span class="gp-glyph gp-key">Space</span>Attack</span>' +
         '<span class="gp-hint"><span class="gp-glyph gp-key">Right-click</span>Emoji</span>' +
+        '<span class="gp-hint"><span class="gp-glyph gp-key">Dbl-click</span>Mouse-drive</span>' +
         '<span class="gp-hint"><span class="gp-glyph gp-key">Esc</span>Leave</span>' +
         '<span class="gp-hint"><span class="gp-glyph gp-key">H</span>Hide</span>';
 }

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -28,18 +28,49 @@ function initEventHandlers() {
         return false;
     }, false);
     isTouchScreen = isTouchDevice();
+    // Experiment: dynamic camera defaults ON for every input method (still
+    // toggleable via the navbar camera button). It auto-falls back to the
+    // whole-map view when >1 local player is sharing the screen (see
+    // computeWorldViewTarget) so local multiplayer isn't cropped.
+    cameraZoomEnabled = true;
+    if (typeof updateCameraToggleUI === "function") {
+        updateCameraToggleUI();
+    }
     if (isTouchScreen) {
         setupVirtualbuttons();
-        goFullScreen();
+        // Don't auto-request fullscreen on load: browsers require a user
+        // gesture (so the first call typically fails anyway), and on iOS Safari
+        // the Fullscreen API isn't available on non-<video> elements at all.
+        // Fullscreen is triggered only by an explicit tap on the on-canvas
+        // button (onTouchStart -> goFullScreen), and that button is hidden where
+        // fullscreen is unsupported.
     }
 
 }
 
 function calcMousePos(evt) {
-    evt.preventDefault();
+    // Only suppress the default (text selection / drag) when the pointer is over
+    // the game canvas, so selecting text elsewhere on the page isn't broken by
+    // the global mousemove listener (item 8).
+    var t = evt.target;
+    if (t === gameCanvas || t === overlayCanvas ||
+        (typeof gameWindow !== "undefined" && gameWindow && gameWindow.contains && gameWindow.contains(t))) {
+        evt.preventDefault();
+    }
     if (myPlayer != null) {
         var rect = gameCanvas.getBoundingClientRect();
-        setMousePos((((evt.pageX - rect.left) / newWidth) * gameCanvas.width), (((evt.pageY - rect.top) / newHeight) * gameCanvas.height));
+        // screen -> logical (the un-zoomed 1366x768 canvas space)
+        var lx = ((evt.pageX - rect.left) / newWidth) * LOGICAL_WIDTH;
+        var ly = ((evt.pageY - rect.top) / newHeight) * LOGICAL_HEIGHT;
+        // logical -> world: invert the dynamic-camera transform so aiming points
+        // at the world spot under the cursor even while zoomed. No-op (identity)
+        // when the camera isn't zoomed (worldView centre = LOGICAL/2, scale 1).
+        var wx = lx, wy = ly;
+        if (typeof worldView !== "undefined" && worldView && worldView.scale) {
+            wx = (lx - LOGICAL_WIDTH / 2) / worldView.scale + worldView.cx;
+            wy = (ly - LOGICAL_HEIGHT / 2) / worldView.scale + worldView.cy;
+        }
+        setMousePos(wx, wy);
     }
 }
 
@@ -84,7 +115,8 @@ function handleClick(event) {
                     closeEmojiWindow();
                 }
             } else {
-                openEmojiWindow(mousex, mousey);
+                // Open at the cursor (client coords); moveEmojiMenu clamps it.
+                openEmojiWindow(event.clientX, event.clientY);
             }
 
             break;
@@ -113,6 +145,27 @@ function handleDblClick(event) {
     }
     movingByMouse = !movingByMouse;
 }
+// Map a key event to a movement action using the modern KeyboardEvent.code
+// (layout-independent), falling back to the deprecated keyCode for older
+// browsers. Returns "turnLeft" | "moveForward" | "turnRight" | "moveBackward" |
+// "attack" | null.
+function movementActionFor(evt) {
+    switch (evt.code) {
+        case "KeyA": case "ArrowLeft": return "turnLeft";
+        case "KeyW": case "ArrowUp": return "moveForward";
+        case "KeyD": case "ArrowRight": return "turnRight";
+        case "KeyS": case "ArrowDown": return "moveBackward";
+        case "Space": return "attack";
+    }
+    switch (evt.keyCode) {
+        case 65: case 37: return "turnLeft";
+        case 87: case 38: return "moveForward";
+        case 68: case 39: return "turnRight";
+        case 83: case 40: return "moveBackward";
+        case 32: return "attack";
+    }
+    return null;
+}
 function keyDown(evt) {
     // While the leave-game confirmation is up, don't let movement keys drive the
     // player (gamepad.js owns that modal; openLeaveModal already stopped motion).
@@ -122,22 +175,17 @@ function keyDown(evt) {
     if (movingByMouse) {
         movingByMouse = false;
     }
-    var gameKey = true;
-    switch (evt.keyCode) {
-        case 65: { turnLeft = true; break; } //Left key
-        case 37: { turnLeft = true; break; } //Left key
-        case 87: { moveForward = true; break; } //Up key
-        case 38: { moveForward = true; break; } //Up key
-        case 68: { turnRight = true; break; }//Right key
-        case 39: { turnRight = true; break; }//Right key
-        case 83: { moveBackward = true; break; } //Down key
-        case 40: { moveBackward = true; break; } //Down key
-        case 32: { attack = true; break; } // Spacebar
-        default: { gameKey = false; }
+    var action = movementActionFor(evt);
+    switch (action) {
+        case "turnLeft": { turnLeft = true; break; }
+        case "moveForward": { moveForward = true; break; }
+        case "turnRight": { turnRight = true; break; }
+        case "moveBackward": { moveBackward = true; break; }
+        case "attack": { attack = true; break; }
     }
     // The keyboard is being used to play -> it owns the primary slot (P1), so
-    // controllers hot-join as P2+. (When this stays false, the first pad takes P1.)
-    if (gameKey) {
+    // controllers hot-join as P2+. (When this stays null, the first pad takes P1.)
+    if (action) {
         claimPrimaryForKbm();
     }
     if (playerList[myID] != null) {
@@ -151,16 +199,12 @@ function keyUp(evt) {
         movingByMouse = false;
     }
 
-    switch (evt.keyCode) {
-        case 65: { turnLeft = false; break; } //Left key
-        case 37: { turnLeft = false; break; } //Left key
-        case 87: { moveForward = false; break; } //Up key
-        case 38: { moveForward = false; break; } //Up key
-        case 68: { turnRight = false; break; }//Right key
-        case 39: { turnRight = false; break; }//Right key
-        case 83: { moveBackward = false; break; } //Down key
-        case 40: { moveBackward = false; break; } //Down key
-        case 32: { attack = false; break; } // Spacebar
+    switch (movementActionFor(evt)) {
+        case "turnLeft": { turnLeft = false; break; }
+        case "moveForward": { moveForward = false; break; }
+        case "turnRight": { turnRight = false; break; }
+        case "moveBackward": { moveBackward = false; break; }
+        case "attack": { attack = false; break; }
     }
     if (playerList[myID] != null) {
         calcAngleFromKeys(playerList[myID]);
@@ -222,45 +266,125 @@ function determineMovement() {
 }
 
 function setupVirtualbuttons() {
-
-
-    //var rect = gameCanvas.getBoundingClientRect();
+    // The world (server dims) must be known before we size the tap regions.
+    // It normally is by the time this runs (gameState -> worldResize -> init),
+    // but guard so an early/ordering call can't throw on world.width (matches
+    // layoutTouchControls' guard).
+    if (typeof world === "undefined" || world == null) {
+        return;
+    }
+    // Movement (left quarter) and attack (right quarter) tap regions. These are
+    // proportional to the world so they always cover their half of the screen;
+    // the control sizes within them are physical (see layoutTouchControls).
     var leftRect = new VirtualButton(0, 85, world.width / 4, world.height, false);
     var rightRect = new VirtualButton(0 + world.width - (world.width / 4), 50, world.width / 4, world.height, false);
-    var upperLeftRect = new VirtualButton(0, 10, world.width / 16, 50, false);
-    var upperRightRect = new VirtualButton(0 + world.width - (world.width / 16), 10, world.width / 16, 50, false);
-    var topRightRect = new VirtualButton(0 + world.width - (world.width / 4), 85, world.width / 4, world.height / 2, false);
-    var bottomRightRect = new VirtualButton(0 + world.width - (world.width / 4), topRightRect.bottom, world.width / 4, world.height / 2, false);
-    //var bottomCenterRect = new VirtualButton(leftRect.right,world.height - (world.height/4)-100,rightRect.left-leftRect.right,200,false);
+    // Top-corner icon hit zones — sized & positioned in layoutTouchControls()
+    // (>=44px square, below the top safe strip). Placeholders until then.
+    var upperLeftRect = new VirtualButton(0, 0, 1, 1, false);
+    var upperRightRect = new VirtualButton(0, 0, 1, 1, false);
 
     virtualButtonList = [];
     joystickMovement = new Joystick(0, 0, false, false);
-    //joystickCamera = new Joystick(0, 0, false);
-    attackButton = new Button(0, 0, 0, 0, rightRect.width * 1.5, true, false);
-    exitButton = new Button(world.width - 50, 0, 0, 0, 12.5, false);
-    chatButton = new Button(50, 0, 0, 0, 12.5, false);
+    attackButton = new Button(0, 0, 0, 0, 0, true, false);
+    // radius is set in layoutTouchControls (single source of truth); no dead 12.5.
+    exitButton = new Button(0, 0, 0, 0, 0, false);
+    chatButton = new Button(0, 0, 0, 0, 0, false);
 
     virtualButtonList.push({ button: joystickMovement, bound: leftRect });
-    //virtualButtonList.push({ button: joystickCamera, bound: topRightRect });
     virtualButtonList.push({ button: attackButton, bound: rightRect });
     virtualButtonList.push({ button: exitButton, bound: upperRightRect });
     virtualButtonList.push({ button: chatButton, bound: upperLeftRect });
 
+    layoutTouchControls();
+}
 
+// Convert a physical (CSS-px) size into the canvas' logical 1366x768 space so
+// touch controls keep a constant physical size regardless of how the canvas is
+// fitted to the screen (5.2). fitRatio = CSS px per logical unit.
+function cssToLogical(px) {
+    return px / (fitRatio || 1);
+}
+
+// (Re)size & position the on-canvas touch controls from the current fit ratio.
+// Called after setup and on every resize, so a thumb-sized joystick/buttons
+// stay thumb-sized on any screen width or orientation (5.2), and the top-corner
+// icons keep a >=44px tap zone that matches the drawn icon (2.2).
+function layoutTouchControls() {
+    if (!virtualButtonList || !joystickMovement || typeof world === "undefined" || world == null) {
+        return;
+    }
+    // Joystick: thumb-sized base ring + stick, preserving the original ratios.
+    joystickMovement.baseRadius = cssToLogical(90);
+    joystickMovement.width = joystickMovement.baseRadius;
+    joystickMovement.height = joystickMovement.baseRadius;
+    joystickMovement.stickRadius = cssToLogical(54);
+    joystickMovement.maxPullRadius = cssToLogical(45);
+    joystickMovement.deadzone = cssToLogical(5);
+
+    // Attack: keep a large right-side tap circle, sized in physical units.
+    if (attackButton) {
+        attackButton.radius = cssToLogical(150);
+    }
+
+    // Top-corner icon buttons: >=44px square tap zones matching the drawn icon,
+    // inset from the edges and dropped below the top strip (URL bar / notch).
+    var hit = Math.max(cssToLogical(52), 44);   // tap zone side (logical)
+    var icon = cssToLogical(34);                // drawn icon size (logical)
+    var margin = cssToLogical(12);
+    var topInset = cssToLogical(14);
+    // chat (emoji) -> top-left; exit (fullscreen) -> top-right.
+    sizeCornerButton(chatButton, margin + hit / 2, topInset + hit / 2, hit, icon);
+    sizeCornerButton(exitButton, world.width - margin - hit / 2, topInset + hit / 2, hit, icon);
+
+    // Centre each button in its bound rect (the joystick base is overridden on
+    // touch-down; this fixes the static buttons' positions).
     for (var i = 0; i < virtualButtonList.length; i++) {
-        virtualButtonList[i].button.baseX = virtualButtonList[i].bound.x + virtualButtonList[i].bound.width / 2 - virtualButtonList[i].button.width / 2;
-        virtualButtonList[i].button.stickX = virtualButtonList[i].bound.x + virtualButtonList[i].bound.width / 2 - virtualButtonList[i].button.width / 2;
-        virtualButtonList[i].button.baseY = virtualButtonList[i].bound.y + virtualButtonList[i].bound.height / 2 - virtualButtonList[i].button.height / 2;
-        virtualButtonList[i].button.stickY = virtualButtonList[i].bound.y + virtualButtonList[i].bound.height / 2 - virtualButtonList[i].button.height / 2;
+        var b = virtualButtonList[i].button;
+        var bound = virtualButtonList[i].bound;
+        b.baseX = bound.x + bound.width / 2 - b.width / 2;
+        b.stickX = b.baseX;
+        b.baseY = bound.y + bound.height / 2 - b.height / 2;
+        b.stickY = b.baseY;
+    }
+}
+
+// Centre a corner icon button's tap zone (its bound rect) on (cx,cy) and set the
+// drawn icon size + a real radius — so the bound rect, the radius and the icon
+// are one source of truth for the target size (replaces the dead 12.5 radius).
+function sizeCornerButton(button, cx, cy, hit, icon) {
+    if (!button) {
+        return;
+    }
+    button.iconSize = icon;
+    button.radius = hit / 2;
+    for (var i = 0; i < virtualButtonList.length; i++) {
+        if (virtualButtonList[i].button === button) {
+            var r = virtualButtonList[i].bound;
+            r.x = cx - hit / 2;
+            r.y = cy - hit / 2;
+            r.width = hit;
+            r.height = hit;
+            r.left = r.x;
+            r.top = r.y;
+            r.right = r.x + r.width;
+            r.bottom = r.y + r.height;
+            break;
+        }
     }
 }
 
 
 function onTouchStart(evt) {
+    // Guard against touch events on devices the touch UI wasn't built for
+    // (hybrids where touch fires but isTouchScreen was false) so we never
+    // dereference a null virtualButtonList.
+    if (!virtualButtonList) {
+        return;
+    }
     var rect = gameCanvas.getBoundingClientRect();
     var touch = evt.changedTouches[0];
-    var touchX = (((touch.pageX - rect.left) / newWidth) * gameCanvas.width);
-    var touchY = (((touch.pageY - rect.top) / newHeight) * gameCanvas.height);
+    var touchX = (((touch.pageX - rect.left) / newWidth) * LOGICAL_WIDTH);
+    var touchY = (((touch.pageY - rect.top) / newHeight) * LOGICAL_HEIGHT);
     for (var i = 0; i < virtualButtonList.length; i++) {
         if (virtualButtonList[i].bound.pointInRect(touchX, touchY)) {
             var button = virtualButtonList[i].button;
@@ -281,7 +405,8 @@ function onTouchStart(evt) {
                     if (menuOpen) {
                         closeEmojiWindow();
                     } else {
-                        openEmojiWindow(rect.width / 2 - 50, rect.height / 2 - 50);
+                        // Touch: open centred on the viewport.
+                        openEmojiWindow(window.innerWidth / 2, window.innerHeight / 2);
                     }
                 }
             }
@@ -290,6 +415,9 @@ function onTouchStart(evt) {
     }
 }
 function onTouchEnd(evt) {
+    if (!virtualButtonList) {
+        return;
+    }
     var touchList = evt.changedTouches;
     for (var i = 0; i < touchList.length; i++) {
         for (var j = 0; j < virtualButtonList.length; j++) {
@@ -309,13 +437,19 @@ function onTouchEnd(evt) {
     }
 }
 function onTouchMove(evt) {
+    if (!virtualButtonList) {
+        return;
+    }
+    // The listener is registered passive:false precisely so we can stop the
+    // page scrolling / rubber-banding / pinch-zooming under a joystick drag (6.2).
+    evt.preventDefault();
     var rect = gameCanvas.getBoundingClientRect();
     var touchList = evt.changedTouches;
     var touch, touchX, touchY;
     for (var i = 0; i < touchList.length; i++) {
         touch = touchList[i];
-        var touchX = (((touch.pageX - rect.left) / newWidth) * gameCanvas.width);
-        var touchY = (((touch.pageY - rect.top) / newHeight) * gameCanvas.height);
+        var touchX = (((touch.pageX - rect.left) / newWidth) * LOGICAL_WIDTH);
+        var touchY = (((touch.pageY - rect.top) / newHeight) * LOGICAL_HEIGHT);
         for (var j = 0; j < virtualButtonList.length; j++) {
             var button = virtualButtonList[j].button;
             if (touch.identifier == button.touchIdx) {
@@ -338,7 +472,17 @@ function onTouchMove(evt) {
 }
 
 const isTouchDevice = () => {
-    return window.matchMedia('(hover: none)').matches
+    // Broadened from `(hover: none)` alone: treat the device as touch-first when
+    // its PRIMARY input is touch-like — a coarse primary pointer or no hover
+    // (phones/tablets). Touch-capable laptops keep a fine primary pointer
+    // (trackpad/mouse) and are correctly left as keyboard+mouse, so this doesn't
+    // over-trigger on hybrids. matchMedia is the source of truth; fall back to
+    // touch-hardware probes only where it's unavailable. (Evaluated once at init.)
+    var mm = window.matchMedia;
+    if (mm) {
+        return mm('(pointer: coarse)').matches || mm('(hover: none)').matches;
+    }
+    return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
 }
 
 function touchMovement() {
@@ -451,7 +595,8 @@ function calcAngleFromKeys(player) {
 
 function openEmojiWindow(x, y) {
     if (menuOpen == false) {
-        emojiMenu.style.transform = "scale(2)";
+        // The wheel's full size comes from CSS (--wheel-size); scale(1) reveals it.
+        emojiMenu.style.transform = "scale(1)";
         menuOpen = true;
         // Mouse/touch/keyboard opens belong to the primary; a pad open overrides
         // this in openEmojiFromPad. Tint the wheel border with the opener's color.
@@ -478,9 +623,17 @@ function closeEmojiWindow(source) {
     sendEmojiForSlot(emoji, owner);
 }
 
-function moveEmojiMenu(x, y) {
-    emojiMenu.style.left = x + "px";
-    emojiMenu.style.top = y + "px";
+// Centre the wheel on (centerX, centerY) given in viewport/client coords, then
+// clamp so the WHOLE wheel stays on-screen even when opened near an edge (3.2).
+function moveEmojiMenu(centerX, centerY) {
+    var size = emojiMenu.offsetWidth || 200;   // full size (unaffected by scale)
+    var half = size / 2;
+    var vw = window.innerWidth;
+    var vh = window.innerHeight;
+    var cx = Math.max(half, Math.min(vw - half, centerX));
+    var cy = Math.max(half, Math.min(vh - half, centerY));
+    emojiMenu.style.left = (cx - half) + "px";
+    emojiMenu.style.top = (cy - half) + "px";
 }
 
 var recursiveOffsetLeftAndTop = function (element) {

--- a/client/scripts/joystick.js
+++ b/client/scripts/joystick.js
@@ -127,7 +127,7 @@ class Joystick {
 	}
 
 	onMove(x, y) {
-		if (this.pressed = true) {
+		if (this.pressed === true) {
 			this.lastTouch = Date.now();
 			this.calcStick(x, y);
 		}
@@ -235,7 +235,7 @@ class Button {
 		}
 	}
 	onMove(x, y) {
-		if (this.pressed = true) {
+		if (this.pressed === true) {
 			this.lastTouch = Date.now();
 		}
 	}

--- a/client/scripts/osk.js
+++ b/client/scripts/osk.js
@@ -59,6 +59,9 @@ function oskOpen(input) {
     kb.setInput(input.value || "");
     var c = document.getElementById("oskContainer");
     c.className = "osk-container visible";
+    // Hide the bottom gamepad prompt bar while typing so the two don't overlap
+    // on short landscape screens (7b).
+    document.body.classList.add("osk-open");
     var btns = _oskButtons();
     _oskSetFocus(btns.length ? btns[0] : null);
 }
@@ -68,6 +71,7 @@ function oskClose() {
     if (c) {
         c.className = "osk-container hidden";
     }
+    document.body.classList.remove("osk-open");
     if (_oskFocusEl) {
         _oskFocusEl.classList.remove("osk-focus");
         _oskFocusEl = null;


### PR DESCRIPTION
## Mobile input polish + dynamic camera

Implements the full `MOBILE_INPUT_POLISH_ANALYSIS.md` backlog (§10/§11) plus a dynamic camera and follow-up tuning. **Client-only** (no `server/config.json` / `game.js` / `engine.js`) → exempt from the CHANGELOG release-notes rule.

### Mobile / input polish (chunks A–H)
- **A** — `viewport-fit=cover` + `env(safe-area-inset-*)` on fixed UI; `100dvh` (vh fallback); fluid `clamp()` title + `-webkit-text-size-adjust`; keyboard `:focus-visible` rings.
- **B** — DPR-aware canvas: backing store = CSS×devicePixelRatio (capped 2×), logical 1366×768 space + all gameplay/input math unchanged → crisp on Retina/phones; HUD/label fonts scale to fit.
- **C** — fullscreen: feature-detect, hide the dead button on iOS Safari, drop the on-load auto-request.
- **D** — touch targets: on-canvas controls sized in CSS px→logical (thumb-sized across widths); ≥44px corner buttons matching their icons; joystick `onMove` assignment-as-condition bug fixed.
- **E** — emoji wheel rebuilt: viewport-sized, JS-generated ring positions (any count), ≥44px slots, clamped on-screen.
- **F** — responsive scaffolding: `(pointer:coarse)` + short-landscape breakpoints, ≥44px tap targets, labelled navbar toggles.
- **G** — touch hardening: `preventDefault`/`touch-action`/`overscroll-behavior` so drags don't scroll/zoom; broadened (static) `isTouchDevice`; OSK ↔ prompt-bar overlap.
- **H** — desktop KB+M: mouse-drive mode indicator, `keyCode`→`code`, scoped mousemove `preventDefault`.
- Landing menu scrolls / top-aligns on short viewports (title no longer clipped under the navbar).

### Dynamic camera (default on; navbar toggle, off-able)
- Slow eased zoom-in timed to the gate countdown (whole-map → player focus, arriving as the gate opens), anchored on the player so they can't slide out of frame mid-transition.
- Focuses the player; the nearest goal eases into frame on approach.
- **Local co-op**: frames every living local player (zooms out as they spread, in as they cluster); single-player framing unchanged.
- **Aim back-off**: holding/throwing a bomb or ice cannon eases the camera wider (easier to aim) until it detonates, then eases back. Scoped to bomb/ice only (excludes hockey puck / clouds / swap).
- Desktop mouse-aim is inverse-mapped through the zoom so aiming stays correct; HUD captions are theme-aware (dark mode).

### Review / testing
- Reviewed via `/code-review` across several passes; all findings fixed (co-op dead/spectator framing, aim back-off over-trigger on puck/swap, dark-mode caption contrast, NaN/empty guards).
- Verified in-browser (DPR sharpness, camera math, co-op framing, aim back-off scoping) and on a phone over LAN; production build green.

Decisions made during build: 6.3 = broadened **static** touch detection (no dynamic scheme switching); 4.2 = lightweight navbar tweaks (no full Bootstrap navbar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
