### PR TITLE
fix(server): harden map-submit & emoji socket handlers against unsafe input

### DIFF
--- a/server/messenger.js
+++ b/server/messenger.js
@@ -58,11 +58,27 @@ function checkForMail(client) {
 	});
 
 	client.on('submitNewMap', function (package) {
-		var vMap = JSON.parse(package);
-		if (vMap.thumbnail == null ||
+		var vMap;
+		try {
+			vMap = JSON.parse(package);
+		} catch (e) {
+			client.emit("githubFailure", "Could not read map data.");
+			return;
+		}
+		if (vMap == null ||
+			vMap.thumbnail == null ||
 			vMap.id == null ||
 			vMap.author == null ||
 			vMap.name == null) {
+			client.emit("githubFailure", "Map is missing required info (name, author, thumbnail).");
+			return;
+		}
+		// Structural validation at the trust boundary — the same check the
+		// preview path runs — so a crafted, non-map payload can never reach the
+		// GitHub API (and the server's credentials) with the submitter's data.
+		var validation = utils.validateMap(vMap, c);
+		if (!validation.valid) {
+			client.emit("githubFailure", validation.reason);
 			return;
 		}
 
@@ -165,7 +181,13 @@ function checkForMail(client) {
 			return;
 		}
 		var room = hostess.getRoomBySig(roomMailList[client.id]);
+		if (room == undefined) {
+			return;
+		}
 		var player = room.playerList[client.id];
+		if (player == null) {
+			return;
+		}
 		if (player.chatCoolDownTimer != null) {
 			return;
 		}

--- a/server/utils.js
+++ b/server/utils.js
@@ -83,6 +83,20 @@ exports.submitPullRequest = async function (map) {
     if (author == '' || email == '' || mapName == '') {
         console.log("Can't submit to github; required info missing:" + author + ":" + email + ":" + mapName);
         returnToClient.status = false;
+        returnToClient.message = "Map name, author, and email are all required.";
+        return returnToClient;
+    }
+    // mapName is interpolated into a repo file path (client/maps/<name>.json) and
+    // into a git branch ref below, both written with the server's GitHub
+    // credentials. The submitter is untrusted, so reject anything that could
+    // escape the maps directory: path separators, leading dots (dotfiles / ".."),
+    // and control characters. Ordinary punctuation real map names use
+    // (apostrophes, "!") is left alone — only traversal-capable input is blocked.
+    // The length cap keeps the resulting filename and ref sane.
+    if (mapName.length > 64 || /[\\/\x00-\x1f]/.test(mapName) || mapName[0] === '.') {
+        console.log("Rejected map submission; unsafe map name: " + JSON.stringify(map.name));
+        returnToClient.status = false;
+        returnToClient.message = "Map name can't contain slashes or control characters, or start with a dot.";
         return returnToClient;
     }
     var branchName = "mapchange-" + mapName.toLowerCase() + "-" + getRandomBranchCode();


### PR DESCRIPTION
## What & why

A security review of the codebase surfaced one Medium finding: the `submitNewMap` socket event is reachable **unauthenticated** and drives the server's privileged GitHub credentials (`GITHUB_AUTH`). The submitter's `map.name` flowed, with only spaces stripped, into a repo file path (`client/maps/<name>.json`) and a git branch ref, and the handler accepted arbitrary JSON with only four non-null checks. This hardens that trust boundary.

## Changes

- **`validateMap()` at the trust boundary** — the `submitNewMap` handler now runs the same structural validation the preview path uses *before* any GitHub call. A crafted, non-map payload (e.g. a `package.json`-shaped object) has no valid cells/goal and is rejected, so it can never reach the GitHub API with the submitter's data.
- **Map-name path/ref sanitization** in `submitPullRequest` — rejects names containing path separators (`/`, `\`), control characters, a leading dot (blocks `..` / dotfiles), or longer than 64 chars, before they're interpolated into the file path or branch ref. Ordinary punctuation real map names use (apostrophes, `!`) is preserved, so legitimate submissions still work.
- **Robust `submitNewMap` entry point** — wraps `JSON.parse` in try/catch and emits a `githubFailure` instead of throwing; null-guards `vMap` and the required fields.
- **`sendEmoji` null-guards** — guards `room`/`player` before dereferencing, matching the existing `movement`/`mousemove` handlers. (The emoji value itself was already whitelisted against `config.emojis`.)

Server-only; no client bundle or game-mechanic config (`config.json`/`game.js`/`engine.js`) touched, so no CHANGELOG entry is required.

## Verification

- Headless smoke test (`.github/scripts/smoke-test.js`) — passed, booted + ticked all 50 maps with no throws.
- Targeted gate tests: `validateMap` rejects a crafted non-map payload; `submitPullRequest` rejects `../../package` and `.git/config` *before* any network call; a legit punctuated name (`Mitch's Dungeon`) passes the name gate. All committed map names (incl. `4suns!`, `Nice knowin' ya`) still validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)