### PR TITLE
Animation & game-feel polish pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- Big pass on animations and game feel: punches now swing with an impact spark, hits and explosions shake the screen with weight, abilities telegraph and flash when used, and players kick up dust at speed and trail embers while on fire.
+- Punches are now directional — your punch lands in front of you, so you have to face an opponent to knock them away. Bashing the hockey puck and swatting infected players stay all-directional, but zombies have to face their prey to bite.
+
+### Ability changes
+
+- Tile Swap now warns before it fires — the tiles about to flip pulse and flicker, and the swap itself lands a few seconds later instead of instantly.
 
 ## v0.5.0 — 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 - Big pass on animations and game feel: punches now swing with an impact spark, hits and explosions shake the screen with weight, abilities telegraph and flash when used, and players kick up dust at speed and trail embers while on fire.
 - Punches are now directional — your punch lands in front of you, so you have to face an opponent to knock them away. Bashing the hockey puck and swatting infected players stay all-directional, but zombies have to face their prey to bite.
+- AI racers move a little faster now, cruising closer to human pace.
 
 ### Ability changes
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -332,6 +332,7 @@ function registerPrimaryHandlers(server) {
 
 	server.on("punch", function (packet) {
 		var punch = spawnPunch(packet);
+		spawnPunchEffect(punch);
 		var owner = playerList[punch.ownerId];
 		if (owner != null && owner.infected) {
 			playSound(zombieSwing);
@@ -347,6 +348,7 @@ function registerPrimaryHandlers(server) {
 	});
 	server.on("spawnBomb", function (owner) {
 		spawnBomb(owner);
+		fireMuzzleFlash(owner, "#ffcf8f");
 		playSound(bombShot);
 	});
 	server.on("spawnPuck", function (owner) {
@@ -355,17 +357,38 @@ function registerPrimaryHandlers(server) {
 	});
 	server.on("applyBlackout", function (owner) {
 		blackout = true;
+		blackoutStart = Date.now();
 		playSound(blackoutSound);
 	});
 
 	server.on("spawnSnowFlake", function (owner) {
 		spawnSnowFlake(owner);
+		fireMuzzleFlash(owner, "#bfefff");
 		playSound(bombShot);
 	});
 	server.on("spawnClouds", function (packet) {
 		spawnClouds(packet);
 	});
-	server.on("playerPunched", function (owner) {
+	server.on("playerPunched", function (payload) {
+		// payload: { owner: attacker id, victim: id of whoever got hit, x, y: the
+		// victim's position }. victim may be a non-player target (e.g. the hockey
+		// puck), so use the payload position rather than a playerList lookup for
+		// the spark — that way bashing the puck still gets a hit effect.
+		var owner = payload != null ? payload.owner : null;
+		var victim = payload != null ? payload.victim : null;
+		var victimPlayer = playerList[victim];
+		var hitX = victimPlayer != null ? victimPlayer.x : (payload != null ? payload.x : null);
+		var hitY = victimPlayer != null ? victimPlayer.y : (payload != null ? payload.y : null);
+		if (hitX != null && hitY != null) {
+			var sparkColor = playerList[owner] != null ? playerList[owner].color : "white";
+			spawnHitEffect(hitX, hitY, sparkColor);
+			// Feel a connecting hit when a local player is on either end of it —
+			// but not during the gated countdown (jostling at the start line
+			// shouldn't rattle the camera while everyone's waiting to race).
+			if ((isLocalId(victim) || isLocalId(owner)) && currentState != config.stateMap.gated) {
+				addTrauma(0.28);
+			}
+		}
 		// Only a real scrum — several hits landing in quick succession — reads as
 		// "a fight broke out." A single punch (or one multi-hit swing) shouldn't
 		// trigger it, and once it fires the crowd stays quiet for a while so it
@@ -404,15 +427,33 @@ function registerPrimaryHandlers(server) {
 	});
 	server.on('explodedCells', function (cells) {
 		if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing || currentState == config.stateMap.lobby) {
+			var center = cellsCentroid(cells);
 			explodedCells(cells);
+			if (center != null) {
+				spawnExplosion(center.x, center.y, config.tileMap.abilities.bomb.explosionRadius);
+			}
 			playSound(bombExplosion);
-			rumbleScreen(100);
+			addTrauma(0.5);
 		}
 	});
-	server.on("snowFlakeExploded", function (owner) {
+	server.on("snowFlakeExploded", function (payload) {
 		if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing || currentState == config.stateMap.lobby) {
+			// payload carries the true detonation point { owner, x, y }; fall back
+			// to the projectile's last position (older shape) if needed. Using the
+			// sent point means the blast renders even if the flake was already
+			// removed by a terminateProj/gameUpdates arriving first.
+			var ex = (payload != null && payload.x != null) ? payload.x : null;
+			var ey = (payload != null && payload.y != null) ? payload.y : null;
+			if (ex == null) {
+				var owner = (payload != null && payload.owner != null) ? payload.owner : payload;
+				var flake = projectileList[owner];
+				if (flake != null) { ex = flake.x; ey = flake.y; }
+			}
+			if (ex != null && ey != null) {
+				spawnExplosion(ex, ey, config.tileMap.abilities.iceCannon.explosionRadius, "#9fe8ff");
+			}
 			playSound(iceExplosion);
-			rumbleScreen(100);
+			addTrauma(0.45);
 		}
 	});
 	server.on("firstBlood", function () {
@@ -517,6 +558,22 @@ function registerPrimaryHandlers(server) {
 			changeTilesBulk(tileChanges);
 		});
 	});
+	// The tiles a tileSwap is about to flip — clients pulse/flicker them for the
+	// (random 3-6s) warn-up before the swap actually lands.
+	server.on("tileSwapPending", function (payload) {
+		$.when.apply($, promises).then(function () {
+			var data = JSON.parse(payload);
+			markPendingSwap(data.ids, data.duration);
+		});
+	});
+	// Fires the instant the swap actually flips the tiles — drives the delayed
+	// swap sound and clears the telegraph for exactly the tiles that flipped.
+	server.on("tileSwapPerformed", function (payload) {
+		$.when.apply($, promises).then(function () {
+			var ids = JSON.parse(payload);
+			tileSwapLanded(ids);
+		});
+	});
 
 	server.on("projBounced", function () {
 		if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing || currentState == config.stateMap.lobby) {
@@ -542,12 +599,17 @@ function registerPrimaryHandlers(server) {
 	});
 	server.on("cutUsed", function (owner) {
 		playSound(cutSound);
+		var cutter = playerList[owner];
+		if (cutter != null) {
+			spawnSlashEffect(cutter.x, cutter.y, cutter.angle, cutter.color);
+		}
 		playerAbilityUsed(owner);
-		rumbleScreen(100);
+		addTrauma(0.4);
 	});
 	server.on("tileSwap", function (owner) {
+		// The swap is telegraphed then delayed (see tileSwapPending); the sound
+		// now plays when the tiles actually flip (see tileSwapPerformed), not here.
 		playerAbilityUsed(owner);
-		playSound(tileSwap);
 	});
 	server.on("iceCannon", function (owner) {
 		playerAbilityUsed(owner);
@@ -556,18 +618,20 @@ function registerPrimaryHandlers(server) {
 	server.on("lavaExplosion", function () {
 		if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing) {
 			playSound(lavaExplosion);
-			rumbleScreen(100);
+			spawnScreenFlash("#ff5a1a", 0.3, 300);
+			addTrauma(0.5);
 		}
 	});
 	server.on("spawnExplosionAimer", function (owner) {
 		spawnExplosionAimer(owner);
 		aimerList[owner].startExplosionCountDown = true;
+		aimerList[owner].countdownStart = Date.now();
+		aimerList[owner].countdownDuration = config.explosionWarnTime * 1000;
 
 		for (var i = 1; i < config.explosionWarnTime + 1; i++) {
 			addTimer(function (params) {
 				if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing) {
 					playSound(teleportWarnSound);
-					params.explosionPulse = true;
 				}
 			}, i * 1000, aimerList[owner]);
 			if (i == config.explosionWarnTime) {
@@ -583,12 +647,13 @@ function registerPrimaryHandlers(server) {
 		playerAbilityUsed(owner);
 		spawnSwapAimer(owner);
 		aimerList[owner].startSwapCountDown = true;
+		aimerList[owner].countdownStart = Date.now();
+		aimerList[owner].countdownDuration = config.tileMap.abilities.swap.warnTime;
 
 		for (var i = 1; i < (config.tileMap.abilities.swap.warnTime / 1000) + 1; i++) {
 			addTimer(function (params) {
 				if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing) {
 					playSound(teleportWarnSound);
-					params.swapCountDownPulse = true;
 				}
 			}, i * 1000, aimerList[owner]);
 			if (i == (config.tileMap.abilities.swap.warnTime / 1000)) {
@@ -600,9 +665,25 @@ function registerPrimaryHandlers(server) {
 			}
 		}
 	});
-	server.on("playerSwapped", function (owner) {
-		if (aimerList[owner].startSwapCountDown) {
-			aimerList[owner].startSwapCountDown = false;
+	server.on("playerSwapped", function (payload) {
+		// payload: { owner, points: [end A, end B] } — the two world positions the
+		// swapped players occupy just after exchanging. Puffing at both ends puts
+		// the effect where players actually appear/vanish; reading the owner's
+		// live position instead would land on the pre-swap spot, since the new
+		// coordinates only arrive in a later gameUpdates.
+		var data = (typeof payload === "string") ? JSON.parse(payload) : payload;
+		var owner = data != null ? data.owner : null;
+		var swapColor = playerList[owner] != null ? playerList[owner].color : "white";
+		var aimer = aimerList[owner];
+		if (aimer != null && aimer.startSwapCountDown) {
+			aimer.startSwapCountDown = false;
+		}
+		if (data != null && data.points != null) {
+			for (var pi = 0; pi < data.points.length; pi++) {
+				spawnTeleportPuff(data.points[pi].x, data.points[pi].y, swapColor);
+			}
+		} else if (playerList[owner] != null) {
+			spawnTeleportPuff(playerList[owner].x, playerList[owner].y, swapColor);
 		}
 		playSound(teleportSound);
 	});
@@ -611,19 +692,30 @@ function registerPrimaryHandlers(server) {
 	});
 	server.on("volcanoEruption", function () {
 		playSound(volcanoErupt);
-		rumbleScreen(2500);
+		spawnScreenFlash("#ff7a18", 0.28, 400);
+		rumbleSustained(2500, 0.7);
 	});
 
 	server.on("speedBuff", function (owner) {
 		playSound(speedBuff);
+		if (playerList[owner] != null) {
+			playerList[owner].speedBuffUntil = Date.now() + config.tileMap.abilities.speedBuff.duration;
+		}
 		playerAbilityUsed(owner);
 	});
 
 	server.on("speedDebuff", function (owner) {
 		playSound(speedDebuff);
+		if (playerList[owner] != null) {
+			playerList[owner].speedDebuffUntil = Date.now() + config.tileMap.abilities.speedDebuff.duration;
+		}
 		playerAbilityUsed(owner);
 	});
 	server.on("triggerUsed", function (owner) {
+		var p = playerList[owner];
+		if (p != null) {
+			spawnTriggerPulse(p.x, p.y, p.color);
+		}
 		playerAbilityUsed(owner);
 	});
 	server.on("startLobbyTimer", function () {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1244,14 +1244,21 @@ function drawMapTitle() {
 }
 
 function drawPlayers(dt) {
+    // Draw remote players first, then ALL local players (the primary plus any
+    // couch co-op slots) on top — so your own karts always read clearly over
+    // other players' floating emojis and name labels.
     for (var id in playerList) {
-        var player = playerList[id];
-        if (id == myID) {
+        if (isLocalId(id)) {
             continue;
         }
-        checkDrawPlayer(player, dt);
+        checkDrawPlayer(playerList[id], dt);
     }
-    checkDrawPlayer(playerList[myID], dt);
+    for (var lid in playerList) {
+        if (!isLocalId(lid)) {
+            continue;
+        }
+        checkDrawPlayer(playerList[lid], dt);
+    }
 }
 function checkDrawPlayer(player, dt) {
     if (player == null) {
@@ -1424,9 +1431,9 @@ function drawEmoji(player) {
     }
 }
 
-// AI racers carry a visible name (and, smaller, their title) below the kart so
-// each personality is recognizable. Aligned with the sprite's camera convention
-// (camera offset is 0 in the default desktop view). Humans have no name.
+// AI racers carry a visible name below the kart so each personality is
+// recognizable. Aligned with the sprite's camera convention (camera offset is 0
+// in the default desktop view). Humans have no name.
 function drawBotName(player) {
     // Use the same raw-coord convention as the emote/chat bubble (drawEmoji) so the
     // name and the bubble stay attached to each other. camera.getCameraX/Y is 0 in
@@ -1443,12 +1450,6 @@ function drawBotName(player) {
     gameContext.font = '11px Times New Roman';
     gameContext.strokeText(player.name, x, y);
     gameContext.fillText(player.name, x, y);
-    if (player.title != null) {
-        gameContext.globalAlpha = 0.38;
-        gameContext.font = 'italic 9px Times New Roman';
-        gameContext.strokeText(player.title, x, y + 11);
-        gameContext.fillText(player.title, x, y + 11);
-    }
     gameContext.restore();
 }
 

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -374,7 +374,7 @@ function drawObjects(dt) {
     applyCanvasTransform();
     drawBackground(dt);
     if (currentState == config.stateMap.overview) {
-        screenShake = false;
+        shakeTrauma = 0;
         drawOverviewBoard();
         return;
     }
@@ -396,6 +396,7 @@ function drawObjects(dt) {
         currentState == config.stateMap.collapsing) {
         drawGate();
         drawMap();
+        drawPendingSwap();
         drawPingCircles();
         drawCollapseShockwaves();
     }
@@ -403,8 +404,8 @@ function drawObjects(dt) {
         drawGateLine();
     }
     drawPlayers(dt);
-    drawPunches();
-    drawProjectiles();
+    drawProjectiles(dt);
+    drawEffects();
     drawAbilties();
     drawOverlay();
     postShake();
@@ -734,13 +735,16 @@ function preShake() {
     if (currentState == config.stateMap.gameOver || currentState == config.stateMap.overview) {
         return;
     }
-    if (screenShake == true) {
+    if (shakeTrauma > 0) {
         gameContext.save();
-        // This translate runs under the world transform; divide by the camera
-        // zoom so the shake is a constant on-screen magnitude at any zoom level.
+        // Offset scales with trauma^2 so small hits barely nudge while big ones
+        // really kick, and it's bidirectional (the old code only ever drifted
+        // down-right). Runs under the world transform, so divide by the camera
+        // zoom to keep a constant on-screen magnitude at any scale.
         var s = (worldView && worldView.scale) ? worldView.scale : 1;
-        var dx = Math.random() * 15 / s;
-        var dy = Math.random() * 15 / s;
+        var mag = maxShakeOffset * shakeTrauma * shakeTrauma / s;
+        var dx = (Math.random() * 2 - 1) * mag;
+        var dy = (Math.random() * 2 - 1) * mag;
         gameContext.translate(dx, dy);
     }
 }
@@ -748,37 +752,332 @@ function postShake() {
     if (currentState == config.stateMap.gameOver || currentState == config.stateMap.overview) {
         return;
     }
-    if (screenShake == true) {
+    if (shakeTrauma > 0) {
         gameContext.restore();
     }
 }
 
-function drawPunches() {
-    for (var id in punchList) {
-        drawPunch(punchList[id]);
+// Walk the effects list and render each one with its own normalized progress
+// (t in 0..1). drawEffects runs inside the world transform (camera zoom/pan +
+// shake), which is correct for world-anchored effects — they follow the camera
+// like the players and projectiles do. Screen-space effects (full-screen
+// flashes) must ignore all of that and cover the viewport at any zoom/pan.
+function drawEffects() {
+    if (effectsList.length === 0) {
+        return;
+    }
+    for (var i = 0; i < effectsList.length; i++) {
+        var e = effectsList[i];
+        var t = clamp01(e.age / e.maxAge);
+        gameContext.save();
+        // For screen-space effects, reset ONLY this context to the logical HUD
+        // matrix. We can't call applyCanvasTransform() here: it also resets
+        // overlayContext, which drawOverlay() (blackout) still needs in world
+        // space later this same pass. The enclosing save/restore undoes this.
+        if (e.screen) {
+            gameContext.setTransform(canvasScaleX, 0, 0, canvasScaleY, 0, 0);
+        }
+        e.draw(gameContext, t, e);
+        gameContext.restore();
     }
 }
 
-function drawPunch(punch) {
-    var punchSize = punch.radius;
-    var player = playerList[punch.ownerId];
-    if (player != null && player.infected == true) {
-        punchSize = config.brutalRounds.infection.punchRadius;
+// Seeded by the server "punch" event (the punch object itself only lives
+// ~100ms). The original three-part look — a quick impact pop, an expanding
+// shockwave ring, and a directional sweep — but scaled down so nothing exceeds
+// ~1.8x the real punch radius (the first cut sprawled to ~3x). The pop + ring
+// are radial and always shown; the sweep is added only for directional punches
+// (radial punches — hockey, survivors swatting zombies, bumpers — skip it).
+function spawnPunchEffect(punch) {
+    if (punch == null) {
+        return;
     }
-    gameContext.save();
-    gameContext.beginPath();
-    gameContext.fillStyle = punch.color;
-    gameContext.arc(punch.x, punch.y, punchSize, 0, 2 * Math.PI);
-    gameContext.fill();
-    gameContext.restore();
+    var owner = playerList[punch.ownerId];
+    var infected = owner != null && owner.infected === true;
+    var baseRadius = infected ? config.brutalRounds.infection.punchRadius : punch.radius;
+    var color = infected ? "#7CFC00" : punch.color;
+    // Derive the swing direction from where the server actually placed the
+    // punch hitbox (offset punchReach in front of the player at throw time),
+    // not the owner's live angle — a player who keeps turning would otherwise
+    // make the sweep point away from where the hit really landed.
+    var angleDeg = null;
+    if (punch.directional && owner != null) {
+        var ddx = punch.x - owner.x;
+        var ddy = punch.y - owner.y;
+        angleDeg = (ddx * ddx + ddy * ddy > 0.0001) ? Math.atan2(ddy, ddx) * 180 / Math.PI : owner.angle;
+    }
+    var px = punch.x;
+    var py = punch.y;
+    addEffect({
+        x: px,
+        y: py,
+        maxAge: 220,
+        draw: function (ctx, t) {
+            var grow = easeOutCubic(t);
+            ctx.lineCap = "round";
+            // Impact pop — a disc that scales up and fades fast (tops ~1.3x).
+            ctx.globalAlpha = (1 - t) * 0.5;
+            ctx.fillStyle = color;
+            ctx.beginPath();
+            ctx.arc(px, py, baseRadius * (0.55 + 0.75 * grow), 0, 2 * Math.PI);
+            ctx.fill();
+            // Expanding shockwave ring (tops ~1.6x — was 2.5x).
+            ctx.globalAlpha = (1 - t);
+            ctx.lineWidth = 2 * (1 - t) + 1;
+            ctx.strokeStyle = color;
+            ctx.beginPath();
+            ctx.arc(px, py, baseRadius * (0.8 + 0.8 * grow), 0, 2 * Math.PI);
+            ctx.stroke();
+            // Directional sweep — a crescent that thrusts out in the facing
+            // direction and narrows as it fades (tops ~1.8x — was 3.1x; thinner).
+            if (angleDeg != null && t < 0.6) {
+                var st = clamp01(t / 0.6);
+                var center = angleDeg * Math.PI / 180;
+                var half = 0.95 * (1 - st * 0.4);
+                var reach = baseRadius * (1.1 + 0.7 * st);
+                ctx.globalAlpha = (1 - st) * 0.85;
+                ctx.lineWidth = baseRadius * 0.45 * (1 - st) + 1.5;
+                ctx.beginPath();
+                ctx.arc(px, py, reach, center - half, center + half);
+                ctx.stroke();
+            }
+        }
+    });
+}
 
-    gameContext.save();
-    gameContext.beginPath();
-    gameContext.lineWidth = 1;
-    gameContext.strokeStyle = "black";
-    gameContext.arc(punch.x, punch.y, punchSize, 0, 2 * Math.PI);
-    gameContext.stroke();
-    gameContext.restore();
+// Burst at the point of contact when a punch connects — a white flash ring
+// plus radiating sparks, so a landed hit has a visible payoff.
+function spawnHitEffect(x, y, color) {
+    addEffect({
+        x: x,
+        y: y,
+        maxAge: 220,
+        draw: function (ctx, t) {
+            var p = easeOutCubic(t);
+            ctx.save();
+            ctx.translate(x, y);
+            ctx.lineCap = "round";
+            ctx.globalAlpha = (1 - t);
+            ctx.strokeStyle = "white";
+            ctx.lineWidth = 3 * (1 - t) + 1;
+            ctx.beginPath();
+            ctx.arc(0, 0, 6 + 22 * p, 0, 2 * Math.PI);
+            ctx.stroke();
+            ctx.strokeStyle = color || "white";
+            ctx.lineWidth = 2 * (1 - t) + 1;
+            for (var i = 0; i < 6; i++) {
+                var a = (i / 6) * Math.PI * 2 + 0.3;
+                var r0 = 2.8 + 8.4 * p;
+                var r1 = 8.4 + 18.2 * p;
+                ctx.beginPath();
+                ctx.moveTo(Math.cos(a) * r0, Math.sin(a) * r0);
+                ctx.lineTo(Math.cos(a) * r1, Math.sin(a) * r1);
+                ctx.stroke();
+            }
+            ctx.restore();
+        }
+    });
+}
+
+// Teleport flash for the swap ability — an expanding ring plus particles
+// spiralling outward, so a swap reads as a "poof" instead of a silent blink.
+function spawnTeleportPuff(x, y, color) {
+    addEffect({
+        x: x,
+        y: y,
+        maxAge: 360,
+        draw: function (ctx, t) {
+            var p = easeOutCubic(t);
+            ctx.save();
+            ctx.translate(x, y);
+            ctx.globalAlpha = (1 - t) * 0.9;
+            ctx.strokeStyle = color || "white";
+            ctx.lineWidth = 3 * (1 - t) + 1;
+            ctx.beginPath();
+            ctx.arc(0, 0, 8 + 38 * p, 0, 2 * Math.PI);
+            ctx.stroke();
+            ctx.fillStyle = color || "white";
+            for (var i = 0; i < 8; i++) {
+                var a = (i / 8) * Math.PI * 2 + t * 3;
+                var r = 6 + 30 * p;
+                ctx.globalAlpha = (1 - t);
+                ctx.beginPath();
+                ctx.arc(Math.cos(a) * r, Math.sin(a) * r, 2.5 * (1 - t) + 0.5, 0, 2 * Math.PI);
+                ctx.fill();
+            }
+            ctx.restore();
+        }
+    });
+}
+
+// Bright slash streak along the cut axis (both directions through the cutter),
+// a white core inside a coloured glow that flashes and fades quickly.
+function spawnSlashEffect(x, y, angleDeg, color) {
+    var a = angleDeg * Math.PI / 180;
+    var len = config.worldWidth;
+    var dx = Math.cos(a) * len;
+    var dy = Math.sin(a) * len;
+    addEffect({
+        x: x,
+        y: y,
+        maxAge: 280,
+        draw: function (ctx, t) {
+            ctx.save();
+            ctx.lineCap = "round";
+            ctx.globalAlpha = (1 - t) * 0.6;
+            ctx.strokeStyle = color || "white";
+            ctx.lineWidth = (10 * (1 - t)) + 2;
+            ctx.shadowColor = color || "white";
+            ctx.shadowBlur = 12 * (1 - t);
+            ctx.beginPath();
+            ctx.moveTo(x - dx, y - dy);
+            ctx.lineTo(x + dx, y + dy);
+            ctx.stroke();
+            ctx.globalAlpha = (1 - t);
+            ctx.strokeStyle = "white";
+            ctx.lineWidth = (4 * (1 - t)) + 1;
+            ctx.shadowBlur = 0;
+            ctx.beginPath();
+            ctx.moveTo(x - dx, y - dy);
+            ctx.lineTo(x + dx, y + dy);
+            ctx.stroke();
+            ctx.restore();
+        }
+    });
+}
+
+// A small fireball at a blast site — a hot radial flash, a white shock ring,
+// and a scatter of debris sparks. Used by bombs (and reused, tinted, for ice).
+function spawnExplosion(x, y, radius, color) {
+    color = color || "#ff7a18";
+    radius = radius || 70;
+    addEffect({
+        x: x,
+        y: y,
+        maxAge: 430,
+        draw: function (ctx, t) {
+            var p = easeOutCubic(t);
+            ctx.save();
+            ctx.translate(x, y);
+            // Hot core: a radial gradient that blooms then fades.
+            var coreR = radius * (0.4 + 0.9 * p);
+            var grad = ctx.createRadialGradient(0, 0, 0, 0, 0, coreR);
+            grad.addColorStop(0, "rgba(255,245,200," + (1 - t) + ")");
+            grad.addColorStop(0.5, color);
+            grad.addColorStop(1, "rgba(0,0,0,0)");
+            ctx.globalAlpha = (1 - t) * 0.85;
+            ctx.fillStyle = grad;
+            ctx.beginPath();
+            ctx.arc(0, 0, coreR, 0, 2 * Math.PI);
+            ctx.fill();
+            // Shock ring.
+            ctx.globalAlpha = (1 - t);
+            ctx.strokeStyle = "rgba(255,255,255,0.9)";
+            ctx.lineWidth = 3 * (1 - t) + 1;
+            ctx.beginPath();
+            ctx.arc(0, 0, radius * (0.6 + 1.0 * p), 0, 2 * Math.PI);
+            ctx.stroke();
+            // Debris sparks.
+            ctx.fillStyle = color;
+            for (var i = 0; i < 10; i++) {
+                var a = (i / 10) * Math.PI * 2 + 0.2;
+                var r = radius * (0.3 + 1.1 * p);
+                ctx.globalAlpha = (1 - t);
+                ctx.beginPath();
+                ctx.arc(Math.cos(a) * r, Math.sin(a) * r, 2.5 * (1 - t) + 0.5, 0, 2 * Math.PI);
+                ctx.fill();
+            }
+            ctx.restore();
+        }
+    });
+}
+
+// Brief full-screen colour wash (e.g. the red flash when a Brutal Round
+// begins). Drawn in screen space, so it ignores world coordinates.
+function spawnScreenFlash(color, peakAlpha, maxAge) {
+    addEffect({
+        screen: true,
+        x: 0,
+        y: 0,
+        maxAge: maxAge || 250,
+        draw: function (ctx, t) {
+            ctx.save();
+            ctx.globalAlpha = (1 - t) * (peakAlpha || 0.35);
+            ctx.fillStyle = color || "red";
+            // drawEffects resets screen effects to the logical HUD matrix, so
+            // fill the logical viewport (a small margin guards against rounding).
+            ctx.fillRect(-40, -40, LOGICAL_WIDTH + 80, LOGICAL_HEIGHT + 80);
+            ctx.restore();
+        }
+    });
+}
+
+// Muzzle flash when a bomb/ice cannon is fired — a bright forward cone with a
+// couple of streaks, at the player's front edge in the facing direction. The
+// "recoil kick" is a small screen shake added for the local shooter.
+function spawnMuzzleFlash(x, y, angleDeg, color) {
+    var a = angleDeg * Math.PI / 180;
+    addEffect({
+        x: x,
+        y: y,
+        maxAge: 160,
+        draw: function (ctx, t) {
+            var p = easeOutCubic(t);
+            var reach = 8 + 20 * p;
+            var spread = 6 * (1 - t) + 3;
+            ctx.save();
+            ctx.translate(x, y);
+            ctx.rotate(a);
+            // Flash cone.
+            ctx.globalAlpha = (1 - t) * 0.9;
+            ctx.fillStyle = color;
+            ctx.beginPath();
+            ctx.moveTo(0, 0);
+            ctx.lineTo(reach, -spread);
+            ctx.lineTo(reach + 6, 0);
+            ctx.lineTo(reach, spread);
+            ctx.closePath();
+            ctx.fill();
+            // Hot white streaks down the middle.
+            ctx.globalAlpha = (1 - t);
+            ctx.strokeStyle = "white";
+            ctx.lineCap = "round";
+            ctx.lineWidth = 2 * (1 - t) + 0.5;
+            for (var i = -1; i <= 1; i++) {
+                ctx.beginPath();
+                ctx.moveTo(2, i * 3);
+                ctx.lineTo(reach * 0.8, i * 4);
+                ctx.stroke();
+            }
+            ctx.restore();
+        }
+    });
+}
+
+// Detonator feedback when the bomb-trigger ability is pressed — a quick ring +
+// inner flash at the player (the blast itself fireballs at the bomb's location).
+function spawnTriggerPulse(x, y, color) {
+    addEffect({
+        x: x,
+        y: y,
+        maxAge: 200,
+        draw: function (ctx, t) {
+            var p = easeOutCubic(t);
+            ctx.save();
+            ctx.globalAlpha = (1 - t);
+            ctx.strokeStyle = color || "white";
+            ctx.lineWidth = 3 * (1 - t) + 1;
+            ctx.beginPath();
+            ctx.arc(x, y, 6 + 18 * p, 0, 2 * Math.PI);
+            ctx.stroke();
+            ctx.globalAlpha = (1 - t) * 0.5;
+            ctx.fillStyle = color || "white";
+            ctx.beginPath();
+            ctx.arc(x, y, 5 * (1 - t), 0, 2 * Math.PI);
+            ctx.fill();
+            ctx.restore();
+        }
+    });
 }
 
 function drawAbilties() {
@@ -791,12 +1090,30 @@ function drawAbilties() {
 
     if (blindfold.color != null) {
         gameContext.save();
+        gameContext.globalAlpha = blindfoldAlpha();
         gameContext.beginPath();
         gameContext.fillStyle = blindfold.color;
         gameContext.rect(world.x, world.y, world.width, world.height);
         gameContext.fill();
         gameContext.restore();
     }
+}
+
+// Ease the blindfold in and out instead of snapping the solid fill on/off.
+function blindfoldAlpha() {
+    if (blindfold.start == null || !blindfold.duration) {
+        return 1;
+    }
+    var e = Date.now() - blindfold.start;
+    var fadeIn = 200;
+    var fadeOut = 500;
+    if (e < fadeIn) {
+        return clamp01(e / fadeIn);
+    }
+    if (e > blindfold.duration - fadeOut) {
+        return clamp01((blindfold.duration - e) / fadeOut);
+    }
+    return 1;
 }
 
 // The player objects for every LOCAL player (slot) that is currently alive. On a
@@ -838,45 +1155,75 @@ function drawOverlay() {
         overlayContext.save();
         overlayContext.globalCompositeOperation = 'destination-out';
         var sprite = getBlackoutHoleSprite();
+        var scale = blackoutHoleScale();
+        var w = sprite.width * scale;
+        var h = sprite.height * scale;
         for (var i = 0; i < living.length; i++) {
             var p = living[i];
-            overlayContext.drawImage(sprite, p.x - sprite.width / 2, p.y - sprite.height / 2);
+            overlayContext.drawImage(sprite, p.x - w / 2, p.y - h / 2, w, h);
         }
         overlayContext.restore();
     }
 }
 
+// The blackout hole starts wide and irises in over ~700ms (the darkness
+// "closes in"), then gently breathes so it feels alive rather than static.
+function blackoutHoleScale() {
+    var breathe = 0.06 * Math.sin(Date.now() / 600);
+    var base = 1;
+    if (blackoutStart != null) {
+        var e = Date.now() - blackoutStart;
+        var irisMs = 700;
+        if (e < irisMs) {
+            base = lerp(2.6, 1, easeOutCubic(e / irisMs));
+        }
+    }
+    return base + breathe;
+}
+
+// How far through its warn-up a countdown aimer is, 0..1. Set when the
+// countdown starts (swapUsed / spawnExplosionAimer handlers).
+function aimerCountdownProgress(aimer) {
+    if (aimer.countdownStart == null || !aimer.countdownDuration) {
+        return 0;
+    }
+    return clamp01((Date.now() - aimer.countdownStart) / aimer.countdownDuration);
+}
+
 function drawAimer(aimer) {
     if (aimer.startSwapCountDown && aimer.hide == false) {
+        // Continuous sine pulse that speeds up and reddens as the swap nears,
+        // instead of the old once-a-second single-frame flash.
+        var prog = aimerCountdownProgress(aimer);
+        var phase = (Date.now() / 1000) * (2 + 5 * prog) * Math.PI * 2;
+        var pulse = 0.5 + 0.5 * Math.sin(phase);
         gameContext.save();
         gameContext.beginPath();
         gameContext.arc(aimer.x, aimer.y, aimer.radius, 0, 2 * Math.PI);
         gameContext.setLineDash([15, 3, 3, 3]);
-        if (aimer.swapCountDownPulse) {
-            aimer.swapCountDownPulse = false;
-            gameContext.lineWidth = 10;
-            gameContext.strokeStyle = "red";
-        } else {
-            gameContext.lineWidth = 3;
-            gameContext.strokeStyle = "black";
-        }
+        gameContext.lineWidth = lerp(2, 10, pulse * (0.4 + 0.6 * prog));
+        gameContext.strokeStyle = prog > 0.66 ? "red" : "black";
+        gameContext.globalAlpha = 0.45 + 0.55 * pulse;
         gameContext.stroke();
         gameContext.restore();
     }
     if (aimer.startExplosionCountDown && aimer.hide == false) {
+        var prog2 = aimerCountdownProgress(aimer);
+        var phase2 = (Date.now() / 1000) * (2 + 5 * prog2) * Math.PI * 2;
+        var pulse2 = 0.5 + 0.5 * Math.sin(phase2);
         gameContext.save();
+        // Fill intensity swells with the pulse and the countdown so the blast
+        // radius "charges up" before it goes off.
         gameContext.beginPath();
         gameContext.arc(aimer.x, aimer.y, aimer.radius, 0, 2 * Math.PI);
-        if (aimer.explosionPulse) {
-            aimer.explosionPulse = false;
-            gameContext.fillStyle = aimer.color;
-            gameContext.fill();
-        } else {
-            gameContext.setLineDash([15, 3, 3, 3]);
-            gameContext.lineWidth = 3;
-            gameContext.strokeStyle = aimer.color;
-            gameContext.stroke();
-        }
+        gameContext.fillStyle = aimer.color;
+        gameContext.globalAlpha = (0.12 + 0.5 * prog2) * pulse2;
+        gameContext.fill();
+        gameContext.globalAlpha = 1;
+        gameContext.setLineDash([15, 3, 3, 3]);
+        gameContext.lineWidth = lerp(2, 7, pulse2);
+        gameContext.strokeStyle = aimer.color;
+        gameContext.stroke();
         gameContext.restore();
     }
 }
@@ -940,6 +1287,7 @@ function drawPlayer(player, dt) {
     if (player.onFire > 0) {
         drawFire(player);
     }
+    drawSpeedFx(player);
 
     var playerStrokeColor = "black";
     for (var aimerID in aimerList) {
@@ -1019,6 +1367,47 @@ function drawPlayer(player, dt) {
         gameContext.drawImage(commentIconSolid, player.x, player.y - 40, commentIconSolid.width * 0.07, commentIconSolid.height * 0.07);
         gameContext.font = '20px Times New Roman';
         gameContext.fillText("😴", player.x + 8, player.y - 17);
+        gameContext.restore();
+    }
+}
+
+// Sustained speed-ability feedback driven by timestamps set on the player when
+// a buff/debuff lands. Buff = wind streaks trailing the direction of travel;
+// debuff = a slow sluggish ripple. Both expire on their own with no server
+// state, and the dust system reinforces the buff via the player's higher speed.
+function drawSpeedFx(player) {
+    var now = Date.now();
+    if (player.speedBuffUntil != null && now < player.speedBuffUntil) {
+        var speed = Math.sqrt(player.velX * player.velX + player.velY * player.velY);
+        if (speed > 0.5) {
+            var dirA = Math.atan2(player.velY, player.velX);
+            gameContext.save();
+            gameContext.translate(player.x, player.y);
+            gameContext.rotate(dirA);
+            gameContext.strokeStyle = "rgba(255,255,255,0.6)";
+            gameContext.lineCap = "round";
+            gameContext.lineWidth = 2;
+            var phase = (now / 60) % 12;
+            for (var i = 0; i < 3; i++) {
+                var off = (i - 1) * player.radius * 0.7;
+                var back = player.radius + 4 + ((phase + i * 4) % 12);
+                gameContext.beginPath();
+                gameContext.moveTo(-back, off);
+                gameContext.lineTo(-back - 10, off);
+                gameContext.stroke();
+            }
+            gameContext.restore();
+        }
+    }
+    if (player.speedDebuffUntil != null && now < player.speedDebuffUntil) {
+        var rp = (now / 700) % 1;
+        gameContext.save();
+        gameContext.globalAlpha = (1 - rp) * 0.4;
+        gameContext.strokeStyle = "rgba(80,80,160,1)";
+        gameContext.lineWidth = 2;
+        gameContext.beginPath();
+        gameContext.arc(player.x, player.y, player.radius + 2 + rp * 12, 0, 2 * Math.PI);
+        gameContext.stroke();
         gameContext.restore();
     }
 }
@@ -1129,11 +1518,14 @@ function drawFlameColor(player, size) {
 
 
 
-function drawProjectiles() {
+function drawProjectiles(dt) {
+    // ~5 degrees per 60fps frame, but scaled by dt so the spin speed is the
+    // same on a 144Hz monitor as on a 60Hz one.
+    var spin = 0.3 * (dt || 16.67);
     for (var proj in projectileList) {
 
         if (projectileList[proj].type == 'bomb') {
-            projectileList[proj].rotation += 5;
+            projectileList[proj].rotation += spin;
             const centerX = bombImage.width * 2;
             const centerY = bombImage.height * 2;
             gameContext.save();
@@ -1152,7 +1544,7 @@ function drawProjectiles() {
             gameContext.restore();
         }
         if (projectileList[proj].type == 'snowFlake') {
-            projectileList[proj].rotation += 5;
+            projectileList[proj].rotation += spin;
             const centerX = snowFlakeImage.width / 2;
             const centerY = snowFlakeImage.height / 2;
             gameContext.save();
@@ -1177,90 +1569,107 @@ function drawProjectiles() {
 
 function drawAbilityIndicator(x, y, player) {
     switch (player.ability) {
-        case config.tileMap.abilities.bomb.id: {
-            if (player.angle % 90 == 0) {
-                drawBombAimer(x, y, player.angle);
-                break;
-            }
-            if ((player.angle + 45) % 90 == 0) {
-                drawBombAimer(x, y, player.angle);
-                break;
-            }
-        }
-        case config.tileMap.abilities.iceCannon.id: {
-            if (player.angle % 90 == 0) {
-                drawBombAimer(x, y, player.angle);
-                break;
-            }
-            if ((player.angle + 45) % 90 == 0) {
-                drawBombAimer(x, y, player.angle);
-                break;
-            }
-        }
-        case config.tileMap.abilities.cut.id: {
-            if (player.angle % 90 == 0) {
-                drawCutAimer(x, y, player.angle, player.color);
-                break;
-            }
-            if ((player.angle + 45) % 90 == 0) {
-                drawCutAimer(x, y, player.angle, player.color);
-                break;
-            }
-        }
-        case config.tileMap.abilities.swap.id: {
-            gameContext.save();
-            gameContext.beginPath();
-            gameContext.setLineDash([15, 3, 3, 3]);
-            gameContext.arc(x, y, 10, 0, 2 * Math.PI);
-            gameContext.stroke();
-            gameContext.restore();
-        }
-        case config.tileMap.abilities.bombTrigger.id: {
-            gameContext.save();
-            gameContext.beginPath();
-            gameContext.lineWidth = 2;
-            gameContext.setLineDash([7, 2, 2]);
-            gameContext.arc(x, y, 10, 0, 2 * Math.PI);
-            gameContext.stroke();
-            gameContext.restore();
-        }
-        default: {
-            gameContext.save();
-            gameContext.beginPath();
-            gameContext.setLineDash([2, 2]);
-            gameContext.arc(x, y, 10, 0, 2 * Math.PI);
-            gameContext.stroke();
-            gameContext.restore();
-        }
+        case config.tileMap.abilities.bomb.id:
+            drawProjectileAimer(x, y, player.angle, "#ff8c3a", config.tileMap.abilities.bomb.aimerLength);
+            break;
+        case config.tileMap.abilities.iceCannon.id:
+            drawProjectileAimer(x, y, player.angle, "#5ad0ff", config.tileMap.abilities.iceCannon.aimerLength);
+            break;
+        case config.tileMap.abilities.cut.id:
+            drawCutAimer(x, y, player.angle, player.color);
+            break;
+        case config.tileMap.abilities.swap.id:
+        case config.tileMap.abilities.bombTrigger.id:
+        default:
+            drawArmedRing(x, y, player.color);
+            break;
     }
 }
 
-function drawBombAimer(x, y, angle) {
+// Directional throw indicator for bomb/ice cannon: a tinted line whose dashes
+// march outward toward the throw direction, capped with a pulsing arrowhead.
+// (It shows direction, not the physics landing spot, so no target/blast ring.)
+function drawProjectileAimer(x, y, angle, color, length) {
+    var now = Date.now();
+    var aimerLength = (length != null) ? length : config.tileMap.abilities.bomb.aimerLength;
+    var tip = pos({ x: x, y: y }, aimerLength, angle);
     gameContext.save();
+    gameContext.lineCap = "round";
+    gameContext.strokeStyle = color;
+    gameContext.lineWidth = 2;
+    gameContext.setLineDash([6, 5]);
+    gameContext.lineDashOffset = -(now / 25) % 11;
     gameContext.beginPath();
-    gameContext.setLineDash([5, 5]);
     gameContext.moveTo(x, y);
-    var point = pos({ x: x, y: y }, config.tileMap.abilities.bomb.aimerLength, angle);
-    gameContext.lineTo(point.x, point.y);
+    gameContext.lineTo(tip.x, tip.y);
+    gameContext.stroke();
+    // Pulsing arrowhead at the tip.
+    gameContext.setLineDash([]);
+    gameContext.globalAlpha = 0.6 + 0.4 * Math.sin(now / 150);
+    gameContext.lineWidth = 2.5;
+    var leftP = pos(tip, 8, angle + 140);
+    var rightP = pos(tip, 8, angle - 140);
+    gameContext.beginPath();
+    gameContext.moveTo(leftP.x, leftP.y);
+    gameContext.lineTo(tip.x, tip.y);
+    gameContext.lineTo(rightP.x, rightP.y);
     gameContext.stroke();
     gameContext.restore();
 }
+
+// Cut telegraph: a soft glowing beam through the player both ways, with a white
+// core whose dashes flow along it and a gentle pulse, plus a bright origin dot.
 function drawCutAimer(x, y, angle, color) {
+    var now = Date.now();
+    var pulse = 0.5 + 0.5 * Math.sin(now / 250);
+    var fwd = pos({ x: x, y: y }, config.worldWidth, angle);
+    var bwd = pos({ x: x, y: y }, config.worldWidth, angle - 180);
     gameContext.save();
-    gameContext.beginPath();
-    gameContext.setLineDash([15, 10, 12, 0, 0, 2]);
+    gameContext.lineCap = "round";
+    // Glow beam.
+    gameContext.globalAlpha = 0.22 + 0.22 * pulse;
+    gameContext.strokeStyle = color;
     gameContext.shadowColor = color;
-    gameContext.shadowBlur = 10;
-    gameContext.lineWidth = 1;
-    gameContext.strokeStyle = "black";
-    gameContext.moveTo(x, y);
-    var pointFWD = pos({ x: x, y: y }, config.worldWidth, angle);
-    gameContext.lineTo(pointFWD.x, pointFWD.y);
+    gameContext.shadowBlur = 12;
+    gameContext.lineWidth = 4;
+    gameContext.beginPath();
+    gameContext.moveTo(bwd.x, bwd.y);
+    gameContext.lineTo(fwd.x, fwd.y);
+    gameContext.stroke();
+    // Flowing white core.
+    gameContext.shadowBlur = 0;
+    gameContext.globalAlpha = 0.7 + 0.3 * pulse;
+    gameContext.strokeStyle = "white";
+    gameContext.lineWidth = 1.5;
+    gameContext.setLineDash([10, 8]);
+    gameContext.lineDashOffset = -(now / 20) % 18;
+    gameContext.beginPath();
+    gameContext.moveTo(bwd.x, bwd.y);
+    gameContext.lineTo(fwd.x, fwd.y);
+    gameContext.stroke();
+    // Bright origin dot.
+    gameContext.setLineDash([]);
+    gameContext.globalAlpha = 0.8;
+    gameContext.fillStyle = color;
+    gameContext.beginPath();
+    gameContext.arc(x, y, 3 + pulse, 0, 2 * Math.PI);
+    gameContext.fill();
+    gameContext.restore();
+}
 
-    gameContext.moveTo(x, y);
-    var pointBWD = pos({ x: x, y: y }, config.worldWidth, angle - 180);
-    gameContext.lineTo(pointBWD.x, pointBWD.y);
-
+// "Ability armed" indicator for swap / bomb-trigger / anything else held: a
+// slowly rotating dashed ring that pulses, in the player's colour.
+function drawArmedRing(x, y, color) {
+    var now = Date.now();
+    gameContext.save();
+    gameContext.translate(x, y);
+    gameContext.rotate((now / 600) % (2 * Math.PI));
+    gameContext.beginPath();
+    gameContext.setLineDash([6, 4]);
+    gameContext.lineWidth = 2;
+    gameContext.globalAlpha = 0.55 + 0.45 * Math.sin(now / 200);
+    gameContext.strokeStyle = color || "black";
+    gameContext.arc(0, 0, 11, 0, 2 * Math.PI);
     gameContext.stroke();
     gameContext.restore();
 }
@@ -1511,6 +1920,70 @@ function drawMap() {
     }
 }
 
+// Trace a voronoi cell's polygon into the current path (no fill/stroke).
+function traceCellPath(ctx, cell) {
+    var halfedges = cell.halfedges;
+    if (halfedges.length == 0) {
+        return false;
+    }
+    ctx.beginPath();
+    var v = getStartpoint(halfedges[0]);
+    ctx.moveTo(v.x, v.y);
+    for (var i = 0; i < halfedges.length; i++) {
+        v = getEndpoint(halfedges[i]);
+        ctx.lineTo(v.x, v.y);
+    }
+    ctx.closePath();
+    return true;
+}
+
+// Overlay drawn on top of the cached map: the tiles a tileSwap is about to flip
+// pulse (a global sine that speeds up as the swap nears) with a brief random
+// flicker per cell, plus a brightening yellow edge. Cleared as tiles flip (see
+// changeTilesBulk) and self-expires if the swap never lands.
+function drawPendingSwap() {
+    if (pendingSwapCells == null || currentMap == null || currentMap.cells == null) {
+        return;
+    }
+    var now = Date.now();
+    var set = pendingSwapCells.set;
+    gameContext.save();
+    for (var i = 0; i < currentMap.cells.length; i++) {
+        var cell = currentMap.cells[i];
+        var tile = set[cell.site.voronoiId];
+        if (tile == null) {
+            continue;
+        }
+        // Fallback self-expiry: a tile whose flip is well past (e.g. it got
+        // converted by something else and never cleared via tileSwapPerformed).
+        if (now - tile.end > 1500) {
+            delete set[cell.site.voronoiId];
+            continue;
+        }
+        // Per-tile progress so overlapping swaps each ramp on their own clock.
+        var span = tile.end - tile.start;
+        var prog = span > 0 ? clamp01((now - tile.start) / span) : 1;
+        var pulse = 0.5 + 0.5 * Math.sin((now / 1000) * (3 + 6 * prog) * Math.PI * 2);
+        // Electrical flicker: occasional dim frames, more frequent near the end.
+        var flicker = Math.random() < (0.08 + 0.2 * prog) ? 0.3 : 1.0;
+        var alpha = (0.18 + 0.4 * pulse) * flicker;
+        if (!traceCellPath(gameContext, cell)) {
+            continue;
+        }
+        gameContext.globalAlpha = alpha;
+        gameContext.fillStyle = "#ffffff";
+        gameContext.fill();
+        gameContext.lineWidth = 2 + 3 * prog;
+        gameContext.strokeStyle = "#ffff66";
+        gameContext.stroke();
+    }
+    gameContext.restore();
+    // Once every tile has flipped/cleared/expired, drop the telegraph.
+    if (Object.keys(set).length === 0) {
+        pendingSwapCells = null;
+    }
+}
+
 function renderMapToCache() {
     if (world == null) {
         return;
@@ -1576,7 +2049,56 @@ function renderMapToCache() {
         mapCtx.fill();
         mapCtx.stroke();
     }
+    drawLavaBorders(mapCtx);
     mapCtx.restore();
+}
+
+// Trace a dark-red rim around every lava grouping. The map is a Voronoi diagram
+// so each edge knows the two cells it separates; we stroke only the edges where
+// a lava cell meets a non-lava cell (or the map boundary), which outlines each
+// island's perimeter without drawing the internal seams between adjacent lava
+// tiles. Runs only on cache rebuilds (map load / tile change), so it's free
+// per-frame. Keys off cell.id, so it tracks bombs/tileSwap/collapse and still
+// works when lava renders as poison in infection rounds.
+var lavaBorderColor = "#7a0000";
+function drawLavaBorders(ctx) {
+    if (currentMap == null || currentMap.cells == null) {
+        return;
+    }
+    var lavaId = config.tileMap.lava.id;
+    var cells = currentMap.cells;
+    var idByVoronoi = {};
+    for (var i = 0; i < cells.length; i++) {
+        idByVoronoi[cells[i].site.voronoiId] = cells[i].id;
+    }
+    ctx.save();
+    ctx.beginPath();
+    for (var c = 0; c < cells.length; c++) {
+        var cell = cells[c];
+        if (cell.id != lavaId) {
+            continue;
+        }
+        var halfedges = cell.halfedges;
+        for (var h = 0; h < halfedges.length; h++) {
+            var he = halfedges[h];
+            // The cell across this edge (null on the map boundary).
+            var neighbor = compareSite(he.edge.lSite, he.site) ? he.edge.rSite : he.edge.lSite;
+            if (neighbor != null && idByVoronoi[neighbor.voronoiId] == lavaId) {
+                continue; // internal seam between two lava tiles — skip
+            }
+            var sp = getStartpoint(he);
+            var ep = getEndpoint(he);
+            ctx.moveTo(sp.x, sp.y);
+            ctx.lineTo(ep.x, ep.y);
+        }
+    }
+    ctx.setLineDash([]);
+    ctx.lineWidth = 3;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.strokeStyle = lavaBorderColor;
+    ctx.stroke();
+    ctx.restore();
 }
 function drawHazard(hazard) {
     if (hazard.id == config.hazards.bumper.id) {
@@ -1846,34 +2368,57 @@ function drawTouchLabel(text, x, y) {
 function drawTitle() {
 
     if (brutalRound == true) {
-        if (brutalRoundConfig.drawTitleAlpha == null) {
-            brutalRoundConfig.drawTitleAlpha = 1.0;
+        // Time-based entrance (so it plays the same on any refresh rate):
+        // a quick scale-in with a little overshoot, a hold, then a fade. A
+        // single red screen flash fires the moment the card appears.
+        if (brutalRoundConfig.titleStart == null) {
+            brutalRoundConfig.titleStart = Date.now();
+            spawnScreenFlash("red", 0.4, 350);
         }
-        if (brutalRoundConfig.drawTitleAlpha < 0) {
-            return;
-        }
-        gameContext.save();
-        gameContext.strokeStyle = "rgba(255, 255, 255, " + brutalRoundConfig.drawTitleAlpha + ")";;
-        gameContext.lineWidth = 10;
-        gameContext.fillStyle = "rgba(255, 0, 0, " + brutalRoundConfig.drawTitleAlpha + ")";
-        gameContext.font = "50px Arial";
-        gameContext.strokeText('Brutal Round', (LOGICAL_WIDTH / 2) - 120, (LOGICAL_HEIGHT / 2) - 25);
-        gameContext.fillText('Brutal Round', (LOGICAL_WIDTH / 2) - 120, (LOGICAL_HEIGHT / 2) - 25);
-        var titles = [];
-        for (var i = 0; i < brutalRoundConfig.brutalTypes.length; i++) {
-            for (var prop in config.brutalRounds) {
-                if (config.brutalRounds[prop].id == brutalRoundConfig.brutalTypes[i]) {
-                    titles.push(config.brutalRounds[prop].title);
+        var e = Date.now() - brutalRoundConfig.titleStart;
+        var inMs = 350, holdMs = 2200, outMs = 1500;
+        if (e <= inMs + holdMs + outMs) {
+            var alpha, scale;
+            if (e < inMs) {
+                var ip = e / inMs;
+                scale = lerp(0.4, 1, easeOutBack(ip));
+                alpha = clamp01(ip);
+            } else if (e < inMs + holdMs) {
+                scale = 1;
+                alpha = 1;
+            } else {
+                var fp = (e - inMs - holdMs) / outMs;
+                scale = 1 + 0.06 * fp;
+                alpha = clamp01(1 - fp);
+            }
+            gameContext.save();
+            gameContext.textAlign = "center";
+            // HUD/screen pass: anchor in logical space so it stays centered and
+            // crisp at any DPR (this runs after applyCanvasTransform, not under
+            // the world camera zoom/pan).
+            gameContext.translate(LOGICAL_WIDTH / 2, LOGICAL_HEIGHT / 2 - 10);
+            gameContext.scale(scale, scale);
+            gameContext.strokeStyle = "rgba(255, 255, 255, " + alpha + ")";
+            gameContext.lineWidth = 10;
+            gameContext.fillStyle = "rgba(255, 0, 0, " + alpha + ")";
+            gameContext.font = "50px Arial";
+            gameContext.strokeText('Brutal Round', 0, 0);
+            gameContext.fillText('Brutal Round', 0, 0);
+            var titles = [];
+            for (var i = 0; i < brutalRoundConfig.brutalTypes.length; i++) {
+                for (var prop in config.brutalRounds) {
+                    if (config.brutalRounds[prop].id == brutalRoundConfig.brutalTypes[i]) {
+                        titles.push(config.brutalRounds[prop].title);
+                    }
                 }
             }
+            gameContext.font = "30px Arial";
+            for (var j = 0; j < titles.length; j++) {
+                gameContext.strokeText(titles[j], 0, 40 + (35 * j));
+                gameContext.fillText(titles[j], 0, 40 + (35 * j));
+            }
+            gameContext.restore();
         }
-        gameContext.font = "30px Arial";
-        for (var j = 0; j < titles.length; j++) {
-            gameContext.strokeText(titles[j], (LOGICAL_WIDTH / 2) - 120, (LOGICAL_HEIGHT / 2) + 15 + (35 * j));
-            gameContext.fillText(titles[j], (LOGICAL_WIDTH / 2) - 120, (LOGICAL_HEIGHT / 2) + 15 + (35 * j));
-        }
-        gameContext.restore();
-        brutalRoundConfig.drawTitleAlpha -= .0025;
     }
     if (currentState == config.stateMap.waiting && lobbyStartButton == null) {
         gameContext.save();

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -15,12 +15,15 @@ var mousex,
 	playerList,
 	blindfold,
 	achievements = null,
-	screenShake = false,
 	blackout = false,
 	timerList = [],
 	playersNearVictory = [],
 	pingCircles = [],
 	collapseShockwaves = [],
+	effectsList = [],
+	shakeTrauma = 0,
+	pendingSwapCells = null,
+	blackoutStart = null,
 	brutalRound = false,
 	brutalRoundConfig = null,
 	clientList;
@@ -45,11 +48,38 @@ function resetGameboard() {
 	brutalRoundConfig = null;
 	projectileList = {};
 	gameID = null;
+	effectsList = [];
+	shakeTrauma = 0;
+	shakeSustainUntil = 0;
+	shakeSustainFloor = 0;
+	pendingSwapCells = null;
 }
 
 function resetRound() {
 	blackout = false;
+	blackoutStart = null;
 	infection = false;
+	// Transient visuals shouldn't bleed into the next round.
+	effectsList = [];
+	shakeTrauma = 0;
+	shakeSustainUntil = 0;
+	shakeSustainFloor = 0;
+	pendingSwapCells = null;
+	blindfold = {};
+	// Buff auras, movement-particle cooldowns and the last-velocity sample all
+	// live on the persistent playerList objects, so they have to be cleared by
+	// hand or they bleed into the next round (stale wind streaks, a phantom skid
+	// burst on the first frame, etc.).
+	for (var pid in playerList) {
+		var rp = playerList[pid];
+		rp.speedBuffUntil = null;
+		rp.speedDebuffUntil = null;
+		rp.prevVelX = null;
+		rp.prevVelY = null;
+		rp.dustCD = 0;
+		rp.skidCD = 0;
+		rp.emberCD = 0;
+	}
 	for (var aimerID in this.aimerList) {
 		delete this.aimerList[aimerID];
 	}
@@ -61,6 +91,11 @@ function updateGameboard(dt) {
 	}
 	updatePingCircles(dt);
 	updateCollapseShockwaves(dt);
+	updateEffects(dt);
+	updateShake(dt);
+	if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing) {
+		updateMovementParticles(dt);
+	}
 	checkTimers(dt);
 }
 
@@ -468,6 +503,7 @@ function spawnPunch(payload) {
 	punch.color = payload[3];
 	punch.radius = payload[4];
 	punch.type = payload[5];
+	punch.directional = payload[6] == 1;
 	punchList[punch.ownerId] = punch;
 	return punch;
 }
@@ -631,6 +667,30 @@ function explodedCells(cells) {
 	invalidateMapCache();
 }
 
+// Average site position of a set of voronoi ids — used to place a blast effect
+// at the centre of the cells a bomb just flattened.
+function cellsCentroid(voronoiIds) {
+	if (currentMap == null || currentMap.cells == null || voronoiIds == null) {
+		return null;
+	}
+	var sumX = 0, sumY = 0, count = 0;
+	for (var i = 0; i < currentMap.cells.length; i++) {
+		var cell = currentMap.cells[i];
+		for (var j = 0; j < voronoiIds.length; j++) {
+			if (voronoiIds[j] == cell.site.voronoiId) {
+				sumX += cell.site.x;
+				sumY += cell.site.y;
+				count++;
+				break;
+			}
+		}
+	}
+	if (count === 0) {
+		return null;
+	}
+	return { x: sumX / count, y: sumY / count, count: count };
+}
+
 function playerPickedUpAbility(payload) {
 	playerList[payload.owner].ability = payload.ability;
 	if (payload.voronoiId == null) {
@@ -656,8 +716,61 @@ function changeTilesBulk(tileChanges) {
 			}
 
 		}
+		// A telegraphed tile that just changed — by ANY cause (the swap itself, a
+		// bomb, the collapse) — no longer needs pulsing. We stop telegraphing it
+		// here but do NOT play the swap sound from this path: an unrelated change
+		// flipping the last pending tile must not trigger the swap audio early.
+		// The sound is driven by the dedicated "tileSwapPerformed" event.
+		if (pendingSwapCells != null && pendingSwapCells.set[prop] != null) {
+			delete pendingSwapCells.set[prop];
+		}
+	}
+	if (pendingSwapCells != null && Object.keys(pendingSwapCells.set).length === 0) {
+		pendingSwapCells = null;
 	}
 	invalidateMapCache();
+}
+
+// Record which tiles a tileSwap is about to flip, so drawPendingSwap can
+// pulse/flicker them during the warn-up. Each tile carries its OWN start/end
+// timeline, so when two tileSwaps overlap the second one doesn't restart the
+// pulse on the first's already-warming tiles. If a tile is telegraphed by both,
+// keep whichever flip is imminent (the earliest end) so its pulse keeps
+// intensifying toward the real flip.
+function markPendingSwap(ids, duration) {
+	if (ids == null || ids.length === 0) {
+		return;
+	}
+	var now = Date.now();
+	var end = now + duration;
+	var set = (pendingSwapCells != null) ? pendingSwapCells.set : {};
+	for (var i = 0; i < ids.length; i++) {
+		var existing = set[ids[i]];
+		if (existing == null || end < existing.end) {
+			set[ids[i]] = { start: now, end: end };
+		}
+	}
+	pendingSwapCells = { set: set };
+}
+
+// The swap actually landed. Driven by a dedicated server event (not inferred
+// from the tile-change batch), so it fires exactly once when the flip happens
+// — never early because some other tile change emptied the pending set, and
+// never dropped because a telegraphed tile got converted before the swap. Plays
+// the delayed swap sound and stops telegraphing the tiles this swap flipped.
+function tileSwapLanded(ids) {
+	playSound(tileSwap);
+	if (pendingSwapCells == null) {
+		return;
+	}
+	if (ids != null) {
+		for (var i = 0; i < ids.length; i++) {
+			delete pendingSwapCells.set[ids[i]];
+		}
+	}
+	if (Object.keys(pendingSwapCells.set).length === 0) {
+		pendingSwapCells = null;
+	}
 }
 
 
@@ -667,17 +780,326 @@ function playerAbilityUsed(owner) {
 
 function createBlindFold(owner) {
 	blindfold.color = makePattern(blindfoldLargeIcon, this.playerList[owner].color);
+	// Timestamps let drawAbilties() ease the overlay in and out (see blindfoldAlpha).
+	blindfold.start = Date.now();
+	blindfold.duration = config.tileMap.abilities.blindfold.duration * 1000;
 	var int = setInterval(function () {
 		clearInterval(int);
 		blindfold.color = null;
 	}, config.tileMap.abilities.blindfold.duration * 1000);
 }
 
+// --- Screen shake (trauma model) ---
+// Callers add "trauma" (0..1); the rendered offset is maxShakeOffset * trauma^2
+// so a big hit reads much harder than a small one, and the shake tapers off
+// smoothly as trauma decays instead of snapping off after a fixed timer.
+var maxShakeOffset = 16;        // px at full trauma
+var shakeDecayPerSec = 1.6;     // trauma units bled off per second
+var shakeSustainUntil = 0;      // for events that should rumble for a while
+var shakeSustainFloor = 0;
+
+function addTrauma(amount) {
+	shakeTrauma = Math.min(1, shakeTrauma + amount);
+}
+// Hold a minimum trauma floor for a duration (e.g. a long volcano eruption),
+// then let it decay normally.
+function rumbleSustained(durationMs, intensity) {
+	shakeSustainUntil = Date.now() + durationMs;
+	shakeSustainFloor = intensity;
+	addTrauma(intensity);
+}
+function updateShake(dt) {
+	if (Date.now() < shakeSustainUntil && shakeTrauma < shakeSustainFloor) {
+		shakeTrauma = shakeSustainFloor;
+	}
+	if (shakeTrauma > 0) {
+		shakeTrauma = Math.max(0, shakeTrauma - shakeDecayPerSec * (dt / 1000));
+	}
+}
+// Back-compat shim: a couple of call sites still pass a duration in ms. Map it
+// to a one-shot trauma jolt (longer => slightly stronger).
 function rumbleScreen(time) {
-	screenShake = true;
-	setTimeout(function () {
-		screenShake = false;
-	}, time);
+	addTrauma(time >= 500 ? 0.6 : 0.45);
+}
+
+// --- Transient render effects (shockwaves, sparks, slashes, puffs) ---
+// Each effect carries its own clock so its visual lifetime is independent of
+// any server object (the punch object, for instance, only lives ~100ms). An
+// effect is { age, maxAge, draw(ctx, t, effect), update?(dt), screen? }; t is
+// the normalized 0..1 progress passed to draw. screen:true skips the camera
+// translate (for screen-space flashes); world-space is the default.
+function addEffect(effect) {
+	if (effect == null) {
+		return null;
+	}
+	effect.age = 0;
+	if (effect.maxAge == null) {
+		effect.maxAge = 300;
+	}
+	effectsList.push(effect);
+	return effect;
+}
+function updateEffects(dt) {
+	for (var i = effectsList.length - 1; i >= 0; i--) {
+		var e = effectsList[i];
+		e.age += dt;
+		if (e.update != null) {
+			e.update(dt);
+		}
+		if (e.age >= e.maxAge) {
+			effectsList.splice(i, 1);
+		}
+	}
+}
+// True if id belongs to a player controlled on this screen (covers couch
+// multiplayer where several local slots share one client).
+function isLocalId(id) {
+	if (id == null) {
+		return false;
+	}
+	if (id == myID) {
+		return true;
+	}
+	if (typeof localPlayers !== "undefined" && localPlayers) {
+		for (var s = 0; s < localPlayers.length; s++) {
+			if (localPlayers[s] && localPlayers[s].myID == id) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+// --- Movement & burn particles ---
+// Driven per-frame from player velocity (decoded from gameUpdates), throttled
+// by per-player cooldowns so a fast lap doesn't flood the effects list.
+
+// A single drifting, fading puff. vx/vy are in px per ms. A faint dark outline
+// keeps it readable even when its colour is close to the terrain underneath.
+function spawnDustParticle(x, y, vx, vy, size, color) {
+	addEffect({
+		x: x,
+		y: y,
+		maxAge: 430,
+		draw: function (ctx, t, e) {
+			var a = 1 - t;
+			var r = size * (1 - 0.35 * t);
+			ctx.save();
+			ctx.beginPath();
+			ctx.arc(x + vx * e.age, y + vy * e.age, r, 0, 2 * Math.PI);
+			ctx.globalAlpha = a * 0.85;
+			ctx.fillStyle = color;
+			ctx.fill();
+			ctx.globalAlpha = a * 0.4;
+			ctx.lineWidth = 1;
+			ctx.strokeStyle = "rgba(0, 0, 0, 1)";
+			ctx.stroke();
+			ctx.restore();
+		}
+	});
+}
+
+// A rising, cooling ember for a burning player (complements the flame sprite).
+function spawnEmber(x, y) {
+	var vx = (Math.random() * 2 - 1) * 0.015;
+	var vy = -(0.03 + Math.random() * 0.03);
+	var hue = 18 + Math.random() * 32;
+	var maxAge = 500 + Math.random() * 300;
+	addEffect({
+		x: x,
+		y: y,
+		maxAge: maxAge,
+		draw: function (ctx, t, e) {
+			ctx.save();
+			ctx.globalAlpha = (1 - t) * 0.9;
+			ctx.fillStyle = "hsl(" + hue + ", 100%, " + (62 - 22 * t) + "%)";
+			ctx.beginPath();
+			ctx.arc(x + vx * e.age, y + vy * e.age, 2.5 * (1 - t) + 0.5, 0, 2 * Math.PI);
+			ctx.fill();
+			ctx.restore();
+		}
+	});
+}
+
+// Fire a muzzle flash from a player's front edge in their facing direction, and
+// a small recoil kick (screen shake) if a local player fired.
+function fireMuzzleFlash(owner, color) {
+	var p = playerList[owner];
+	if (p == null) {
+		return;
+	}
+	var front = pos({ x: p.x, y: p.y }, p.radius, p.angle);
+	spawnMuzzleFlash(front.x, front.y, p.angle, color);
+	if (isLocalId(owner)) {
+		addTrauma(0.18);
+	}
+}
+
+// Terrain palette for movement particles. Colours are picked to CONTRAST the
+// tile they land on (bright lime over green grass, pale dust over tan sand,
+// deep cyan over pale ice) so the flecks read instead of blending in.
+function dustColor() { return "rgba(170, 150, 120, 1)"; }   // dirt
+function grassColor() { return "rgba(150, 230, 70, 1)"; }    // bright lime
+function sandColor() { return "rgba(250, 238, 205, 1)"; }    // pale dust puff
+function iceColor() { return "rgba(70, 165, 220, 1)"; }      // deep cyan scrape
+function terrainParticleColor(tile) {
+	if (config != null) {
+		if (tile == config.tileMap.fast.id) { return grassColor(); }
+		if (tile == config.tileMap.slow.id) { return sandColor(); }
+		if (tile == config.tileMap.ice.id) { return iceColor(); }
+	}
+	return dustColor();
+}
+
+// Which tile id a point sits on. The map is a Voronoi diagram, so the cell a
+// point belongs to is simply the one whose site is nearest — cheap and exact,
+// and it tracks tile changes (bombs, tileSwap) since cell.id is mutated in place.
+function tileIdAt(x, y) {
+	if (currentMap == null || currentMap.cells == null) {
+		return null;
+	}
+	var cells = currentMap.cells;
+	var bestId = null, bestD = Infinity;
+	for (var i = 0; i < cells.length; i++) {
+		var s = cells[i].site;
+		var dx = s.x - x, dy = s.y - y;
+		var d = dx * dx + dy * dy;
+		if (d < bestD) { bestD = d; bestId = cells[i].id; }
+	}
+	return bestId;
+}
+
+// `count` flecks kicked up behind a moving player, coloured by the terrain and
+// scattered a little so they read as a puff rather than a single dot.
+function spawnTerrainParticle(p, color, minSize, count) {
+	count = count || 1;
+	var dir = Math.atan2(p.velY, p.velX);
+	for (var i = 0; i < count; i++) {
+		var bx = p.x - Math.cos(dir) * p.radius + (Math.random() * 2 - 1) * p.radius * 0.5;
+		var by = p.y - Math.sin(dir) * p.radius + (Math.random() * 2 - 1) * p.radius * 0.5;
+		var spread = (Math.random() * 2 - 1) * 0.03;
+		var vx = -Math.cos(dir) * 0.013 + Math.cos(dir + Math.PI / 2) * spread;
+		var vy = -Math.sin(dir) * 0.013 + Math.sin(dir + Math.PI / 2) * spread;
+		spawnDustParticle(bx, by, vx, vy, minSize + Math.random() * 2, color);
+	}
+}
+
+// One lingering skate streak (blade mark) left on ice.
+function addIceStreak(bx, by, ex, ey) {
+	addEffect({
+		x: bx,
+		y: by,
+		maxAge: 700,
+		draw: function (ctx, t) {
+			ctx.save();
+			ctx.globalAlpha = (1 - t) * 0.6;
+			ctx.strokeStyle = iceColor();
+			ctx.lineWidth = 3;
+			ctx.lineCap = "round";
+			ctx.beginPath();
+			ctx.moveTo(bx, by);
+			ctx.lineTo(ex, ey);
+			ctx.stroke();
+			ctx.restore();
+		}
+	});
+}
+// A pair of skate marks behind a player gliding over ice.
+function spawnIceTrail(p) {
+	var dir = Math.atan2(p.velY, p.velX);
+	var len = p.radius * 1.7;
+	var perp = dir + Math.PI / 2;
+	var gap = p.radius * 0.5;
+	for (var s = -1; s <= 1; s += 2) {
+		var bx = p.x + Math.cos(perp) * gap * s;
+		var by = p.y + Math.sin(perp) * gap * s;
+		addIceStreak(bx, by, bx - Math.cos(dir) * len, by - Math.sin(dir) * len);
+	}
+}
+
+// A skid burst when a player whips around — particles fly off in the old
+// direction of travel, coloured by the terrain underfoot.
+function spawnSkid(p, color) {
+	var dir = Math.atan2(p.prevVelY, p.prevVelX);
+	for (var i = 0; i < 4; i++) {
+		var spread = (Math.random() * 2 - 1) * 0.04;
+		var vx = Math.cos(dir) * 0.02 + Math.cos(dir + Math.PI / 2) * spread;
+		var vy = Math.sin(dir) * 0.02 + Math.sin(dir + Math.PI / 2) * spread;
+		spawnDustParticle(p.x, p.y, vx, vy, 2.5 + Math.random() * 2, color);
+	}
+}
+
+function updateMovementParticles(dt) {
+	if (config == null) {
+		return;
+	}
+	var maxSpeed = config.playerMaxSpeed;
+	var fastThresh = maxSpeed * 0.55;
+	var walkThresh = maxSpeed * 0.08;
+	for (var id in playerList) {
+		var p = playerList[id];
+		if (p == null || p.alive == false || p.velX == null) {
+			continue;
+		}
+		var speed = Math.sqrt(p.velX * p.velX + p.velY * p.velY);
+
+		if (p.dustCD == null) { p.dustCD = 0; }
+		if (p.skidCD == null) { p.skidCD = 0; }
+		if (p.emberCD == null) { p.emberCD = 0; }
+		p.dustCD -= dt;
+		p.skidCD -= dt;
+		p.emberCD -= dt;
+
+		// Sharp turn at speed -> skid burst (dot product of old/new velocity).
+		if (p.prevVelX != null && p.skidCD <= 0 && speed > fastThresh * 0.5) {
+			var prevSpeed = Math.sqrt(p.prevVelX * p.prevVelX + p.prevVelY * p.prevVelY);
+			if (prevSpeed > 1) {
+				var dot = (p.velX * p.prevVelX + p.velY * p.prevVelY) / (speed * prevSpeed);
+				if (dot < 0.6) {
+					spawnSkid(p, terrainParticleColor(tileIdAt(p.x, p.y)));
+					p.skidCD = 140;
+				}
+			}
+		}
+
+		// Moving -> terrain-aware trail. Ice leaves skate marks even at a walk;
+		// grass/sand sprinkle flecks; bare dirt only kicks up dust at speed.
+		if (speed > walkThresh && p.dustCD <= 0) {
+			var tile = tileIdAt(p.x, p.y);
+			if (tile == config.tileMap.ice.id) {
+				// Skate trails only when actually gliding fast across the ice.
+				if (speed > fastThresh) {
+					spawnIceTrail(p);
+					p.dustCD = 40;
+				} else {
+					p.dustCD = 60;
+				}
+			} else if (tile == config.tileMap.fast.id) {
+				// Grass dialed back ~20% (smaller flecks) — it read a touch strong.
+				spawnTerrainParticle(p, grassColor(), 1.8, 2);
+				p.dustCD = speed > fastThresh ? 45 : 70;
+			} else if (tile == config.tileMap.slow.id) {
+				spawnTerrainParticle(p, sandColor(), 3, 2);
+				p.dustCD = speed > fastThresh ? 45 : 70;
+			} else if (speed > fastThresh) {
+				spawnTerrainParticle(p, dustColor(), 2.5, 2);
+				p.dustCD = 50;
+			} else {
+				// Bare dirt at a walk: nothing to emit; recheck shortly (keeps the
+				// per-frame nearest-cell lookup throttled).
+				p.dustCD = 60;
+			}
+		}
+
+		// Burning -> rising embers.
+		if (p.onFire > 0 && p.emberCD <= 0) {
+			spawnEmber(p.x + (Math.random() * 2 - 1) * p.radius, p.y + (Math.random() * 2 - 1) * p.radius);
+			p.emberCD = 70;
+		}
+
+		p.prevVelX = p.velX;
+		p.prevVelY = p.velY;
+	}
 }
 
 function setupEmojiWheel() {

--- a/client/scripts/utils.js
+++ b/client/scripts/utils.js
@@ -73,3 +73,28 @@ function pos(point, length, angle) {
     var y = point.y + length * Math.sin(a);
     return { x, y };
 }
+
+// --- Animation easing + small render helpers (client render only) ---
+// Used by the effects/particle system, screen-shake trauma, the brutal-round
+// title entrance, and the tileSwap telegraph. All take/return normalized t in
+// [0,1] unless noted.
+function clamp01(t) {
+    if (t < 0) return 0;
+    if (t > 1) return 1;
+    return t;
+}
+function lerp(a, b, t) {
+    return a + (b - a) * t;
+}
+function easeOutQuad(t) {
+    return 1 - (1 - t) * (1 - t);
+}
+function easeOutCubic(t) {
+    return 1 - Math.pow(1 - t, 3);
+}
+// Overshoots past 1 then settles — gives the title card a little "pop".
+function easeOutBack(t) {
+    var c1 = 1.70158;
+    var c3 = c1 + 1;
+    return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+}

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -768,7 +768,7 @@ function steerBot(bot, ctx, dt) {
     // of this range is set high enough that a max-skill bot's effective input
     // (0.8 x speedFactor) reaches/*slightly* exceeds a human's — otherwise even the
     // best bots are hard-capped below human top speed and trivially beatable.
-    var speedFactor = (0.6 + 0.55 * effSkill) * (ctx.rubberBand || 1);
+    var speedFactor = (0.72 + 0.55 * effSkill) * (ctx.rubberBand || 1);
     if (speedFactor > 1.45) { speedFactor = 1.45; }
     if (speedFactor < 0.4) { speedFactor = 0.4; }
     throttle *= speedFactor;

--- a/server/compressor.js
+++ b/server/compressor.js
@@ -186,6 +186,7 @@ exports.sendPunch = function (punch) {
 	packet[3] = punch.color;
 	packet[4] = punch.radius;
 	packet[5] = punch.type;
+	packet[6] = punch.directional ? 1 : 0;
 	packet = JSON.stringify(packet);
 	player = null;
 	listItem = null;

--- a/server/config.json
+++ b/server/config.json
@@ -2,6 +2,8 @@
     "port": 3000,
     "serverTickSpeed": 33.33,
     "punchRadius": 11,
+    "directionalPunch": true,
+    "punchReach": 14,
     "worldWidth": 1366,
     "worldHeight": 768,
     "worldCollapseSpeed": 6,
@@ -170,7 +172,9 @@
             },
             "tileSwap": {
                 "spawnable": true,
-                "id": 106
+                "id": 106,
+                "minSwapDelay": 3000,
+                "maxSwapDelay": 6000
             },
             "iceCannon": {
                 "spawnable": true,

--- a/server/game.js
+++ b/server/game.js
@@ -1165,7 +1165,7 @@ class GameBoard {
 			}
 			if (this.abilityList[id].tileSwap) {
 				this.abilityList[id].tileSwap = false;
-				this.swapTiles();
+				this.startTileSwap();
 			}
 			if (this.abilityList[id].blind) {
 				this.abilityList[id].blind = false;
@@ -1186,6 +1186,13 @@ class GameBoard {
 		}
 	}
 	updatePlayers(currentState, dt) {
+		// Punch directionality policy (resolved here, applied in checkAttack):
+		//  - Hockey: radial for everyone, so you can smack the puck from any side.
+		//  - Infection: zombies must aim their bite (directional), but survivors
+		//    swat zombies in any direction (radial).
+		//  - Otherwise: per config.directionalPunch.
+		var hockeyRound = this.checkForActiveBrutal(c.brutalRounds.hockey.id);
+		var infectionRound = this.checkForActiveBrutal(c.brutalRounds.infection.id);
 		for (var playerID in this.playerList) {
 			var player = this.playerList[playerID];
 			// handleHit (during checkCollisions, just above) flags lobby lava/goal hits
@@ -1216,7 +1223,13 @@ class GameBoard {
 				}
 				player.acquiredAbility = null;
 			}
-			player.update(currentState, dt);
+			var punchDirectional = c.directionalPunch;
+			if (hockeyRound) {
+				punchDirectional = false;
+			} else if (infectionRound && !player.isZombie) {
+				punchDirectional = false;
+			}
+			player.update(currentState, dt, punchDirectional);
 			if (currentState == c.stateMap.lobby) {
 				this.updateLobbyInvulnHold(player);
 			}
@@ -1331,6 +1344,44 @@ class GameBoard {
 		return this.tileChanges;
 	}
 
+	// TileSwap now telegraphs before it fires: clients are told which tiles are
+	// about to flip (so they can pulse/flicker), and the actual swap is delayed
+	// a random 3-6s. swapTiles() below still performs the flip when the timer
+	// fires.
+	startTileSwap() {
+		if (this.currentMap == null || this.currentMap.cells == null) {
+			return;
+		}
+		var cells = this.currentMap.cells;
+		var pending = [];
+		for (var i = 0; i < cells.length; i++) {
+			if (cells[i].id == c.tileMap.fast.id || cells[i].id == c.tileMap.ice.id) {
+				pending.push(cells[i].site.voronoiId);
+			}
+		}
+		if (pending.length == 0) {
+			return;
+		}
+		var ts = c.tileMap.abilities.tileSwap;
+		var min = ts.minSwapDelay != null ? ts.minSwapDelay : 3000;
+		var max = ts.maxSwapDelay != null ? ts.maxSwapDelay : 6000;
+		var delay = min + Math.floor(Math.random() * (max - min + 1));
+		messenger.messageRoomBySig(this.roomSig, "tileSwapPending", JSON.stringify({ ids: pending, duration: delay }));
+		// Track the timer like every other ability timer so it gets cancelled on
+		// round/match end — otherwise it can fire against a torn-down room or swap
+		// tiles after the round has logically ended.
+		this.pendingAbilityTimers.push(setTimeout(this.performTileSwap, delay, { context: this, map: this.currentMap }));
+	}
+	performTileSwap(packet) {
+		var gameBoard = packet.context;
+		// Bail if the round/map changed while the timer was pending — currentMap
+		// is a fresh object each round, so a reference check catches that.
+		if (gameBoard.currentMap !== packet.map) {
+			return;
+		}
+		gameBoard.swapTiles();
+	}
+
 	swapTiles() {
 		//Find all fast tiles, find all ice tiles, swap them
 		var cells = this.currentMap.cells;
@@ -1350,6 +1401,13 @@ class GameBoard {
 			}
 		}
 		messenger.messageRoomBySig(this.roomSig, "tileChanges", JSON.stringify(tileDelta));
+		// Tell clients the swap itself just landed (distinct from any other tile
+		// change), carrying the ids it flipped, so the delayed swap sound fires
+		// exactly once at the flip and the right tiles stop telegraphing.
+		var swappedIds = Object.keys(tileDelta);
+		if (swappedIds.length > 0) {
+			messenger.messageRoomBySig(this.roomSig, "tileSwapPerformed", JSON.stringify(swappedIds));
+		}
 	}
 	cutPlayers(owner) {
 		for (var id in this.playerList) {
@@ -1411,7 +1469,16 @@ class GameBoard {
 			randomPlayer[prop] = ownerPlayer[prop];
 			ownerPlayer[prop] = tempVars[prop];
 		}
-		messenger.messageRoomBySig(gameBoard.roomSig, "playerSwapped", packet.owner);
+		// Send both endpoints (the players' positions just after they exchanged)
+		// so the client can puff teleport effects where players actually land,
+		// not where the owner used to be.
+		messenger.messageRoomBySig(gameBoard.roomSig, "playerSwapped", JSON.stringify({
+			owner: packet.owner,
+			points: [
+				{ x: ownerPlayer.x, y: ownerPlayer.y },
+				{ x: randomPlayer.x, y: randomPlayer.y }
+			]
+		}));
 	}
 	spawnBomb(owner) {
 		var player = this.playerList[owner];
@@ -1480,7 +1547,7 @@ class GameBoard {
 		this.applyExplosionForce(explodeLoc, owner);
 		this.lobbyMapDirty = true;
 		this.lobbyLastActivity = Date.now();
-		messenger.messageRoomBySig(this.roomSig, 'snowFlakeExploded', owner);
+		messenger.messageRoomBySig(this.roomSig, 'snowFlakeExploded', { owner: owner, x: explodeLoc.x, y: explodeLoc.y });
 		messenger.messageRoomBySig(this.roomSig, "tileChanges", JSON.stringify(tileDelta));
 	}
 	explodeLava(explodeLoc, radius) {
@@ -2747,7 +2814,7 @@ class Player extends Circle {
 		//Scratch space for the bot brain (aiController) — path cache, timers, etc.
 		this.ai = null;
 	}
-	update(currentState, dt) {
+	update(currentState, dt, punchDirectional) {
 		this.currentState = currentState;
 		// Bots have no socket and never AFK — the sleep/kick path ends in
 		// messageClientBySig (Room.checkAFK), which would throw on a socketless
@@ -2760,7 +2827,7 @@ class Player extends Circle {
 		}
 		this.dt = dt;
 		this.move();
-		this.checkAttack(currentState);
+		this.checkAttack(currentState, punchDirectional);
 		this.checkChatCoolDownTimer();
 		this.checkFireTimer();
 	}
@@ -2768,7 +2835,7 @@ class Player extends Circle {
 		this.x = this.newX;
 		this.y = this.newY;
 	}
-	checkAttack(currentState) {
+	checkAttack(currentState, punchDirectional) {
 		if (this.attack) {
 			if ((currentState == c.stateMap.racing || currentState == c.stateMap.collapsing || currentState == c.stateMap.lobby) && this.ability != null) {
 				this.punchedTimer = Date.now();
@@ -2795,7 +2862,21 @@ class Player extends Circle {
 			if (this.isZombie == true) {
 				punchRadius = c.brutalRounds.infection.punchRadius;
 			}
-			this.punch = new Punch(this.x, this.y, punchRadius, this.color, this.id, this.roomSig, 1, this.isZombie);
+			// Directional punch: place the hitbox in front of the player along its
+			// facing angle so you have to aim, and the radial knockback shoves the
+			// target forward. The decision (per round/mode) is resolved in
+			// GameBoard.updatePlayers and passed in. (Bumper/hazard punches are
+			// created elsewhere and stay centered/radial.)
+			var directional = punchDirectional === undefined ? c.directionalPunch : punchDirectional;
+			var punchX = this.x;
+			var punchY = this.y;
+			if (directional) {
+				var aim = utils.pos({ x: this.x, y: this.y }, c.punchReach, this.angle);
+				punchX = aim.x;
+				punchY = aim.y;
+			}
+			this.punch = new Punch(punchX, punchY, punchRadius, this.color, this.id, this.roomSig, 1, this.isZombie);
+			this.punch.directional = directional;
 			// No scoring in the lobby: punches still land (knockback feel) but must not
 			// tick the bully achievement stat, which isn't gated by checkForWinners.
 			if (currentState != c.stateMap.lobby) {
@@ -3032,7 +3113,7 @@ class Player extends Circle {
 				this.setPunchedBy(object.ownerId);
 			}
 			_engine.punchPlayer(this, object);
-			messenger.messageRoomBySig(this.roomSig, "playerPunched", object.ownerId);
+			messenger.messageRoomBySig(this.roomSig, "playerPunched", { owner: object.ownerId, victim: this.id, x: this.x, y: this.y });
 			emitBotEmote(this, "hurt"); // an AI racer reacts to getting knocked
 			return;
 		}
@@ -3041,7 +3122,7 @@ class Player extends Circle {
 				return;
 			}
 			_engine.puckPlayer(object, this);
-			messenger.messageRoomBySig(this.roomSig, "playerPunched", object.ownerId);
+			messenger.messageRoomBySig(this.roomSig, "playerPunched", { owner: object.ownerId, victim: this.id, x: this.x, y: this.y });
 			return;
 		}
 		if (object.isGate) {
@@ -3656,7 +3737,7 @@ class Puck extends Projectile {
 	handleHit(object) {
 		if (object.isPunch && object.ownerId != this.ownerId) {
 			_engine.punchPuck(this, object);
-			messenger.messageRoomBySig(this.roomSig, "playerPunched", object.ownerId);
+			messenger.messageRoomBySig(this.roomSig, "playerPunched", { owner: object.ownerId, victim: this.id, x: this.x, y: this.y });
 			return;
 		}
 	}


### PR DESCRIPTION
A polish pass on combat/ability/brutal-round animations and game feel, plus small AI-racer tweaks.

## Animations & game feel
- Effects/particle system + trauma screen shake; punch impact + shockwave + directional swipe; connecting-hit sparks.
- Server-authoritative directional punch with per-mode rules (hockey radial; infection zombies must face prey; survivors/puck all-directional).
- Ability feedback: ramping aimer pulse, teleport puffs, cut slash, blindfold fade, speed auras, restyled reticles, bomb/ice muzzle flash + recoil + trigger pulse.
- Brutal rounds: title scale-in + flashes, blackout iris, bomb/ice fireballs.
- Terrain-aware movement particles (dust/skid, ice trails at speed, embers while on fire).
- TileSwap telegraph (tiles pulse/flicker during a 3–6s warn-up; sound plays on the flip via a dedicated event).
- Dark-red border around lava islands.
- Integrated with the v0.5.0 dynamic camera: world-anchored effects follow the zoom/pan; screen-space flashes/title render in the HUD matrix.

## AI racer tweaks
- Racers cruise a bit faster (closer to human pace).
- Show only the racer name (dropped the subtitle).
- Local players (primary + couch co-op slots) render above remote players' emojis/labels.

## Testing
- Headless smoke test (boots + ticks across all 50 maps), content validation, production build, and JS syntax checks — all green.
- Two recall-mode code-review passes plus a post-rebase review of the dynamic-camera × effects integration; findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
