### PR TITLE
AI racers + fair single-player lava

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- You're no longer racing alone: solo and small games now fill out with a roster of named AI racers that drive the course — finding their way to the goal, braking through corners, and steering clear of lava and bumpers — so there's always a full grid to race against.
+- The AI racers fight back: they grab and use abilities (bombs, speed boosts and slows, swaps, ice, blindfolds), and throw punches — including shoving a rival toward the lava when you give them the opening.
+- AI racers handle the brutal rounds: infected bots turn zombie and chase you across the lava to spread it (and healthy bots fend them off), they bash and dodge the hockey puck, ease up for the lightning round's speed, and — fair's fair — they lose their bearings in the blackout, blindfold, and clouds just like you do.
+- The AI racers have personalities now: a pace-setter who runs clean optimal lines, a wrecking ball who'd rather punch than race, a high-roller who corner-cuts past the lava (and sometimes into it), a rival who fixates on you, a chaos-merchant who hoards nothing and fires everything, a cautious tortoise who rarely dies, and a hothead who goes reckless when behind. They also rubber-band to your pace within a race — easing off when you're struggling and pushing when you're ahead — so a win feels earned, not handed to you.
+- Each AI racer shows its name and title under its kart, and they talk: a little taunt pops up when one wins or knocks somebody out, in character.
+- Playing solo is winnable now: when you're the only one in a room, the lava closes in from the goal you're nearest to and at a pace tuned to how far you have to travel, so a clean run actually beats the map instead of getting swallowed by a random, map-blind collapse.
+- The collapse now telegraphs itself: an erupting shockwave sweeps in from where the lava starts toward the goal it's closing on (with the volcano rumble), so you can read which way to run. Volcano rounds use the same warning shockwave.
+- Volcano rounds now erupt on a timer scaled to the map — about how long it takes to reach the nearest goal — instead of a fixed delay, so bigger maps give you proportionally more warning.
 
 ## v0.4.0 — 2026-05-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run start:prod` — start with `NODE_ENV=production`, which makes `index.js` rewrite the `<!-- BUILD: bundle-start -->…<!-- BUILD: bundle-end -->` block in each served HTML page to point at the corresponding bundle in `client/scripts/dist/`. The bundles must already exist; run `npm run build` first.
 - `npm run heroku-postbuild` — invoked automatically by Heroku to build bundles during deploy.
 
