### PR TITLE
fix: stop overview-screen punches and clear ice grip behind the starting gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- You can no longer throw a punch (or hear the punch sound) on the "next map" screen between rounds — punching now only works during a race, at the starting gate, and in the practice lobby.
+- Getting knocked back behind the starting gate no longer leaves you sliding around like you're still on ice — your grip returns to normal off the track.
 
 ## v0.6.1 — 2026-05-24
 

--- a/server/engine.js
+++ b/server/engine.js
@@ -647,6 +647,13 @@ function checkCollideCells(player, map) {
 			return; // a point lies in exactly one Voronoi cell
 		}
 	}
+	// No cell contains this point — it's outside the playable terrain (e.g. punched
+	// back behind the starting gate). Reset grip to normal ground so the last tile's
+	// physics (notably ice) doesn't persist there. Only players carry grip; snowFlake
+	// projectiles also reach this path and have no resetGrip, so guard the call.
+	if (typeof player.resetGrip === "function") {
+		player.resetGrip();
+	}
 }
 function pointIntersection(x, y, cell) {
 	{

--- a/server/game.js
+++ b/server/game.js
@@ -2854,6 +2854,16 @@ class Player extends Circle {
 				this.attack = false;
 				return;
 			}
+			// Punching is only meaningful during active play: the race itself
+			// (racing/collapsing), the pre-race gate where players jostle at the start
+			// (gated), and the lobby tutorial. In the non-play screens — the overview
+			// "next map" screen, waiting, and gameOver — swallow the input so no punch
+			// (and no punch sound, which the client only plays on the server's "punch"
+			// event) is thrown.
+			if (currentState != c.stateMap.racing && currentState != c.stateMap.collapsing && currentState != c.stateMap.lobby && currentState != c.stateMap.gated) {
+				this.attack = false;
+				return;
+			}
 			if (this.checkPunchCoolDown()) {
 				return;
 			}
@@ -3093,6 +3103,22 @@ class Player extends Circle {
 		this.acel = object.acel * c.brutalRounds.infection.acelModifer;
 		this.dragCoeff = object.dragCoeff * c.brutalRounds.infection.dragModifer;
 		this.brakeCoeff = object.brakeCoeff * c.brutalRounds.infection.brakeModifer;
+	}
+	// Restore normal ground grip (accel/drag/brake). Called when a player is off every
+	// map cell — e.g. shoved back behind the starting gate, a region with no terrain
+	// tile to stamp physics. Without this, the last tile they touched (ice in particular)
+	// keeps them sliding there until they step back onto real terrain. Zombies keep their
+	// infection handicap, measured against normal ground.
+	resetGrip() {
+		if (this.isZombie == true) {
+			this.acel = c.playerBaseAcel * c.brutalRounds.infection.acelModifer;
+			this.dragCoeff = c.playerDragCoeff * c.brutalRounds.infection.dragModifer;
+			this.brakeCoeff = c.playerBrakeCoeff * c.brutalRounds.infection.brakeModifer;
+			return;
+		}
+		this.acel = c.playerBaseAcel;
+		this.dragCoeff = c.playerDragCoeff;
+		this.brakeCoeff = c.playerBrakeCoeff;
 	}
 	handleHit(object) {
 		if (object.isLobbyStart) {


### PR DESCRIPTION
Two gameplay bug fixes reported during play.

## Punching on the "next map" screen
Previously a punch fired in **any** game state, so on the overview / "next map" screen between rounds you could still throw a punch and hear the punch sound. `Player.checkAttack` now gates the punch to active-play states only: **racing, collapsing, the pre-race gated start, and the lobby tutorial**. On the overview screen (and waiting / gameOver) the attack input is swallowed. The client only plays the punch cue on the server's `"punch"` event, so gating it server-side stops the audio too.

Note: punching at the **starting gate (gated)** is intentionally kept — players jostle there before the race.

## Ice grip persisting behind the starting gate
Tile physics (accel/drag/brake) are only re-stamped while a player sits inside a Voronoi cell. The start/gate region has no terrain cells, so a player punched back across ice into it kept the ice physics and stayed slippery "until they stepped out of the gate." `checkCollideCells` now restores normal ground grip via a new `Player.resetGrip()` whenever a player is off every map cell. Zombies keep their infection handicap; the call is guarded by `typeof` so snowflake projectiles (which also flow through `checkCollideCells`) are untouched.

## Notes
- Touches `server/game.js` and `server/engine.js` (game-mechanic files) → CHANGELOG `## Unreleased` updated with two player-facing bullets.
- Speed buffs/debuffs are unaffected: they live on `dragMultiplier`/`currentSpeedBonus` (applied separately by the engine), not the `acel`/`dragCoeff`/`brakeCoeff` that `resetGrip` writes — matching existing tile `handleHit` behavior.

## Testing
- `node -c` syntax check on both edited files.
- Headless engine smoke test (`.github/scripts/smoke-test.js`): boots + ticks the real engine across all maps through overview/gated/racing without crashing.
- Content validator: config + all maps valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)