### PR TITLE
Player visibility + controller & mobile polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- Other players' karts and trails now fade a little during a race, so your own kart stands out in a crowded pack (danger like fire and ability rings stays at full brightness).
+- Press attack while you're knocked out to ping the spot where you fell, making it easy to find where you died.
+- Kart colours are now chosen to be as visually distinct as possible, so you're far less likely to see two players in lookalike shades.
+- New colour-blind assist toggle in the top bar recolours every kart with a colour-blind-friendly palette.
 
 ## v0.7.0 — 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,25 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 ### General
 
 - Other players' karts and trails now fade a little during a race, so your own kart stands out in a crowded pack (danger like fire and ability rings stays at full brightness).
-- Press attack while you're knocked out to ping the spot where you fell, making it easy to find where you died.
+- Other players' emote bubbles are fainter and fade away over a few seconds, so chat stops cluttering the action.
 - Kart colours are now chosen to be as visually distinct as possible, so you're far less likely to see two players in lookalike shades.
 - New colour-blind assist toggle in the top bar recolours every kart with a colour-blind-friendly palette.
+- Tile Swap's warning now reads as a calmer glow instead of an intense flicker.
+
+### When you're knocked out
+
+- Press attack while you're down to ping where players fell — it reveals every knocked-out player's spot at once, so you can read the whole board.
+- The skull markers left by knocked-out players now fade away after a few seconds so they stop cluttering the board (a ping brings them back).
+
+### Controller & couch co-op
+
+- Leaving the game on a controller now takes a deliberate button hold, so a mashed attack can't make you quit by accident.
+- In couch co-op, each player's on-screen controller guide (which pad you are, plus your buttons) now stays put instead of fading out.
+
+### Display
+
+- Fullscreen no longer stretches the game on non-16:9 screens — it fits with clean letterbox bars instead of looking squished.
+- On a phone held in portrait, a prompt now asks you to rotate to landscape (the game is built for a wide view).
 
 ## v0.7.0 — 2026-05-25
 

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -307,6 +307,47 @@ canvas {
     position: relative;
     margin: 0;
 }
+/* Rotate-to-play overlay. The game is a fixed 16:9 landscape arena, so rather
+   than squeeze it into a portrait sliver we cover the screen on touch devices
+   held in portrait and ask the player to rotate. Pure CSS via a media query —
+   it appears/clears instantly on orientation change, no JS. */
+#rotatePrompt {
+    display: none;
+}
+@keyframes rotateHint {
+    0%, 30% { transform: rotate(0deg); }
+    60%, 100% { transform: rotate(90deg); }
+}
+@media (orientation: portrait) and (hover: none) and (pointer: coarse) {
+    #rotatePrompt {
+        display: flex;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 10000;
+        background: var(--board-bg);
+        color: var(--canvas-ink);
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 24px;
+    }
+    #rotatePrompt .rotate-inner {
+        max-width: 320px;
+    }
+    #rotatePrompt .rotate-icon {
+        font-size: 3.5rem;
+        display: block;
+        margin: 0 auto 18px;
+        animation: rotateHint 1.8s ease-in-out infinite;
+    }
+    #rotatePrompt .rotate-text {
+        font-size: 1.15rem;
+        line-height: 1.4;
+    }
+}
 #progressContainer{
     width: 50%;
     border-style: solid;

--- a/client/play.html
+++ b/client/play.html
@@ -34,6 +34,8 @@
             color: inherit;"><i class="music-btn fas fa-music"></i> [<i class="music-btn fa fa-volume-up" aria-hidden="true"></i>]</a>
             <a id="cameraControl" class="nav-toggle" role="button" tabindex="0" aria-label="Toggle dynamic camera zoom" style="cursor:pointer; text-decoration: inherit;
             color: inherit;"><i class="music-btn fas fa-video" aria-hidden="true"></i> [<i class="music-btn fa fa-check" aria-hidden="true"></i>]</a>
+            <a id="colorblindControl" class="nav-toggle" role="button" tabindex="0" aria-label="Toggle colour-blind assist (distinct kart colours)" style="cursor:pointer; text-decoration: inherit;
+            color: inherit;"><i class="music-btn fas fa-eye" aria-hidden="true"></i> [<i class="music-btn fa fa-ban" aria-hidden="true"></i>]</a>
           </nav>
         <section>
             <!-- Game enclosed here -->

--- a/client/play.html
+++ b/client/play.html
@@ -39,6 +39,14 @@
           </nav>
         <section>
             <!-- Game enclosed here -->