-There is no test suite, no linter, and no formatter configured. `client/scripts/dist/` is ignored by `.gitignore` (the `dist` rule), so bundles are produced at deploy time, not committed.
+There is no unit-test framework, linter, or formatter configured. `client/scripts/dist/` is ignored by `.gitignore` (the `dist` rule), so bundles are produced at deploy time, not committed.
+
+### Testing gameplay (headless)
+
+CI (`.github/workflows/pr-validation.yml`) runs `.github/scripts/smoke-test.js` — it boots the **real** server modules with no network/browser, drives the live tick loop (`hostess.updateRooms(dt)` / `room.update(dt)`), and ticks every committed map through waiting→racing→collapsing, failing on any throw or malformed compressor payload. There is no separate physics simulator: to test game logic you run the actual engine headlessly the same way.
+
+`smoke-test.js` is the canonical template. The reusable techniques for richer assertions: a fake `socket.io` `io` (`messenger.build`) whose `emit` *records* events so you can assert on them (`bombTriggered`, `botEmote`, `playerInfected`, …); pinning a map via the editor preview path (`gameBoard.isPreview` + `previewMap`); forcing states (`startGated`/`startRace`/`applyBrutalAbilityRound`) to skip timers; and — **important** — mocking `Date.now` + `setTimeout` into a clock you advance per tick, because a tight synchronous tick loop freezes wall-clock and otherwise no cooldown, projectile fuse, or `setTimeout` callback ever fires.
 
 ## Release notes for game mechanic changes
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -108,12 +108,12 @@ function registerPrimaryHandlers(server) {
 		playSound(playerJoinSound);
 	});
 	server.on("playerLeft", function (id) {
-		var name = clientList[id];
-		if (name != null) {
-			delete clientList[id];
-			delete playerList[id];
-			return;
-		}
+		// Always drop the rendered player. AI racers live in playerList but may be
+		// absent from a mid-game joiner's clientList (the server room's clientList
+		// excludes bots), so gating the delete on clientList left them as frozen
+		// ghost karts when removeBots() fired. Delete from both unconditionally.
+		delete clientList[id];
+		delete playerList[id];
 	});
 
 	server.on("gameUpdates", function (updatePacket) {
@@ -297,9 +297,16 @@ function registerPrimaryHandlers(server) {
 		decodedColorName = Colors.decode(playerList[packet.winner].color);
 		currentState = config.stateMap.gameOver;
 	});
-	server.on("startCollapse", function () {
+	server.on("startCollapse", function (info) {
 		currentState = config.stateMap.collapsing;
 		playSound(lavaCollapse);
+		// Telegraph: erupt a shockwave from where the lava first appears and
+		// spreads, plus the volcano cue. info may be null from an older server.
+		if (info && typeof info.originX === "number") {
+			spawnCollapseShockwave(info.originX, info.originY);
+			playSound(volcanoErupt);
+			rumbleScreen(1500);
+		}
 	});
 
 	server.on("resetPlayers", function () {
@@ -520,6 +527,18 @@ function registerPrimaryHandlers(server) {
 		createBlindFold(owner);
 		playerAbilityUsed(owner);
 		playSound(blindSound);
+	});
+	server.on("botEmote", function (payload) {
+		if (payload == null || playerList[payload.id] == null) {
+			return;
+		}
+		// Reuse the chat-bubble render path (drawEmoji) for the bot's taunt.
+		playerList[payload.id].chatMessage = payload.emote;
+		setTimeout(function () {
+			if (playerList[payload.id] != null && playerList[payload.id].chatMessage === payload.emote) {
+				playerList[payload.id].chatMessage = null;
+			}
+		}, 2500);
 	});
 	server.on("cutUsed", function (owner) {
 		playSound(cutSound);

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -397,6 +397,7 @@ function drawObjects(dt) {
         drawGate();
         drawMap();
         drawPingCircles();
+        drawCollapseShockwaves();
     }
     if (currentState == config.stateMap.gated) {
         drawGateLine();
@@ -670,7 +671,9 @@ function drawBackground() {
     overlayContext.clearRect(0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT);
 }
 function drawGameOverScreen() {
-    if (playerWon == null) {
+    // playerList[playerWon] can be gone if the winner was an AI racer that
+    // removeBots() cleared at the gameOver->waiting transition — guard the deref.
+    if (playerWon == null || playerList[playerWon] == null) {
         return;
     }
     gameContext.save();
@@ -1008,6 +1011,9 @@ function drawPlayer(player, dt) {
         drawAbilityIndicator(player.x, player.y, player);
     }
     drawEmoji(player);
+    if (player.name != null) {
+        drawBotName(player);
+    }
     if (player.awake == false) {
         gameContext.save();
         gameContext.drawImage(commentIconSolid, player.x, player.y - 40, commentIconSolid.width * 0.07, commentIconSolid.height * 0.07);
@@ -1029,6 +1035,34 @@ function drawEmoji(player) {
     }
 }
 
+// AI racers carry a visible name (and, smaller, their title) below the kart so
+// each personality is recognizable. Aligned with the sprite's camera convention
+// (camera offset is 0 in the default desktop view). Humans have no name.
+function drawBotName(player) {
+    // Use the same raw-coord convention as the emote/chat bubble (drawEmoji) so the
+    // name and the bubble stay attached to each other. camera.getCameraX/Y is 0 in
+    // the default desktop view, so this also aligns with the kart there.
+    var x = player.x;
+    var y = player.y + player.radius + 12;
+    gameContext.save();
+    gameContext.textAlign = "center";
+    // Kept translucent so the labels read without obscuring the action underneath.
+    gameContext.globalAlpha = 0.5;
+    gameContext.lineWidth = 2;
+    gameContext.strokeStyle = themeColor('inkOutline', 'white');
+    gameContext.fillStyle = themeColor('ink', 'black');
+    gameContext.font = '11px Times New Roman';
+    gameContext.strokeText(player.name, x, y);
+    gameContext.fillText(player.name, x, y);
+    if (player.title != null) {
+        gameContext.globalAlpha = 0.38;
+        gameContext.font = 'italic 9px Times New Roman';
+        gameContext.strokeText(player.title, x, y + 11);
+        gameContext.fillText(player.title, x, y + 11);
+    }
+    gameContext.restore();
+}
+
 function drawDeathMessage(player) {
     if (player.deathMessage != null) {
         gameContext.save();
@@ -1047,40 +1081,12 @@ function drawDeathMessage(player) {
 }
 function drawFire(player) {
     gameContext.save();
-    switch (player.angle) {
-        case 0: {
-            gameContext.translate(player.x - 5, player.y);
-            break;
-        }
-        case 45: {
-            gameContext.translate(player.x - 5, player.y - 5);
-            break;
-        }
-        case 90: {
-            gameContext.translate(player.x, player.y - 5);
-            break;
-        }
-        case 135: {
-            gameContext.translate(player.x + 5, player.y - 5);
-            break;
-        }
-        case 180: {
-            gameContext.translate(player.x + 5, player.y);
-            break;
-        }
-        case 225: {
-            gameContext.translate(player.x + 5, player.y + 5);
-            break;
-        }
-        case 270: {
-            gameContext.translate(player.x, player.y + 5);
-            break;
-        }
-        case 315: {
-            gameContext.translate(player.x - 5, player.y + 5);
-            break;
-        }
-    }
+    // Offset the flame to the player's trailing edge based on facing. Computed
+    // continuously from the angle so it works for ANY heading — the old 8-way
+    // switch left the flame unplaced (invisible) for the AI racers and for
+    // mouse-aimed players, whose angles aren't multiples of 45.
+    var ar = player.angle * (Math.PI / 180);
+    gameContext.translate(player.x - 5 * Math.cos(ar), player.y - 5 * Math.sin(ar));
 
     gameContext.rotate((player.angle - 90) * (Math.PI / 180));
     gameContext.beginPath();
@@ -1371,6 +1377,23 @@ function drawPingCircles() {
         gameContext.arc(ping.x, ping.y, ping.radius, 0, 2 * Math.PI);
     }
     gameContext.stroke();
+    gameContext.restore();
+}
+function drawCollapseShockwaves() {
+    if (collapseShockwaves.length == 0) {
+        return;
+    }
+    gameContext.save();
+    gameContext.lineWidth = 6;
+    gameContext.strokeStyle = config.tileMap.lava.color;
+    for (var i = 0; i < collapseShockwaves.length; i++) {
+        var s = collapseShockwaves[i];
+        if (s.radius <= 0) { continue; }
+        gameContext.globalAlpha = 0.6 * (1 - s.radius / s.maxRadius);
+        gameContext.beginPath();
+        gameContext.arc(s.x, s.y, s.radius, 0, 2 * Math.PI);
+        gameContext.stroke();
+    }
     gameContext.restore();
 }
 // Lobby-only "practice room" floor treatment: a faint grid + a dashed inset frame

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -20,6 +20,7 @@ var mousex,
 	timerList = [],
 	playersNearVictory = [],
 	pingCircles = [],
+	collapseShockwaves = [],
 	brutalRound = false,
 	brutalRoundConfig = null,
 	clientList;
@@ -59,12 +60,17 @@ function updateGameboard(dt) {
 		updateTrails();
 	}
 	updatePingCircles(dt);
+	updateCollapseShockwaves(dt);
 	checkTimers(dt);
 }
 
 function updatePingCircles(dt) {
 	if (pingCircles.length == 0) return;
-	if (currentState != config.stateMap.gated) return;
+	// The goal ping is a gated-phase telegraph. drawPingCircles renders during
+	// racing/collapsing too, but pings were only advanced/cleared while gated — so
+	// any still alive when the race started froze on screen. Clear them on leaving
+	// the gate so they don't linger into the race.
+	if (currentState != config.stateMap.gated) { pingCircles.length = 0; return; }
 	var wrapped = false;
 	for (var i = pingCircles.length - 1; i >= 0; i--) {
 		var ping = pingCircles[i];
@@ -81,6 +87,24 @@ function updatePingCircles(dt) {
 	}
 	if (wrapped) {
 		playSound(countDownA);
+	}
+}
+// Telegraph for an incoming collapse: a shockwave ring centered on the goal the
+// collapse converges on, starting at the outer front (where the lava appears
+// first) and contracting inward toward the goal, matching how the lava sweeps.
+// Used by the solo collapse and the volcano brutal round (both route through
+// the server startCollapse).
+function spawnCollapseShockwave(x, y) {
+	collapseShockwaves.push({ x: x, y: y, radius: 0, maxRadius: 650, pass: 0 });
+}
+function updateCollapseShockwaves(dt) {
+	if (collapseShockwaves.length == 0) { return; }
+	if (currentState != config.stateMap.collapsing) { collapseShockwaves.length = 0; return; }
+	for (var i = collapseShockwaves.length - 1; i >= 0; i--) {
+		var s = collapseShockwaves[i];
+		if (s.pass >= 3) { collapseShockwaves.splice(i, 1); continue; }
+		s.radius += 600 * dt / 1000;
+		if (s.radius >= s.maxRadius) { s.radius = 0; s.pass++; }
 	}
 }
 function resetTrails() {
@@ -154,6 +178,8 @@ function createPlayer(dataArray) {
 	playerList[index].onFire = dataArray[8];
 	playerList[index].ability = null;
 	playerList[index].angle = dataArray[9];
+	playerList[index].name = dataArray[10] || null;   // AI racer identity (humans: null)
+	playerList[index].title = dataArray[11] || null;
 	playerList[index].deathMessage = null;
 	playerList[index].trail = new Trail({ x: dataArray[1], y: dataArray[2] });
 	playerList[index].fizzle = function () {

--- a/docs/ai-racers-implementation-plan.md
+++ b/docs/ai-racers-implementation-plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan: Fair Single-Player Lava + AI Racers with Personalities
+
+Status: **Design complete, not yet built.** This plan covers two linked problems with the single-player experience and the AI system that fixes the second.
+
+## Problems
+
+1. **The lava is not tuned per map, so solo rounds are often unwinnable.** There is no general fixed lava timer. In a solo game there is exactly one player, so `alivePlayerCount == 1` is true from the start and every round falls into the **last-player-standing** branch (`server/game.js:363-376`): 15 s after the start, the collapse begins from a *randomly chosen* goal tile (`gameBoard.findRandomGoalTile()`) and advances radially at a fixed `lastPlayerCollapseSpeed: 0.75` units/tick, blind to map size or where the player spawned. The 15 s start, the random center, and the map-blind speed have nothing to do with the distance the player must travel, so beating the map is effectively luck.
+
+2. **There are no AI players to race against.** Every player today is tied to a Socket.IO connection; nothing creates a non-socket player.
+
+## Core architecture decisions
+
+### Bots are headless server-side players
+A bot is a `Player` object in `room.playerList` with **no socket**. It does not round-trip through Socket.IO. An `aiController.update(dt)` runs each tick (before `engine.updatePlayers`) and writes the exact `Player` fields the socket handlers would have written:
+
+| Field | Consumed by | Purpose |
+|---|---|---|
+| `targetDirX`, `targetDirY`, `braking` | `server/engine.js:65` (existing `isAI` branch) | steering |
+| `angle` (degrees) | `cutPlayer`, `spawnBomb`, `spawnSnowFlake` | aiming directional abilities |
+| `attack` | `checkAttack` (`server/game.js:2044`) | fires held ability, else punches |
+
+The engine **already has** the `isAI` movement branch — it reads `targetDirX * .8`, `targetDirY * .8`, `braking`. Nothing currently sets those. The bot's "hands" exist; we are building the "brain."
+
+### Both fixes share one foundation: a traversability graph
+Maps are player-made Voronoi diagrams, but **adjacency is already in the map JSON**. Each cell carries `site{x,y,voronoiId}`, a tile `id`, and `halfedges[]` whose `edge.lSite`/`edge.rSite` give the neighbor on each side. No recomputation and no voronoi library at runtime — neighbors are extracted directly. Tile `id` gives passability (lava = blocked/deadly, goal = win, all else traversable). From this we build a cell adjacency graph once at map load and run A* / reachability over it. This single graph powers:
+- **Lava fairness** — optimal spawn→goal distance → a "par time" → a tuned collapse.
+- **Map validation** — is any goal reachable from spawn? (also useful for the Preview/Playtest editor feature).
+- **Bot navigation** — A* to the nearest reachable goal.
+
+### Difficulty model (locked)
+**Within-race rubber-banding only.** No persistence. The difficulty signal is the player's live progress-to-goal versus the bot field, reset each race.
+
+### Grid size (locked)
+Fill to a **random total in the 6–10 range**: `target = randomInt(6, 10)`, then spawn `target - humanCount` bots (local-multiplayer humans count against the total).
+
+### Personalities (locked)
+**Fixed cast, exact every time** — each character is a static profile in `config.json`, used verbatim with no per-race jitter. Per-race variety comes from (a) the random subset of the cast that spawns and (b) the within-race rubber-band. Deterministic personalities + a seed give reproducible races for tuning/debugging. **Full identity + emotes** — names, titles, and reactive taunts triggered by server-detected events.
+
+---
+
+## The four behavior pillars
+
+### Pillar 1 — Racing brain
+Per bot, per tick:
+1. A* over the cell graph to the nearest reachable goal; edge cost weighted by tile type (slow/ice expensive, fast cheap), lava blocked.
+2. Steer `targetDirX/Y` toward the next waypoint, set `braking` into turns (lookahead smoothing to avoid wiggle — the fiddly part).
+3. Re-path on the `collapsedCells` event (mark newly-lava cells blocked) and avoid the advancing collapse.
+
+### Pillar 2 — Nuanced ability use
+The bot holds at most one ability (`player.ability`). An **ability policy** scores the held ability against current state `(rank, distance-to-goal, collapse state, rival positions, path geometry)` and returns *fire?* + *angle*, gated by a difficulty-scaled threshold. Per-ability heuristics (mechanics confirmed in code):
+
+| Ability (id) | Mechanic | Bot heuristic |
+|---|---|---|
+| **bomb** (102) | projectile (speed 11000, life 3 s, blast 100) → slow tiles + knockback; grants `bombTrigger` (103) after 200 ms | aim at a rival cluster / chokepoint ahead; hold, then detonate via trigger when a rival is in blast. *Two-step timing.* |
+| **swap** (101) | aimer grows 15→300 over 3 s, swaps pos/vel/physics with a random nearby player | fire only when **behind**, near a leader; never when leading (random target risk) |
+| **speedBuff** (104) | self ×1.5, 3 s | spend on a low-curvature straight or to beat a closing collapse |
+| **speedDebuff** (105) | all rivals slowed, 4 s | when leading, to extend the gap, or near finish |
+| **cut** (108) | shoves all other players perpendicular to facing (5 px) | when rivals cluster near; angle to shove them toward lava/edge |
+| **iceCannon** (107) | projectile → ice tiles + self +100 speed, life 1 s | ice a rival's path ahead, or self-boost on a straight |
+| **tileSwap** (106) | swaps all fast↔ice map-wide | fire only if net route-cost delta improves bot ETA vs field |
+| **blindfold** (100) | vision effect (target TBD — see open items) | irrelevant to bot navigation; offensive vs humans only |
+
+Trigger path: set `angle` (degrees) for directional abilities, then `attack = true`. `checkAttack` (`game.js:2044`) fires `ability.use()` which sets a flag; `checkAbilities` (`game.js:791-835`) executes it next tick.
+
+### Pillar 3 — Brutal-mode handling
+A **strategy layer** keyed on the active brutal mode sits above the base racer. Most modes are parameter nudges; two flip the objective:
+
+| Mode (id) | Effect | Bot adaptation |
+|---|---|---|
+| **ability** (1000) | everyone spawns armed | raise threat awareness; use own ability per policy |
+| **cloudy** (1002) | 10 clouds, **cosmetic vision-only (confirmed)** | ignore for pathing; apply vision self-handicap when a cloud overlaps the bot (see fairness guard) |
+| **lightning** (1006) | +800 speed all, hazards ×3 | more lookahead + earlier braking (physics envelope changed); treat bumpers as faster |
+| **volcano** (1007) | collapse starts early at a goal, speed 1 | collapse-avoidance brain with earlier trigger; flee eruption origin |
+| **infection** (1008) | first to goal becomes a zombie, **can't win**, slowed, can't grab abilities; punches spread it | **objective flip:** deliberately do *not* finish first — hang back until someone else is infected. If infected → chase-and-punch humans to spread it |
+| **hockey** (1009) | puck at center; punch toward goal; 800-force knockback | **objective flip:** target the puck, set angle/attack to punch it toward a goal; dodge puck |
+| **explosive** (1010) | reaching goal spawns a growing 100px explosion | finish, but avoid lingering near a finishing rival |
+| **blackout** (1011) | client vision message | ignore for pathing; vision self-handicap (fairness guard) |
+
+### Pillar 4 — Difficulty, rubber-banding & personalities
+**Skill knobs** (per bot, 0–1 each): reaction delay, steering noise, speed cap (fraction of `playerMaxSpeed 350`), path optimality, ability competence (threshold + targeting accuracy + timing).
+
+**Composition:** `final behavior = personality biases × difficulty scaling`. Personality sets *style* (constant); rubber-band moves *competence* (live).
+
+**Within-race rubber-band:** scale each bot's effective cap/competence by the player's progress-to-goal delta — player far behind → bots ease off; player leading → bots push. Per-race randomization + occasional "off moments" keep outcomes non-deterministic so a player win feels earned.
+
+**Vision-fairness guard:** because the bot reads game state rather than the rendered screen, it is naturally immune to blindfold/blackout/cloud. When "blinded" (under a cloud, or hit by blindfold/blackout), the bot self-imposes degraded steering + reaction lag for the duration, so vision effects bite the AI as they bite a human.
+
+**Personality trait axes** (bias weights over things the brain already computes): aggression, risk tolerance, ability tempo (hoarder vs trigger-happy), target focus (ignore combat / target leader / fixate on the human), tilt (rage-comeback / fold / unbothered), brutal-mode flavor.
+
+**Starter cast** (static profiles in `config.json`):
+
+| Name | Style |
+|---|---|
+| The Ghost | pure racer, optimal lines, ignores combat, hoards speed buffs — pace-setter |
+| Bulldozer | max aggression (punch/cut/bomb), poor racing lines |
+| The Gambler | high risk — corner-cuts by lava, impulsive abilities; big wins and big deaths |
+| Nemesis | fixates on the human — swap/cut/debuff aimed at you, rubber-bands hardest to stay near you |
+| Trickster | ability-chaos (tileSwap/blindfold/iceCannon), modest raw speed |
+| Tortoise | cautious, safe lines, rarely dies, conservative in collapse |
+| Hothead | calm when leading, reckless when behind (plays into the rubber-band) |
+
+Grid draws a varied subset (distinct names/colors, no dupes), weighted so a race usually includes a pace-setter (Ghost) and a rival (Nemesis).
+
+**Identity + emotes:** names/colors render for free (bots are `Player` objects the client already draws). Emotes need a new one-shot message `botEmote {id, emote}` + client render of a speech bubble and a title under the name. Triggered server-side off events already detected — `playerConcluded` (win/finish), `playerPunched` (knockout), near-collapse escapes, overtakes, swap/infection — filtered through each personality's taunt set, throttled to avoid spam. Converges with the **audience-sounds** backlog (crowd reacts to the same events) and the **skins** in the monetization plan (each personality = a recognizable skin).
+
+---
+
+## Phased build
+
+Each phase from Phase 2 on touches `server/config.json` / `server/game.js` / `server/engine.js`, so each **requires a player-facing `## Unreleased` bullet in `CHANGELOG.md` in the same commit** (CLAUDE.md release-notes rule; enforced by `.github/workflows/release-notes-check.yml`).
+
+### Phase 0 — Cell adjacency graph (shared foundation)
+- **New:** a graph builder run at map load that, for each cell, derives neighbors from `halfedges[].edge.lSite`/`rSite` (the neighbor is whichever site's `voronoiId` ≠ the cell's own), and an A* / reachability query over it with tile-weighted edge costs and lava as blocked.
+- **Where:** server-side map load (`server/utils.js` map loading ~`:393-401`; graph attached to the map object used as `currentMap` in `server/game.js`).
+- **Acceptance:** given a map + a point, return shortest traversable path (cell sequence) to the nearest reachable goal, or `null` if none reachable.
+- Pure addition; no CHANGELOG entry required (not yet a player-facing mechanic change).
+
+### Phase 1 — Lava fairness + a real solo mode
+- Detect single-player and route it to a dedicated solo collapse instead of the last-player branch.
+- Compute par time from the Phase 0 spawn→nearest-goal distance + known physics (`playerMaxSpeed 350`, `playerBaseAcel 375`); derive collapse **start delay and/or speed** as `par_time × margin` (≈1.5–2×, tunable).
+- Choose the collapse center as the **goal nearest the player's path** (not random), so the destination stays safe longest.
+- Reject/flag maps with no goal reachable from spawn (reuse for editor Preview/Playtest validation).
+- **Where:** `server/game.js` collapse trigger (`:363-376`), `startCollapse`, `collapseMap` (`:1168-1206`); new tuning keys in `server/config.json`.
+- **Acceptance:** a competent line beats a representative sample of player maps; unbeatable maps are flagged. **CHANGELOG bullet required.**
+
+### Phase 2 — Headless bot plumbing
+- Spawn socketless `Player` objects; fill grid to `randomInt(6,10) - humanCount`.
+- Guard the two socket-coupled spots: `messageClientBySig` (used by the AFK kick, `game.js:76`) — skip for bots; and `clientList`/`mailBoxList` registration in `messenger.js` (`:114-117`) — bots go in `playerList` only. (`messageRoomBySig` via `io.to().emit` and `compressor.js` are already socket-agnostic — bots render for free.)
+- Add the `isAI` flag + bot identity fields (name, color, personality id) to the `Player` constructor (`game.js:1938-2027`) and `world.createNewPlayer`.
+- **Acceptance:** bots appear in a solo room, render on the client, do not crash AFK/kick paths, sit still (no brain yet). **CHANGELOG bullet required.**
+
+### Phase 3 — Base racing brain
+- `aiController.update(dt)` per bot: A* → waypoint → `targetDirX/Y` + `braking`, with lookahead smoothing; collapse avoidance; re-path on `collapsedCells`.
+- **Acceptance:** bots complete a representative sample of maps without getting stuck or driving into lava. **CHANGELOG bullet required.**
+
+### Phase 4 — Ability policy
+- Per-ability scoring + directional aiming; bomb throw-then-detonate timing via `bombTrigger`.
+- **Acceptance:** bots pick up and use abilities in sensible situations (measured: ability not wasted into walls/empty space; bomb detonates near rivals). **CHANGELOG bullet required.**
+
+### Phase 5 — Brutal strategy layer
+- Param nudges (lightning/volcano/cloudy) + objective swaps (infection delay-or-hunt, hockey puck-push); vision-fairness self-handicap.
+- **Acceptance:** bots don't suicide-finish in infection, do push the puck in hockey, and survive lightning/volcano. **CHANGELOG bullet required.**
+
+### Phase 6 — Difficulty, rubber-band & personality profiles
+- Skill knobs; live progress-based scaling; per-race randomization; personality bias bundles in `config.json` read by all upstream pillars.
+- **Acceptance:** across many solo races the player wins a healthy-but-not-guaranteed share; distinct personalities are recognizable by behavior. **CHANGELOG bullet required.**
+
+### Phase 7 — Identity + emotes (client)
+- `botEmote {id, emote}` one-shot message; client renders speech bubble + title; server triggers off existing events filtered by personality, throttled.
+- **Client changes:** new handler in `client/scripts/client.js`, render in `client/scripts/draw.js`; add any new script to the `play` bundle list in `build.js` **and** the `<!-- BUILD: bundle-start -->` block in `play.html`.
+- **Acceptance:** characters taunt/emote on the right moments without spam. (UI/CSS-only parts are CHANGELOG-exempt; any mechanic-coupled bits carry a bullet.)
+
+---
+
+## Networking / client touch-points
+- Bots serialize through `compressor.js` from `playerList` with no changes (socket-agnostic). Per-tick `gameUpdates` reach clients via `messageRoomBySig` → `io.to(room).emit`.
+- New server→client message: `botEmote` (Phase 7). Update the matching handler in `client/scripts/client.js`.
+- Personality profiles ride the existing `config` socket event (they live in `config.json`), so name/color/title are available client-side automatically.
+
+## Open verification items (confirm in code before the relevant phase)
+1. **blindfold target** — the search read it as self-blinding, which is suspicious; confirm whether it blinds the user or everyone else (affects Pillar 2 + the vision-fairness guard). *Phase 4/5.*
+2. ~~clouds collidable vs cosmetic~~ — **resolved: cosmetic vision-only.** Bot ignores them for pathing; vision self-handicap applies.
+
+## Risks / caveats
+- **Par-time is an estimate** (graph distance ignores acceleration and turning) — lean on a generous margin and playtest-tune (Phase 1).
+- **Steering a momentum car along a cell-center polyline** needs lookahead smoothing or bots visibly wiggle (Phase 3) — standard but not free.
+- **Voronoi adjacency** assumes a shared edge means a passable boundary; passability is really "tile is not lava," and the world boundary (`bounceOffBoundry`) is the only wall, so the graph stays simple.
+- **Performance:** A* runs per bot; cache paths and re-path on a throttle / on `collapsedCells` rather than every tick.
+
+## Source references (as of this writing — verify before editing)
+- State map: `server/config.json:255-262`. Collapse triggers: `server/game.js:343`, `:363-376`; `collapseMap` `:1168-1206`; `collapseLine` init `:1304`.
+- Speeds: `worldCollapseSpeed 6`, `lastPlayerCollapseSpeed 0.75`, volcano `collapseSpeed 1` (`config.json`).
+- Goal detection: `server/game.js:2341-2352`; `server/engine.js:504-539`.
+- Player object: `server/game.js:1938-2027`. `isAI` movement branch: `server/engine.js:56-139` (esp. `:65`).
+- Input handlers: `server/messenger.js:175-191` (movement), `:193-204` (mousemove/angle); join/add player `:114-117`.
+- Socket coupling: `messageClientBySig` `server/messenger.js:212`, AFK kick `server/game.js:76`.
+- Abilities: `config.json:99-152`; acquire/trigger `server/game.js:2354-2424`, `checkAttack :2044-2070`, `checkAbilities :791-835`; cut `server/engine.js:462-484`.
+- Brutal rounds: `config.json:155-231`; implementations across `server/game.js` (`applyBrutal*`, `checkForActiveBrutal`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chaochao",
-    "version": "0.3.0",
+    "version": "0.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chaochao",
-            "version": "0.3.0",
+            "version": "0.3.3",
             "dependencies": {
                 "@octokit/core": "^5.2.2",
                 "compression": "^1.7.4",

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -1,0 +1,1004 @@
+// AI racer brain (Phase 3 — base racing).
+//
+// Runs once per server tick, BEFORE engine.updatePlayers (called from
+// GameBoard.update). For each alive bot it writes the exact Player fields the
+// socket handlers would have written for a human:
+//   targetDirX, targetDirY  unit steering vector (engine.js isAI branch reads
+//                            them as the movement axis, scaled by .8)
+//   braking                  true to bleed speed into a sharp turn
+//   angle                    heading in degrees (facing; used by directional
+//                            abilities in Phase 4)
+//
+// Navigation is pure-pursuit over the Phase 0 cell graph: A* (Dijkstra) to the
+// nearest reachable goal, then chase a "carrot" point a fixed look-ahead
+// distance along the path so a momentum car tracks the cell-center polyline
+// without wiggling. Collapsed/about-to-collapse cells are blocked so bots flee
+// the lava, and bumpers/moving-bumpers (hazardList) are dodged with local
+// repulsion steering.
+
+var c = require('./config.json');
+var cellGraph = require('./cellGraph.js');
+
+// --- Tunables (Phase 6 will fold per-personality/difficulty scaling on top) ---
+// In-race speeds are drag-limited and modest (~40/s normal .. ~78/s fast — the
+// gate's +500 boost is zeroed when racing starts), so brake thresholds are set
+// to those real speeds, not the 500 velocity cap.
+var REPATH_INTERVAL = 0.3;      // seconds between A* re-paths per bot
+var ARRIVE_RADIUS = 26;         // px: treat a waypoint as reached within this
+var LOOKAHEAD = 60;             // px: carrot distance ahead along the path
+var TURN_BRAKE_COS = 0.45;      // brake when the upcoming bend is sharper than this (cos)
+var BRAKE_SPEED_MIN = 30;       // only brake for turns/lava when moving faster than this
+var HAZARD_AVOID_RADIUS = 58;   // px: start steering away from a bumper within this
+var HAZARD_AVOID_STRENGTH = 1.7;// weight of hazard repulsion vs desired heading
+var COLLAPSE_DANGER_MARGIN = 55;// px: also block cells this close to the lava front
+var LAVA_AVOID_RADIUS = 70;     // px: soft repulsion from a lava cell center within this
+var LAVA_AVOID_STRENGTH = 2.2;  // weight of the soft lava field
+var FEELER_BASE = 34;           // px: shortest predictive feeler reach
+var FEELER_SPEED_K = 0.7;       // feeler grows with speed (stopping-distance proxy)
+var FEELER_MAX = 120;           // px: cap feeler reach
+var FEELER_SIDE_DEG = 32;       // angle of the two side feelers off the heading
+var FEELER_AVOID_STRENGTH = 3.0;// weight of the predictive feeler push (strongest)
+
+function clamp01(v) { return v < 0 ? 0 : (v > 1 ? 1 : v); }
+
+// Initialise a bot's brain state from its personality profile (config cast entry)
+// plus a small per-race skill jitter so the same character isn't identical every
+// race. Falls back to a competent generalist when no profile is given.
+function newBotState(profile) {
+    profile = profile || {};
+    var pick = function (k, d) { return profile[k] != null ? profile[k] : d; };
+    var jitter = (Math.random() - 0.5) * 0.12; // ±0.06
+    return {
+        repathTimer: 0,
+        path: null,        // [voronoiId...]
+        waypoints: null,   // [{x,y}...]
+        wpIndex: 0,
+        goal: null,        // {x,y} of the targeted goal
+        bombFiredAt: 0,    // ms timestamp the bot threw its current bomb
+        blindDrift: 0,     // deg: vision-handicap steering error (random walk)
+        wander: 0,         // deg: skill-based steering imprecision (random walk)
+        offUntil: 0,       // ms: end of a transient "off moment" (skill dip)
+        combatUntil: 0,    // ms: end of the current offensive-punch burst
+        combatRestUntil: 0,// ms: earliest a new combat burst may start (refractory)
+        gateY: null,       // gated-phase vertical jockey target
+        heldAbilityId: null,// which ability the bot is currently holding
+        abilityHeldSince: 0,// ms: when it picked up the held ability (hold-timeout)
+        pathSeed: 1 + Math.floor(Math.random() * 1e9), // per-bot route-diversity seed
+        // Personality knobs (0..1 unless noted).
+        skill: clamp01(pick('skill', 0.7) + jitter), // speed + precision + reaction
+        aggression: clamp01(pick('aggression', 0.5)),// punch willingness
+        abilityTempo: clamp01(pick('tempo', 0.5)),    // spend vs hoard abilities
+        risk: clamp01(pick('risk', 0.4)),             // how tight to the lava (corner-cut)
+        focus: pick('focus', 'race'),                 // race|combat|human|chaos
+        tilt: pick('tilt', null)                      // 'rage' = reckless when behind
+    };
+}
+
+function mag(x, y) { return Math.sqrt(x * x + y * y); }
+
+// Build a voronoiId -> {x,y} site lookup once per tick (shared across bots).
+function buildSiteIndex(map) {
+    var idx = {};
+    var cells = map.cells;
+    for (var i = 0; i < cells.length; i++) {
+        if (cells[i] && cells[i].site) {
+            idx[cells[i].site.voronoiId] = { x: cells[i].site.x, y: cells[i].site.y };
+        }
+    }
+    return idx;
+}
+
+// Cells already lava or about to be (within COLLAPSE_DANGER_MARGIN of the front)
+// during a collapse, returned as a Set of voronoiIds for findPathToNearestGoal's
+// `blocked` option. Lava cells are blocked by the graph already; this adds the
+// soon-to-flip ring so a bot doesn't path into cells the lava is about to claim.
+function collapseDangerSet(ctx) {
+    if (!ctx.collapsing || ctx.collapseLoc == null || ctx.collapseLine == null) {
+        return null;
+    }
+    var blocked = new Set();
+    var cells = ctx.map.cells;
+    var GOAL = c.tileMap.goal.id;
+    var threshold = ctx.collapseLine - COLLAPSE_DANGER_MARGIN;
+    for (var i = 0; i < cells.length; i++) {
+        if (!cells[i] || !cells[i].site || cells[i].id === GOAL) { continue; }
+        var d = mag(ctx.collapseLoc.x - cells[i].site.x, ctx.collapseLoc.y - cells[i].site.y);
+        // collapseMap turns a cell to lava once collapseLine < d; block the ring
+        // just inside that so the bot keeps clear of the advancing edge.
+        if (d > threshold) {
+            blocked.add(cells[i].site.voronoiId);
+        }
+    }
+    return blocked;
+}
+
+// Carrot point: walk LOOKAHEAD px along the waypoint polyline starting from the
+// bot's position, so steering aims at a smoothed point ahead instead of snapping
+// to the next cell center (which makes a momentum car oscillate).
+function carrotPoint(bot, waypoints, startIndex) {
+    var remaining = LOOKAHEAD;
+    var curX = bot.x, curY = bot.y;
+    var i = startIndex;
+    var last = waypoints.length - 1;
+    if (i > last) { return { x: waypoints[last].x, y: waypoints[last].y }; }
+    while (i <= last) {
+        var wp = waypoints[i];
+        var dx = wp.x - curX, dy = wp.y - curY;
+        var segLen = mag(dx, dy);
+        if (segLen >= remaining) {
+            var t = remaining / (segLen || 1);
+            return { x: curX + dx * t, y: curY + dy * t };
+        }
+        remaining -= segLen;
+        curX = wp.x; curY = wp.y;
+        i++;
+    }
+    return { x: waypoints[last].x, y: waypoints[last].y };
+}
+
+// Sum of repulsion away from nearby bumpers/moving bumpers, scaled so it ramps
+// up sharply as the bot closes on a hazard's strike range. Returns {x,y} (may be
+// {0,0} when clear).
+function hazardRepulsion(bot, hazardList) {
+    var rx = 0, ry = 0;
+    for (var id in hazardList) {
+        var h = hazardList[id];
+        if (h.alive === false) { continue; }
+        var dx = bot.x - h.x, dy = bot.y - h.y;
+        var d = mag(dx, dy);
+        var range = HAZARD_AVOID_RADIUS + (h.radius || 0);
+        if (d > 0 && d < range) {
+            var w = (range - d) / range; // 0 at edge -> 1 at center
+            w = w * w;                   // ramp harder up close
+            rx += (dx / d) * w;
+            ry += (dy / d) * w;
+        }
+    }
+    return { x: rx, y: ry };
+}
+
+// Sum of repulsion away from nearby lava cell centers. Lava is instant death, so
+// the path routes around it (graph-blocked) but a momentum car still cuts corners
+// into it — this field pushes the bot back toward the safe side of a lava edge.
+function lavaRepulsion(bot, lavaCells) {
+    var rx = 0, ry = 0;
+    for (var i = 0; i < lavaCells.length; i++) {
+        var l = lavaCells[i];
+        var dx = bot.x - l.x, dy = bot.y - l.y;
+        var d = mag(dx, dy);
+        if (d > 0 && d < LAVA_AVOID_RADIUS) {
+            var w = (LAVA_AVOID_RADIUS - d) / LAVA_AVOID_RADIUS;
+            w = w * w;
+            rx += (dx / d) * w;
+            ry += (dy / d) * w;
+        }
+    }
+    return { x: rx, y: ry };
+}
+
+// True if the Voronoi cell containing (x,y) — the nearest site — is lava. Used by
+// the predictive feelers to catch a momentum car about to slide off the path.
+function isLavaAt(ctx, x, y) {
+    var cells = ctx.map.cells;
+    var best = Infinity, bestId = -1;
+    for (var i = 0; i < cells.length; i++) {
+        if (!cells[i] || !cells[i].site) { continue; }
+        var s = cells[i].site;
+        var dx = s.x - x, dy = s.y - y;
+        var d = dx * dx + dy * dy;
+        if (d < best) { best = d; bestId = cells[i].id; }
+    }
+    return bestId === ctx.lavaId;
+}
+
+function rotate(x, y, deg) {
+    var r = deg * Math.PI / 180, cs = Math.cos(r), sn = Math.sin(r);
+    return { x: x * cs - y * sn, y: x * sn + y * cs };
+}
+
+// Predictive avoidance: cast three feelers ahead along the bot's heading (center
+// + two sides). If a feeler lands on lava, push perpendicular toward the clear
+// side and flag a hard brake. Returns { x, y, brake } where x/y is a steer push.
+function feelerAvoid(bot, ctx, headX, headY, speed) {
+    var reach = FEELER_BASE + speed * FEELER_SPEED_K;
+    // Lightning round speeds everyone up — look farther ahead to keep control.
+    if (ctx.lightning) { reach *= LIGHTNING_FEELER_MULT; }
+    var cap = FEELER_MAX * (ctx.lightning ? LIGHTNING_FEELER_MULT : 1);
+    if (reach > cap) { reach = cap; }
+    // Risk: high-risk personalities use shorter feelers, cutting closer to lava.
+    if (ctx.riskMult != null) { reach *= ctx.riskMult; }
+    var px = 0, py = 0, brake = false;
+    // Center feeler — straight ahead.
+    if (isLavaAt(ctx, bot.x + headX * reach, bot.y + headY * reach)) {
+        brake = true;
+    }
+    // Side feelers, slightly shorter. Lava on one side pushes toward the other.
+    var sd = reach * 0.8;
+    var lDir = rotate(headX, headY, FEELER_SIDE_DEG);
+    var rDir = rotate(headX, headY, -FEELER_SIDE_DEG);
+    var lLava = isLavaAt(ctx, bot.x + lDir.x * sd, bot.y + lDir.y * sd);
+    var rLava = isLavaAt(ctx, bot.x + rDir.x * sd, bot.y + rDir.y * sd);
+    // Perpendicular to heading: right = (headY, -headX), left = (-headY, headX).
+    if (lLava && !rLava) { px += headY; py += -headX; }        // push right
+    else if (rLava && !lLava) { px += -headY; py += headX; }   // push left
+    else if (lLava && rLava) { brake = true; }                 // boxed in — slow down
+    if (brake && !(lLava || rLava)) { /* only center lava: rely on carrot + brake */ }
+    return { x: px, y: py, brake: brake };
+}
+
+// --- Phase 4: combat + ability tunables ---
+var SHOVE_PROBE = 42;       // px past a rival to check for lava (punch shoves them away from us)
+var BOMB_THROW_RANGE = 340; // px: throw a bomb at a rival within this
+var SWAP_RANGE = 280;       // px: only swap with a rival this near (and only when behind)
+var CUT_RANGE = 78;         // px: cut when a rival is this close
+var BOMB_MAX_HOLD = 2.6;    // s: detonate before the bomb's 3s auto-expire
+
+// --- Phase 5: brutal-round tunables ---
+var BLIND_DRIFT_STEP = 7;       // deg/tick random-walk of the blind steering error
+var BLIND_DRIFT_MAX = 55;       // deg: max veer off the intended line when blinded
+var BLIND_THROTTLE = 0.72;      // speed factor while blinded (tentative)
+var ZOMBIE_AVOID_RADIUS = 95;   // px: non-zombies steer away from zombies (contact infects)
+var ZOMBIE_AVOID_STRENGTH = 2.1;
+var PUCK_AVOID_RADIUS = 115;    // px: the hockey puck hits hard — give it room
+var PUCK_AVOID_STRENGTH = 2.6;
+var LIGHTNING_FEELER_MULT = 1.45; // see farther ahead when everyone's sped up
+var HAZARD_PATH_PENALTY = 12;     // cost x for routing a path through a bumper's cell
+
+var AB = c.tileMap.abilities;
+
+function snap45(deg) {
+    var d = Math.round(deg / 45) * 45;
+    return ((d % 360) + 360) % 360;
+}
+function angleDeg(fromX, fromY, toX, toY) {
+    return Math.atan2(toY - fromY, toX - fromX) * 180 / Math.PI;
+}
+function punchReady(bot) {
+    return bot.punchedTimer == null || (Date.now() - bot.punchedTimer) >= bot.punchWaitTime;
+}
+function isRacer(p, self) {
+    return p !== self && p.alive && !p.reachedGoal && !p.isSpectator;
+}
+function nearestRival(bot, players) {
+    var best = null, bd = Infinity;
+    for (var id in players) {
+        var p = players[id];
+        if (!isRacer(p, bot)) { continue; }
+        var d = mag(p.x - bot.x, p.y - bot.y);
+        if (d < bd) { bd = d; best = p; }
+    }
+    return best == null ? null : { player: best, dist: bd };
+}
+function nearestRivalToPoint(px, py, players, self) {
+    var bd = Infinity;
+    for (var id in players) {
+        var p = players[id];
+        if (!isRacer(p, self)) { continue; }
+        var d = mag(p.x - px, p.y - py);
+        if (d < bd) { bd = d; }
+    }
+    return bd;
+}
+function hasRacingRival(bot, players) {
+    for (var id in players) { if (isRacer(players[id], bot)) { return true; } }
+    return false;
+}
+function countRacers(players) {
+    var n = 0;
+    for (var id in players) { var p = players[id]; if (p.alive && !p.isSpectator && !p.reachedGoal) { n++; } }
+    return n;
+}
+// The rival a bot prefers to target: a 'human'-focused bot (Nemesis) goes after
+// the nearest human; everyone else targets the nearest rival of any kind.
+function preferredTarget(bot, ctx) {
+    if (bot.ai && bot.ai.focus === 'human') {
+        var h = nearestMatch(bot, ctx.players, function (p) { return !p.isAI; });
+        if (h != null) { return h; }
+    }
+    return nearestRival(bot, ctx.players);
+}
+function hasHumanRival(bot, players) {
+    for (var id in players) {
+        var p = players[id];
+        if (isRacer(p, bot) && !p.isAI) { return true; }
+    }
+    return false;
+}
+// How many rivals are closer to `goal` than the bot (0 = the bot is leading).
+function goalRank(bot, players, goal) {
+    if (goal == null) { return 0; }
+    var mine = mag(goal.x - bot.x, goal.y - bot.y);
+    var ahead = 0;
+    for (var id in players) {
+        var p = players[id];
+        if (p === bot || !p.alive || p.isSpectator) { continue; }
+        if (p.reachedGoal) { ahead++; continue; }
+        if (mag(goal.x - p.x, goal.y - p.y) < mine) { ahead++; }
+    }
+    return ahead;
+}
+// Is there lava just beyond `target` along the bot->target ray? (so a punch, which
+// shoves the target directly away from the bot, knocks them into it).
+function lavaBeyond(ctx, bot, target, dist) {
+    var dx = target.x - bot.x, dy = target.y - bot.y;
+    var m = mag(dx, dy) || 1;
+    return isLavaAt(ctx, target.x + (dx / m) * dist, target.y + (dy / m) * dist);
+}
+
+// --- Phase 5 helpers ---
+function nearestMatch(bot, players, pred) {
+    var best = null, bd = Infinity;
+    for (var id in players) {
+        var p = players[id];
+        if (p === bot || !p.alive || p.isSpectator) { continue; }
+        if (!pred(p)) { continue; }
+        var d = mag(p.x - bot.x, p.y - bot.y);
+        if (d < bd) { bd = d; best = p; }
+    }
+    return best == null ? null : { player: best, dist: bd };
+}
+function notZombiePrey(p) { return !p.isZombie && !p.reachedGoal; }
+function isZombieP(p) { return p.isZombie; }
+
+// Nearest goal point to (x,y) from the precomputed goal tiles.
+function nearestGoalPoint(x, y, goalTiles) {
+    var best = null, bd = Infinity;
+    for (var i = 0; i < goalTiles.length; i++) {
+        var d = mag(goalTiles[i].x - x, goalTiles[i].y - y);
+        if (d < bd) { bd = d; best = goalTiles[i]; }
+    }
+    return best;
+}
+
+// Where a hunting zombie should aim to HEAD OFF its prey: lead it along its route
+// to the goal (prey are racing for a goal), not its current spot — and lead more
+// the farther away the zombie is, so it cuts the prey off rather than tail-chasing.
+// Zombies are lava-immune, so the straight beeline to the intercept is valid.
+function zombieInterceptDir(bot, prey, ctx) {
+    var px = prey.x, py = prey.y;
+    var leadX, leadY;
+    var g = ctx.goalTiles && ctx.goalTiles.length ? nearestGoalPoint(px, py, ctx.goalTiles) : null;
+    if (g != null) {
+        leadX = g.x - px; leadY = g.y - py; // they're running toward this goal
+    } else {
+        leadX = prey.velX || 0; leadY = prey.velY || 0; // fall back to current heading
+    }
+    var lm = mag(leadX, leadY);
+    var distToPrey = mag(px - bot.x, py - bot.y);
+    var lead = distToPrey * 0.6;
+    if (lead < 40) { lead = 40; } else if (lead > 240) { lead = 240; }
+    var ix = px, iy = py;
+    if (lm > 0.001) { ix = px + (leadX / lm) * lead; iy = py + (leadY / lm) * lead; }
+    var dx = ix - bot.x, dy = iy - bot.y, m = mag(dx, dy) || 1;
+    return { x: dx / m, y: dy / m };
+}
+
+// Repulsion away from a point within `radius` (ramped up close). Shared by zombie
+// and puck avoidance.
+function pointRepulsion(bot, x, y, radius) {
+    var dx = bot.x - x, dy = bot.y - y, d = mag(dx, dy);
+    if (d > 0 && d < radius) {
+        var w = (radius - d) / radius; w = w * w;
+        return { x: (dx / d) * w, y: (dy / d) * w };
+    }
+    return { x: 0, y: 0 };
+}
+
+// Is the bot currently "blinded" — blackout round, an active blindfold, or sitting
+// under a cloud? Bots read game state (not pixels), so without this they'd be
+// immune; the self-handicap makes vision effects bite the AI as they bite a human.
+function isBlinded(bot, ctx, now) {
+    if (ctx.blackoutActive) { return true; }
+    if (ctx.visionBlockedUntil > now) { return true; }
+    if (ctx.cloudy) {
+        for (var i = 0; i < ctx.clouds.length; i++) {
+            var cl = ctx.clouds[i];
+            if (mag(cl.x - bot.x, cl.y - bot.y) < (cl.radius || 0)) { return true; }
+        }
+    }
+    return false;
+}
+
+// Brutal-round punches take priority over the generic punch/ability policy:
+// zombies hunt-and-bite, non-zombies fend off an adjacent zombie, and anyone
+// clears the puck when it's on top of them. Returns true if it set an attack.
+// Face a punch target before swinging — needed where the punch is directional
+// (lands in front of the kart); harmless where it's omnidirectional.
+function facePunch(bot, x, y) { bot.angle = angleDeg(bot.x, bot.y, x, y); }
+
+function decideBrutalPunch(bot, ctx) {
+    // A "punch" is attack with no held ability. If the bot holds an ability,
+    // setting attack would FIRE THE ABILITY (Player.checkAttack), not punch — and
+    // at this function's non-8-way facing that breaks directional projectiles
+    // (clampPlayerAngle -> undefined -> NaN). So defer to the ability policy here.
+    if (bot.ability != null) { return false; }
+    if (!punchReady(bot)) { return false; }
+    if (ctx.infection && bot.isZombie) {
+        var prey = nearestMatch(bot, ctx.players, notZombiePrey);
+        if (prey != null && prey.dist < c.punchRadius + bot.radius + prey.player.radius + 8) {
+            facePunch(bot, prey.player.x, prey.player.y); bot.attack = true; return true;
+        }
+        return false; // not in range — the chase is handled in steering
+    }
+    if (ctx.infection && !bot.isZombie) {
+        var z = nearestMatch(bot, ctx.players, isZombieP);
+        if (z != null && z.dist < c.punchRadius + bot.radius + z.player.radius + 8) {
+            facePunch(bot, z.player.x, z.player.y); bot.attack = true; return true; // knock the zombie back
+        }
+    }
+    if (ctx.hockey && ctx.puck != null) {
+        if (mag(ctx.puck.x - bot.x, ctx.puck.y - bot.y) < c.punchRadius + bot.radius + (ctx.puck.radius || 0) + 8) {
+            facePunch(bot, ctx.puck.x, ctx.puck.y); bot.attack = true; return true; // clear the puck off us
+        }
+    }
+    return false;
+}
+
+// Decide whether to fire the held ability this tick; may set bot.angle (snapped to
+// the 8-way the engine's clampPlayerAngle requires) and bot.attack.
+function decideAbility(bot, ctx, ability, nav) {
+    var id = ability.id;
+
+    if (id === AB.bombTrigger.id) {
+        // Two-step bomb: detonate when a rival is inside the blast, or just before
+        // the bomb auto-expires (so the trigger isn't wasted).
+        var bomb = ctx.projectileList[bot.id];
+        var held = (Date.now() - (bot.ai.bombFiredAt || 0)) / 1000;
+        if (bomb == null) { bot.attack = true; return; } // bomb gone — clear the trigger
+        if (nearestRivalToPoint(bomb.x, bomb.y, ctx.players, bot) < AB.bomb.explosionRadius * 0.9) { bot.attack = true; return; }
+        if (held > BOMB_MAX_HOLD) { bot.attack = true; }
+        return;
+    }
+    // Abilities persist all round, so bots use them strategically but never hoard:
+    // each has a "good moment" to fire, plus a hold-timeout (longer for hoarders,
+    // shorter for trigger-happy) after which it fires at the next safe opportunity.
+    var held = nav.held || 0;
+    var maxHold = 2 + (1 - bot.ai.abilityTempo) * 5; // ~2s (eager) .. ~7s (hoarder)
+    var forced = held > maxHold;
+    var rank = goalRank(bot, ctx.players, bot.ai.goal);
+    var aimAhead = function () { bot.angle = snap45(Math.atan2(bot.targetDirY, bot.targetDirX) * 180 / Math.PI); };
+
+    if (id === AB.bomb.id) {
+        var nr = preferredTarget(bot, ctx); // Nemesis aims at the human
+        if (nr != null && nr.dist < BOMB_THROW_RANGE) {
+            bot.angle = snap45(angleDeg(bot.x, bot.y, nr.player.x, nr.player.y));
+            bot.attack = true; bot.ai.bombFiredAt = Date.now();
+        } else if (forced) {
+            // No target in range — lob it down the track to lay slow tiles ahead.
+            aimAhead(); bot.attack = true; bot.ai.bombFiredAt = Date.now();
+        }
+        return;
+    }
+    if (id === AB.swap.id) {
+        // Swap with a leader when behind (a random-target swap while leading risks
+        // giving away the lead, so never force it while in front).
+        if (rank >= 1) {
+            var nrs = preferredTarget(bot, ctx);
+            if (nrs != null && (nrs.dist < SWAP_RANGE || forced)) { bot.attack = true; }
+        }
+        return;
+    }
+    if (id === AB.cut.id) {
+        // Shove nearby rivals aside (perpendicular to facing); aim along travel.
+        var nrc = nearestRival(bot, ctx.players);
+        var range = forced ? CUT_RANGE * 2 : CUT_RANGE;
+        if (nrc != null && nrc.dist < range) { aimAhead(); bot.attack = true; }
+        return;
+    }
+    if (id === AB.speedDebuff.id) {
+        if (hasRacingRival(bot, ctx.players)) { bot.attack = true; } // slows ALL rivals
+        return;
+    }
+    if (id === AB.speedBuff.id) {
+        // Self speed boost: spend it on the move (just not braking into lava).
+        if (!nav.lavaAhead) { bot.attack = true; }
+        return;
+    }
+    if (id === AB.iceCannon.id) {
+        if (!nav.lavaAhead) { aimAhead(); bot.attack = true; } // self-boost + ice the lane ahead
+        return;
+    }
+    if (id === AB.blindfold.id) {
+        // Room-wide blind: best when a human rival is in play and the bot isn't out
+        // front; otherwise use it once held a while so it isn't wasted.
+        if ((hasHumanRival(bot, ctx.players) && rank >= 1) || forced) { bot.attack = true; }
+        return;
+    }
+    if (id === AB.tileSwap.id) {
+        // Map-wide chaos: best when behind, but use it before the round's out.
+        if (rank >= 2 || forced) { bot.attack = true; }
+        return;
+    }
+}
+
+// Offensive combat comes in BURSTS, not a continuous punch-lock: a bot engages
+// for a short window then disengages and races for a stretch, so bots don't just
+// stand and trade punches. Returns true if the bot may throw an offensive punch
+// now; starts a fresh burst (and schedules the following rest) on the first punch.
+function offensiveCombatAllowed(bot, now) {
+    var ai = bot.ai;
+    if (now < ai.combatUntil) { return true; }          // mid-burst
+    if (now < ai.combatRestUntil) { return false; }     // resting -> race only
+    // Rested: open a new burst. Aggressive bots fight longer and rest less.
+    var burst = 400 + ai.aggression * 850;              // 0.4s .. 1.25s
+    var rest = 2200 + (1 - ai.aggression) * 3200;       // 2.2s .. 5.4s
+    ai.combatUntil = now + burst;
+    ai.combatRestUntil = ai.combatUntil + rest;
+    return true;
+}
+
+// Decide whether to throw a (cooldown-gated, bursty) punch this tick. Priority:
+// shove a rival into adjacent lava; aggressive bots also punch a rival pressed
+// against them — but only during a combat burst. Brutal-round combat (zombies,
+// pucks) is objective-driven and handled separately (not rate-limited here).
+function decidePunch(bot, ctx) {
+    if (!punchReady(bot)) { return; }
+    var nr = preferredTarget(bot, ctx); // Nemesis hounds the human
+    if (nr == null) { return; }
+    // The punch (radius punchRadius at the bot's position) only lands on a rival
+    // within punchRadius + both radii; add a small buffer for closing speed.
+    var landRange = c.punchRadius + bot.radius + nr.player.radius + 6;
+    if (nr.dist > landRange) { return; }
+    var shove = lavaBeyond(ctx, bot, nr.player, SHOVE_PROBE);
+    // A free shove into the lava is always worth it; routine aggression only in bursts.
+    if (!shove && bot.ai.aggression < 0.6) { return; }
+    if (!offensiveCombatAllowed(bot, Date.now())) { return; }
+    facePunch(bot, nr.player.x, nr.player.y);
+    bot.attack = true;
+}
+
+// Top-level per-tick combat decision: fire the held ability, else consider a punch.
+function decideAttack(bot, ctx, nav) {
+    bot.attack = false;
+    if (decideBrutalPunch(bot, ctx)) { return; } // zombies / puck / zombie-defense first
+    if (bot.ability != null) {
+        // Track how long this ability has been held so it gets used within the
+        // round (strategically when possible, but never hoarded indefinitely).
+        var now = Date.now();
+        if (bot.ai.heldAbilityId !== bot.ability.id) {
+            bot.ai.heldAbilityId = bot.ability.id;
+            bot.ai.abilityHeldSince = now;
+        }
+        nav.held = (now - bot.ai.abilityHeldSince) / 1000;
+        decideAbility(bot, ctx, bot.ability, nav);
+        return;
+    }
+    bot.ai.heldAbilityId = null;
+    decidePunch(bot, ctx);
+}
+
+function steerBot(bot, ctx, dt) {
+    var ai = bot.ai || (bot.ai = newBotState(bot.profile));
+
+    // --- Re-path on a throttle (and immediately if we have no path) ---
+    ai.repathTimer -= dt;
+    if (ai.repathTimer <= 0 || ai.waypoints == null) {
+        var blocked = collapseDangerSet(ctx);
+        // Per-bot route diversity: jitter edge costs by a seeded amount so bots
+        // don't all take the identical optimal line. Weaker (lower-skill) bots
+        // wander a bit more; skilled bots stay closer to optimal.
+        var pathOpts = {
+            blocked: blocked,
+            noiseSeed: ai.pathSeed,
+            noiseAmount: 0.15 + (1 - ai.skill) * 0.2,
+            penaltySet: ctx.hazardCells, // route AROUND bumper cells (soft penalty)
+            penaltyMult: HAZARD_PATH_PENALTY
+        };
+        var route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, pathOpts);
+        // If the danger ring walled us off, retry without it so we still aim at a
+        // goal (better a tight line than freezing in front of the lava). Keep the
+        // hazard penalty on the retry — it's soft, so it never nulls the path.
+        if (route == null && blocked != null) {
+            route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, { noiseSeed: ai.pathSeed, noiseAmount: pathOpts.noiseAmount, penaltySet: ctx.hazardCells, penaltyMult: HAZARD_PATH_PENALTY });
+        }
+        if (route != null) {
+            var pts = [];
+            for (var p = 0; p < route.path.length; p++) {
+                var site = ctx.siteById[route.path[p]];
+                if (site) { pts.push(site); }
+            }
+            ai.path = route.path;
+            ai.waypoints = pts;
+            ai.goal = route.goal;
+            // Skip the start cell (≈ current position) so the carrot looks ahead.
+            ai.wpIndex = pts.length > 1 ? 1 : 0;
+        } else {
+            ai.waypoints = null;
+            ai.goal = null;
+        }
+        // Lower-skill bots react slower (re-path less often) — laggier, less optimal.
+        ai.repathTimer = REPATH_INTERVAL * (1 + (1 - ai.skill) * 1.2);
+    }
+
+    var desiredX = 0, desiredY = 0;
+    var speed = mag(bot.velX, bot.velY);
+    var sharpTurn = false;
+
+    if (ai.waypoints != null && ai.waypoints.length > 0) {
+        // Advance past waypoints we've effectively reached.
+        var last = ai.waypoints.length - 1;
+        while (ai.wpIndex < last) {
+            var wp = ai.waypoints[ai.wpIndex];
+            if (mag(wp.x - bot.x, wp.y - bot.y) < ARRIVE_RADIUS) { ai.wpIndex++; } else { break; }
+        }
+        var carrot = carrotPoint(bot, ai.waypoints, ai.wpIndex);
+        var dx = carrot.x - bot.x, dy = carrot.y - bot.y;
+        var dm = mag(dx, dy) || 1;
+        desiredX = dx / dm;
+        desiredY = dy / dm;
+
+        // Detect a sharp upcoming bend so we can ease off and brake before it.
+        if (ai.wpIndex < last) {
+            var a = ai.waypoints[ai.wpIndex];
+            var b = ai.waypoints[ai.wpIndex + 1];
+            var inX = a.x - bot.x, inY = a.y - bot.y;
+            var outX = b.x - a.x, outY = b.y - a.y;
+            var im = mag(inX, inY) || 1, om = mag(outX, outY) || 1;
+            var turnCos = (inX * outX + inY * outY) / (im * om);
+            if (turnCos < TURN_BRAKE_COS) { sharpTurn = true; }
+        }
+    } else if (ctx.collapsing && ctx.collapseLoc != null) {
+        // Walled off with no reachable goal during a collapse: the collapse closes
+        // inward toward collapseLoc (the safe center / goal), so flee toward it.
+        var fx = ctx.collapseLoc.x - bot.x, fy = ctx.collapseLoc.y - bot.y;
+        var fm = mag(fx, fy) || 1;
+        desiredX = fx / fm; desiredY = fy / fm;
+    } else if (ctx.infection && bot.isZombie && nearestMatch(bot, ctx.players, notZombiePrey) != null) {
+        // A zombie with no reachable goal path (it's lava-immune and often sits on
+        // lava) still HUNTS — fall through to the intercept override below, which
+        // sets desired toward the prey. Don't freeze in the no-path hold.
+    } else {
+        // No path and not collapsing: hold position (don't drive blindly).
+        bot.targetDirX = 0; bot.targetDirY = 0; bot.braking = true; bot.attack = false;
+        return;
+    }
+
+    // --- Brutal-round steering overrides (objective flips + vision fairness) ---
+    var now = Date.now();
+    // Infection: a zombie's whole job is to infect non-zombies. It abandons the
+    // goal, picks the nearest non-zombie prey, and aims to HEAD IT OFF on its way
+    // to a goal (intercept lead) rather than tail-chase. Lava-immune, so it beelines.
+    if (ctx.infection && bot.isZombie) {
+        var prey = nearestMatch(bot, ctx.players, notZombiePrey);
+        if (prey != null) {
+            var idir = zombieInterceptDir(bot, prey.player, ctx);
+            desiredX = idir.x; desiredY = idir.y;
+        }
+    }
+    // Vision self-handicap: random-walk a heading error and slow down when blinded.
+    // Feelers still keep local lava safety (a human keeps a small vision circle).
+    var blinded = isBlinded(bot, ctx, now);
+    if (blinded) {
+        ai.blindDrift += (Math.random() - 0.5) * 2 * BLIND_DRIFT_STEP;
+        if (ai.blindDrift > BLIND_DRIFT_MAX) { ai.blindDrift = BLIND_DRIFT_MAX; }
+        if (ai.blindDrift < -BLIND_DRIFT_MAX) { ai.blindDrift = -BLIND_DRIFT_MAX; }
+        var rd = rotate(desiredX, desiredY, ai.blindDrift);
+        desiredX = rd.x; desiredY = rd.y;
+    } else {
+        ai.blindDrift *= 0.85;
+    }
+
+    // --- Personality: effective skill, off-moments, tilt, and line precision ---
+    var effSkill = ai.skill;
+    // Occasional "off moment" (a fumble) — likelier for lower-skill bots — so a
+    // player win feels earned rather than scripted.
+    if (now < ai.offUntil) {
+        effSkill *= 0.55;
+    } else if (Math.random() < 0.0015 * (1.2 - ai.skill)) {
+        ai.offUntil = now + 350 + Math.random() * 550;
+    }
+    // Hothead tilt: reckless (faster, cuts tighter) when behind the field.
+    var rank = goalRank(bot, ctx.players, ai.goal);
+    var racers = countRacers(ctx.players);
+    var behind = racers > 1 && rank >= Math.ceil(racers / 2);
+    if (ai.tilt === 'rage' && behind) { effSkill = clamp01(effSkill + 0.2); }
+    // Steering imprecision: low-skill bots wander off the optimal line (the
+    // "scenic route"); high-skill bots hold a tight, smart line.
+    var wobble = (1 - effSkill);
+    ai.wander += (Math.random() - 0.5) * 2 * 5 * wobble;
+    var wanderMax = 38 * wobble;
+    if (ai.wander > wanderMax) { ai.wander = wanderMax; }
+    if (ai.wander < -wanderMax) { ai.wander = -wanderMax; }
+    if (wobble > 0.02) {
+        var rw = rotate(desiredX, desiredY, ai.wander);
+        desiredX = rw.x; desiredY = rw.y;
+    }
+    // Risk: tighter lines hug the lava (corner-cutting); cautious bots keep clear.
+    ctx.riskMult = 1 - 0.45 * ai.risk;
+
+    // --- Avoidance: predictive feelers (primary) + soft fields (secondary) ---
+    // Heading the feelers look along: actual velocity when moving, else desired.
+    var headX = desiredX, headY = desiredY;
+    if (speed > 5) { headX = bot.velX / speed; headY = bot.velY / speed; }
+
+    // Zombies don't die on lava (and ignore the collapse) — they cut straight
+    // across it to chase prey, so a zombie bot turns OFF all lava avoidance.
+    var ignoreLava = bot.isZombie === true;
+    var fl = ignoreLava ? { x: 0, y: 0, brake: false } : feelerAvoid(bot, ctx, headX, headY, speed);
+    var hz = hazardRepulsion(bot, ctx.hazardList);
+    var lv = ignoreLava ? { x: 0, y: 0 } : lavaRepulsion(bot, ctx.lavaCells);
+
+    // Lava dead ahead means the current line is bad — re-path next tick to find a
+    // route around it instead of crawling toward the edge until we clip it.
+    if (fl.brake) { ai.repathTimer = 0; }
+
+    // Extra brutal-round repulsions: dodge zombies (contact infects) and the puck.
+    var exX = 0, exY = 0;
+    if (ctx.infection && !bot.isZombie && !bot.infected) {
+        for (var zi in ctx.players) {
+            var zp = ctx.players[zi];
+            if (zp === bot || !zp.alive || !zp.isZombie) { continue; }
+            var zr = pointRepulsion(bot, zp.x, zp.y, ZOMBIE_AVOID_RADIUS);
+            exX += zr.x * ZOMBIE_AVOID_STRENGTH; exY += zr.y * ZOMBIE_AVOID_STRENGTH;
+        }
+    }
+    if (ctx.hockey && ctx.puck != null) {
+        var pr = pointRepulsion(bot, ctx.puck.x, ctx.puck.y, PUCK_AVOID_RADIUS);
+        exX += pr.x * PUCK_AVOID_STRENGTH; exY += pr.y * PUCK_AVOID_STRENGTH;
+    }
+
+    var lavaW = LAVA_AVOID_STRENGTH * (ctx.riskMult != null ? ctx.riskMult : 1);
+    var sx = desiredX + fl.x * FEELER_AVOID_STRENGTH + lv.x * lavaW + hz.x * HAZARD_AVOID_STRENGTH + exX;
+    var sy = desiredY + fl.y * FEELER_AVOID_STRENGTH + lv.y * lavaW + hz.y * HAZARD_AVOID_STRENGTH + exY;
+    var sm = mag(sx, sy);
+    var steerX = desiredX, steerY = desiredY;
+    if (sm > 0.0001) { steerX = sx / sm; steerY = sy / sm; }
+
+    // --- Throttle governor: don't outdrive the sensors. Crawl when lava is close
+    // ahead so steering can redirect momentum before instant death; ease into
+    // sharp bends; full throttle on open, straight runway. The engine reads the
+    // targetDir magnitude as the accel input, so a shorter vector = lower speed.
+    var throttle = 1.0;
+    var braking = false;
+    var lavaField = mag(lv.x, lv.y);
+    if (fl.brake || lavaField > 1.2) {
+        throttle = 0.42;
+        if (speed > BRAKE_SPEED_MIN) { braking = true; }
+    } else if (sharpTurn || lavaField > 0.6) {
+        throttle = 0.7;
+        if (sharpTurn && speed > BRAKE_SPEED_MIN * 1.3) { braking = true; }
+    }
+    // Blinded racers feel their way forward more tentatively.
+    if (blinded) { throttle *= BLIND_THROTTLE; }
+
+    // Personality + rubber-band speed: skill sets the cruise pace (slow Tortoise ..
+    // quick Ghost); the within-race rubber-band eases the field off when the human
+    // is behind and pushes it when the human is leading, so wins feel earned.
+    // NOTE: the engine scales a bot's input by 0.8 (vs a human's 1.0), so the top
+    // of this range is set high enough that a max-skill bot's effective input
+    // (0.8 x speedFactor) reaches/*slightly* exceeds a human's — otherwise even the
+    // best bots are hard-capped below human top speed and trivially beatable.
+    var speedFactor = (0.6 + 0.55 * effSkill) * (ctx.rubberBand || 1);
+    if (speedFactor > 1.45) { speedFactor = 1.45; }
+    if (speedFactor < 0.4) { speedFactor = 0.4; }
+    throttle *= speedFactor;
+
+    // A hunting zombie commits fully: it ignores lava and only wants to catch prey,
+    // so skip the cautious governor, rubber-band easing, and braking — full chase.
+    if (bot.isZombie) { throttle = 1; braking = false; }
+
+    bot.targetDirX = steerX * throttle;
+    bot.targetDirY = steerY * throttle;
+    bot.angle = Math.atan2(steerY, steerX) * (180 / Math.PI);
+    bot.braking = braking;
+
+    // Combat & abilities (may override bot.angle to an 8-way aim and set bot.attack).
+    decideAttack(bot, ctx, { sharpTurn: sharpTurn, lavaAhead: fl.brake });
+}
+
+// The non-lava launch lanes along the gate's front row: the Y positions where a
+// bot can stand (and be released) onto solid ground, not lava. On a lava-walled
+// map only a few exist, so bots contest them — like real players fighting over
+// the safe spots — instead of spreading evenly onto the lava.
+function computeSafeLanes(ctx, gate, standX) {
+    var lanes = [];
+    var topY = gate.y + 16, botY = gate.y + gate.height - 16;
+    for (var y = topY; y <= botY; y += 20) {
+        if (!isLavaAt(ctx, standX, y)) { lanes.push(y); }
+    }
+    return lanes;
+}
+
+// Gated phase: bots aren't racing yet (held inside the start gate). They press to
+// the front row, target a SAFE (non-lava) launch lane so they don't drive into
+// lava the instant the gate opens, and bursty-punch to contest a lane. Everyone
+// converges on the safe lanes, so they jostle for them. preventEscape keeps them
+// in the gate; lava can't kill here, only once racing starts.
+function steerGated(bot, ctx, dt) {
+    var ai = bot.ai || (bot.ai = newBotState(bot.profile));
+    var gate = ctx.gate;
+    var frontX = (gate ? gate.x + gate.width : 75) - bot.radius - 3;
+    var topY = (gate ? gate.y : 0) + bot.radius + 4;
+    var botYmax = (gate ? gate.y + gate.height : c.worldHeight) - bot.radius - 4;
+    var ty;
+    if (ctx.safeLanes && ctx.safeLanes.length > 0) {
+        // Each bot is assigned a safe lane by its seed so the field SPREADS across
+        // the available lanes (route diversity) instead of all converging on the
+        // nearest one. When safe lanes are scarce (lava-walled gate) several bots
+        // share a lane and jostle for it. Sticky per-bot jitter avoids exact stacks.
+        if (ai.gateJitter == null) { ai.gateJitter = (Math.random() - 0.5) * 16; }
+        ty = ctx.safeLanes[ai.pathSeed % ctx.safeLanes.length] + ai.gateJitter;
+    } else {
+        // No safe-lane reading: gentle shuffle along the gate (fallback).
+        if (ai.gateY == null) { ai.gateY = bot.y; }
+        ai.gateY += (Math.random() - 0.5) * 12;
+        if (ai.gateY < topY) { ai.gateY = topY; }
+        if (ai.gateY > botYmax) { ai.gateY = botYmax; }
+        ty = ai.gateY;
+    }
+    if (ty < topY) { ty = topY; } else if (ty > botYmax) { ty = botYmax; }
+    var dx = frontX - bot.x, dy = ty - bot.y;
+    var m = mag(dx, dy) || 1;
+    bot.targetDirX = (dx / m) * 0.75; // press to the front, not flat out
+    bot.targetDirY = (dy / m) * 0.75;
+    bot.braking = false;
+    bot.angle = Math.atan2(dy, dx) * (180 / Math.PI);
+    decideAttack(bot, ctx, { sharpTurn: false, lavaAhead: false }); // bursty jockey punches
+}
+
+function steerGatedPhase(gameBoard) {
+    var playerList = gameBoard.playerList;
+    var hasBot = false;
+    for (var id in playerList) { if (playerList[id].isAI && playerList[id].alive) { hasBot = true; break; } }
+    if (!hasBot) { return; }
+    var gate = gameBoard.startingGate;
+    var ctx = {
+        map: gameBoard.currentMap,
+        lavaId: c.tileMap.lava.id,
+        players: playerList,
+        projectileList: gameBoard.projectileList,
+        gate: gate,
+        infection: false, hockey: false, cloudy: false, lightning: false,
+        puck: null, clouds: [], blackoutActive: false, visionBlockedUntil: 0
+    };
+    // Where a gated bot ends up standing (front row, inside the gate); the lava
+    // check uses that X so a "safe lane" is one the bot can actually launch from.
+    var standX = gate ? gate.x + gate.width - 10 : 65;
+    ctx.safeLanes = gate ? computeSafeLanes(ctx, gate, standX) : [];
+    for (var pid in playerList) {
+        var bot = playerList[pid];
+        if (!bot.isAI || !bot.alive || bot.isSpectator) { continue; }
+        steerGated(bot, ctx);
+    }
+}
+
+// Entry point: steer every alive bot for this tick. Bots jockey during the gated
+// phase, race/avoid during racing & collapsing, and sit still otherwise.
+function update(gameBoard, currentState, dt) {
+    var map = gameBoard.currentMap;
+    if (map == null || !Array.isArray(map.cells) || map.cells.length === 0) {
+        return;
+    }
+    if (currentState === c.stateMap.gated) {
+        steerGatedPhase(gameBoard);
+        return;
+    }
+    if (currentState !== c.stateMap.racing && currentState !== c.stateMap.collapsing) {
+        return;
+    }
+    var hasBot = false;
+    var playerList = gameBoard.playerList;
+    for (var id in playerList) {
+        if (playerList[id].isAI && playerList[id].alive && !playerList[id].reachedGoal) { hasBot = true; break; }
+    }
+    if (!hasBot) { return; }
+
+    // Lava cell centers + goal tiles, rebuilt each tick (cells flip during collapse).
+    var lavaCells = [];
+    var goalTiles = [];
+    var LAVA = c.tileMap.lava.id;
+    var GOAL = c.tileMap.goal.id;
+    for (var li = 0; li < map.cells.length; li++) {
+        if (!map.cells[li] || !map.cells[li].site) { continue; }
+        if (map.cells[li].id === LAVA) {
+            lavaCells.push({ x: map.cells[li].site.x, y: map.cells[li].site.y });
+        } else if (map.cells[li].id === GOAL) {
+            goalTiles.push({ x: map.cells[li].site.x, y: map.cells[li].site.y });
+        }
+    }
+
+    // Cells holding a bumper hazard — bumpers aren't in the cell graph, so without
+    // this A* routes straight through them and the bot gets knocked/stuck. Penalize
+    // those cells so routes go AROUND. Recomputed each tick so a moving bumper's
+    // cell is tracked (re-pathing is throttled; local repulsion handles the rest).
+    var hazardCells = null;
+    var hazardList = gameBoard.hazardList;
+    for (var hkey in hazardList) {
+        var hz = hazardList[hkey];
+        if (!hz || hz.alive === false) { continue; }
+        var bestI = -1, bestD = Infinity;
+        for (var ci2 = 0; ci2 < map.cells.length; ci2++) {
+            var cc = map.cells[ci2];
+            if (!cc || !cc.site) { continue; }
+            var ddx = cc.site.x - hz.x, ddy = cc.site.y - hz.y;
+            var dd = ddx * ddx + ddy * ddy;
+            if (dd < bestD) { bestD = dd; bestI = ci2; }
+        }
+        if (bestI >= 0) {
+            if (hazardCells == null) { hazardCells = new Set(); }
+            hazardCells.add(map.cells[bestI].site.voronoiId);
+        }
+    }
+
+    // Within-race rubber-band: compare the leading human's progress-to-goal with
+    // the bot field's and ease the bots off when the human is behind, push them
+    // when the human is ahead. Straight-line distance to the nearest goal is the
+    // progress proxy. No human (or no goal) -> neutral.
+    var rubberBand = 1;
+    if (goalTiles.length > 0) {
+        var nearestGoalDist = function (px, py) {
+            var b = Infinity;
+            for (var g = 0; g < goalTiles.length; g++) {
+                var d = mag(goalTiles[g].x - px, goalTiles[g].y - py);
+                if (d < b) { b = d; }
+            }
+            return b;
+        };
+        var humanMin = Infinity, botDists = [];
+        for (var rid in playerList) {
+            var rp = playerList[rid];
+            if (!rp.alive || rp.isSpectator || rp.reachedGoal) { continue; }
+            var gd = nearestGoalDist(rp.x, rp.y);
+            if (rp.isAI) { botDists.push(gd); }
+            else if (gd < humanMin) { humanMin = gd; }
+        }
+        if (humanMin < Infinity && botDists.length > 0) {
+            botDists.sort(function (a, b) { return a - b; });
+            var botMed = botDists[Math.floor(botDists.length / 2)];
+            // Positive delta = human closer to a goal than the bots (leading).
+            var delta = (botMed - humanMin) / c.worldWidth;
+            if (delta > 1) { delta = 1; } else if (delta < -1) { delta = -1; }
+            rubberBand = 1 + delta * (c.aiRacers.rubberBandStrength || 0.18);
+        }
+    }
+    module.exports.lastRubberBand = rubberBand; // diagnostic for tests
+
+    // Active brutal modes + the special objects/state their strategies need.
+    var br = c.brutalRounds;
+    var infection = gameBoard.checkForActiveBrutal(br.infection.id);
+    var hockey = gameBoard.checkForActiveBrutal(br.hockey.id);
+    var cloudy = gameBoard.checkForActiveBrutal(br.cloudy.id);
+    var lightning = gameBoard.checkForActiveBrutal(br.lightning.id);
+    var puck = null, clouds = [];
+    if (hockey || cloudy) {
+        for (var prj in gameBoard.projectileList) {
+            var o = gameBoard.projectileList[prj];
+            if (hockey && o.type === "puck") { puck = o; }
+            else if (cloudy && o.type === "cloud") { clouds.push(o); }
+        }
+    }
+
+    var ctx = {
+        map: map,
+        lavaId: LAVA,
+        siteById: buildSiteIndex(map),
+        lavaCells: lavaCells,
+        goalTiles: goalTiles, // for zombie intercept (prey are racing to a goal)
+        hazardCells: hazardCells, // bumper cells to penalize in pathing
+        players: playerList,
+        projectileList: gameBoard.projectileList,
+        hazardList: gameBoard.hazardList,
+        collapsing: currentState === c.stateMap.collapsing,
+        collapseLoc: gameBoard.collapseLoc && gameBoard.collapseLoc.x != null ? gameBoard.collapseLoc : null,
+        collapseLine: gameBoard.collapseLine,
+        // Phase 5 brutal-round state
+        infection: infection,
+        hockey: hockey,
+        cloudy: cloudy,
+        lightning: lightning,
+        puck: puck,
+        clouds: clouds,
+        blackoutActive: gameBoard.blackoutActive === true,
+        visionBlockedUntil: gameBoard.visionBlockedUntil || 0,
+        rubberBand: rubberBand,
+        riskMult: 1 // overwritten per-bot in steerBot from personality risk
+    };
+
+    for (var pid in playerList) {
+        var bot = playerList[pid];
+        if (!bot.isAI || !bot.alive || bot.reachedGoal || bot.isSpectator) { continue; }
+        steerBot(bot, ctx, dt);
+    }
+}
+
+module.exports = { update: update };

--- a/server/cellGraph.js
+++ b/server/cellGraph.js
@@ -1,0 +1,406 @@
+// Cell adjacency graph + pathfinding over a map's Voronoi cells.
+//
+// Maps are player-made Voronoi diagrams. Adjacency is already encoded in the map
+// JSON: each cell carries site{x,y,voronoiId}, a tile id, and halfedges[] whose
+// edge.lSite/edge.rSite name the site on each side of the boundary. The neighbor
+// across an edge is whichever side's voronoiId differs from the cell's own;
+// boundary edges have a null lSite/rSite and are skipped (the world boundary is
+// the only wall — see engine.bounceOffBoundry).
+//
+// This is the shared foundation for fair single-player lava (spawn->goal "par
+// distance") and, later, bot navigation (A* to the nearest reachable goal).
+//
+// Passability is read LIVE from cell.id at query time (lava cells are blocked),
+// because tiles flip to lava during a collapse and "random" tiles resolve at
+// round start. Only the static adjacency (which cell borders which) is cached.
+
+var c = require('./config.json');
+
+// Cache adjacency (arrays of neighbor cell indices) keyed by map id + cell count.
+// currentMap is a JSON deep-copy per round (server/game.js determineNextMap), so
+// the cache can't live on the map object itself; geometry is identical for a
+// given source map, and the +cellCount guard rebuilds if an edited preview map
+// reuses an id with different geometry.
+var adjacencyCache = new Map();
+
+// Per-tile traversal cost multiplier ~ real travel TIME per unit distance, so the
+// path minimizes time, not arbitrary preference: it favours grass but takes a
+// direct sand shortcut when that's genuinely faster than a long grass detour.
+// Steady-state speed on a tile ∝ acel/drag, so time/distance ∝ drag/acel,
+// normalized to grass = 1.0: grass 2333, dirt 1200, sand 625 -> 1.0 / 1.9 / 3.7.
+// Ice/bumper get a control-risk bump above their raw time. Lava is blocked.
+//   grass = fast (id 2), dirt = normal (id 1), sand = slow (id 0).
+function tileWeight(id) {
+    switch (id) {
+        case c.tileMap.fast.id: return 1.0;   // grass — fastest (baseline)
+        case c.tileMap.normal.id: return 1.9; // dirt — ~2x grass time
+        case c.tileMap.slow.id: return 3.7;   // sand — ~3.7x grass time (avoid unless clearly shorter)
+        case c.tileMap.ice.id: return 2.5;    // fast but uncontrollable — penalize for control risk
+        case c.tileMap.bumper.id: return 3.0; // knockback hazard
+        default: return 1.0; // goal, ability, random
+    }
+}
+
+function buildAdjacency(map) {
+    var cells = map.cells;
+    var idToIndex = {};
+    for (var i = 0; i < cells.length; i++) {
+        if (cells[i] && cells[i].site && typeof cells[i].site.voronoiId === "number") {
+            idToIndex[cells[i].site.voronoiId] = i;
+        }
+    }
+    var neighbors = new Array(cells.length);
+    for (var ci = 0; ci < cells.length; ci++) {
+        var cell = cells[ci];
+        var set = {};
+        var list = [];
+        if (cell && cell.site && Array.isArray(cell.halfedges)) {
+            var own = cell.site.voronoiId;
+            for (var h = 0; h < cell.halfedges.length; h++) {
+                var he = cell.halfedges[h];
+                var edge = he && he.edge;
+                if (!edge) {
+                    continue;
+                }
+                // Exactly one of lSite/rSite is this cell's own site on an
+                // interior edge; the other is the neighbor. Boundary edges have
+                // a null on one side and are skipped.
+                var otherId = null;
+                if (edge.lSite && edge.lSite.voronoiId !== own) {
+                    otherId = edge.lSite.voronoiId;
+                } else if (edge.rSite && edge.rSite.voronoiId !== own) {
+                    otherId = edge.rSite.voronoiId;
+                }
+                if (otherId == null) {
+                    continue;
+                }
+                var ni = idToIndex[otherId];
+                if (ni != null && ni !== ci && !set[ni]) {
+                    set[ni] = true;
+                    list.push(ni);
+                }
+            }
+        }
+        neighbors[ci] = list;
+    }
+    return neighbors;
+}
+
+function getAdjacency(map) {
+    var key = (map.id != null ? map.id : "anon") + ":" + map.cells.length;
+    var entry = adjacencyCache.get(key);
+    if (entry && entry.count === map.cells.length) {
+        return entry.neighbors;
+    }
+    var neighbors = buildAdjacency(map);
+    adjacencyCache.set(key, { neighbors: neighbors, count: map.cells.length });
+    return neighbors;
+}
+
+// Minimal binary min-heap of { node, cost }. A* / Dijkstra over ~250 cells is
+// cheap, but bots re-path repeatedly so a heap keeps it linearithmic.
+function Heap() {
+    this.items = [];
+}
+Heap.prototype.push = function (node, cost) {
+    var items = this.items;
+    items.push({ node: node, cost: cost });
+    var i = items.length - 1;
+    while (i > 0) {
+        var parent = (i - 1) >> 1;
+        if (items[parent].cost <= items[i].cost) {
+            break;
+        }
+        var tmp = items[parent]; items[parent] = items[i]; items[i] = tmp;
+        i = parent;
+    }
+};
+Heap.prototype.pop = function () {
+    var items = this.items;
+    var top = items[0];
+    var last = items.pop();
+    if (items.length > 0) {
+        items[0] = last;
+        var i = 0, n = items.length;
+        while (true) {
+            var l = 2 * i + 1, r = 2 * i + 2, smallest = i;
+            if (l < n && items[l].cost < items[smallest].cost) smallest = l;
+            if (r < n && items[r].cost < items[smallest].cost) smallest = r;
+            if (smallest === i) break;
+            var tmp = items[smallest]; items[smallest] = items[i]; items[i] = tmp;
+            i = smallest;
+        }
+    }
+    return top;
+};
+Heap.prototype.size = function () {
+    return this.items.length;
+};
+
+function dist(a, b) {
+    var dx = a.x - b.x, dy = a.y - b.y;
+    return Math.sqrt(dx * dx + dy * dy);
+}
+
+// Index of the cell whose site is nearest to `point`. In a Voronoi diagram the
+// region containing a point is exactly the nearest-site cell.
+function nearestCellIndex(cells, point) {
+    var best = Infinity, bestIdx = 0;
+    for (var i = 0; i < cells.length; i++) {
+        var s = cells[i].site;
+        var dx = s.x - point.x, dy = s.y - point.y;
+        var d = dx * dx + dy * dy;
+        if (d < best) {
+            best = d;
+            bestIdx = i;
+        }
+    }
+    return bestIdx;
+}
+
+// Shortest traversable route from `point` to the nearest reachable goal cell.
+// Dijkstra over the live (lava-blocked) graph, edge cost = geometric site
+// distance x tileWeight(destination). Returns:
+//   { path: [voronoiId...], distance: <geometric path length>, goal: {x,y},
+//     goalIndex, startIndex }
+// or null if no goal is reachable. `distance` is the raw (unweighted) geometric
+// length, used for the single-player par-time estimate.
+//
+// options.blocked: optional Set/array of voronoiIds to treat as impassable (e.g.
+// already-collapsed cells a re-pathing bot must avoid).
+function findPathToNearestGoal(map, point, options) {
+    options = options || {};
+    if (!map || !Array.isArray(map.cells) || map.cells.length === 0) {
+        return null;
+    }
+    var cells = map.cells;
+    var neighbors = getAdjacency(map);
+    var LAVA = c.tileMap.lava.id;
+    var GOAL = c.tileMap.goal.id;
+
+    var blocked = null;
+    if (options.blocked) {
+        blocked = {};
+        var src = options.blocked.forEach ? null : options.blocked;
+        if (options.blocked.forEach) {
+            options.blocked.forEach(function (id) { blocked[id] = true; });
+        } else {
+            for (var bi = 0; bi < src.length; bi++) { blocked[src[bi]] = true; }
+        }
+    }
+
+    // Per-bot path diversity: a stable pseudo-random cost jitter keyed on the
+    // cell's voronoiId and the caller's noiseSeed, so different bots (different
+    // seeds) find different near-optimal routes instead of all taking the exact
+    // same line. Deterministic per (cell,seed) so Dijkstra stays consistent in a
+    // run. noiseAmount is the +/- fraction (e.g. 0.2 = +/-20%); 0 disables it.
+    var noiseAmount = options.noiseAmount || 0;
+    var noiseSeed = options.noiseSeed || 0;
+    function cellJitter(voronoiId) {
+        if (noiseAmount <= 0) { return 1; }
+        // 32-bit integer hash via Math.imul — plain `*` overflows 2^53 and loses
+        // precision (noiseSeed*668265263 ~ 6.7e17), mangling the mix.
+        var h = (Math.imul(voronoiId | 0, 374761393) + Math.imul(noiseSeed | 0, 668265263)) | 0;
+        h = Math.imul(h ^ (h >>> 13), 1274126177);
+        h = (h ^ (h >>> 16)) >>> 0;
+        var r = h / 0x100000000; // [0,1)
+        return 1 + (r - 0.5) * 2 * noiseAmount;
+    }
+
+    // Soft penalty for cells the caller wants the route to avoid but still cross as
+    // a last resort (e.g. cells holding bumper hazards, which aren't in the graph).
+    // A multiplier (not a hard block) so a hazard in a chokepoint doesn't null the
+    // path. options.penaltySet: Set/array of voronoiIds; options.penaltyMult: cost x.
+    var penaltyMult = options.penaltyMult || 1;
+    var penalty = null;
+    if (options.penaltySet && penaltyMult > 1) {
+        penalty = {};
+        if (options.penaltySet.forEach) {
+            options.penaltySet.forEach(function (id) { penalty[id] = true; });
+        } else {
+            for (var pj = 0; pj < options.penaltySet.length; pj++) { penalty[options.penaltySet[pj]] = true; }
+        }
+    }
+
+    var start = nearestCellIndex(cells, point);
+
+    var N = cells.length;
+    var cost = new Array(N).fill(Infinity);
+    var geo = new Array(N).fill(Infinity);
+    var prev = new Array(N).fill(-1);
+    var done = new Array(N).fill(false);
+    cost[start] = 0;
+    geo[start] = 0;
+
+    var heap = new Heap();
+    heap.push(start, 0);
+
+    var goalIndex = -1;
+    while (heap.size() > 0) {
+        var top = heap.pop();
+        var u = top.node;
+        if (done[u]) {
+            continue;
+        }
+        done[u] = true;
+        // Goal found: Dijkstra pops nodes in cost order, so this is the
+        // cheapest-cost reachable goal.
+        if (cells[u].id === GOAL) {
+            goalIndex = u;
+            break;
+        }
+        var nbrs = neighbors[u];
+        for (var k = 0; k < nbrs.length; k++) {
+            var v = nbrs[k];
+            if (done[v]) {
+                continue;
+            }
+            // Lava is impassable; so are caller-blocked cells. The goal is always
+            // enterable. The start cell is allowed even if it sits on lava.
+            if (cells[v].id === LAVA && cells[v].id !== GOAL) {
+                continue;
+            }
+            if (blocked && blocked[cells[v].site.voronoiId]) {
+                continue;
+            }
+            var step = dist(cells[u].site, cells[v].site);
+            var pen = (penalty && penalty[cells[v].site.voronoiId]) ? penaltyMult : 1;
+            var nc = cost[u] + step * tileWeight(cells[v].id) * cellJitter(cells[v].site.voronoiId) * pen;
+            if (nc < cost[v]) {
+                cost[v] = nc;
+                geo[v] = geo[u] + step;
+                prev[v] = u;
+                heap.push(v, nc);
+            }
+        }
+    }
+
+    if (goalIndex === -1) {
+        return null;
+    }
+
+    var path = [];
+    for (var node = goalIndex; node !== -1; node = prev[node]) {
+        path.push(cells[node].site.voronoiId);
+    }
+    path.reverse();
+
+    return {
+        path: path,
+        distance: geo[goalIndex],
+        goal: { x: cells[goalIndex].site.x, y: cells[goalIndex].site.y },
+        goalIndex: goalIndex,
+        startIndex: start
+    };
+}
+
+// Convenience: is any goal reachable (not lava-walled) from `point`?
+function reachableGoalExists(map, point) {
+    return findPathToNearestGoal(map, point) != null;
+}
+
+// Per-tile movement physics (accel + drag coefficient) from config.
+function tilePhysics(id) {
+    var tm = c.tileMap;
+    for (var k in tm) {
+        if (tm[k] && tm[k].id === id && tm[k].acel != null) {
+            return { acel: tm[k].acel, drag: tm[k].dragCoeff };
+        }
+    }
+    return { acel: tm.normal.acel, drag: tm.normal.dragCoeff };
+}
+
+// Estimate the seconds for the player's momentum car to drive `path` (voronoiIds)
+// under the REAL in-race physics: per-tile accel/drag, the velocity cap, starting
+// from rest, with NO gate speed bonus (it is zeroed the instant racing starts --
+// server/game.js startRacing), and a cornering brake (a momentum car must slow
+// for sharp turns). This is the honest "walk the A* path with the player's
+// physics" par-time, replacing distance / a flat assumed speed.
+function estimatePathTime(map, path) {
+    if (!map || !Array.isArray(map.cells) || !Array.isArray(path) || path.length < 2) {
+        return 0;
+    }
+    var cells = map.cells;
+    var idToIndex = {};
+    for (var i = 0; i < cells.length; i++) {
+        idToIndex[cells[i].site.voronoiId] = i;
+    }
+    var pts = [];
+    for (var p = 0; p < path.length; p++) {
+        var ci = idToIndex[path[p]];
+        if (ci == null) { continue; }
+        var cell = cells[ci];
+        var ph = tilePhysics(cell.id);
+        pts.push({ x: cell.site.x, y: cell.site.y, acel: ph.acel, drag: ph.drag });
+    }
+    if (pts.length < 2) { return 0; }
+    var dt = c.serverTickSpeed / 1000;
+    var maxV = c.playerMaxSpeed;
+    var v = 0, t = 0;
+    for (var seg = 0; seg < pts.length - 1; seg++) {
+        var a = pts[seg], b = pts[seg + 1];
+        if (seg > 0) {
+            // Brake for the turn at waypoint `seg`: keep less speed the sharper it is.
+            var px = pts[seg - 1];
+            var inx = a.x - px.x, iny = a.y - px.y;
+            var oux = b.x - a.x, ouy = b.y - a.y;
+            var im = Math.sqrt(inx * inx + iny * iny) || 1;
+            var om = Math.sqrt(oux * oux + ouy * ouy) || 1;
+            var dot = (inx * oux + iny * ouy) / (im * om);
+            if (dot > 1) { dot = 1; } else if (dot < -1) { dot = -1; }
+            var keep = Math.cos(Math.acos(dot) / 2); // 1 straight .. 0 u-turn
+            if (keep < 0.2) { keep = 0.2; }
+            v *= keep;
+        }
+        var dx = b.x - a.x, dy = b.y - a.y;
+        var segLen = Math.sqrt(dx * dx + dy * dy);
+        var traveled = 0, guard = 0;
+        while (traveled < segLen && guard < 200000) {
+            v = v + a.acel * dt - a.drag * v; // NO gate bonus in-race
+            if (v > maxV) { v = maxV; }
+            if (v < 5) { v = 5; }
+            traveled += v * dt;
+            t += dt;
+            guard++;
+        }
+    }
+    return t;
+}
+
+// Canonical per-map "par" time: the median real-physics drive time
+// (estimatePathTime) from the start gate (left edge) to the nearest reachable
+// goal, sampled down the gate height. A fixed property of a map's geometry, so
+// it's computed once (at map submission or server boot) and stored as
+// map.parTime rather than recomputed. Returns 0 if no goal is reachable.
+// NOTE: a solo player spawns at a RANDOM y in the gate, so the live solo
+// collapse still pars from the player's actual spawn; this canonical value is
+// for map metadata and the volcano round's eruption timing.
+function computeMapParTime(map) {
+    if (!map || !Array.isArray(map.cells) || map.cells.length === 0) {
+        return 0;
+    }
+    var H = c.worldHeight;
+    var step = H / 10;
+    if (step < 1) { step = 1; }
+    var pars = [];
+    for (var y = 40; y < H; y += step) {
+        var route = findPathToNearestGoal(map, { x: 40, y: y });
+        if (route != null) {
+            var par = estimatePathTime(map, route.path);
+            if (par > 0) { pars.push(par); }
+        }
+    }
+    if (pars.length === 0) { return 0; }
+    pars.sort(function (a, b) { return a - b; });
+    return pars[Math.floor(pars.length / 2)];
+}
+
+module.exports = {
+    getAdjacency: getAdjacency,
+    buildAdjacency: buildAdjacency,
+    findPathToNearestGoal: findPathToNearestGoal,
+    reachableGoalExists: reachableGoalExists,
+    tileWeight: tileWeight,
+    estimatePathTime: estimatePathTime,
+    computeMapParTime: computeMapParTime
+};

--- a/server/compressor.js
+++ b/server/compressor.js
@@ -171,6 +171,10 @@ function newPlayerPacket(player) {
 	packet[7] = player.awake;
 	packet[8] = player.onFire;
 	packet[9] = player.angle;
+	// Bot identity (null for human players, who stay nameless). Sent only in the
+	// spawn/append packets, not every tick — name/title are static.
+	packet[10] = player.name || null;
+	packet[11] = player.title || null;
 	return packet;
 }
 

--- a/server/config.json
+++ b/server/config.json
@@ -9,6 +9,31 @@
     "audienceNearBurnMargin": 70,
     "audienceNearBurnCooldown": 3500,
     "audienceClutchMargin": 150,
+    "soloCollapse": {
+        "marginFactor": 1.4,
+        "spawnBufferSeconds": 5,
+        "graceDelayFactor": 0.6,
+        "minGraceSeconds": 9,
+        "maxGraceSeconds": 12,
+        "minCollapseSpeed": 0.35,
+        "startDistanceBuffer": 150
+    },
+    "aiRacers": {
+        "enabled": true,
+        "minGrid": 6,
+        "maxGrid": 10,
+        "rubberBandStrength": 0.18,
+        "_traits": "skill 0..1 (speed+precision+reaction); aggression 0..1 (punch); tempo 0..1 (spend vs hoard abilities); risk 0..1 (tight lava lines / corner-cut); focus race|combat|human|chaos; tilt rage = reckless when behind",
+        "cast": [
+            { "id": "ghost", "name": "The Ghost", "title": "Pace-setter", "skill": 1.0, "aggression": 0.1, "tempo": 0.25, "risk": 0.15, "focus": "race", "emotes": { "win": ["😎", "👋"], "kill": ["😎"], "hurt": ["😳"], "cheer": ["👌"], "greet": ["👋", "😎"] } },
+            { "id": "bulldozer", "name": "Bulldozer", "title": "Wrecking Ball", "skill": 0.55, "aggression": 1.0, "tempo": 0.7, "risk": 0.7, "focus": "combat", "emotes": { "win": ["💪", "😤"], "kill": ["💪", "😤"], "hurt": ["😤"], "cheer": ["💪"], "greet": ["💪", "😤"] } },
+            { "id": "gambler", "name": "The Gambler", "title": "High Roller", "skill": 0.9, "aggression": 0.5, "tempo": 0.95, "risk": 1.0, "focus": "race", "emotes": { "win": ["👌", "😎"], "kill": ["😎"], "hurt": ["😨"], "cheer": ["👌"], "greet": ["👋", "👌"] } },
+            { "id": "nemesis", "name": "Nemesis", "title": "Your Shadow", "skill": 0.93, "aggression": 0.8, "tempo": 0.7, "risk": 0.45, "focus": "human", "emotes": { "win": ["😈"], "kill": ["😈"], "hurt": ["😤"], "cheer": ["🤔"], "greet": ["😈"] } },
+            { "id": "trickster", "name": "Trickster", "title": "Chaos Agent", "skill": 0.6, "aggression": 0.4, "tempo": 1.0, "risk": 0.55, "focus": "chaos", "emotes": { "win": ["😄", "🤔"], "kill": ["😎"], "hurt": ["🥱"], "cheer": ["😄", "👌"], "greet": ["😄", "👋"] } },
+            { "id": "tortoise", "name": "Tortoise", "title": "Slow and Steady", "skill": 0.7, "aggression": 0.15, "tempo": 0.25, "risk": 0.05, "focus": "race", "emotes": { "win": ["👌"], "kill": ["👌"], "hurt": ["😨"], "cheer": ["😄", "👌"], "greet": ["👋", "😄"] } },
+            { "id": "hothead", "name": "Hothead", "title": "Loose Cannon", "skill": 0.7, "aggression": 0.6, "tempo": 0.6, "risk": 0.5, "focus": "race", "tilt": "rage", "emotes": { "win": ["😤"], "kill": ["😤"], "hurt": ["😳"], "cheer": ["😎"], "greet": ["😤", "👋"] } }
+        ]
+    },
     "minPlayersToStart": 1,
     "maxPlayersInRoom": 25,
     "forceConstant": 5000,
@@ -207,6 +232,10 @@
         "volcano": {
             "id": 1007,
             "collapseSpeed": 1,
+            "parFactor": 1.0,
+            "eruptionParBonus": 3,
+            "minEruptionDelay": 7,
+            "maxEruptionDelay": 65,
             "active": true,
             "title": "Volcano"
         },

--- a/server/game.js
+++ b/server/game.js
@@ -6,9 +6,51 @@ var hostess = require('./hostess.js');
 var _engine = require('./engine.js');
 var compressor = require('./compressor.js');
 var debug = require('./debug.js');
+var cellGraph = require('./cellGraph.js');
+var aiController = require('./aiController.js');
 
 exports.getRoom = function (sig, size) {
 	return new Room(sig, size);
+}
+
+// Monotonic id source for headless AI racers. Bot ids are namespaced ("bot-N")
+// so they never collide with socket ids (which key human players in playerList).
+var botSeq = 0;
+
+// Reactive bot emotes: pick a chat-wheel emoji from the personality's emote set
+// for an event category (win/kill/hurt/cheer/greet) and broadcast a one-shot
+// botEmote. Each bot is rate-limited to one emote every 45-90s (randomized per bot
+// so they don't all chime at once and the chatter stays sparse). Bots use the full
+// emotional range — celebrating, clapping for others, reacting to hits — not just
+// taunting. The client renders it as a speech bubble. The cooldown lives on the
+// Player and is NOT cleared by reset(), so the cadence holds across rounds.
+function emitBotEmote(player, category) {
+	if (player == null || !player.isAI || player.profile == null) {
+		return;
+	}
+	var emotes = player.profile.emotes;
+	if (emotes == null || emotes[category] == null || emotes[category].length === 0) {
+		return;
+	}
+	var now = Date.now();
+	if (player.emoteReadyAt != null && now < player.emoteReadyAt) {
+		return;
+	}
+	player.emoteReadyAt = now + utils.getRandomInt(45000, 90000);
+	var opts = emotes[category];
+	var emote = opts[Math.floor(Math.random() * opts.length)];
+	messenger.messageRoomBySig(player.roomSig, "botEmote", { id: player.id, emote: emote });
+}
+
+// When a racer reaches the goal, other AI racers react — a wheel emote, often a
+// clap/acknowledgement (cheer), throttled so only a couple pipe up.
+function botsCheerFor(playerList, finisherId) {
+	for (var id in playerList) {
+		var p = playerList[id];
+		if (p.isAI && p.alive && id !== finisherId && Math.random() < 0.3) {
+			emitBotEmote(p, "cheer");
+		}
+	}
 }
 
 class Room {
@@ -72,6 +114,12 @@ class Room {
 	}
 	checkAFK() {
 		for (var id in this.playerList) {
+			// Bots have no socket/mailbox; messageClientBySig would throw. They
+			// also never set kick (Player.update skips checkForSleep for AI), but
+			// guard here too so a bot can never reach the socket-only kick path.
+			if (this.playerList[id].isAI) {
+				continue;
+			}
 			if (this.playerList[id].kick) {
 				messenger.messageClientBySig(id, "serverKick", null);
 				hostess.kickFromRoom(id);
@@ -111,6 +159,8 @@ class Game {
 		this.notchesToWin = c.baseNotchesToWin;
 		this.firstPlaceSig = null;
 		this.secondPlaceSig = null;
+		//AI racers: grid size is rolled once per game and held across rounds.
+		this.botTarget = null;
 
 		//Timers
 		this.lobbyWaitTime = c.lobbyWaitTime;
@@ -365,6 +415,8 @@ class Game {
 					this.playerList[player].addNotch(this.notchesToWin);
 					this.playerList[player].addNotch(this.notchesToWin);
 					this.gameBoard.firstPlaceSig = player;
+					emitBotEmote(this.playerList[player], "win");
+					botsCheerFor(this.playerList, player); // others clap/react
 					this.startCollapse(this.playerList[player].x, this.playerList[player].y);
 					messenger.messageRoomBySig(this.roomSig, "firstPlaceWinner", player);
 					continue;
@@ -388,6 +440,12 @@ class Game {
 		if (this.alivePlayerCount == 1) {
 			if (this.currentState != c.stateMap.collapsing && !this.collapseInitated) {
 				this.collapseInitated = true;
+				// A true single-player room (no rivals, no bots) gets a collapse
+				// tuned to the map so a competent line can win, instead of the
+				// map-blind 15s/random-goal last-player collapse.
+				if (this.playerCount == 1 && this.scheduleSoloCollapse()) {
+					return;
+				}
 				setTimeout(function (context) {
 					if (context.currentState == c.stateMap.racing || context.currentState == c.stateMap.collapsing) {
 						var goal = context.gameBoard.findRandomGoalTile();
@@ -399,6 +457,170 @@ class Game {
 				}, 15000, this);
 			}
 		}
+	}
+	// Fill the race grid with headless AI racers. Called at the start of each
+	// race (startGated). The grid total is rolled once per game (botTarget) and
+	// held across rounds; we only ever top up toward it, never despawn bots when
+	// humans join mid-game. A bot-only room is never created (humanCount == 0
+	// bails). Bots are spawned exactly like a joining human — added to playerList
+	// (not clientList), placed by determineGameState for the current state, and
+	// announced with playerJoin so connected clients render them.
+	fillGridWithBots() {
+		var ai = c.aiRacers;
+		if (!ai || !ai.enabled) {
+			return;
+		}
+		var humanCount = 0, botCount = 0;
+		for (var pid in this.playerList) {
+			if (this.playerList[pid].isAI) { botCount++; } else { humanCount++; }
+		}
+		if (humanCount === 0) {
+			return;
+		}
+		if (this.botTarget == null) {
+			this.botTarget = utils.getRandomInt(ai.minGrid, ai.maxGrid);
+		}
+		var desiredBots = this.botTarget - humanCount;
+		if (desiredBots < 0) { desiredBots = 0; }
+		if (desiredBots <= botCount) {
+			return;
+		}
+		var roster = this.pickBotCast(desiredBots);
+		for (var i = botCount; i < desiredBots; i++) {
+			var id = "bot-" + (++botSeq);
+			var bot = this.world.createNewBot(id, roster[i]);
+			this.playerList[id] = bot;
+			this.determineGameState(bot);
+			messenger.messageRoomBySig(this.roomSig, "playerJoin", {
+				id: id,
+				player: compressor.appendPlayer(bot)
+			});
+		}
+	}
+	// Draw `count` racer identities from the config cast. Distinct personalities
+	// while the cast lasts (shuffled), then repeats with a numeric suffix so the
+	// grid can exceed the cast size without confusing duplicate names. Biased to
+	// open with the pace-setter (Ghost) and the rival (Nemesis) when present.
+	pickBotCast(count) {
+		var cast = (c.aiRacers && c.aiRacers.cast) ? c.aiRacers.cast.slice() : [];
+		if (cast.length === 0) {
+			cast = [{ id: "racer", name: "Racer", title: "Racer" }];
+		}
+		// Fisher-Yates shuffle.
+		for (var s = cast.length - 1; s > 0; s--) {
+			var j = Math.floor(Math.random() * (s + 1));
+			var tmp = cast[s]; cast[s] = cast[j]; cast[j] = tmp;
+		}
+		// Float Ghost then Nemesis to the front so a typical race has a pace-setter
+		// and a rival without forcing them every time the grid is small.
+		this.floatToFront(cast, "nemesis");
+		this.floatToFront(cast, "ghost");
+		var roster = [];
+		for (var i = 0; i < count; i++) {
+			var base = cast[i % cast.length];
+			var rep = Math.floor(i / cast.length);
+			if (rep === 0) {
+				roster.push(base);
+			} else {
+				// A repeat shares the base personality's FULL profile (skill, traits,
+				// emotes) — only the name is suffixed — so it behaves and emotes like
+				// its namesake rather than a generic, silent bot.
+				var dup = Object.assign({}, base);
+				dup.name = base.name + " " + (rep + 1);
+				roster.push(dup);
+			}
+		}
+		return roster;
+	}
+	floatToFront(cast, id) {
+		for (var i = 0; i < cast.length; i++) {
+			if (cast[i].id === id) {
+				var picked = cast.splice(i, 1)[0];
+				cast.unshift(picked);
+				return;
+			}
+		}
+	}
+	// Drop all AI racers and re-roll the grid size for the next game.
+	removeBots() {
+		for (var id in this.playerList) {
+			if (this.playerList[id].isAI) {
+				messenger.messageRoomBySig(this.roomSig, "playerLeft", id);
+				delete this.playerList[id];
+			}
+		}
+		this.botTarget = null;
+	}
+	// Schedule a fair, map-aware collapse for a solo player. Uses the Phase 0
+	// cell graph to find the goal nearest the player's current position and the
+	// shortest traversable distance to it, derives a "par time" from that
+	// distance and the player's realistic speed, then collapses from that goal at a
+	// front speed slower than that realistic speed by config.soloCollapse.marginFactor
+	// (so an optimal line beats it with margin to spare). Returns true if a solo
+	// collapse was scheduled, false to fall back to the legacy last-player path
+	// (e.g. no reachable goal from where the player is).
+	scheduleSoloCollapse() {
+		var player = null;
+		for (var id in this.playerList) {
+			var p = this.playerList[id];
+			if (p.alive && !p.isSpectator && !p.isZombie && p.awake) {
+				player = p;
+				break;
+			}
+		}
+		if (player == null) {
+			return false;
+		}
+		var map = this.gameBoard.currentMap;
+		var route = cellGraph.findPathToNearestGoal(map, { x: player.x, y: player.y });
+		if (route == null) {
+			// No goal reachable without crossing lava from where the player is.
+			// Flag it and let the lenient legacy collapse run so the room never
+			// soft-locks on an unbeatable layout.
+			console.warn("Solo map has no goal reachable from player position (mapId=" + map.id + "); using fallback collapse.");
+			return false;
+		}
+
+		var cfg = c.soloCollapse;
+		var secondsPerTick = c.serverTickSpeed / 1000;
+		// Par = the map's stored canonical par (physics drive gate->nearest goal)
+		// plus a buffer for the random gate-spawn y (a solo player can spawn farther
+		// from the goal than the canonical line). Live fallback if the map lacks it.
+		var parTime = (map.parTime != null && map.parTime > 0) ? map.parTime : cellGraph.estimatePathTime(map, route.path);
+		if (parTime <= 0) { parTime = route.distance / 40; }
+		parTime += cfg.spawnBufferSeconds;
+
+		// Front starts at the player's path distance from the goal (cap at the
+		// world diagonal so a very mazey route doesn't create a long dead lead-in)
+		// plus a buffer so the player's current cell isn't lava on the first tick.
+		var worldDiagonal = Math.sqrt(this.world.width * this.world.width + this.world.height * this.world.height);
+		var startDistance = Math.min(route.distance, worldDiagonal) + cfg.startDistanceBuffer;
+
+		// Front closes the whole start distance in parTime * marginFactor seconds,
+		// so it adapts to how slow/twisty the map actually is and a competent line
+		// always beats it. (Was a flat speed that outran players on hard maps.)
+		var collapseSpeed = (startDistance / (parTime * cfg.marginFactor)) * secondsPerTick;
+		if (collapseSpeed < cfg.minCollapseSpeed) {
+			collapseSpeed = cfg.minCollapseSpeed;
+		}
+
+		var grace = parTime * cfg.graceDelayFactor;
+		if (grace < cfg.minGraceSeconds) grace = cfg.minGraceSeconds;
+		if (grace > cfg.maxGraceSeconds) grace = cfg.maxGraceSeconds;
+
+		this.gameBoard.soloMode = true;
+		this.gameBoard.soloCollapseSpeed = collapseSpeed;
+		this.gameBoard.soloStartDistance = startDistance;
+
+		var context = this;
+		var goal = route.goal;
+		setTimeout(function () {
+			if (context.currentState == c.stateMap.racing || context.currentState == c.stateMap.collapsing) {
+				context.gameBoard.collapseLine = context.gameBoard.soloStartDistance;
+				context.startCollapse(goal.x, goal.y);
+			}
+		}, grace * 1000);
+		return true;
 	}
 	startWaiting() {
 		messenger.messageRoomBySig(this.roomSig, "startWaiting", null);
@@ -501,11 +723,21 @@ class Game {
 		this.resetForRace();
 		this.currentState = this.stateMap.gated;
 		this.gameBoard.setupMap(this.currentState);
+		// Fill the grid with AI racers after the map (and starting gate) are laid
+		// out, so each bot can be placed at the gate via determineGameState.
+		this.fillGridWithBots();
 		messenger.messageRoomBySig(this.roomSig, "startGated", null);
 	}
 	startRace() {
 		console.log("Start Race");
 		this.currentState = this.stateMap.racing;
+
+		// A few AI racers greet/hype as the gate opens (full emote range, not just taunts).
+		for (var gid in this.playerList) {
+			if (this.playerList[gid].isAI && Math.random() < 0.3) {
+				emitBotEmote(this.playerList[gid], "greet");
+			}
+		}
 
 		var lightningRound = this.gameBoard.checkForActiveBrutal(c.brutalRounds.lightning.id);
 
@@ -515,7 +747,7 @@ class Game {
 			}
 		}
 		if (this.gameBoard.checkForActiveBrutal(c.brutalRounds.volcano.id)) {
-			var eruptionDelay = utils.getRandomInt(8, 15);
+			var eruptionDelay = this.gameBoard.computeVolcanoEruptionDelay();
 			if (lightningRound) {
 				eruptionDelay = utils.getRandomInt(1, 4);
 			}
@@ -561,7 +793,11 @@ class Game {
 		console.log("Start Collapse");
 		this.currentState = this.stateMap.collapsing;
 		this.gameBoard.startCollapse({ x: xloc, y: yloc });
-		messenger.messageRoomBySig(this.roomSig, "startCollapse", null);
+		// Telegraph: erupt the shockwave from where the lava FIRST appears (the
+		// point farthest from the collapse center, which turns to lava first),
+		// not from the goal it converges on.
+		var origin = this.gameBoard.getCollapseOrigin({ x: xloc, y: yloc });
+		messenger.messageRoomBySig(this.roomSig, "startCollapse", { x: xloc, y: yloc, originX: origin.x, originY: origin.y });
 	}
 	resetLobbyTimer() {
 		this.lobbyTimer = null;
@@ -581,6 +817,9 @@ class Game {
 		this.notchesToWin = c.baseNotchesToWin;
 		this.currentMusic = null;
 		this.musicChangedAt = null;
+		// A full game is over: drop the AI racers and re-roll the grid for the
+		// next game so the cast and field size vary game to game.
+		this.removeBots();
 		this.gameBoard.resetGame(this.currentState);
 		messenger.messageRoomBySig(this.roomSig, "resetGame", null);
 	}
@@ -604,13 +843,19 @@ class Game {
 		return playerCount;
 	}
 	checkForDynamicGameLength() {
-		//For every dynamicGameLengthModifier players the number of notches to win decreases by 1
+		//For every dynamicGameLengthModifier players the number of notches to win decreases by 1.
+		//Count HUMANS only — AI racers fill the grid but shouldn't shorten the game
+		//(otherwise a solo human + bots would collapse to the minimum notches).
 		var dynamicGameLengthModifier = 6;
 
-		if (this.playerCount < dynamicGameLengthModifier) {
+		var humanCount = 0;
+		for (var hid in this.playerList) {
+			if (!this.playerList[hid].isAI) { humanCount++; }
+		}
+		if (humanCount < dynamicGameLengthModifier) {
 			return;
 		}
-		var notchesToRemove = Math.ceil(this.playerCount / dynamicGameLengthModifier);
+		var notchesToRemove = Math.ceil(humanCount / dynamicGameLengthModifier);
 		var minimumNotches = c.minimumNotchesToWin;
 		if (this.notchesToWin - notchesToRemove <= minimumNotches) {
 			this.notchesToWin = minimumNotches;
@@ -746,6 +991,11 @@ class GameBoard {
 		this.allAbilityIDs = this.indexAbilities();
 		this.collapseLoc = {};
 		this.collapseLine = this.world.height;
+		this.visionBlockedUntil = 0;
+		this.blackoutActive = false;
+		this.soloMode = false;
+		this.soloCollapseSpeed = c.lastPlayerCollapseSpeed;
+		this.soloStartDistance = this.world.height + 400;
 		this.firstPlaceSig = null;
 		// Room-wide throttle (ms timestamp) so the crowd's near-burn gasp fires
 		// at most once per audienceNearBurnCooldown, no matter how many racers
@@ -755,6 +1005,9 @@ class GameBoard {
 	update(currentState, playerAliveCount, sleepingPlayerCount, dt) {
 		this.alivePlayerCount = playerAliveCount;
 		this.sleepingPlayerCount = sleepingPlayerCount;
+		// Drive the AI racers' steering before the engine integrates movement, so
+		// bots set the same targetDir/braking/angle inputs a human's socket would.
+		aiController.update(this, currentState, dt);
 		this.engine.update(dt);
 		this.collapseMap(currentState);
 		this.checkCollisions(currentState);
@@ -870,6 +1123,10 @@ class GameBoard {
 	}
 	checkAbilities(currentState) {
 		for (var id in this.abilityList) {
+			if (this.abilityList[id] == null) {
+				delete this.abilityList[id];
+				continue;
+			}
 			if (this.abilityList[id].swap) {
 				this.abilityList[id].swap = false;
 				var aimer = new SwapAimer(this.playerList[this.abilityList[id].ownerId].x, this.playerList[this.abilityList[id].ownerId].y, c.tileMap.abilities.swap.startSize, "red", this.abilityList[id].ownerId, this.roomSig);
@@ -890,7 +1147,13 @@ class GameBoard {
 			}
 			if (this.abilityList[id].explodeBomb) {
 				this.abilityList[id].explodeBomb = false;
-				this.projectileList[this.abilityList[id].ownerId].explodeBomb();
+				// The bomb may already be gone (auto-expired after its lifetime, or
+				// detonated) by the time the trigger fires — guard the deref so
+				// triggering a spent bomb just clears the trigger instead of crashing.
+				var bombProj = this.projectileList[this.abilityList[id].ownerId];
+				if (bombProj != null) {
+					bombProj.explodeBomb();
+				}
 			}
 			if (this.abilityList[id].applyBuff) {
 				this.abilityList[id].applyBuff = false;
@@ -903,6 +1166,12 @@ class GameBoard {
 			if (this.abilityList[id].tileSwap) {
 				this.abilityList[id].tileSwap = false;
 				this.swapTiles();
+			}
+			if (this.abilityList[id].blind) {
+				this.abilityList[id].blind = false;
+				// Room-wide vision block: bots self-handicap their steering for the
+				// duration so a blindfold bites the AI as it bites a human.
+				this.visionBlockedUntil = Date.now() + c.tileMap.abilities.blindfold.duration * 1000;
 			}
 			if (this.abilityList[id].applyCut) {
 				this.abilityList[id].applyCut = false;
@@ -927,7 +1196,11 @@ class GameBoard {
 				player.lobbyRespawnPending = null;
 			}
 			if (player.acquiredAbility != null) {
-				this.abilityList[playerID] = player.ability;
+				// Never register a null ability — a null entry would crash
+				// checkAbilities on the next tick (it reads abilityList[id].flag).
+				if (player.ability != null) {
+					this.abilityList[playerID] = player.ability;
+				}
 				if (player.acquiredAbility.mapID != null) {
 					var consumedVid = player.acquiredAbility.mapID;
 					this.changeTile(consumedVid, c.tileMap.normal.id);
@@ -1494,6 +1767,42 @@ class GameBoard {
 	startCollapse(loc) {
 		this.collapseLoc = loc;
 	}
+	// Where the lava first appears for a collapse centered at loc: the cell
+	// farthest from loc (the collapse turns the farthest cells to lava first,
+	// then closes inward toward loc). Used to telegraph the eruption origin.
+	getCollapseOrigin(loc) {
+		var cells = this.currentMap.cells;
+		var best = loc, bestD = -1;
+		if (cells != null) {
+			for (var i = 0; i < cells.length; i++) {
+				if (cells[i].id == c.tileMap.goal.id) { continue; }
+				var d = utils.getMag(loc.x - cells[i].site.x, loc.y - cells[i].site.y);
+				if (d > bestD) { bestD = d; best = { x: cells[i].site.x, y: cells[i].site.y }; }
+			}
+		}
+		return best;
+	}
+	// Seconds for a competent line to reach the nearest goal from the start gate
+	// (graph par-time at the realistic player speed) so a volcano round erupts
+	// "around par" -- scaled to the map, not a flat random delay. Samples a few
+	// points down the gate and uses the shortest reachable line; falls back to a
+	// random 8-15s if no goal is reachable.
+	computeVolcanoEruptionDelay() {
+		var vcfg = c.brutalRounds.volcano;
+		// Use the map's stored canonical par (computed at submission/boot); only
+		// compute live if this map somehow lacks it.
+		var bestPar = this.currentMap.parTime;
+		if (bestPar == null || bestPar <= 0) {
+			bestPar = cellGraph.computeMapParTime(this.currentMap);
+		}
+		if (!(bestPar > 0)) {
+			return utils.getRandomInt(8, 15);
+		}
+		var delay = bestPar * vcfg.parFactor + vcfg.eruptionParBonus;
+		if (delay < vcfg.minEruptionDelay) { delay = vcfg.minEruptionDelay; }
+		if (delay > vcfg.maxEruptionDelay) { delay = vcfg.maxEruptionDelay; }
+		return delay;
+	}
 	collapseMap(currentState) {
 		if (currentState != c.stateMap.collapsing) {
 			return;
@@ -1505,6 +1814,11 @@ class GameBoard {
 		if (this.firstPlaceSig == null) {
 
 			collapseSpeed = c.lastPlayerCollapseSpeed;
+
+			//Solo player: map-aware collapse speed tuned to spawn->goal distance
+			if (this.soloMode) {
+				collapseSpeed = this.soloCollapseSpeed;
+			}
 
 			//Brutal round is active
 			if (this.checkForActiveBrutal(c.brutalRounds.volcano.id)) {
@@ -1607,6 +1921,12 @@ class GameBoard {
 		var loc = this.startingGate.findFreeLoc(player);
 		player.x = loc.x;
 		player.y = loc.y;
+		// Sync the engine's integration position too. The engine advances newX/newY
+		// and then move() copies them back to x/y, so a player whose newX/newY were
+		// never set (a freshly spawned bot still at the constructor's 0,0) would snap
+		// to that stale point on the first tick instead of staying at the gate.
+		player.newX = loc.x;
+		player.newY = loc.y;
 		if (!this.checkForActiveBrutal(c.brutalRounds.lightning.id)) {
 			player.setSpeedBonus(500);
 		}
@@ -1654,8 +1974,14 @@ class GameBoard {
 		this.lobbyStartButton = null;
 		this.collapseLoc = {};
 		this.collapseLine = this.world.height + 400;
+		this.soloMode = false;
+		this.soloCollapseSpeed = c.lastPlayerCollapseSpeed;
+		this.soloStartDistance = this.world.height + 400;
 		this.tileChanges = {};
 		this.pendingAbilityTimers = []; // bound growth; lobby ones are canceled in clearLobbyAbilities
+		// AI vision-fairness state, reset each round.
+		this.visionBlockedUntil = 0;
+		this.blackoutActive = false;
 		this.resetProjectiles();
 		this.resetHazards();
 	}
@@ -1836,6 +2162,9 @@ class GameBoard {
 	}
 	applyBrutalBlackoutRound(packet) {
 		var context = packet.context;
+		// Blackout lasts the rest of the round; bots self-handicap their steering
+		// for fairness (a human can only see a small circle around themselves).
+		context.gameBoard.blackoutActive = true;
 		messenger.messageRoomBySig(context.roomSig, "applyBlackout", context.roomSig);
 	}
 
@@ -2179,6 +2508,22 @@ class World extends Rect {
 		var player = new Player(0, 0, 90, color, id, this.roomSig);
 		return player;
 	}
+	// A headless AI racer: a Player with no socket, flagged isAI, given an
+	// identity (name/title/personality) from the config cast. Reuses the same
+	// unique-color picker so bots are visually distinct from the human and each
+	// other. The bot brain (aiController) drives it via targetDirX/Y/braking.
+	createNewBot(id, identity) {
+		var color = this.getUniqueColorR();
+		var bot = new Player(0, 0, 90, color, id, this.roomSig);
+		bot.isAI = true;
+		bot.name = identity.name;
+		bot.title = identity.title;
+		bot.personality = identity.id;
+		// Full personality profile (trait weights) for the AI brain; the
+		// suffix-numbered duplicates share their base personality's traits.
+		bot.profile = identity;
+		return bot;
+	}
 	spawnPlayerRandomLoc(player) {
 		var loc = this.findFreeLoc(player);
 		player.initialLoc = loc;
@@ -2387,10 +2732,29 @@ class Player extends Circle {
 		this.acel = c.playerBaseAcel;
 
 		this.currentSpeedBonus = 0;
+
+		//AI (set on bot players by world.createNewBot; humans leave these untouched)
+		this.isAI = false;
+		this.name = null;
+		this.title = null;
+		this.personality = null;
+		this.profile = null;
+		this.emoteReadyAt = 0;
+		//Steering outputs the engine's isAI branch reads each tick.
+		this.targetDirX = 0;
+		this.targetDirY = 0;
+		this.braking = false;
+		//Scratch space for the bot brain (aiController) — path cache, timers, etc.
+		this.ai = null;
 	}
 	update(currentState, dt) {
 		this.currentState = currentState;
-		this.checkForSleep(currentState);
+		// Bots have no socket and never AFK — the sleep/kick path ends in
+		// messageClientBySig (Room.checkAFK), which would throw on a socketless
+		// bot. Skip it entirely; bots stay awake for their whole life.
+		if (!this.isAI) {
+			this.checkForSleep(currentState);
+		}
 		if (this.alive == false) {
 			return;
 		}
@@ -2503,6 +2867,7 @@ class Player extends Circle {
 		clearTimeout(multiKillIndex);
 		this.roundKills += 1;
 		this.totalKills += 1;
+		emitBotEmote(this, "kill");
 		this.addFire(c.playerKillFireBonus);
 		if (player.fellFromVictory) {
 			this.savior += 1;
@@ -2668,6 +3033,7 @@ class Player extends Circle {
 			}
 			_engine.punchPlayer(this, object);
 			messenger.messageRoomBySig(this.roomSig, "playerPunched", object.ownerId);
+			emitBotEmote(this, "hurt"); // an AI racer reacts to getting knocked
 			return;
 		}
 		if (object.isPuck) {
@@ -2921,6 +3287,11 @@ class Player extends Circle {
 		this.infected = false;
 		this.isZombie = false;
 		this.exploded = false;
+		// Drop any stale AI path from the previous round so the bot re-paths fresh
+		// on the new map instead of steering toward old-map coordinates. Identity,
+		// personality knobs and the emote cooldown live on the Player/profile and
+		// are intentionally preserved.
+		if (this.ai != null) { this.ai.waypoints = null; this.ai.repathTimer = 0; }
 		this.x = this.initialLoc.x;
 		this.y = this.initialLoc.y;
 		this.newX = this.x;
@@ -3309,12 +3680,16 @@ class Blindfold extends Ability {
 	constructor(owner, roomSig) {
 		super(owner, roomSig);
 		this.id = c.tileMap.abilities.blindfold.id;
+		this.blind = false;
 	}
 	use() {
 		if (this.alive == false) {
 			return;
 		}
 		this.alive = false;
+		// Flag the room-wide blind so checkAbilities can record it for the AI
+		// vision-fairness self-handicap (bots read state, not pixels).
+		this.blind = true;
 		messenger.messageRoomBySig(this.roomSig, "blindfoldUsed", this.ownerId);
 	}
 }

--- a/server/utils.js
+++ b/server/utils.js
@@ -7,6 +7,7 @@ var soundListing = [];
 var imgListing = [];
 
 var c = require('./config.json');
+var cellGraph = require('./cellGraph.js');
 c.port = process.env.PORT || c.port;
 
 let octokitInstance;
@@ -128,6 +129,10 @@ exports.submitPullRequest = async function (map) {
             sha: head.object.sha,
         })
 
+        // Embed the canonical par time so the committed map carries it.
+        if (map.parTime == null) {
+            map.parTime = cellGraph.computeMapParTime(map);
+        }
         var bufferObj = Buffer.from(JSON.stringify(map, null, 2), 'utf8');
         var base64String = bufferObj.toString("base64");
         var title = 'INSERT - ' + map.name + "/" + map.author + " from " + email;
@@ -397,7 +402,14 @@ function loadMaps() {
     fs.readdirSync(normalizedPath).forEach(function (file) {
         if (file != ".DS_Store") {
             mapListing.push(file);
-            maps.push(require("../client/maps/" + file));
+            var loadedMap = require("../client/maps/" + file);
+            // Par-time is a fixed property of a map's geometry; compute it once
+            // at boot for any map lacking it (submitted maps embed it). Deep
+            // copies (currentMap) preserve the number.
+            if (loadedMap.parTime == null) {
+                loadedMap.parTime = cellGraph.computeMapParTime(loadedMap);
+            }
+            maps.push(loadedMap);
         }
     });
 }


### PR DESCRIPTION
## AI racers + fair single-player lava

Adds headless **AI racers** that fill out solo and small games so there's always a full grid to race, built on a **fair single-player lava** foundation that makes solo rounds winnable.

### What players get
- **A full grid to race.** Solo/small games fill to a random 6–10 total with named AI racers (humans count against the total). Always-on, with a config kill switch.
- **They actually race.** A* over the map's Voronoi cell graph → pure-pursuit steering with predictive lava feelers, a throttle governor, grass-preference / sand-avoidance (time-accurate tile costs), bumper-hazard routing, and per-bot route diversity. Bots flee the collapse.
- **They fight.** Pick up and use every ability (bomb throw→detonate, swaps, speed buffs/slows, ice, blindfold, tileSwap, cut) and punch — including shoving rivals toward the lava. Combat happens in bursts, not a punch-lock.
- **Brutal rounds.** Zombies hunt and head off prey across the lava to infect them (healthy bots fend them off); bots dodge/clear the hockey puck; lightning caution; and — fair's fair — they lose their bearings in blackout/blindfold/clouds (a server-side actor would otherwise be immune).
- **Personalities + difficulty.** Seven distinct characters (pace-setter, wrecking ball, high-roller, your-shadow rival, chaos agent, tortoise, hothead) via config trait weights, with a within-race rubber-band that eases off when you're behind and pushes when you're ahead so a win feels earned. Names + titles render under each kart and they emote in character (chat-wheel emojis, rate-limited).
- **Fair solo lava (foundation).** The collapse is now tuned per map: a "par time" from a real physics walk of the spawn→nearest-goal path drives a winnable collapse, the front converges on the goal nearest your path, and a directional shockwave telegraphs it. Volcano rounds erupt on a par-scaled timer.

### Implementation
- New `server/aiController.js` (the bot brain, run each tick before the engine integrates movement — it writes the same `targetDir/braking/angle/attack` a human's socket would) and `server/cellGraph.js` (cell adjacency + Dijkstra + physics-accurate par-time). Bots are socketless `Player` objects in `playerList` only; the AFK/kick path is guarded.
- Tunables live in `config.aiRacers` (enabled, grid min/max, rubber-band strength, the personality cast). No new dependencies; fully server-authoritative.
- A couple of small pre-existing fixes surfaced and fixed along the way: a stuck gated-phase goal ping, a bombTrigger deref of an expired bomb, and `drawFire`'s flame only rendering at 8-way angles.

### Testing
Verified headless across all 49 committed maps: the CI boot+tick smoke test plus per-phase harnesses (grid fill, navigation, abilities, brutal modes, personalities, identity) — **0 crashes / 0 NaN**. Bundle builds.

### Notes for reviewers
- Bots can win games and earn achievement medals (they're real racers). A future auth/XP/progression hook should filter `bot-` ids out of winner/leaderboard payloads.
- Pre-existing: the start gate's `getSafeLoc` doesn't avoid lava, so on lava-heavy maps a player (human **or** bot) can spawn on a lava lane and die at the gun. Bots mitigate by contesting the safe lanes during the gate phase; a proper fix (spawns prefer non-lava) would help humans too and is left as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
