### PR TITLE
feat(editor): preview runs solo by default — add "Enable AI racers" toggle

### DIFF
--- a/.github/scripts/preview-ai-toggle-test.js
+++ b/.github/scripts/preview-ai-toggle-test.js
@@ -1,0 +1,269 @@
+'use strict';
+
+// Headless test for the map-editor "Enable AI racers" preview toggle.
+//
+// Boots REAL server modules (no network/browser) and exercises the preview
+// path through the actual createPreviewRoom messenger handler, the way the
+// editor does:
+//
+//   Phase A (AI OFF, the default): createPreviewRoom with enableAI:false -> a
+//     lone human joins -> assert ZERO bots are added at startGated -> drive
+//     gated -> racing -> collapsing -> overview, then force the documented win
+//     condition and assert it reaches gameOver, all without throwing or
+//     emitting a malformed compressor payload.
+//
+//   Phase B (AI ON): createPreviewRoom with enableAI:true -> a lone human joins
+//     -> assert bots DO fill the grid (the toggle still works like before).
+//
+// Run: node .github/scripts/preview-ai-toggle-test.js   (from the repo root)
+
+const fs = require('fs');
+const path = require('path');
+
+// Resolve the repo root from this file's location so the test runs from any
+// checkout / worktree (.github/scripts/ -> repo root is two levels up).
+const repoRoot = process.env.REPO_ROOT || path.join(__dirname, '..', '..');
+const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
+const hostess = require(path.join(repoRoot, 'server', 'hostess.js'));
+const compressor = require(path.join(repoRoot, 'server', 'compressor.js'));
+const config = require(path.join(repoRoot, 'server', 'config.json'));
+
+const DT = config.serverTickSpeed / 1000;
+const MOVES = ['moveForward', 'moveBackward', 'turnLeft', 'turnRight', 'attack'];
+
+let failures = 0;
+function fail(msg) { failures++; console.log('::error::' + msg); }
+function ok(msg) { console.log('  ok - ' + msg); }
+
+// Fake socket that RECORDS outbound emits so we can read previewRoomCreated.
+function makeFakeSocket(id) {
+    const handlers = {};
+    const emits = [];
+    return {
+        id, handlers, emits,
+        on(event, fn) { handlers[event] = fn; },
+        emit(event, payload) { emits.push({ event, payload }); },
+        join() { }, leave() { },
+        broadcast: { to() { return { emit() { } }; } },
+        fire(event, payload) { if (handlers[event]) handlers[event](payload); },
+        lastEmit(event) {
+            for (let i = emits.length - 1; i >= 0; i--) if (emits[i].event === event) return emits[i].payload;
+            return null;
+        }
+    };
+}
+
+const fakeIo = { to() { return { emit() { } }; }, sockets: { emit() { } } };
+
+function randomInput() {
+    const p = { moveForward: false, moveBackward: false, turnLeft: false, turnRight: false, attack: false };
+    for (const m of MOVES) if (Math.random() < 0.5) p[m] = true;
+    return p;
+}
+
+function assertUpdatesWellFormed(room, label) {
+    const checks = {
+        playerList: compressor.sendPlayerUpdates(room.playerList),
+        projList: compressor.sendProjUpdates(room.projectileList),
+        aimerList: compressor.sendAimerUpdates(room.aimerList),
+        hazardList: compressor.sendHazardUpdates(room.hazardList)
+    };
+    for (const key in checks) {
+        if (!Array.isArray(checks[key])) fail(label + ': compressor.' + key + ' non-array');
+    }
+}
+
+function countPlayers(room) {
+    let humans = 0, bots = 0;
+    for (const id in room.playerList) {
+        if (room.playerList[id].isAI) bots++; else humans++;
+    }
+    return { humans, bots };
+}
+
+// Pick the first committed map (any valid map works for the state-machine test).
+function loadAMap() {
+    const mapsDir = path.join(repoRoot, 'client', 'maps');
+    const files = fs.readdirSync(mapsDir).filter(f => f.endsWith('.json'));
+    return JSON.parse(fs.readFileSync(path.join(mapsDir, files[0]), 'utf8'));
+}
+
+// Create a preview room through the REAL messenger handler, then join one human.
+function bootPreview(label, enableAI, map) {
+    const editor = makeFakeSocket(label + '-editor');
+    messenger.addMailBox(editor.id, editor);
+    editor.fire('createPreviewRoom', JSON.stringify({ map, enableAI }));
+
+    const created = editor.lastEmit('previewRoomCreated');
+    if (created == null || created.gameID == null) {
+        fail(label + ': createPreviewRoom did not emit previewRoomCreated');
+        return null;
+    }
+    const sig = created.gameID;
+    const room = hostess.getRoomBySig(sig);
+    if (room == null) { fail(label + ': preview room not found for sig ' + sig); return null; }
+
+    // A human joins the preview room (the editor's play page does this).
+    const human = makeFakeSocket(label + '-human');
+    messenger.addMailBox(human.id, human);
+    human.fire('enterGame', sig);
+
+    return { sig, room, human, editor };
+}
+
+function teardown(boot) {
+    hostess.kickFromRoom(boot.human.id);
+    messenger.removeMailBox(boot.human.id);
+    messenger.removeMailBox(boot.editor.id);
+}
+
+// ---------------------------------------------------------------------------
+// Phase A: AI OFF -> zero bots, full state machine runs clean.
+// ---------------------------------------------------------------------------
+function phaseAOff(map) {
+    console.log('Phase A: preview with AI OFF (default)');
+    const boot = bootPreview('A', false, map);
+    if (boot == null) return;
+    const { room, human } = boot;
+
+    // Verify the flag landed on the gameBoard as "off".
+    if (room.game.gameBoard.previewAI !== false) {
+        fail('Phase A: gameBoard.previewAI should be false, got ' + room.game.gameBoard.previewAI);
+    }
+
+    // Drive the preview's race-start path. startLobby() first (world.resize builds
+    // the engine quadTree), exactly like the live waiting->lobby->gated progression;
+    // startGated() is where bots would fill.
+    room.game.startLobby();
+    room.game.startGated();
+    let pc = countPlayers(room);
+    if (pc.bots !== 0) fail('Phase A: expected 0 bots after startGated, got ' + pc.bots);
+    else ok('0 bots added at startGated');
+    if (pc.humans !== 1) fail('Phase A: expected 1 human, got ' + pc.humans);
+    else ok('1 human present');
+
+    // gated -> racing, tick a while.
+    room.game.startRace();
+    for (let f = 0; f < 200; f++) {
+        human.fire('movement', randomInput());
+        human.fire('mousemove', Math.random() * 360);
+        hostess.updateRooms(DT);
+        assertUpdatesWellFormed(room, 'Phase A racing frame ' + f);
+        if (failures > 0) { teardown(boot); return; }
+    }
+    ok('racing ticked 200 frames, no throw / well-formed payloads');
+
+    // racing -> collapsing: force the collapse (live path is a wall-clock timer).
+    room.game.startCollapse(config.worldWidth / 2, config.worldHeight / 2);
+    for (let f = 0; f < 400; f++) {
+        human.fire('movement', randomInput());
+        hostess.updateRooms(DT);
+        assertUpdatesWellFormed(room, 'Phase A collapsing frame ' + f);
+        if (failures > 0) { teardown(boot); return; }
+        // The lone human eventually concludes (dies in lava) -> startOverview.
+        if (room.game.currentState === config.stateMap.overview) break;
+    }
+    if (room.game.currentState === config.stateMap.overview) {
+        ok('collapse concluded -> reached overview (no stall, no div-by-zero)');
+    } else {
+        // Not necessarily a failure (player may have survived the window), but
+        // report it so we know whether the lone-player conclude path was hit.
+        console.log('  note - did not reach overview within window; state=' + room.game.currentState +
+            ' alive=' + countPlayers(room).humans);
+    }
+
+    // gameOver: force the documented win condition for the lone human and confirm
+    // checkForWinners drives to gameOver without throwing / dividing by zero.
+    let hid = null;
+    for (const id in room.playerList) { if (!room.playerList[id].isAI) { hid = id; break; } }
+    if (hid == null) { fail('Phase A: lost the human before gameOver test'); teardown(boot); return; }
+    const p = room.playerList[hid];
+    room.game.currentState = config.stateMap.racing;
+    room.game.firstPlaceSig = null;
+    room.game.secondPlaceSig = null;
+    p.alive = true; p.awake = true; p.isSpectator = false; p.isZombie = false;
+    p.reachedGoal = true;
+    p.notches = room.game.notchesToWin;
+    try {
+        room.game.checkForWinners();
+    } catch (e) {
+        fail('Phase A: checkForWinners threw on lone-human win: ' + e.message + '\n' + e.stack);
+        teardown(boot);
+        return;
+    }
+    if (room.game.currentState === config.stateMap.gameOver) {
+        ok('lone-human win -> reached gameOver cleanly');
+    } else {
+        fail('Phase A: expected gameOver, state=' + room.game.currentState);
+    }
+
+    teardown(boot);
+}
+
+// ---------------------------------------------------------------------------
+// Phase B: AI ON -> bots fill the grid as before.
+// ---------------------------------------------------------------------------
+function phaseBOn(map) {
+    console.log('Phase B: preview with AI ON');
+    const boot = bootPreview('B', true, map);
+    if (boot == null) return;
+    const { room } = boot;
+
+    if (room.game.gameBoard.previewAI !== true) {
+        fail('Phase B: gameBoard.previewAI should be true, got ' + room.game.gameBoard.previewAI);
+    }
+    room.game.startLobby();
+    room.game.startGated();
+    const pc = countPlayers(room);
+    if (config.aiRacers && config.aiRacers.enabled) {
+        if (pc.bots <= 0) fail('Phase B: expected bots to fill the grid, got ' + pc.bots);
+        else ok('bots filled the grid: ' + pc.bots + ' (humans ' + pc.humans + ')');
+    } else {
+        console.log('  note - config.aiRacers.enabled is false; no bots expected globally');
+    }
+
+    teardown(boot);
+}
+
+// ---------------------------------------------------------------------------
+// Phase C: legacy raw-map payload (no { map, enableAI } wrapper) must still work
+// and default to AI off, so an older client can't break the handler.
+// ---------------------------------------------------------------------------
+function phaseCLegacy(map) {
+    console.log('Phase C: legacy raw-map payload (no wrapper) -> AI off');
+    const editor = makeFakeSocket('C-editor');
+    messenger.addMailBox(editor.id, editor);
+    // Pre-toggle payload: the bare map object, exactly as the old editor sent it.
+    editor.fire('createPreviewRoom', JSON.stringify(map));
+    const created = editor.lastEmit('previewRoomCreated');
+    if (created == null || created.gameID == null) {
+        fail('Phase C: legacy payload did not emit previewRoomCreated');
+        messenger.removeMailBox(editor.id);
+        return;
+    }
+    const room = hostess.getRoomBySig(created.gameID);
+    if (room == null) { fail('Phase C: preview room not found'); messenger.removeMailBox(editor.id); return; }
+    if (room.game.gameBoard.previewAI !== false) {
+        fail('Phase C: legacy payload should default previewAI to false, got ' + room.game.gameBoard.previewAI);
+    } else {
+        ok('legacy raw-map payload accepted and defaulted AI off');
+    }
+    messenger.removeMailBox(editor.id);
+}
+
+messenger.build(fakeIo);
+const map = loadAMap();
+try {
+    phaseAOff(map);
+    phaseBOn(map);
+    phaseCLegacy(map);
+} catch (e) {
+    fail('Unhandled exception: ' + e.message + '\n' + e.stack);
+}
+
+if (failures > 0) {
+    console.log('\nPreview AI-toggle test FAILED with ' + failures + ' error(s).');
+    process.exit(1);
+}
+console.log('\nPreview AI-toggle test passed.');
+process.exit(0);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Map editor
+
+- Previews now run solo by default — it's just you and your map, no bots. Tick the new "Enable AI racers" box before hitting Preview / Playtest to fill the grid with AI opponents like before. Your choice is remembered for next time.
 
 ## v0.8.2 — 2026-05-25
 