+            <!-- Shown only on touch devices held in portrait (CSS media query):
+                 the game is a 16:9 landscape arena, so prompt a rotate. -->
+            <div id="rotatePrompt">
+                <div class="rotate-inner">
+                    <i class="fas fa-mobile-alt rotate-icon" aria-hidden="true"></i>
+                    <div class="rotate-text">Rotate your device to landscape to play</div>
+                </div>
+            </div>
             <div id="progressContainer" class="row justify-content-center align-self-center mx-auto">Loading Assets..<div id="progressWindow"><div id="progressBar"></div></div></div>
             <div id="gameWindow" >
             <div id="mapContainer">

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -197,10 +197,12 @@ function registerPrimaryHandlers(server) {
 			playerList[id].alive = false;
 			playerList[id].onFire = 0;
 			playerList[id].deathMessage = '💀';
-			// Remember where they fell so a local player can ping their own spot
-			// (press attack while dead) — see updateDeathPings() in draw.js.
+			// Remember where/when they fell: a dead local player can press attack
+			// to ping every dead player's spot, and the floating skull fades from
+			// deathAt — see updateDeathPings()/drawDeathMessage() in draw.js.
 			playerList[id].deathX = playerList[id].x;
 			playerList[id].deathY = playerList[id].y;
+			playerList[id].deathAt = Date.now();
 		}
 		recapMarkHighlight('death', [id]); // flag an elimination moment for the recap
 		createDownRankSymbol(id);

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -217,16 +217,27 @@ function registerPrimaryHandlers(server) {
 	server.on("playerInfected", function (id) {
 		playerList[id].alive = true;
 		playerList[id].deathMessage = null;
+		// Revived as a zombie — clear the death spot so no stale skull/ping data
+		// lingers on a now-alive player (keeps the death-state guards consistent
+		// across every revive/reset path).
+		playerList[id].deathX = null;
+		playerList[id].deathY = null;
+		playerList[id].deathAt = null;
 		playerList[id].infected = true;
 		playSound(newZombie);
 	});
 	server.on("broadCastEmoji", function (payload) {
 		playerList[payload.ownerId].chatMessage = payload.emoji;
 		// Stamp when/how long so drawEmoji can fade other players' bubbles out.
-		playerList[payload.ownerId].chatMessageAt = Date.now();
+		var emoteStamp = Date.now();
+		playerList[payload.ownerId].chatMessageAt = emoteStamp;
 		playerList[payload.ownerId].chatMessageDuration = 4000;
 		setTimeout(function (owner) {
-			playerList[owner].chatMessage = null;
+			// Only clear if still the same emote — a newer one re-stamps
+			// chatMessageAt, so this older timeout must not cut it short.
+			if (playerList[owner] != null && playerList[owner].chatMessageAt === emoteStamp) {
+				playerList[owner].chatMessage = null;
+			}
 		}, 4000, payload.ownerId);
 	});
 	server.on('playerSleeping', function (id) {
@@ -313,7 +324,9 @@ function registerPrimaryHandlers(server) {
 		// Decode the SERVER colour (not the live .color, which colour-blind assist
 		// may have remapped to an off-palette CVD hex that Colors.decode can't name).
 		var winner = playerList[packet.winner];
-		decodedColorName = Colors.decode((winner._serverColor != null) ? winner._serverColor : winner.color);
+		decodedColorName = (winner != null)
+			? Colors.decode((winner._serverColor != null) ? winner._serverColor : winner.color)
+			: "";
 		currentState = config.stateMap.gameOver;
 	});
 	server.on("startCollapse", function (info) {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -197,6 +197,10 @@ function registerPrimaryHandlers(server) {
 			playerList[id].alive = false;
 			playerList[id].onFire = 0;
 			playerList[id].deathMessage = '💀';
+			// Remember where they fell so a local player can ping their own spot
+			// (press attack while dead) — see updateDeathPings() in draw.js.
+			playerList[id].deathX = playerList[id].x;
+			playerList[id].deathY = playerList[id].y;
 		}
 		recapMarkHighlight('death', [id]); // flag an elimination moment for the recap
 		createDownRankSymbol(id);

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -305,7 +305,10 @@ function registerPrimaryHandlers(server) {
 		recapBuild(achievements); // assemble the recap montage from the buffer
 		stopAllSounds();
 		playSound(gameOverSound);
-		decodedColorName = Colors.decode(playerList[packet.winner].color);
+		// Decode the SERVER colour (not the live .color, which colour-blind assist
+		// may have remapped to an off-palette CVD hex that Colors.decode can't name).
+		var winner = playerList[packet.winner];
+		decodedColorName = Colors.decode((winner._serverColor != null) ? winner._serverColor : winner.color);
 		currentState = config.stateMap.gameOver;
 	});
 	server.on("startCollapse", function (info) {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -220,6 +220,9 @@ function registerPrimaryHandlers(server) {
 	});
 	server.on("broadCastEmoji", function (payload) {
 		playerList[payload.ownerId].chatMessage = payload.emoji;
+		// Stamp when/how long so drawEmoji can fade other players' bubbles out.
+		playerList[payload.ownerId].chatMessageAt = Date.now();
+		playerList[payload.ownerId].chatMessageDuration = 4000;
 		setTimeout(function (owner) {
 			playerList[owner].chatMessage = null;
 		}, 4000, payload.ownerId);
@@ -611,6 +614,8 @@ function registerPrimaryHandlers(server) {
 		}
 		// Reuse the chat-bubble render path (drawEmoji) for the bot's taunt.
 		playerList[payload.id].chatMessage = payload.emote;
+		playerList[payload.id].chatMessageAt = Date.now();
+		playerList[payload.id].chatMessageDuration = 2500;
 		setTimeout(function () {
 			if (playerList[payload.id] != null && playerList[payload.id].chatMessage === payload.emote) {
 				playerList[payload.id].chatMessage = null;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -2301,10 +2301,11 @@ function drawPendingSwap() {
         // Per-tile progress so overlapping swaps each ramp on their own clock.
         var span = tile.end - tile.start;
         var prog = span > 0 ? clamp01((now - tile.start) / span) : 1;
-        var pulse = 0.5 + 0.5 * Math.sin((now / 1000) * (3 + 6 * prog) * Math.PI * 2);
-        // Electrical flicker: occasional dim frames, more frequent near the end.
-        var flicker = Math.random() < (0.08 + 0.2 * prog) ? 0.3 : 1.0;
-        var alpha = (0.18 + 0.4 * pulse) * flicker;
+        var pulse = 0.5 + 0.5 * Math.sin((now / 1000) * (2 + 3 * prog) * Math.PI * 2);
+        // Occasional, gentle dim frames (rarer and shallower than a hard strobe)
+        // so the warn-up reads as a calm electric glow, not an intense flicker.
+        var flicker = Math.random() < (0.03 + 0.07 * prog) ? 0.6 : 1.0;
+        var alpha = (0.15 + 0.32 * pulse) * flicker;
         if (!traceCellPath(gameContext, cell)) {
             continue;
         }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -67,9 +67,11 @@ function cbAssignColor(id) {
         }
     }
     if (best == null) {
-        // More than 8 karts: palette exhausted. Cycle deterministically — server
-        // colours already differ, so this only affects the CVD overlay.
-        best = CB_PALETTE[used.length % CB_PALETTE.length];
+        // More than 8 karts: the CVD palette is exhausted. Return null (don't
+        // cache) so the caller keeps this kart's already-max-distinct SERVER
+        // colour instead of handing out a duplicate CVD colour. Re-resolves on a
+        // later frame once a palette slot frees up.
+        return null;
     }
     cbAssigned[id] = best;
     return best;
@@ -100,7 +102,8 @@ function syncColorblind() {
                 p._serverColor = p.color;
             }
             var cb = cbAssignColor(id);
-            if (p.color !== cb) {
+            // cb == null => palette exhausted; keep the server colour (already set).
+            if (cb != null && p.color !== cb) {
                 p.color = cb;
             }
         } else if (p._serverColor != null && p.color !== p._serverColor) {
@@ -475,7 +478,6 @@ function drawObjects(dt) {
     if (config == null) {
         return;
     }
-    updateDeathPings();
     syncColorblind();
 
     updateWorldCamera(dt);
@@ -486,6 +488,10 @@ function drawObjects(dt) {
         drawOverviewBoard();
         return;
     }
+    // After the overview early-return (which skips drawEffects): only spawn death
+    // pings in states where the effect will actually be rendered this frame, so a
+    // press never burns its cooldown invisibly.
+    updateDeathPings();
 
     // ---- WORLD PASS: zoomed/panned by the dynamic camera (touch); identity
     // elsewhere. Everything positioned in world coords goes here. ----

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -10,6 +10,9 @@ var complexPatternScale = 0.1;
 // punches) are NOT dimmed — danger always stays full strength.
 var NONLOCAL_KART_ALPHA = 0.55;
 var NONLOCAL_TRAIL_ALPHA = 0.3;
+// Other players' emote bubbles draw fainter than your own and fade out over the
+// back half of their lifetime, so chat clutter doesn't crowd the action.
+var NONLOCAL_EMOJI_ALPHA = 0.5;
 
 // --- Colour-blind assist ---
 // When colorblindEnabled (navbar toggle, persisted) is on, every kart is remapped
@@ -1623,6 +1626,20 @@ function drawSpeedFx(player) {
 function drawEmoji(player) {
     if (player.chatMessage != null) {
         gameContext.save();
+        // Other players' bubble + emoji read fainter and fade out over the back
+        // half of their lifetime so they don't clutter the view; your own stays
+        // full-strength and crisp.
+        if (!isLocalId(player.id)) {
+            var alpha = NONLOCAL_EMOJI_ALPHA;
+            if (player.chatMessageAt != null && player.chatMessageDuration) {
+                var elapsed = Date.now() - player.chatMessageAt;
+                var fadeStart = player.chatMessageDuration * 0.5;
+                if (elapsed > fadeStart) {
+                    alpha *= clamp01(1 - (elapsed - fadeStart) / (player.chatMessageDuration - fadeStart));
+                }
+            }
+            gameContext.globalAlpha = alpha;
+        }
         gameContext.drawImage(commentIconSolid, player.x, player.y - 40, commentIconSolid.width * 0.07, commentIconSolid.height * 0.07);
         gameContext.font = '20px Times New Roman';
         gameContext.fillStyle = "white";

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1496,16 +1496,21 @@ function drawPlayer(player, dt) {
         gameContext.save();
         gameContext.globalAlpha = NONLOCAL_KART_ALPHA;
     }
-    gameContext.drawImage(
-        sprite,
-        player.x + camera.getCameraX() - sprite.halfSize,
-        player.y + camera.getCameraY() - sprite.halfSize
-    );
-    if (dimKart) {
-        gameContext.restore();
-    }
-    if (immune) {
-        gameContext.restore();
+    // try/finally so a thrown drawImage (e.g. an undecoded sprite -> InvalidStateError)
+    // can't skip the restore() and leak the dimmed/flash alpha onto the rest of the frame.
+    try {
+        gameContext.drawImage(
+            sprite,
+            player.x + camera.getCameraX() - sprite.halfSize,
+            player.y + camera.getCameraY() - sprite.halfSize
+        );
+    } finally {
+        if (dimKart) {
+            gameContext.restore();
+        }
+        if (immune) {
+            gameContext.restore();
+        }
     }
 
     if (player.ability != null) {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1672,7 +1672,21 @@ function drawBotName(player) {
 
 function drawDeathMessage(player) {
     if (player.deathMessage != null) {
+        // Fade the skull out over time so dead karts don't clutter the board
+        // (a ping re-reveals them). deathAt is stamped on race deaths only; lobby
+        // respawns leave it null and clear the message quickly on their own.
+        var alpha = 1;
+        if (player.deathAt != null) {
+            var elapsed = Date.now() - player.deathAt;
+            if (elapsed > DEATH_SKULL_HOLD_MS) {
+                alpha = clamp01(1 - (elapsed - DEATH_SKULL_HOLD_MS) / DEATH_SKULL_FADE_MS);
+            }
+        }
+        if (alpha <= 0.02) {
+            return;
+        }
         gameContext.save();
+        gameContext.globalAlpha = alpha;
         gameContext.drawImage(commentIconSolid, player.x, player.y - 40, commentIconSolid.width * 0.07, commentIconSolid.height * 0.07);
         gameContext.font = '20px Times New Roman';
         // theme-aware so the message stays readable where it overflows the
@@ -1908,11 +1922,16 @@ function drawTrail(player) {
 }
 
 // --- Death ping ---
-// While you're dead, pressing attack pulses a sonar marker at the spot where
-// you fell — a local-only nudge to help you find your body in the chaos (it is
-// never sent to the server or shown to other players). Works for every local
-// slot (couch co-op): each dead controller pings its own spot.
+// Floating death skulls (drawDeathMessage) fade out a few seconds after a death
+// so the board declutters. While you're dead, pressing attack pulses a sonar
+// marker over EVERY dead player's spot (yours plus all others) so you can see
+// the whole carnage at a glance. Local-only/visual — never sent to the server.
+// Works for every local slot (couch co-op).
 var DEATH_PING_COOLDOWN_MS = 900;
+// Death-skull fade: fully visible for HOLD ms after death, then fades to gone
+// over FADE ms (re-revealed by a ping's sonar pulse).
+var DEATH_SKULL_HOLD_MS = 1500;
+var DEATH_SKULL_FADE_MS = 4000;
 
 function spawnDeathPingEffect(x, y, color) {
     var ringColor = color || "rgb(255, 215, 0)";
@@ -1952,13 +1971,21 @@ function spawnDeathPingEffect(x, y, color) {
     });
 }
 
-function requestDeathPing(lp, player) {
+// Pulse a sonar marker over every dead player's death spot (yours included),
+// each in that player's colour — pressing punch while dead reveals the whole
+// board's carnage at once. Cooldown-gated per local slot to prevent spam.
+function pingAllDeathSpots(lp) {
     var now = Date.now();
     if (lp._lastDeathPingAt != null && now - lp._lastDeathPingAt < DEATH_PING_COOLDOWN_MS) {
         return;
     }
     lp._lastDeathPingAt = now;
-    spawnDeathPingEffect(player.deathX, player.deathY, player.color);
+    for (var id in playerList) {
+        var p = playerList[id];
+        if (p != null && p.alive === false && p.deathX != null) {
+            spawnDeathPingEffect(p.deathX, p.deathY, p.color);
+        }
+    }
 }
 
 // Per-frame: detect a fresh attack press on each local slot whose player is
@@ -1981,9 +2008,11 @@ function updateDeathPings() {
         var prev = !!lp._deadAttackPrev;
         lp._deadAttackPrev = atk;
         if (atk && !prev) {
+            // Only a player who actually died this round (deathX set) can ping;
+            // the ping then reveals ALL dead players' spots.
             var p = playerList[lp.myID];
             if (p != null && p.alive === false && p.deathX != null) {
-                requestDeathPing(lp, p);
+                pingAllDeathSpots(lp);
             }
         }
     }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3,6 +3,112 @@ var spreadScale = 0.15;
 var bombScale = 0.025;
 var complexPatternScale = 0.1;
 
+// --- Visibility tuning ---
+// During the race, other players' kart bodies and trails are drawn fainter so
+// your own kart(s) read clearly in a crowded pack (your kart already carries a
+// pulsing halo via drawLocalPlayerHighlight). Threat FX (fire, ability rings,
+// punches) are NOT dimmed — danger always stays full strength.
+var NONLOCAL_KART_ALPHA = 0.55;
+var NONLOCAL_TRAIL_ALPHA = 0.3;
+
+// --- Colour-blind assist ---
+// When colorblindEnabled (navbar toggle, persisted) is on, every kart is remapped
+// to the Okabe-Ito palette — eight colours chosen to stay distinguishable under
+// the common forms of colour-blindness. We mutate player.color in place (keeping
+// the server's colour in player._serverColor) so every existing draw site — kart
+// sprite, trail, ability rings, scoreboard icons — picks it up with no extra
+// threading. Assignment is stable per player id and greedily maximises distance
+// among the colours already handed out.
+var CB_PALETTE = ['#E69F00', '#56B4E9', '#009E73', '#F0E442', '#0072B2', '#D55E00', '#CC79A7', '#000000'];
+var cbAssigned = {}; // player id -> CVD-safe colour
+
+function cbHexToRgb(hex) {
+    if (typeof hex !== "string") {
+        return null;
+    }
+    var m = /^#([0-9a-f]{6})$/i.exec(hex.trim());
+    if (!m) {
+        return null;
+    }
+    var h = m[1];
+    return { r: parseInt(h.slice(0, 2), 16), g: parseInt(h.slice(2, 4), 16), b: parseInt(h.slice(4, 6), 16) };
+}
+function cbColorDist(a, b) {
+    var ca = cbHexToRgb(a), cb = cbHexToRgb(b);
+    if (ca == null || cb == null) {
+        return Infinity;
+    }
+    var rmean = (ca.r + cb.r) / 2, dr = ca.r - cb.r, dg = ca.g - cb.g, db = ca.b - cb.b;
+    return Math.sqrt((((512 + rmean) * dr * dr) / 256) + 4 * dg * dg + (((767 - rmean) * db * db) / 256));
+}
+function cbAssignColor(id) {
+    if (cbAssigned[id] != null) {
+        return cbAssigned[id];
+    }
+    var used = [];
+    for (var k in cbAssigned) {
+        used.push(cbAssigned[k]);
+    }
+    var best = null, bestScore = -1;
+    for (var i = 0; i < CB_PALETTE.length; i++) {
+        if (used.indexOf(CB_PALETTE[i]) !== -1) {
+            continue; // hand out each palette colour once before repeating
+        }
+        var minDist = Infinity;
+        for (var j = 0; j < used.length; j++) {
+            var d = cbColorDist(CB_PALETTE[i], used[j]);
+            if (d < minDist) {
+                minDist = d;
+            }
+        }
+        if (minDist > bestScore) {
+            bestScore = minDist;
+            best = CB_PALETTE[i];
+        }
+    }
+    if (best == null) {
+        // More than 8 karts: palette exhausted. Cycle deterministically — server
+        // colours already differ, so this only affects the CVD overlay.
+        best = CB_PALETTE[used.length % CB_PALETTE.length];
+    }
+    cbAssigned[id] = best;
+    return best;
+}
+// Per-frame, cheap: keep every player's display colour in sync with the toggle.
+// Idempotent — only writes when a colour actually needs to change.
+function syncColorblind() {
+    if (typeof playerList === "undefined" || !playerList) {
+        return;
+    }
+    var on = (typeof colorblindEnabled !== "undefined" && colorblindEnabled);
+    if (on) {
+        // Drop assignments for players who have left so the 8-colour palette
+        // doesn't appear "used up" over a session with lots of joins/leaves.
+        for (var aid in cbAssigned) {
+            if (playerList[aid] == null) {
+                delete cbAssigned[aid];
+            }
+        }
+    }
+    for (var id in playerList) {
+        var p = playerList[id];
+        if (p == null) {
+            continue;
+        }
+        if (on) {
+            if (p._serverColor == null) {
+                p._serverColor = p.color;
+            }
+            var cb = cbAssignColor(id);
+            if (p.color !== cb) {
+                p.color = cb;
+            }
+        } else if (p._serverColor != null && p.color !== p._serverColor) {
+            p.color = p._serverColor;
+        }
+    }
+}
+
 // Theme-aware colours for canvas elements that sit on the board surface and
 // must stay readable in dark mode (playfield fill/border + on-board text).
 // theme.js keeps window.themePalette in sync with the active theme; the
@@ -369,6 +475,8 @@ function drawObjects(dt) {
     if (config == null) {
         return;
     }
+    updateDeathPings();
+    syncColorblind();
 
     updateWorldCamera(dt);
     applyCanvasTransform();
@@ -1370,11 +1478,23 @@ function drawPlayer(player, dt) {
         gameContext.save();
         gameContext.globalAlpha = 0.35 + 0.45 * Math.abs(Math.sin(Date.now() / pulsePeriod));
     }
+    // Fade other players' kart bodies during the race so yours pops. Never dims
+    // a flashing (immune) kart — that flash carries its own alpha — and never
+    // your own. Threat FX drawn elsewhere (fire/ability rings) stay full.
+    var dimKart = !isLocalId(player.id) && !immune &&
+        (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing);
+    if (dimKart) {
+        gameContext.save();
+        gameContext.globalAlpha = NONLOCAL_KART_ALPHA;
+    }
     gameContext.drawImage(
         sprite,
         player.x + camera.getCameraX() - sprite.halfSize,
         player.y + camera.getCameraY() - sprite.halfSize
     );
+    if (dimKart) {
+        gameContext.restore();
+    }
     if (immune) {
         gameContext.restore();
     }
@@ -1751,7 +1871,98 @@ function drawArmedRing(x, y, color) {
 
 function drawTrail(player) {
     if (player.trail.canvas != null) {
+        // Fade other players' trails so your own line stays legible in the pack.
+        var dim = !isLocalId(player.id);
+        if (dim) {
+            gameContext.save();
+            gameContext.globalAlpha = NONLOCAL_TRAIL_ALPHA;
+        }
         gameContext.drawImage(player.trail.canvas, player.trail.canvasOriginX, player.trail.canvasOriginY);
+        if (dim) {
+            gameContext.restore();
+        }
+    }
+}
+
+// --- Death ping ---
+// While you're dead, pressing attack pulses a sonar marker at the spot where
+// you fell — a local-only nudge to help you find your body in the chaos (it is
+// never sent to the server or shown to other players). Works for every local
+// slot (couch co-op): each dead controller pings its own spot.
+var DEATH_PING_COOLDOWN_MS = 900;
+
+function spawnDeathPingEffect(x, y, color) {
+    var ringColor = color || "rgb(255, 215, 0)";
+    addEffect({
+        x: x,
+        y: y,
+        maxAge: 1100,
+        draw: function (ctx, t) {
+            // World-space: add the camera offset so the ping stays pinned to the
+            // death spot under the dynamic camera (same convention as the kart).
+            var cx = x + camera.getCameraX();
+            var cy = y + camera.getCameraY();
+            ctx.save();
+            ctx.lineCap = "round";
+            // Three staggered sonar rings expanding outward.
+            for (var k = 0; k < 3; k++) {
+                var rt = t - k * 0.18;
+                if (rt <= 0 || rt >= 1) {
+                    continue;
+                }
+                var grow = easeOutCubic(rt);
+                ctx.globalAlpha = (1 - rt) * 0.9;
+                ctx.lineWidth = 3 * (1 - rt) + 1;
+                ctx.strokeStyle = ringColor;
+                ctx.beginPath();
+                ctx.arc(cx, cy, 8 + grow * 70, 0, 2 * Math.PI);
+                ctx.stroke();
+            }
+            // A skull marker holding at the spot, fading over the ping's life.
+            ctx.globalAlpha = 0.85 * (1 - t);
+            ctx.font = "22px Times New Roman";
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            ctx.fillText("💀", cx, cy);
+            ctx.restore();
+        }
+    });
+}
+
+function requestDeathPing(lp, player) {
+    var now = Date.now();
+    if (lp._lastDeathPingAt != null && now - lp._lastDeathPingAt < DEATH_PING_COOLDOWN_MS) {
+        return;
+    }
+    lp._lastDeathPingAt = now;
+    spawnDeathPingEffect(player.deathX, player.deathY, player.color);
+}
+
+// Per-frame: detect a fresh attack press on each local slot whose player is
+// dead, and fire that slot's death ping. The primary slot reads the shared
+// movement globals (keyboard/mouse/primary pad); couch pad slots read their own
+// per-slot input. Edge-triggered so holding the button doesn't spam pings.
+function updateDeathPings() {
+    if (typeof localPlayers === "undefined" || !localPlayers ||
+        typeof playerList === "undefined" || !playerList) {
+        return;
+    }
+    for (var s = 0; s < localPlayers.length; s++) {
+        var lp = localPlayers[s];
+        if (!lp || lp.myID == null) {
+            continue;
+        }
+        var atk = (s === primarySlot)
+            ? (typeof attack !== "undefined" && !!attack)
+            : !!(lp.input && lp.input.attack);
+        var prev = !!lp._deadAttackPrev;
+        lp._deadAttackPrev = atk;
+        if (atk && !prev) {
+            var p = playerList[lp.myID];
+            if (p != null && p.alive === false && p.deathX != null) {
+                requestDeathPing(lp, p);
+            }
+        }
     }
 }
 

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -372,6 +372,9 @@ function gameLoop(dt) {
 
 
 function resize() {
+    // LOGICAL_WIDTH/HEIGHT are captured in setupPage; if a resize fires before
+    // that (early rotation/devtools), bail so we don't divide by 0 -> Infinity.
+    if (!LOGICAL_WIDTH || !LOGICAL_HEIGHT) return;
     var gameWindowRect = canvasWindow.getBoundingClientRect();
     if (gameWindowRect.width === 0 || gameWindowRect.height === 0) return;
     var viewport = { width: gameWindowRect.width, height: gameWindowRect.height };

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -38,6 +38,9 @@ var server = null,
     // initEventHandlers), toggleable by anyone via the navbar camera button.
     // Auto-falls back to whole-map when >1 local player shares the screen.
     cameraZoomEnabled = false,
+    // Colour-blind assist: when on, draw.js remaps every kart to a CVD-safe
+    // palette. Persisted in localStorage (see the #colorblindControl wiring).
+    colorblindEnabled = false,
     worldViewFocusedElapsed = 0,  // ms accumulated in the focus phase (frame-dt based, not wall-clock)
     WORLD_ZOOM_MAX = 1.8,      // tightest focus on the player while racing (shows some surroundings)
     WORLD_ZOOM_ENGAGE = 460,   // world-units: nearest goal pulls into frame within this
@@ -245,6 +248,19 @@ function setupPage() {
     });
     $("#cameraControl").on("keydown", activateToggleOnKey);
     updateCameraToggleUI();
+    // Colour-blind assist toggle — persisted so the choice sticks across visits.
+    try {
+        colorblindEnabled = localStorage.getItem("colorblindPref") === "on";
+    } catch (e) {
+        colorblindEnabled = false;
+    }
+    $("#colorblindControl").on("click", function () {
+        colorblindEnabled = !colorblindEnabled;
+        try { localStorage.setItem("colorblindPref", colorblindEnabled ? "on" : "off"); } catch (e) {}
+        updateColorblindToggleUI();
+    });
+    $("#colorblindControl").on("keydown", activateToggleOnKey);
+    updateColorblindToggleUI();
     volumeChange();
     gameCanvas = document.getElementById('gameCanvas');
     overlayCanvas = document.getElementById('overlayCanvas');
@@ -520,6 +536,18 @@ function updateCameraToggleUI() {
         ? '[<i class="music-btn fa fa-check" aria-hidden="true"></i>]'
         : '[<i class="music-btn fa fa-ban" aria-hidden="true"></i>]';
     el.innerHTML = '<i class="music-btn fas fa-video" aria-hidden="true"></i> ' + status;
+}
+
+// Reflect the colour-blind assist on/off state in the navbar toggle.
+function updateColorblindToggleUI() {
+    var el = document.getElementById("colorblindControl");
+    if (!el) {
+        return;
+    }
+    var status = colorblindEnabled
+        ? '[<i class="music-btn fa fa-check" aria-hidden="true"></i>]'
+        : '[<i class="music-btn fa fa-ban" aria-hidden="true"></i>]';
+    el.innerHTML = '<i class="music-btn fas fa-eye" aria-hidden="true"></i> ' + status;
 }
 
 // iOS Safari does NOT implement the Fullscreen API on arbitrary elements (only

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -375,18 +375,16 @@ function resize() {
     var gameWindowRect = canvasWindow.getBoundingClientRect();
     if (gameWindowRect.width === 0 || gameWindowRect.height === 0) return;
     var viewport = { width: gameWindowRect.width, height: gameWindowRect.height };
+    // Fit the canvas to the available space at its native 16:9 aspect ratio,
+    // scaling BOTH axes by the same factor so the game is never stretched. This
+    // also covers fullscreen: on any screen that isn't exactly 16:9 the canvas
+    // is letterboxed/pillarboxed — the #gameWindow flex container centres it and
+    // its --board-bg shows in the bars. (Filling the raw fullscreen viewport
+    // would scale X and Y independently and visibly distort the game — circles
+    // became ovals on 16:10 / ultrawide / notched displays.)
     var optimalRatio = Math.min(viewport.width / LOGICAL_WIDTH, viewport.height / LOGICAL_HEIGHT);
-
-    if (window.document.fullscreenElement) {
-        newWidth = viewport.width;
-        newHeight = viewport.height;
-    } else {
-        // Fit the canvas to the available space at its native 16:9
-        // aspect ratio (no padding shrink — the gameWindow flex
-        // container provides any breathing room).
-        newWidth = LOGICAL_WIDTH * optimalRatio;
-        newHeight = LOGICAL_HEIGHT * optimalRatio;
-    }
+    newWidth = LOGICAL_WIDTH * optimalRatio;
+    newHeight = LOGICAL_HEIGHT * optimalRatio;
 
     // Logical->CSS scale; used to keep canvas-drawn labels a stable physical
     // size across phone/desktop widths (see drawTouchLabel).

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -1202,6 +1202,18 @@ class Trail {
 	update(currentPosition, player) {
 		var last = this.vertices.length > 0 ? this.vertices[this.vertices.length - 1] : null;
 		if (last != null && currentPosition.x == last.x && currentPosition.y == last.y) {
+			// Parked, so no new segment — but still repaint if the colour changed
+			// (e.g. toggling colour-blind assist while stationary), otherwise the
+			// cached strip stays two-toned until the kart next moves.
+			if (this.canvas != null && player != null && this.lastColor != null && this.lastColor !== player.color) {
+				var nvStill = player.notches == gameLength;
+				if (DEBUG_FORCE_NEAR_VICTORY && player.id == myID) {
+					nvStill = true;
+				}
+				this._redrawAll(player.color, nvStill);
+				this.wasNearVictory = nvStill;
+				this.lastColor = player.color;
+			}
 			return;
 		}
 		if (this.vertices.length > this.maxLength) {

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -601,6 +601,7 @@ function resetPlayers() {
 		player.deathMessage = null;
 		player.deathX = null;
 		player.deathY = null;
+		player.deathAt = null;
 		player.trail = new Trail({ x: player.x, y: player.y });
 	}
 }
@@ -637,6 +638,7 @@ function fullReset() {
 		player.deathMessage = null;
 		player.deathX = null;
 		player.deathY = null;
+		player.deathAt = null;
 		player.infected = false;
 		player.onFire = 0;
 		player.trail = new Trail({ x: player.x, y: player.y });

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -599,6 +599,8 @@ function resetPlayers() {
 		var player = playerList[id];
 		player.alive = true;
 		player.deathMessage = null;
+		player.deathX = null;
+		player.deathY = null;
 		player.trail = new Trail({ x: player.x, y: player.y });
 	}
 }
@@ -633,6 +635,8 @@ function fullReset() {
 		player.nearVictory = false;
 		player.ability = null;
 		player.deathMessage = null;
+		player.deathX = null;
+		player.deathY = null;
 		player.infected = false;
 		player.onFire = 0;
 		player.trail = new Trail({ x: player.x, y: player.y });
@@ -1149,6 +1153,7 @@ class Trail {
 		this.canvasOriginY = 0;
 		this.wasNearVictory = false;
 		this.accumulatedLength = 0;
+		this.lastColor = null;
 	}
 	_ensureCanvas() {
 		if (this.canvas != null || world == null) {
@@ -1211,7 +1216,12 @@ class Trail {
 		if (DEBUG_FORCE_NEAR_VICTORY && player.id == myID) {
 			isNearVictory = true;
 		}
-		if (isNearVictory != this.wasNearVictory) {
+		// Repaint the whole strip in one colour when the near-victory style flips OR
+		// the player's colour changes mid-round (e.g. toggling colour-blind assist),
+		// so the cached canvas never ends up two-toned.
+		var colorChanged = (this.lastColor != null && this.lastColor !== player.color);
+		this.lastColor = player.color;
+		if (isNearVictory != this.wasNearVictory || colorChanged) {
 			this._redrawAll(player.color, isNearVictory);
 			this.wasNearVictory = isNearVictory;
 			return;
@@ -1236,6 +1246,7 @@ class Trail {
 		this.vertices = [];
 		this.wasNearVictory = false;
 		this.accumulatedLength = 0;
+		this.lastColor = null;
 		if (this.ctx != null) {
 			this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
 		}

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -25,8 +25,8 @@ var GP_AIM_DEADZONE = 0.35;      // right stick: only re-aim when pushed past th
 var GP_TRIGGER_THRESHOLD = 0.5;  // analog trigger counts as "pressed" past this
 var GP_AIM_MIN_DELTA = 2;        // deg; skip aim emits smaller than this
 var GP_AIM_MIN_INTERVAL = 50;    // ms; cap aim emits at ~20 Hz
-var LEAVE_CONFIRM_TIMEOUT_MS = 5000; // auto-cancel the inline "Leave?" confirm
-var LEAVE_HOLD_MS = 1500;            // hold the Leave button this long to confirm (anti-misfire)
+var LEAVE_CONFIRM_TIMEOUT_MS = 5000; // auto-cancel the inline "Leave?" confirm (when idle, not mid-hold)
+var LEAVE_HOLD_MS = 5000;            // hold the Leave button this long to confirm (anti-misfire)
 
 // --- standard-mapping button indices ---
 var GP_BTN_A = 0;     // attack / confirm
@@ -1416,6 +1416,12 @@ function pollLeaveConfirm(pad, lp) {
     if (bHeld) {
         if (lp._leaveHoldStart == null) {
             lp._leaveHoldStart = Date.now();
+            // Pause the idle auto-cancel while a hold is in progress, so the hold
+            // (which can be as long as the idle timeout) never gets cut short.
+            if (lp.leaveConfirmTimer) {
+                clearTimeout(lp.leaveConfirmTimer);
+                lp.leaveConfirmTimer = null;
+            }
         }
         var held = Date.now() - lp._leaveHoldStart;
         setBlockLeaveProgress(lp.slot, held / LEAVE_HOLD_MS);
@@ -1430,7 +1436,15 @@ function pollLeaveConfirm(pad, lp) {
         }
         return;
     }
-    lp._leaveHoldStart = null;
+    // Released before completing: reset progress and re-arm the idle auto-cancel.
+    if (lp._leaveHoldStart != null) {
+        lp._leaveHoldStart = null;
+        if (lp.leaveConfirm && !lp.leaveConfirmTimer) {
+            lp.leaveConfirmTimer = setTimeout(function () {
+                cancelLeaveConfirm(lp);
+            }, LEAVE_CONFIRM_TIMEOUT_MS);
+        }
+    }
     setBlockLeaveProgress(lp.slot, 0);
     // Not holding Leave: an attack press means "I want to keep playing" — resume.
     if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -1377,13 +1377,20 @@ function leaveGlyphFor(type) {
     return type === "playstation" ? "○" : "B";
 }
 
-// B opens an inline "Leave?" confirm in this player's block; A confirms (drops
-// the player / disconnects), B cancels. Per-slot, so it never freezes the others.
-// Opening the confirm does NOT halt movement (the player keeps steering while
-// deciding, matching the keyboard Esc behavior). The block is highlighted, and
-// the prompt auto-cancels after LEAVE_CONFIRM_TIMEOUT_MS with no confirm.
+// B opens an inline "Leave?" confirm in this player's block; HOLDING B for
+// LEAVE_HOLD_MS confirms (drops the player / disconnects), and an attack (A)
+// press resumes play. Hold-to-confirm so a mashed attack can't leave by
+// accident. Per-slot, so it never freezes the others. Opening the confirm does
+// NOT halt movement (the player keeps steering while deciding, matching the
+// keyboard Esc behavior). The block is highlighted, and the prompt auto-cancels
+// after LEAVE_CONFIRM_TIMEOUT_MS with no hold.
 function openLeaveConfirm(lp) {
     lp.leaveConfirm = true;
+    // Re-anchor the hold clock so a freshly-opened confirm always starts the 5s
+    // hold from zero — never inherits a stale _leaveHoldStart left behind when a
+    // prior hold was aborted out-of-band (reconnect, blocks->bar), which would
+    // otherwise make the first held frame fire an instant, accidental leave.
+    lp._leaveHoldStart = null;
     setBlockLeaveConfirm(lp.slot, true);
     scheduleHintFade(); // un-fade the header so the "Leave?" prompt is readable
     if (lp.leaveConfirmTimer) {
@@ -1404,6 +1411,7 @@ function cancelLeaveConfirm(lp) {
         lp.leaveConfirmTimer = null;
     }
     lp.leaveConfirm = false;
+    lp._leaveHoldStart = null; // drop any in-progress hold so it can't carry over
     setBlockLeaveConfirm(lp.slot, false);
 }
 

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -26,7 +26,7 @@ var GP_TRIGGER_THRESHOLD = 0.5;  // analog trigger counts as "pressed" past this
 var GP_AIM_MIN_DELTA = 2;        // deg; skip aim emits smaller than this
 var GP_AIM_MIN_INTERVAL = 50;    // ms; cap aim emits at ~20 Hz
 var LEAVE_CONFIRM_TIMEOUT_MS = 5000; // auto-cancel the inline "Leave?" confirm
-var LEAVE_HOLD_MS = 800;             // hold the Leave button this long to confirm (anti-misfire)
+var LEAVE_HOLD_MS = 1500;            // hold the Leave button this long to confirm (anti-misfire)
 
 // --- standard-mapping button indices ---
 var GP_BTN_A = 0;     // attack / confirm

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -26,6 +26,7 @@ var GP_TRIGGER_THRESHOLD = 0.5;  // analog trigger counts as "pressed" past this
 var GP_AIM_MIN_DELTA = 2;        // deg; skip aim emits smaller than this
 var GP_AIM_MIN_INTERVAL = 50;    // ms; cap aim emits at ~20 Hz
 var LEAVE_CONFIRM_TIMEOUT_MS = 5000; // auto-cancel the inline "Leave?" confirm
+var LEAVE_HOLD_MS = 800;             // hold the Leave button this long to confirm (anti-misfire)
 
 // --- standard-mapping button indices ---
 var GP_BTN_A = 0;     // attack / confirm
@@ -1034,6 +1035,12 @@ function scheduleHintFade() {
     gpFadeTimer = setTimeout(function () {
         var e = hintFadeEls();
         for (var j = 0; j < e.length; j++) {
+            // In local co-op the per-player blocks stay up permanently so each
+            // player can always see which controller they are and their controls
+            // (slot + colour dot + glyphs). Only the solo bottom bar auto-fades.
+            if (hintUiMode === "blocks" && e[j] === padPlayersEl) {
+                continue;
+            }
             e[j].classList.add("faded");
         }
     }, HINT_FADE_MS);
@@ -1401,17 +1408,33 @@ function cancelLeaveConfirm(lp) {
 }
 
 function pollLeaveConfirm(pad, lp) {
-    if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
-        if (lp.leaveConfirmTimer) {
-            clearTimeout(lp.leaveConfirmTimer);
-            lp.leaveConfirmTimer = null;
+    // Confirm only on a sustained HOLD of the Leave button (B). A tap, or the
+    // attack button (A) that players mash mid-fight, never leaves — that
+    // accidental "B then A-mash" exit was the whole problem. Releasing B before
+    // the hold completes, or pressing attack, cancels and resumes play.
+    var bHeld = !!(pad.buttons[GP_BTN_B] && pad.buttons[GP_BTN_B].pressed);
+    if (bHeld) {
+        if (lp._leaveHoldStart == null) {
+            lp._leaveHoldStart = Date.now();
         }
-        lp.leaveConfirm = false;
-        dropLocalPlayer(lp.slot); // confirmed — disconnect this player
+        var held = Date.now() - lp._leaveHoldStart;
+        setBlockLeaveProgress(lp.slot, held / LEAVE_HOLD_MS);
+        if (held >= LEAVE_HOLD_MS) {
+            if (lp.leaveConfirmTimer) {
+                clearTimeout(lp.leaveConfirmTimer);
+                lp.leaveConfirmTimer = null;
+            }
+            lp.leaveConfirm = false;
+            lp._leaveHoldStart = null;
+            dropLocalPlayer(lp.slot); // confirmed by a deliberate hold
+        }
         return;
     }
-    if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
-        cancelLeaveConfirm(lp); // cancelled
+    lp._leaveHoldStart = null;
+    setBlockLeaveProgress(lp.slot, 0);
+    // Not holding Leave: an attack press means "I want to keep playing" — resume.
+    if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
+        cancelLeaveConfirm(lp);
     }
 }
 
@@ -1424,22 +1447,50 @@ function setBlockLeaveConfirm(slot, confirming) {
         b.el.classList.add("confirming");
         var lp = localPlayers[slot];
         var confirmHints;
+        var prompt;
         if (lp && lp.padIndex != null) {
-            // controller: A confirms, B cancels
-            confirmHints = '<span class="gp-glyph gp-face">' + attackGlyphFor(lp.padType) + '</span>' +
-                '<span class="gp-glyph gp-face">' + leaveGlyphFor(lp.padType) + '</span>';
+            // controller: HOLD B to leave; attack (A) resumes. Hold-to-confirm so
+            // a mashed attack can no longer leave the game by accident.
+            prompt = "Hold to leave";
+            confirmHints = '<span class="gp-glyph gp-face">' + leaveGlyphFor(lp.padType) + '</span>';
         } else {
             // keyboard: Enter confirms, Esc cancels
+            prompt = "Leave?";
             confirmHints = '<span class="gp-glyph gp-key">Enter</span>' +
                 '<span class="gp-glyph gp-key">Esc</span>';
         }
-        b.hints.innerHTML = '<span class="pp-confirm">Leave?</span>' + confirmHints;
+        b.hints.innerHTML = '<span class="pp-confirm">' + prompt + '</span>' + confirmHints;
     } else {
         b.el.classList.remove("confirming");
         b.lastMethod = null; // force a hint rebuild on the next refresh
         if (localPlayers[slot]) {
             setBlockHints(localPlayers[slot]);
         }
+    }
+}
+
+// Live feedback while holding the Leave button: fills a small text bar in the
+// "Hold to leave" prompt so the player sees the hold registering. No new CSS —
+// just swaps the prompt label, and only when the bar actually changes.
+function setBlockLeaveProgress(slot, progress) {
+    var b = padBlocks[slot];
+    if (!b || !b.hints) {
+        return;
+    }
+    var span = b.hints.querySelector(".pp-confirm");
+    if (!span) {
+        return;
+    }
+    var p = progress < 0 ? 0 : (progress > 1 ? 1 : progress);
+    var label;
+    if (p <= 0) {
+        label = "Hold to leave";
+    } else {
+        var filled = Math.round(p * 5);
+        label = "Leaving " + "█".repeat(filled) + "░".repeat(5 - filled);
+    }
+    if (span.textContent !== label) {
+        span.textContent = label;
     }
 }
 

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -25,8 +25,8 @@ var GP_AIM_DEADZONE = 0.35;      // right stick: only re-aim when pushed past th
 var GP_TRIGGER_THRESHOLD = 0.5;  // analog trigger counts as "pressed" past this
 var GP_AIM_MIN_DELTA = 2;        // deg; skip aim emits smaller than this
 var GP_AIM_MIN_INTERVAL = 50;    // ms; cap aim emits at ~20 Hz
-var LEAVE_CONFIRM_TIMEOUT_MS = 5000; // auto-cancel the inline "Leave?" confirm (when idle, not mid-hold)
 var LEAVE_HOLD_MS = 5000;            // hold the Leave button this long to confirm (anti-misfire)
+var LEAVE_CONFIRM_TIMEOUT_MS = 8000; // idle auto-cancel of the "Leave?" confirm; kept > LEAVE_HOLD_MS so a hold started late in the window can't race the cancel (and it's paused while actively holding)
 
 // --- standard-mapping button indices ---
 var GP_BTN_A = 0;     // attack / confirm

--- a/client/scripts/utils.js
+++ b/client/scripts/utils.js
@@ -79,7 +79,10 @@ function pos(point, length, angle) {
 // title entrance, and the tileSwap telegraph. All take/return normalized t in
 // [0,1] unless noted.
 function clamp01(t) {
-    if (t < 0) return 0;
+    // NaN-safe: a NaN here (e.g. a 0/0 from a zero-duration fade) would otherwise
+    // slip through both comparisons and poison globalAlpha, hiding every draw in
+    // the context. Clamp it to 0 so a bad input degrades to "invisible", not "NaN".
+    if (!(t > 0)) return 0;   // false for t<=0 AND for NaN
     if (t > 1) return 1;
     return t;
 }

--- a/server/utils.js
+++ b/server/utils.js
@@ -238,12 +238,58 @@ exports.getColor = function () {
     return Colors.random();
 };
 
+// Parse a '#rrggbb' (or '#rgb') hex string into {r,g,b}, else null. Non-hex
+// inputs (the rare hsl() fallback below, or an unexpected value) return null and
+// are simply skipped by the distance check, so they never throw.
+function hexToRgb(hex) {
+    if (typeof hex !== 'string') {
+        return null;
+    }
+    var m = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex.trim());
+    if (!m) {
+        return null;
+    }
+    var h = m[1];
+    if (h.length === 3) {
+        h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+    }
+    return {
+        r: parseInt(h.slice(0, 2), 16),
+        g: parseInt(h.slice(2, 4), 16),
+        b: parseInt(h.slice(4, 6), 16)
+    };
+}
+
+// Perceptual-ish distance between two hex colors using the "redmean" weighting
+// (a cheap, dependency-free approximation of how different two colors LOOK,
+// noticeably better than raw RGB). Returns Infinity if either color can't be
+// parsed, so unparseable used-colors don't constrain the pick.
+function colorDistance(a, b) {
+    var ca = hexToRgb(a);
+    var cb = hexToRgb(b);
+    if (ca == null || cb == null) {
+        return Infinity;
+    }
+    var rmean = (ca.r + cb.r) / 2;
+    var dr = ca.r - cb.r;
+    var dg = ca.g - cb.g;
+    var db = ca.b - cb.b;
+    return Math.sqrt(
+        (((512 + rmean) * dr * dr) / 256) +
+        4 * dg * dg +
+        (((767 - rmean) * db * db) / 256)
+    );
+}
+
 // Returns a color not already present in usedColors (a map of color -> true).
-// Picks a RANDOM unused color from the fixed named palette; once the palette is
-// exhausted (a room can hold more players than there are named colors) it picks
-// a random generated fallback color, retrying a bounded number of times to dodge
-// collisions. Never recurses, so it can't blow the stack and crash the process
-// when a room fills up.
+// Picks the unused palette color that is the most PERCEPTUALLY DISTINCT from the
+// colors already in the room (greedy max-min distance), so a full lobby never
+// hands out two lookalikes (e.g. Blue vs Navy, Red vs Maroon). The first player
+// in an empty room gets a random palette color so games still vary. Once the
+// palette is exhausted (a room can hold more players than there are named
+// colors) it picks a random generated fallback color, retrying a bounded number
+// of times to dodge collisions. Never recurses, so it can't blow the stack and
+// crash the process when a room fills up.
 exports.getUniqueColor = function (usedColors) {
     usedColors = usedColors || {};
     var available = [];
@@ -253,7 +299,26 @@ exports.getUniqueColor = function (usedColors) {
         }
     }
     if (available.length > 0) {
-        return available[Math.floor(Math.random() * available.length)];
+        var used = Object.keys(usedColors);
+        if (used.length === 0) {
+            return available[Math.floor(Math.random() * available.length)];
+        }
+        var best = available[0];
+        var bestScore = -1;
+        for (var i = 0; i < available.length; i++) {
+            var minDist = Infinity;
+            for (var j = 0; j < used.length; j++) {
+                var d = colorDistance(available[i], used[j]);
+                if (d < minDist) {
+                    minDist = d;
+                }
+            }
+            if (minDist > bestScore) {
+                bestScore = minDist;
+                best = available[i];
+            }
+        }
+        return best;
     }
     var color = 'hsl(' + Math.floor(Math.random() * 360) + ', 70%, 50%)';
     for (var tries = 0; tries < 100 && usedColors[color]; tries++) {

--- a/server/utils.js
+++ b/server/utils.js
@@ -318,6 +318,13 @@ exports.getUniqueColor = function (usedColors) {
                 best = available[i];
             }
         }
+        // bestScore stays Infinity only when NO used color was parseable (e.g. the
+        // whole room is on hsl() fallbacks): the greedy has nothing to measure, so
+        // fall back to a random palette pick rather than deterministically
+        // returning the first palette entry every time.
+        if (bestScore === Infinity) {
+            return available[Math.floor(Math.random() * available.length)];
+        }
         return best;
     }
     var color = 'hsl(' + Math.floor(Math.random() * 360) + ', 70%, 50%)';


### PR DESCRIPTION
Builds on the v0.6.1 self-glow ring with a set of "find yourself in the chaos" improvements, plus controller/mobile UX polish that came out of playtesting.

### Visibility
- Dim other players' karts/trails during a race (threat FX — fire, ability rings — stay full strength); other players' emote bubbles are fainter and fade out over time.
- Smart max-perceptual-distance kart colour assignment (redmean) so a full lobby never gets lookalikes, plus a persisted colour-blind assist toggle (Okabe-Ito palette).

### When you're knocked out
- Press attack to ping every fallen player's spot at once, so you can read the whole board. Death skulls fade over a few seconds and a ping brings them back.

### Controller & couch co-op
- Hold-to-leave (5s) so a mashed attack can't make you quit by accident.
- Per-player controller guides stay on screen in couch co-op instead of fading out.
- Calmer Tile Swap telegraph (was an intense strobe).

### Display
- Fullscreen letterboxes instead of stretching the game on non-16:9 screens.
- Phones held in portrait get a rotate-to-play prompt (the game is a 16:9 landscape arena).

### Notes
- Two `/code-review` passes (xhigh effort); all findings fixed except one cosmetic item (the leave prompt doesn't show an explicit cancel glyph — releasing/attack cancels and it auto-dismisses).
- Backlog (not in this PR): force-landscape via CSS-rotate (truly always-landscape incl. iOS), off-screen death-ping arrow, colour-blind pattern fills.
- Verified: `npm run build`, 50-map headless smoke test, content validator, and in-browser checks all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
