### PR TITLE
docs(changelog): pin landing banner headline back to local co-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### Controller & couch co-op
 
+- [headline] Local co-op with controller support — up to 4 players on one screen (controllers plus one on keyboard/mouse), all in the same game as anyone online.
 - Leaving the game on a controller now takes a deliberate button hold, so a mashed attack can't make you quit by accident.
 - In couch co-op, each player's on-screen controller guide (which pad you are, plus your buttons) now stays put instead of fading out.
 


### PR DESCRIPTION
## What

Re-flags the **local co-op** bullet with `[headline]` in the v0.8.0 "Controller & couch co-op" section so the landing-page "Patch notes" banner pins to the operator-chosen headline again:

> Local co-op with controller support — up to 4 players on one screen (controllers plus one on keyboard/mouse), all in the same game as anyone online.

## Why

`loadWeeklyNews()` in `index.js` picks the banner headline at server boot: within the newest release's calendar week, it uses the first bullet flagged `- [headline] ...`, falling back to the newest release's first bullet when nothing is flagged. v0.7.0 and v0.8.0 shipped with no flag, so each release silently replaced the operator-curated headline (recap montage, then "fade other players"). This restores manual control.

## Verification

Ran the exact `loadWeeklyNews()` selection logic against the edited `CHANGELOG.md` — resolves to the local-co-op headline via the flag (`usedFlag: true`). No code changed (CHANGELOG only); `index.js` reads it at boot, so this takes effect on redeploy. Does **not** add `## Unreleased` notes, so it won't trigger a new release on merge.

## Caveat (known)

The flag holds the headline only for the current Monday-week (2026‑05‑25). A release dated in a **new week** rolls the active week forward and the headline drifts again unless that release re-carries a `[headline]` flag. A durable fix would require changing the headline mechanism itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)