--- a/client/create.html
+++ b/client/create.html
@@ -203,6 +203,24 @@
       border-top: thin solid #e6e6e6;
     }
 
+    /* "Enable AI racers" preview toggle. Label colour follows the theme via
+       --text (dark mode is handled by the shared styles.css vars); the box
+       itself uses a fixed brand green that reads on both light and dark. */
+    #enableAIRow {
+      text-align: left;
+      font-size: 0.85rem;
+    }
+    #enableAIRow .form-check-label {
+      color: var(--text);
+      cursor: pointer;
+      -webkit-user-select: none;
+      user-select: none;
+    }
+    #enableAICheckbox {
+      cursor: pointer;
+      accent-color: #2f8f4e;
+    }
+
     @media screen and (max-width:768px) {
       #controlPanel {
         display: none;
@@ -274,6 +292,11 @@
               Actions
             </div>
             <hr />
+            <div id="enableAIRow" class="form-check mb-2"
+              title="Fill the grid with AI racers. Off = a solo, bot-free run of your map.">
+              <input type="checkbox" class="form-check-input" id="enableAICheckbox">
+              <label class="form-check-label" for="enableAICheckbox">Enable AI racers</label>
+            </div>
             <button id="previewButton" class="btn btn-block">Preview / Playtest<i class="fa fa-play ml-2" aria-hidden="true"></i></button>
             <button id="previewStatus" class="btn btn-block" disabled style="display:none;"><span></span></button>
             <button id="exportButton" class="btn btn-block">Copy to Clipboard<i class="fa fa-clipboard ml-2" aria-hidden="true"></i></button>

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -342,6 +342,17 @@ function setupPage() {
         previewMap();
         return false;
     });
+    // Remember the "Enable AI racers" preview choice across sessions. Default
+    // off: a missing/garbled value leaves the box unchecked. Wrapped in try/catch
+    // so a disabled localStorage (private mode) just falls back to the default.
+    try {
+        $("#enableAICheckbox").prop("checked", localStorage.getItem("previewEnableAI") === "true");
+    } catch (e) { }
+    $("#enableAICheckbox").on("change", function () {
+        try {
+            localStorage.setItem("previewEnableAI", $(this).is(":checked") ? "true" : "false");
+        } catch (e) { }
+    });
     $("#exportButton").on("click", function () {
         exportToJSON();
         return false;
@@ -917,7 +928,11 @@ function previewMap() {
     // object goes to the server so both sides resolve the same id.
     var json = JSON.stringify(vMap);
     sessionStorage.setItem('previewMap', json);
-    server.emit('createPreviewRoom', json);
+    // Default off: preview a bot-free solo run unless the editor ticked the box.
+    // sessionStorage.previewMap stays the raw map (the play page reads it from
+    // there); only the socket payload carries the { map, enableAI } wrapper.
+    var enableAI = $("#enableAICheckbox").is(":checked");
+    server.emit('createPreviewRoom', JSON.stringify({ map: vMap, enableAI: enableAI }));
 }
 
 function basicSanitize() {

--- a/server/game.js
+++ b/server/game.js
@@ -621,7 +621,12 @@ class Game {
 		this.gameBoard.setupMap(this.currentState);
 		// Fill the grid with AI racers after the map (and starting gate) are laid
 		// out, so each bot can be placed at the gate via determineGameState.
-		this.fillGridWithBots();
+		// Preview rooms only fill when the editor opted in (previewAI); default
+		// off gives the creator a solo, bot-free run of their map. Non-preview
+		// rooms are unaffected (isPreview is false -> always fill, as before).
+		if (!this.gameBoard.isPreview || this.gameBoard.previewAI) {
+			this.fillGridWithBots();
+		}
 		messenger.messageRoomBySig(this.roomSig, "startGated", null);
 	}
 	startRace() {
@@ -816,6 +821,9 @@ class GameBoard {
 		// NEVER push it into the shared this.maps array.
 		this.isPreview = false;
 		this.previewMap = null;
+		// Preview-only: whether the editor asked to fill the grid with AI racers.
+		// Default off, so a preview is a solo, bot-free run unless opted in.
+		this.previewAI = false;
 
 		this.allAbilityIDs = this.indexAbilities();
 		this.collapseLoc = {};

--- a/server/hostess.js
+++ b/server/hostess.js
@@ -107,13 +107,15 @@ exports.getRoomBySig = function (sig) {
 // ever placing a stranger here (findARoom skips isLocked; getRooms skips
 // isPreview; once the creator joins hasSpace() is false anyway). The map is
 // injected onto this room's gameBoard only — never the shared map library.
-exports.createPreviewRoom = function (previewMap) {
+exports.createPreviewRoom = function (previewMap, enableAI) {
 	var sig = generateRoomSig();
 	var room = game.getRoom(sig, 1);
 	room.isPreview = true;
 	room.game.locked = true;
 	room.game.gameBoard.isPreview = true;
 	room.game.gameBoard.previewMap = previewMap;
+	// Default off: a preview is a solo, bot-free run unless the editor opted in.
+	room.game.gameBoard.previewAI = enableAI === true;
 	roomList[sig] = room;
 	// Safety net: if the creator's play page never connects (abandoned launch),
 	// reclaim the empty room so it can't linger. A joined room is left alone.

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -94,19 +94,24 @@ function checkForMail(client) {
 	});
 
 	client.on('createPreviewRoom', function (package) {
-		var previewMap;
+		var parsed;
 		try {
-			previewMap = JSON.parse(package);
+			parsed = JSON.parse(package);
 		} catch (e) {
 			client.emit("previewRejected", { reason: "Could not read map data." });
 			return;
 		}
+		// Accept either a { map, enableAI } wrapper (current editor) or a raw map
+		// object (legacy payload). AI defaults off, so a preview is bot-free
+		// unless the editor explicitly opted in.
+		var previewMap = (parsed && parsed.map != null) ? parsed.map : parsed;
+		var enableAI = (parsed && parsed.enableAI === true);
 		var result = utils.validateMap(previewMap, c);
 		if (!result.valid) {
 			client.emit("previewRejected", { reason: result.reason });
 			return;
 		}
-		var sig = hostess.createPreviewRoom(previewMap);
+		var sig = hostess.createPreviewRoom(previewMap, enableAI);
 		client.emit("previewRoomCreated", { gameID: sig });
 	});
 


### PR DESCRIPTION
## What & why

Map-editor previews always padded the grid with 6–10 bots, so there was no way to walk your own map solo. This makes a preview a **solo, bot-free run by default**, with a new **"Enable AI racers"** checkbox in the editor's Actions panel to fill the grid like before. The choice is remembered across sessions (localStorage), default off.

Productionizes the spike on `docs/spike-ai-toggle-preview` (`docs/spikes/ai-toggle-preview.md`).

## Feasibility note (from the spike, re-verified here)

The lone-human path already existed — `Game.scheduleSoloCollapse()`, `config.minPlayersToStart = 1`, and dynamic game-length counting **humans only** — so a 0-bot preview runs `gated → racing → collapsing → gameOver` cleanly. Default off means *truly zero bots*, no minimum-1 fallback. No `compressor.js`/decoder change (the flag never rides `gameUpdates`).

## Changes

- **`client/create.html`** — themed `#enableAICheckbox` above Preview/Playtest: label colour via `--text` (dark handled by shared `styles.css` vars), fixed brand-green accent that reads in both themes, plus a tooltip. Editor gamepad nav covers it for free (`editorGamepad`'s `#controlPanel input` selector + A→`.click()`, which toggles the box and fires `change`).
- **`client/scripts/create.js`** — `previewMap()` emits `{ map, enableAI }`; `sessionStorage.previewMap` stays the **raw** map (the play page reads it from there). Restore + persist the checkbox.
- **`server/messenger.js`** — unwrap `{ map, enableAI }`; still tolerates a legacy raw-map payload (defaults AI off).
- **`server/hostess.js`** — pass `enableAI` onto `gameBoard.previewAI`.
- **`server/game.js`** — `GameBoard.previewAI = false`; `startGated()` gates `fillGridWithBots()` on `(!isPreview || previewAI)`, so non-preview rooms are unchanged.
- **CHANGELOG** — `## Unreleased` Map-editor bullet (required: gating `fillGridWithBots` touches `server/game.js`).

## Validation

- **Headless** `node .github/scripts/preview-ai-toggle-test.js` (boots a preview room via the real `createPreviewRoom` handler): **AI off → 0 bots** + full `gated → racing → collapsing → overview → gameOver` with no throw / well-formed compressor payloads; **AI on → bots fill** (9 observed); **legacy raw-map payload → accepted, AI off**. PASS.
- **Regression** `node .github/scripts/smoke-test.js` → PASS (50 maps, normal games unaffected).
- **Manual (browser, localhost)** — checkbox renders default-off; label + tooltip correct; persists across reload; renders correctly in **both light and dark** themes; real clicks update localStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)