### PR TITLE
Author-selectable map start edges (single + opposite-edge combos)

### DIFF
--- a/.github/scripts/start-edges-test.js
+++ b/.github/scripts/start-edges-test.js
@@ -1,0 +1,294 @@
+'use strict';
+
+// Headless validation for author-selectable map START EDGES (single edge +
+// opposite-edge combos). Boots the REAL server engine (no network/browser) and,
+// for every supported edge configuration, ticks a pinned map gated -> racing ->
+// collapsing while asserting:
+//
+//   * the engine never throws and the per-tick compressor arrays stay well-formed
+//   * the multi-gate gameState payload round-trips (compressor.gameState ->
+//     the gameboard.js#checkGameState decode shape), with the right gate count,
+//     edges, and in-world rects
+//   * players are held in THEIR gate (per-gate preventEscape) on every edge
+//   * AI racers are distributed across gates (balanced for opposite-edge maps),
+//     press toward their assigned gate, and settle onto NON-LAVA launch lanes
+//     even when the front row is partly lava-walled (top/bottom/combo included)
+//
+// Run: node .github/scripts/start-edges-test.js   (exit 1 on any failure)
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const game = require(path.join(repoRoot, 'server', 'game.js'));
+const compressor = require(path.join(repoRoot, 'server', 'compressor.js'));
+const aiController = require(path.join(repoRoot, 'server', 'aiController.js'));
+const config = require(path.join(repoRoot, 'server', 'config.json'));
+
+const DT = config.serverTickSpeed / 1000;
+const LAVA = config.tileMap.lava.id;
+const GATE_DEPTH = 75;
+const W = config.worldWidth, H = config.worldHeight;
+
+let failures = 0;
+function fail(msg) { failures++; console.log('::error::' + msg); }
+function ok(msg) { console.log('  ok: ' + msg); }
+
+// Deterministic Math.random so bot counts / cast shuffles are reproducible.
+(function seedRandom(seed) {
+    let s = seed >>> 0;
+    Math.random = function () {
+        s = (s * 1664525 + 1013904223) >>> 0;
+        return s / 4294967296;
+    };
+})(0xC0FFEE);
+
+// A socket.io io stand-in so messenger room broadcasts don't throw.
+require(path.join(repoRoot, 'server', 'messenger.js')).build({
+    to() { return { emit() { } }; },
+    sockets: { emit() { } }
+});
+
+// Nearest-cell tile id at a point (mirrors aiController.isLavaAt's nearest-site
+// rule) so the test can check whether a bot ended up standing on lava.
+function tileIdAt(map, x, y) {
+    let best = Infinity, id = -1;
+    for (let i = 0; i < map.cells.length; i++) {
+        const cell = map.cells[i];
+        if (!cell || !cell.site) { continue; }
+        const dx = cell.site.x - x, dy = cell.site.y - y;
+        const d = dx * dx + dy * dy;
+        if (d < best) { best = d; id = cell.id; }
+    }
+    return id;
+}
+
+// Decode a serialized gameState packet the way client gameboard.js#checkGameState
+// does for the gated/racing/collapsing branch, returning the gate list.
+function decodeGates(serialized) {
+    const payload = JSON.parse(serialized);
+    const out = [];
+    const gateData = payload[1] || [];
+    for (let i = 0; i < gateData.length; i++) {
+        const gd = gateData[i];
+        out.push({ x: gd[0], y: gd[1], width: gd[2], height: gd[3], edge: gd[4] });
+    }
+    return out;
+}
+
+// Clone a real committed map (valid Voronoi geometry) and stamp startEdges.
+// Optionally paints a lava band across PART of one edge's front row so the
+// safe-lane steering has something to dodge.
+const sampleMapFile = fs.readdirSync(path.join(repoRoot, 'client', 'maps'))
+    .filter(f => f.endsWith('.json') && !f.startsWith('_'))[0];
+const baseMap = JSON.parse(fs.readFileSync(path.join(repoRoot, 'client', 'maps', sampleMapFile), 'utf8'));
+
+function makeMap(startEdges, lavaEdge) {
+    const map = JSON.parse(JSON.stringify(baseMap));
+    map.id = 'se-test-' + startEdges.join('+');
+    map.startEdges = startEdges.slice();
+    map.parTime = null; // force a fresh par-time computation through the new axis logic
+    if (lavaEdge != null) {
+        // Lava across the inner half of the lavaEdge's front strip, leaving the
+        // other half as safe lanes the bots must find.
+        for (let i = 0; i < map.cells.length; i++) {
+            const s = map.cells[i].site;
+            if (!s) { continue; }
+            let inStrip = false, inHalf = false;
+            if (lavaEdge === 'left') { inStrip = s.x < GATE_DEPTH + 120; inHalf = s.y < H / 2; }
+            else if (lavaEdge === 'right') { inStrip = s.x > W - GATE_DEPTH - 120; inHalf = s.y < H / 2; }
+            else if (lavaEdge === 'top') { inStrip = s.y < GATE_DEPTH + 120; inHalf = s.x < W / 2; }
+            else if (lavaEdge === 'bottom') { inStrip = s.y > H - GATE_DEPTH - 120; inHalf = s.x < W / 2; }
+            if (inStrip && inHalf) { map.cells[i].id = LAVA; }
+        }
+    }
+    return map;
+}
+
+function gateBBoxContains(gate, x, y) {
+    return x >= gate.x - 2 && x <= gate.x + gate.width + 2 &&
+        y >= gate.y - 2 && y <= gate.y + gate.height + 2;
+}
+
+// Inner-edge ("launch") coordinate + axis for a gate, mirroring the server's
+// gate geometry, so we can assert bots press toward their gate.
+function innerEdge(gate) {
+    const vertical = gate.width < gate.height;
+    if (vertical) {
+        return { axis: 'x', pos: gate.edge === 'left' ? gate.x + gate.width : gate.x };
+    }
+    return { axis: 'y', pos: gate.edge === 'top' ? gate.y + gate.height : gate.y };
+}
+
+let roomSeq = 0;
+function runConfig(startEdges, lavaEdge, label) {
+    console.log('\n[' + label + ']');
+    const map = makeMap(startEdges, lavaEdge);
+    const sig = 'se-room-' + (roomSeq++);
+    const room = game.getRoom(sig, 12);
+    const gb = room.game.gameBoard;
+    gb.isPreview = true;
+    gb.previewAI = true; // opt the preview room into the AI grid fill (v0.8.4+)
+    gb.previewMap = map;
+
+    for (let i = 0; i < 2; i++) {
+        const id = sig + '-p' + i;
+        const player = room.world.createNewPlayer(id);
+        room.playerList[id] = player;
+        room.game.determineGameState(player);
+    }
+
+    try {
+        room.game.startLobby();
+        room.game.startGated();
+    } catch (e) {
+        fail(label + ': threw during gated setup: ' + e.message + '\n' + e.stack);
+        return;
+    }
+
+    // ---- gate model ----
+    if (gb.startingGates.length !== startEdges.length) {
+        fail(label + ': expected ' + startEdges.length + ' gate(s), got ' + gb.startingGates.length);
+    }
+
+    // ---- compressor round-trip ----
+    const decoded = decodeGates(compressor.gameState(room.game));
+    if (decoded.length !== startEdges.length) {
+        fail(label + ': decoded ' + decoded.length + ' gate(s) from gameState, expected ' + startEdges.length);
+    } else {
+        for (let i = 0; i < decoded.length; i++) {
+            const g = decoded[i];
+            if (startEdges.indexOf(g.edge) === -1) {
+                fail(label + ': decoded gate has unexpected edge "' + g.edge + '"');
+            }
+            if (g.x < 0 || g.y < 0 || g.x + g.width > W + 0.5 || g.y + g.height > H + 0.5) {
+                fail(label + ': decoded gate ' + JSON.stringify(g) + ' is out of world bounds');
+            }
+            if (typeof g.width !== 'number' || typeof g.height !== 'number' || g.width <= 0 || g.height <= 0) {
+                fail(label + ': decoded gate has a bad size ' + JSON.stringify(g));
+            }
+        }
+        ok('gameState round-trips ' + decoded.length + ' gate(s): ' + decoded.map(g => g.edge).join(', '));
+    }
+
+    // ---- gateIndex + placement + distribution ----
+    const perGate = gb.startingGates.map(() => 0);
+    let bots = 0;
+    for (const id in room.playerList) {
+        const p = room.playerList[id];
+        if (p.isAI) { bots++; }
+        if (p.gateIndex < 0 || p.gateIndex >= gb.startingGates.length) {
+            fail(label + ': player ' + id + ' has invalid gateIndex ' + p.gateIndex);
+            continue;
+        }
+        perGate[p.gateIndex]++;
+        const gate = gb.startingGates[p.gateIndex];
+        if (!gateBBoxContains(gate, p.x, p.y)) {
+            fail(label + ': player ' + id + ' (' + p.x.toFixed(0) + ',' + p.y.toFixed(0) +
+                ') is not inside its gate ' + p.gateIndex + ' [' + gate.edge + ']');
+        }
+    }
+    if (bots === 0) { fail(label + ': no AI racers were spawned to test gated steering'); }
+    if (gb.startingGates.length === 2) {
+        if (Math.abs(perGate[0] - perGate[1]) > 2) {
+            fail(label + ': unbalanced gate split ' + perGate.join(' vs '));
+        } else {
+            ok('balanced split across gates: ' + perGate.join(' / ') + ' (' + bots + ' bots total)');
+        }
+    } else {
+        ok(bots + ' bots, all at gate 0');
+    }
+
+    // ---- gated steering: press toward gate + avoid lava ----
+    // Re-pin gated each tick so the wall-clock racing timer can't flip us early.
+    // Bots spawn at a random spot across the gate (which may be a lava lane when
+    // the front row is partly lava-walled) and then migrate to a safe launch lane,
+    // so allow enough ticks for that lateral migration to settle.
+    const gated = room.game.stateMap.gated;
+    let pressOk = 0, pressTotal = 0;
+    for (let f = 0; f < 150; f++) {
+        room.game.currentState = gated;
+        room.update(DT);
+        const arrs = [
+            compressor.sendPlayerUpdates(room.playerList),
+            compressor.sendProjUpdates(room.projectileList),
+            compressor.sendAimerUpdates(room.aimerList),
+            compressor.sendHazardUpdates(room.hazardList)
+        ];
+        for (const a of arrs) { if (!Array.isArray(a)) { fail(label + ': malformed per-tick array at gated frame ' + f); } }
+        if (failures > 0) { return; }
+    }
+    // After settling, assert each bot pressed toward its gate's inner edge and is
+    // not standing on lava.
+    let lavaStanders = 0;
+    for (const id in room.playerList) {
+        const p = room.playerList[id];
+        if (!p.isAI || !p.alive) { continue; }
+        const gate = gb.startingGates[p.gateIndex];
+        const edge = innerEdge(gate);
+        // velocity intent toward the inner edge (averaged over the run is noisy per
+        // tick; check the steady-state target direction sign set this frame).
+        const towardInner = (edge.axis === 'x')
+            ? Math.sign(edge.pos - p.x) === Math.sign(p.targetDirX || (edge.pos - p.x))
+            : Math.sign(edge.pos - p.y) === Math.sign(p.targetDirY || (edge.pos - p.y));
+        pressTotal++;
+        if (towardInner || Math.abs((edge.axis === 'x' ? p.x : p.y) - edge.pos) < 30) { pressOk++; }
+        if (tileIdAt(map, p.x, p.y) === LAVA) { lavaStanders++; }
+    }
+    if (pressTotal > 0 && pressOk < pressTotal) {
+        // Not a hard fail by itself (a bot at the front presses laterally), but flag
+        // if a large fraction face the wrong way.
+        if (pressOk < Math.ceil(pressTotal * 0.5)) {
+            fail(label + ': only ' + pressOk + '/' + pressTotal + ' bots oriented toward their gate');
+        }
+    }
+    if (lavaEdge != null) {
+        // The generalized per-gate safe-lane steering should send the bots to the
+        // NON-lava half of the front row. A broken edge/axis generalization would
+        // instead pile most of them straight onto the lava band, so require a
+        // strong majority off lava. (A few can be jostled onto the lava edge by
+        // crowding in a half-walled gate — that's the known "gate spawns don't
+        // avoid lava" limitation, not a steering-axis bug, and lava can't kill
+        // during the gated phase anyway.)
+        const offLava = pressTotal - lavaStanders;
+        if (pressTotal > 0 && offLava < Math.ceil(pressTotal * 0.6)) {
+            fail(label + ': only ' + offLava + '/' + pressTotal +
+                ' bots found a non-lava lane — the safe-lane generalization looks broken on the ' + lavaEdge + ' edge');
+        } else {
+            ok(offLava + '/' + pressTotal + ' bots settled on a non-lava lane on the ' + lavaEdge + ' front row');
+        }
+    } else {
+        ok('bots pressed toward their gate(s)');
+    }
+
+    // ---- racing -> collapsing ----
+    try {
+        room.game.startRace();
+        for (let f = 0; f < 120; f++) { room.update(DT); }
+        room.game.startCollapse(W / 2, H / 2);
+        for (let f = 0; f < 120; f++) {
+            room.update(DT);
+            const a = compressor.sendPlayerUpdates(room.playerList);
+            if (!Array.isArray(a)) { fail(label + ': malformed player array while collapsing'); break; }
+        }
+        ok('ran racing -> collapsing clean');
+    } catch (e) {
+        fail(label + ': threw during race/collapse: ' + e.message + '\n' + e.stack);
+    }
+}
+
+// Single edges (with a lava band each, to exercise per-edge safe-lane steering)
+// and the two opposite-edge combos.
+runConfig(['left'], 'left', 'single: left (lava band)');
+runConfig(['right'], 'right', 'single: right (lava band)');
+runConfig(['top'], 'top', 'single: top (lava band)');
+runConfig(['bottom'], 'bottom', 'single: bottom (lava band)');
+runConfig(['left', 'right'], 'right', 'combo: left+right (lava on right)');
+runConfig(['top', 'bottom'], 'top', 'combo: top+bottom (lava on top)');
+
+if (failures > 0) {
+    console.log('\nstart-edges test FAILED with ' + failures + ' error(s).');
+    process.exit(1);
+}
+console.log('\nstart-edges test passed: every edge config gated -> raced -> collapsed cleanly.');
+process.exit(0);

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -114,3 +114,6 @@ jobs:
 
       - name: Headless game-loop smoke test
         run: node .github/scripts/smoke-test.js
+
+      - name: Headless start-edges test (single edges + opposite-edge combos)
+        run: node .github/scripts/start-edges-test.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Map editor
+
+- Map makers can now pick which edge the race starts from — left, right, top, or bottom — instead of always starting on the left. You can also choose a two-sided start (left + right, or top + bottom) that splits the racers across opposite edges for a head-on dash to the middle. The editor draws the start gate(s) where you picked so you can line up your goal; two-sided maps play fairest with a goal near the center.
 
 ## v0.8.4 — 2026-05-26
 

--- a/client/create.html
+++ b/client/create.html
@@ -288,6 +288,21 @@
               <button id="movingBumperButton" style="background-color: orange" title="Moving Bumper" class="mapEditorTile"><span>Moving Bumper</span></button>
             </div>
           </div>
+          <div class="palette mb-3">
+            <div class="h5">
+              Start edge
+            </div>
+            <hr />
+            <div>
+              <button data-edges="left" title="Players start on the left" class="mapEditorTile startEdgeButton"><span>Left</span></button>
+              <button data-edges="right" title="Players start on the right" class="mapEditorTile startEdgeButton"><span>Right</span></button>
+              <button data-edges="top" title="Players start at the top" class="mapEditorTile startEdgeButton"><span>Top</span></button>
+              <button data-edges="bottom" title="Players start at the bottom" class="mapEditorTile startEdgeButton"><span>Bottom</span></button>
+              <button data-edges="left+right" title="Players split across left & right" class="mapEditorTile startEdgeButton"><span>Left + Right</span></button>
+              <button data-edges="top+bottom" title="Players split across top & bottom" class="mapEditorTile startEdgeButton"><span>Top + Bottom</span></button>
+            </div>
+            <small id="startEdgeHint" style="display:none; color:#555;">Two-sided maps play fairest with a goal near the center.</small>
+          </div>
           <div id="actionsSection">
             <div class="h5">
               Actions

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -21,12 +21,16 @@ var server,
     newWidth = 0,
     newHeight = 0,
     world = { x: 0, y: 0, width: 1366, height: 768 },
-    gate = { x: 0, y: 0, width: 75, height: world.height },
+    startEdges = ["left"],
+    gates = [],
     map = { x: 75, y: 0, width: world.width, height: world.height },
     canvasWindow = document.getElementById("canvasWindow"),
     createContext;
 
 var scale = 0.035;
+// Gate strip depth (px), matching server/game.js GATE_DEPTH so the previewed gate
+// lines up with where the server actually holds players.
+var GATE_DEPTH = 75;
 
 // Tile textures. Attach load + error BEFORE setting src so cached images
 // still fire and a missing/broken asset can't hang the gate forever.
@@ -91,6 +95,7 @@ window.onload = function () {
     }
     if (restored != null) {
         vMap = restored;
+        syncStartEdgesFromMap();
         $('#author').val(vMap.author);
         $('#name').val(vMap.name);
         mapReady = true;
@@ -164,6 +169,7 @@ function clientConnect() {
                     for (var j = 0; j < maps.length; j++) {
                         if (maps[j].id == this.id) {
                             vMap = JSON.parse(JSON.stringify(maps[j]));
+                            syncStartEdgesFromMap();
                             $('#author').val(vMap.author);
                             $('#name').val(vMap.name);
                             showEditor();
@@ -326,6 +332,11 @@ function setupPage() {
         drawObject = null;
         return false;
     });
+    $(".startEdgeButton").on("click", function () {
+        var edges = ($(this).attr("data-edges") || "left").split("+");
+        setStartEdges(edges);
+        return false;
+    });
     $("#bumperButton").on("click", function () {
         drawBrushAimer = false;
         drawObject = null;
@@ -442,6 +453,8 @@ function rebuild() {
 
 function init() {
     initEditorGamepad();
+    recomputeStartLayout();
+    updateStartEdgeButtons();
     animloop();
 }
 
@@ -508,16 +521,91 @@ function drawWorld() {
         createContext.restore();
     }
 }
-function drawGate() {
-    if (gate != null) {
-        createContext.save();
-        createContext.beginPath();
-        createContext.lineWidth = 5;
-        createContext.rect(gate.x, gate.y, gate.width, gate.height);
-        createContext.fillStyle = "grey";
-        createContext.fill();
-        createContext.restore();
+// Rebuild the drawn gate(s) and the cell-generation region from the chosen start
+// edges. Mirrors server/game.js buildStartingGates so the previewed/submitted gate
+// matches where the server holds players. Cells are kept off the gate strip(s) so
+// spawns don't land under a gate.
+function recomputeStartLayout() {
+    var W = world.width, H = world.height, D = GATE_DEPTH;
+    var rects = {
+        left: { x: 0, y: 0, width: D, height: H },
+        right: { x: W - D, y: 0, width: D, height: H },
+        top: { x: 0, y: 0, width: W, height: D },
+        bottom: { x: 0, y: H - D, width: W, height: D }
+    };
+    gates = [];
+    for (var i = 0; i < startEdges.length; i++) {
+        var r = rects[startEdges[i]];
+        if (r != null) {
+            gates.push({ x: r.x, y: r.y, width: r.width, height: r.height, edge: startEdges[i] });
+        }
     }
+    // Cell region as a far-corner box {x, y, width(=xr), height(=yb)}: reserve a
+    // strip on each selected edge.
+    var xl = 0, yt = 0, xr = W, yb = H;
+    for (var j = 0; j < startEdges.length; j++) {
+        if (startEdges[j] === "left") { xl = Math.max(xl, D); }
+        else if (startEdges[j] === "right") { xr = Math.min(xr, W - D); }
+        else if (startEdges[j] === "top") { yt = Math.max(yt, D); }
+        else if (startEdges[j] === "bottom") { yb = Math.min(yb, H - D); }
+    }
+    map = { x: xl, y: yt, width: xr, height: yb };
+}
+
+// Apply a new start-edge selection from the picker. Writes it onto the working
+// map immediately so a Preview/Upload right after picking carries it.
+function setStartEdges(edges) {
+    startEdges = edges.slice();
+    recomputeStartLayout();
+    if (vMap != null) { vMap.startEdges = startEdges.slice(); }
+    updateStartEdgeButtons();
+    dirty = true;
+}
+
+// Sync the picker to whatever start edges the loaded/restored map declares
+// (legacy maps without the field default to a single left gate).
+function syncStartEdgesFromMap() {
+    var se = (vMap != null && Array.isArray(vMap.startEdges) && vMap.startEdges.length > 0) ? vMap.startEdges : ["left"];
+    startEdges = se.slice();
+    recomputeStartLayout();
+    if (vMap != null) { vMap.startEdges = startEdges.slice(); }
+    updateStartEdgeButtons();
+}
+
+// Highlight the active picker button and toggle the "centered goal" combo hint.
+// Matches on the sorted edge set, so button order (e.g. "top+bottom") doesn't
+// have to match the stored order.
+function updateStartEdgeButtons() {
+    var activeKey = startEdges.slice().sort().join("+");
+    $(".startEdgeButton").each(function () {
+        var edges = ($(this).attr("data-edges") || "").split("+").sort().join("+");
+        if (edges === activeKey) {
+            $(this).addClass("active-edge").css("outline", "3px solid #1e90ff");
+        } else {
+            $(this).removeClass("active-edge").css("outline", "");
+        }
+    });
+    if (startEdges.length === 2) {
+        $("#startEdgeHint").show();
+    } else {
+        $("#startEdgeHint").hide();
+    }
+}
+
+function drawGate() {
+    if (gates == null || gates.length === 0) {
+        return;
+    }
+    createContext.save();
+    createContext.lineWidth = 5;
+    createContext.fillStyle = "grey";
+    for (var i = 0; i < gates.length; i++) {
+        var g = gates[i];
+        createContext.beginPath();
+        createContext.rect(g.x, g.y, g.width, g.height);
+        createContext.fill();
+    }
+    createContext.restore();
 }
 function drawMap() {
     if (map != null) {
@@ -691,12 +779,16 @@ function generateVMap() {
     var margin = 0.07;
     var localbbox = { xl: map.x, xr: map.width, yt: map.y, yb: map.height };
 
-    var xmargin = map.width * margin,
-        ymargin = map.height * margin,
-        xo = xmargin,
-        dx = map.width - xmargin * 2,
-        yo = ymargin,
-        dy = map.height - ymargin * 2;
+    // Span of the cell region (map.width/height are far-corner coords), so sites
+    // honor the reserved gate strip(s) on whichever edge(s) were chosen.
+    var spanX = map.width - map.x,
+        spanY = map.height - map.y;
+    var xmargin = spanX * margin,
+        ymargin = spanY * margin,
+        xo = map.x + xmargin,
+        dx = spanX - xmargin * 2,
+        yo = map.y + ymargin,
+        dy = spanY - ymargin * 2;
 
     for (var i = 0; i < siteNum; i++) {
         sites.push({ x: Math.round((xo + Math.random() * dx) * 10) / 10, y: Math.round((yo + Math.random() * dy) * 10) / 10 });
@@ -708,6 +800,7 @@ function generateVMap() {
         cells[iCells].id = 1;
     }
     localMap.hazards = [];
+    localMap.startEdges = startEdges.slice();
     return localMap;
 }
 
@@ -884,6 +977,33 @@ function validateMap(map) {
                 typeof hazard.angle !== "number") {
                 return { valid: false, reason: "Map has a moving bumper with no direction." };
             }
+        }
+    }
+    if (map.startEdges != null) {
+        var startEdgeCheck = validateStartEdges(map.startEdges);
+        if (!startEdgeCheck.valid) {
+            return startEdgeCheck;
+        }
+    }
+    return { valid: true };
+}
+// Mirror of server/utils.js validateStartEdges — one edge, or an opposite pair.
+function validateStartEdges(startEdges) {
+    var OPPOSITE = { left: "right", right: "left", top: "bottom", bottom: "top" };
+    if (!Array.isArray(startEdges) || startEdges.length < 1 || startEdges.length > 2) {
+        return { valid: false, reason: "startEdges must list 1 or 2 edges." };
+    }
+    for (var i = 0; i < startEdges.length; i++) {
+        if (OPPOSITE[startEdges[i]] == null) {
+            return { valid: false, reason: "startEdges has an unknown edge." };
+        }
+    }
+    if (startEdges.length === 2) {
+        if (startEdges[0] === startEdges[1]) {
+            return { valid: false, reason: "startEdges can't repeat the same edge." };
+        }
+        if (OPPOSITE[startEdges[0]] !== startEdges[1]) {
+            return { valid: false, reason: "Two start edges must be opposite (left+right or top+bottom)." };
         }
     }
     return { valid: true };

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -2227,35 +2227,56 @@ function drawLobbyStartButton() {
     }
 }
 function drawGate() {
-    if (gate != null) {
-        gameContext.save();
-        gameContext.beginPath();
-        gameContext.lineWidth = 5;
-        gameContext.rect(gate.x, gate.y, gate.width, gate.height);
-        if (brutalRound == false) {
-            gameContext.fillStyle = "grey";
-        } else {
-            gameContext.fillStyle = brutalPatterns[brutalRoundConfig.brutalTypes.toString()];
-        }
-        if (currentState == config.stateMap.collapsing) {
-            gameContext.fillStyle = patterns[config.tileMap.lava.id];
-        }
-        gameContext.fill();
-        gameContext.restore();
+    if (gates == null || gates.length == 0) {
+        return;
     }
+    gameContext.save();
+    gameContext.lineWidth = 5;
+    if (brutalRound == false) {
+        gameContext.fillStyle = "grey";
+    } else {
+        gameContext.fillStyle = brutalPatterns[brutalRoundConfig.brutalTypes.toString()];
+    }
+    if (currentState == config.stateMap.collapsing) {
+        gameContext.fillStyle = patterns[config.tileMap.lava.id];
+    }
+    for (var i = 0; i < gates.length; i++) {
+        var g = gates[i];
+        gameContext.beginPath();
+        gameContext.rect(g.x, g.y, g.width, g.height);
+        gameContext.fill();
+    }
+    gameContext.restore();
 }
 
 function drawGateLine() {
-    if (gate != null) {
-        gameContext.save();
-        gameContext.beginPath();
-        gameContext.moveTo(gate.x + gate.width, gate.y);
-        gameContext.lineTo(gate.x + gate.width, gate.y + gate.height);
-        gameContext.lineWidth = 5;
-        gameContext.strokeStyle = "red";
-        gameContext.stroke();
-        gameContext.restore();
+    if (gates == null || gates.length == 0) {
+        return;
     }
+    gameContext.save();
+    gameContext.lineWidth = 5;
+    gameContext.strokeStyle = "red";
+    for (var i = 0; i < gates.length; i++) {
+        var g = gates[i];
+        gameContext.beginPath();
+        // Release line on the gate's INNER edge (the side players launch toward).
+        if (g.edge == "right") {
+            gameContext.moveTo(g.x, g.y);
+            gameContext.lineTo(g.x, g.y + g.height);
+        } else if (g.edge == "top") {
+            gameContext.moveTo(g.x, g.y + g.height);
+            gameContext.lineTo(g.x + g.width, g.y + g.height);
+        } else if (g.edge == "bottom") {
+            gameContext.moveTo(g.x, g.y);
+            gameContext.lineTo(g.x + g.width, g.y);
+        } else {
+            // left (default): inner edge is the right side of the strip.
+            gameContext.moveTo(g.x + g.width, g.y);
+            gameContext.lineTo(g.x + g.width, g.y + g.height);
+        }
+        gameContext.stroke();
+    }
+    gameContext.restore();
 }
 function drawPingCircles() {
     if (pingCircles.length == 0) {

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -3,6 +3,7 @@ var mousex,
 	mousey,
 	lobbyStartButton,
 	gate,
+	gates = [],
 	world,
 	mapID,
 	gameID,
@@ -347,11 +348,17 @@ function checkGameState(payload) {
 	}
 	if (currentState == config.stateMap.gated || currentState == config.stateMap.racing || currentState == config.stateMap.collapsing) {
 		lobbyStartButton = null;
-		gate = {};
-		gate.x = payload[1];
-		gate.y = payload[2];
-		gate.width = payload[3];
-		gate.height = payload[4];
+		// payload[1] is an array of gates [x, y, width, height, edge] (one for a
+		// single-edge map, two for an opposite-edge combo) — mirrors
+		// compressor.gameState. `gate` keeps pointing at gate 0 for any reader that
+		// still wants "the gate".
+		gates = [];
+		var gateData = payload[1] || [];
+		for (var gi = 0; gi < gateData.length; gi++) {
+			var gd = gateData[gi];
+			gates.push({ x: gd[0], y: gd[1], width: gd[2], height: gd[3], edge: gd[4] });
+		}
+		gate = gates.length > 0 ? gates[0] : null;
 	}
 
 }

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -993,48 +993,91 @@ function steerBot(bot, ctx, dt) {
     decideAttack(bot, ctx, { sharpTurn: sharpTurn, lavaAhead: fl.brake, braking: braking });
 }
 
-// The non-lava launch lanes along the gate's front row: the Y positions where a
-// bot can stand (and be released) onto solid ground, not lava. On a lava-walled
-// map only a few exist, so bots contest them — like real players fighting over
-// the safe spots — instead of spreading evenly onto the lava.
-function computeSafeLanes(ctx, gate, standX) {
+// Per-gate launch geometry, agnostic to which edge the gate hugs. A gate is thin
+// on one axis: left/right gates are vertical (lanes run along Y, bots launch
+// along X); top/bottom gates are horizontal (lanes run along X, launch along Y).
+//   launchPos  — the inner-edge coordinate on the launch axis (release line)
+//   launchDir  — +1 / -1 sign of the launch direction along that axis
+//   standPos   — coordinate on the launch axis where a held bot actually stands
+//   laneMin/Max— span on the lane (perpendicular) axis, inset off the corners
+function gateGeometry(gate) {
+    var vertical = gate.width < gate.height; // left/right are thin in width
+    var edge = gate.edge || (vertical
+        ? (gate.x <= 0 ? "left" : "right")
+        : (gate.y <= 0 ? "top" : "bottom"));
+    var g;
+    if (vertical) {
+        var innerX = (edge === "left") ? gate.x + gate.width : gate.x;
+        g = {
+            vertical: true,
+            launchPos: innerX,
+            launchDir: (edge === "left") ? 1 : -1,
+            standPos: innerX + ((edge === "left") ? -10 : 10),
+            laneMin: gate.y + 16,
+            laneMax: gate.y + gate.height - 16,
+            penMin: gate.y, penMax: gate.y + gate.height
+        };
+    } else {
+        var innerY = (edge === "top") ? gate.y + gate.height : gate.y;
+        g = {
+            vertical: false,
+            launchPos: innerY,
+            launchDir: (edge === "top") ? 1 : -1,
+            standPos: innerY + ((edge === "top") ? -10 : 10),
+            laneMin: gate.x + 16,
+            laneMax: gate.x + gate.width - 16,
+            penMin: gate.x, penMax: gate.x + gate.width
+        };
+    }
+    return g;
+}
+
+// The non-lava launch lanes along the gate's front row: positions on the lane
+// axis where a bot can stand (and be released) onto solid ground, not lava. On a
+// lava-walled map only a few exist, so bots contest them — like real players
+// fighting over the safe spots — instead of spreading evenly onto the lava.
+function computeSafeLanes(ctx, geo) {
     var lanes = [];
-    var topY = gate.y + 16, botY = gate.y + gate.height - 16;
-    for (var y = topY; y <= botY; y += 20) {
-        if (!isLavaAt(ctx, standX, y)) { lanes.push(y); }
+    for (var p = geo.laneMin; p <= geo.laneMax; p += 20) {
+        var x = geo.vertical ? geo.standPos : p;
+        var y = geo.vertical ? p : geo.standPos;
+        if (!isLavaAt(ctx, x, y)) { lanes.push(p); }
     }
     return lanes;
 }
 
-// Gated phase: bots aren't racing yet (held inside the start gate). They press to
-// the front row, target a SAFE (non-lava) launch lane so they don't drive into
+// Gated phase: bots aren't racing yet (held inside their start gate). They press
+// to the front row, target a SAFE (non-lava) launch lane so they don't drive into
 // lava the instant the gate opens, and bursty-punch to contest a lane. Everyone
 // converges on the safe lanes, so they jostle for them. preventEscape keeps them
 // in the gate; lava can't kill here, only once racing starts.
-function steerGated(bot, ctx, dt) {
+function steerGated(bot, ctx) {
     var ai = bot.ai || (bot.ai = newBotState(bot.profile));
-    var gate = ctx.gate;
-    var frontX = (gate ? gate.x + gate.width : 75) - bot.radius - 3;
-    var topY = (gate ? gate.y : 0) + bot.radius + 4;
-    var botYmax = (gate ? gate.y + gate.height : c.worldHeight) - bot.radius - 4;
-    var ty;
+    var geo = ctx.geo;
+    // Stand just behind the release line, inside the gate.
+    var front = geo.launchPos - geo.launchDir * (bot.radius + 3);
+    var perpMin = geo.penMin + bot.radius + 4;
+    var perpMax = geo.penMax - bot.radius - 4;
+    var tperp;
     if (ctx.safeLanes && ctx.safeLanes.length > 0) {
         // Each bot is assigned a safe lane by its seed so the field SPREADS across
         // the available lanes (route diversity) instead of all converging on the
         // nearest one. When safe lanes are scarce (lava-walled gate) several bots
         // share a lane and jostle for it. Sticky per-bot jitter avoids exact stacks.
         if (ai.gateJitter == null) { ai.gateJitter = (Math.random() - 0.5) * 16; }
-        ty = ctx.safeLanes[ai.pathSeed % ctx.safeLanes.length] + ai.gateJitter;
+        tperp = ctx.safeLanes[ai.pathSeed % ctx.safeLanes.length] + ai.gateJitter;
     } else {
         // No safe-lane reading: gentle shuffle along the gate (fallback).
-        if (ai.gateY == null) { ai.gateY = bot.y; }
+        if (ai.gateY == null) { ai.gateY = geo.vertical ? bot.y : bot.x; }
         ai.gateY += (Math.random() - 0.5) * 12;
-        if (ai.gateY < topY) { ai.gateY = topY; }
-        if (ai.gateY > botYmax) { ai.gateY = botYmax; }
-        ty = ai.gateY;
+        if (ai.gateY < perpMin) { ai.gateY = perpMin; }
+        if (ai.gateY > perpMax) { ai.gateY = perpMax; }
+        tperp = ai.gateY;
     }
-    if (ty < topY) { ty = topY; } else if (ty > botYmax) { ty = botYmax; }
-    var dx = frontX - bot.x, dy = ty - bot.y;
+    if (tperp < perpMin) { tperp = perpMin; } else if (tperp > perpMax) { tperp = perpMax; }
+    var tx = geo.vertical ? front : tperp;
+    var ty = geo.vertical ? tperp : front;
+    var dx = tx - bot.x, dy = ty - bot.y;
     var m = mag(dx, dy) || 1;
     bot.targetDirX = (dx / m) * 0.75; // press to the front, not flat out
     bot.targetDirY = (dy / m) * 0.75;
@@ -1048,24 +1091,32 @@ function steerGatedPhase(gameBoard) {
     var hasBot = false;
     for (var id in playerList) { if (playerList[id].isAI && playerList[id].alive) { hasBot = true; break; } }
     if (!hasBot) { return; }
-    var gate = gameBoard.startingGate;
-    var ctx = {
-        map: gameBoard.currentMap,
-        lavaId: c.tileMap.lava.id,
-        players: playerList,
-        projectileList: gameBoard.projectileList,
-        gate: gate,
-        infection: false, hockey: false, cloudy: false, lightning: false,
-        puck: null, clouds: [], blackoutActive: false, visionBlockedUntil: 0
-    };
-    // Where a gated bot ends up standing (front row, inside the gate); the lava
-    // check uses that X so a "safe lane" is one the bot can actually launch from.
-    var standX = gate ? gate.x + gate.width - 10 : 65;
-    ctx.safeLanes = gate ? computeSafeLanes(ctx, gate, standX) : [];
+    var gates = gameBoard.startingGates || [];
+    if (gates.length === 0) { return; }
+    // Build a per-gate steering context once (geometry + safe lanes for that gate),
+    // so each bot is steered toward the gate it was assigned (player.gateIndex).
+    var gateCtxs = [];
+    for (var gi = 0; gi < gates.length; gi++) {
+        var geo = gateGeometry(gates[gi]);
+        var ctx = {
+            map: gameBoard.currentMap,
+            lavaId: c.tileMap.lava.id,
+            players: playerList,
+            projectileList: gameBoard.projectileList,
+            gate: gates[gi],
+            geo: geo,
+            infection: false, hockey: false, cloudy: false, lightning: false,
+            puck: null, clouds: [], blackoutActive: false, visionBlockedUntil: 0
+        };
+        ctx.safeLanes = computeSafeLanes(ctx, geo);
+        gateCtxs.push(ctx);
+    }
     for (var pid in playerList) {
         var bot = playerList[pid];
         if (!bot.isAI || !bot.alive || bot.isSpectator) { continue; }
-        steerGated(bot, ctx);
+        var idx = bot.gateIndex || 0;
+        if (idx >= gateCtxs.length) { idx = 0; }
+        steerGated(bot, gateCtxs[idx]);
     }
 }
 

--- a/server/cellGraph.js
+++ b/server/cellGraph.js
@@ -386,12 +386,23 @@ function computeMapParTime(map) {
     if (!map || !Array.isArray(map.cells) || map.cells.length === 0) {
         return 0;
     }
-    var H = c.worldHeight;
-    var step = H / 10;
-    if (step < 1) { step = 1; }
+    var W = c.worldWidth, H = c.worldHeight;
+    // Sample along the start edge. Opposite-edge combos are symmetric about the
+    // world center, so either edge gives the same par — sample the first.
+    var edge = (Array.isArray(map.startEdges) && map.startEdges.length > 0) ? map.startEdges[0] : "left";
+    var samples = [];
+    if (edge === "top" || edge === "bottom") {
+        var fixedY = (edge === "top") ? 40 : H - 40;
+        var stepX = W / 10; if (stepX < 1) { stepX = 1; }
+        for (var x = 40; x < W; x += stepX) { samples.push({ x: x, y: fixedY }); }
+    } else {
+        var fixedX = (edge === "right") ? W - 40 : 40;
+        var stepY = H / 10; if (stepY < 1) { stepY = 1; }
+        for (var y = 40; y < H; y += stepY) { samples.push({ x: fixedX, y: y }); }
+    }
     var pars = [];
-    for (var y = 40; y < H; y += step) {
-        var route = findPathToNearestGoal(map, { x: 40, y: y });
+    for (var s = 0; s < samples.length; s++) {
+        var route = findPathToNearestGoal(map, samples[s]);
         if (route != null) {
             var par = estimatePathTime(map, route.path);
             if (par > 0) { pars.push(par); }

--- a/server/compressor.js
+++ b/server/compressor.js
@@ -130,10 +130,16 @@ exports.gameState = function (game) {
 		packet[4] = game.gameBoard.lobbyStartButton.color;
 	}
 	if (game.currentState == game.stateMap.gated || game.currentState == game.stateMap.racing || game.currentState == game.stateMap.collapsing) {
-		packet[1] = game.gameBoard.startingGate.x;
-		packet[2] = game.gameBoard.startingGate.y;
-		packet[3] = game.gameBoard.startingGate.width;
-		packet[4] = game.gameBoard.startingGate.height;
+		// One or two starting gates (opposite-edge maps have two). Each gate is
+		// [x, y, width, height, edge]; width/height are true dimensions. The client
+		// decoder in gameboard.js#checkGameState mirrors this shape (lockstep rule).
+		var gates = game.gameBoard.startingGates || [];
+		var gatePackets = [];
+		for (var gi = 0; gi < gates.length; gi++) {
+			var g = gates[gi];
+			gatePackets.push([g.x, g.y, g.width, g.height, g.edge || "left"]);
+		}
+		packet[1] = gatePackets;
 	}
 	packet = JSON.stringify(packet);
 	return packet;

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -61,6 +61,10 @@ class Player extends Circle {
 
 		//Game Variables
 		this.hittingLobbyButton = false;
+		// Which starting gate this player is held in / launches from. Maps with
+		// opposite-edge starts (e.g. left+right) split players across two gates;
+		// single-edge maps keep everyone at gate 0.
+		this.gateIndex = 0;
 		this.reachedGoal = false;
 		this.timeReached = null;
 		this.collapseMargin = null; // distance to the lava front while collapsing (for clutch-goal cheer)

--- a/server/entities/shapes.js
+++ b/server/entities/shapes.js
@@ -99,10 +99,40 @@ class Rect extends Shape {
 	}
 }
 
+// A Gate is the start-pen players are held in before the race. Unlike the base
+// Rect (whose width/height double as the far-corner coordinates and so only
+// line up with true dimensions when x=y=0), a Gate can sit on ANY edge of the
+// world (left/right/top/bottom), so it stores width/height as TRUE dimensions
+// and overrides the two Rect methods that assumed far-corner coords. With this,
+// preventEscape (bound.x + bound.width), the gate-line render (gate.x+width),
+// and getSafeLoc all compute the correct edges for a non-origin gate.
 class Gate extends Rect {
 	constructor(x, y, width, height) {
 		super(x, y, width, height, 0, "grey");
 		this.isGate = true;
+		// Which world edge this gate hugs ("left"/"right"/"top"/"bottom"); set by
+		// the GameBoard when it builds the gate from the map's startEdges. Used by
+		// the client to draw the release line on the gate's inner edge.
+		this.edge = null;
+	}
+	getVertices() {
+		var x2 = this.x + this.width,
+			y2 = this.y + this.height;
+		return [
+			{ x: this.x, y: this.y },
+			{ x: x2, y: this.y },
+			{ x: x2, y: y2 },
+			{ x: this.x, y: y2 }
+		];
+	}
+	getSafeLoc(size) {
+		var objW = size + 5 + c.playerBaseRadius * 2;
+		var objH = size + 5 + c.playerBaseRadius * 2;
+		return {
+			x: Math.floor(Math.random() * (this.width - 2 * objW)) + this.x + objW,
+			y: Math.floor(Math.random() * (this.height - 2 * objH)) + this.y + objH,
+			width: objW
+		};
 	}
 	handleHit() {
 

--- a/server/game.js
+++ b/server/game.js
@@ -26,6 +26,11 @@ exports.getRoom = function (sig, size) {
 // so they never collide with socket ids (which key human players in playerList).
 var botSeq = 0;
 
+// Depth (px) of a starting gate measured inward from its world edge. The gate
+// spans the full extent of the perpendicular axis. Matches the editor's gate
+// strip width so the previewed gate lines up with the server's.
+var GATE_DEPTH = 75;
+
 class Room {
 	constructor(sig, size) {
 		this.sig = sig;
@@ -807,7 +812,11 @@ class GameBoard {
 		this.lobbyStartButton;
 		this.alivePlayerCount = 0;
 		this.sleepingPlayerCount = 0;
-		this.startingGate = null;
+		// One gate per start edge: single-edge maps have one, opposite-edge combos
+		// (left+right / top+bottom) have two. Built in setupMap from the map's
+		// startEdges. The `startingGate` getter below returns gate 0 so older
+		// single-gate readers keep working.
+		this.startingGates = [];
 		var allMaps = utils.loadMaps();
 		// lobbyOnly maps (e.g. the lobby tutorial islands) are kept out of the race
 		// rotation; the lobby loads its map from lobbyMaps separately.
@@ -838,6 +847,11 @@ class GameBoard {
 		// at most once per audienceNearBurnCooldown, no matter how many racers
 		// are skating the lava edge at once.
 		this.nextNearBurnTime = 0;
+	}
+	// Back-compat alias: most of the codebase only ever needs "the gate", which is
+	// gate 0. Opposite-edge maps add a second gate read through startingGates[].
+	get startingGate() {
+		return this.startingGates.length > 0 ? this.startingGates[0] : null;
 	}
 	update(currentState, playerAliveCount, sleepingPlayerCount, dt) {
 		this.alivePlayerCount = playerAliveCount;
@@ -928,7 +942,11 @@ class GameBoard {
 				continue;
 			}
 			_engine.preventEscape(this.playerList[player], this.world);
-			_engine.preventEscape(this.playerList[player], this.startingGate);
+			// Clamp each player to THEIR gate (opposite-edge maps hold two groups).
+			var gate = this.startingGates[this.playerList[player].gateIndex] || this.startingGates[0];
+			if (gate != null) {
+				_engine.preventEscape(this.playerList[player], gate);
+			}
 			objectArray.push(this.playerList[player]);
 		}
 		for (var punchId in this.punchList) {
@@ -936,12 +954,15 @@ class GameBoard {
 		}
 	}
 	collectRaceCollisionObjects(currentState, objectArray) {
+		// During collapse every gate becomes a lava wall players are crushed into.
+		if (currentState == this.stateMap.collapsing) {
+			for (var g = 0; g < this.startingGates.length; g++) {
+				objectArray.push(this.startingGates[g]);
+			}
+		}
 		for (var player in this.playerList) {
 			if (!this.playerList[player].alive) {
 				continue;
-			}
-			if (currentState == this.stateMap.collapsing) {
-				objectArray.push(this.startingGate);
 			}
 			_engine.preventEscape(this.playerList[player], this.world);
 			_engine.checkCollideCells(this.playerList[player], this.currentMap);
@@ -1675,8 +1696,51 @@ class GameBoard {
 		this.resetPlayers(currentState);
 		this.loadNextMap(currentState);
 		this.checkApplyBrutalConfig();
-		this.startingGate = new Gate(0, 0, 75, this.world.height);
+		this.startingGates = this.buildStartingGates(this.resolveStartEdges());
 		this.gatePlayers();
+	}
+	// The edges players start from for the current map. Legacy maps (and anything
+	// malformed) default to a single left gate, so behaviour is unchanged for
+	// every committed map that predates this field.
+	resolveStartEdges() {
+		var KNOWN = { left: 1, right: 1, top: 1, bottom: 1 };
+		var se = (this.currentMap != null) ? this.currentMap.startEdges : null;
+		if (!Array.isArray(se) || se.length === 0) {
+			return ["left"];
+		}
+		var edges = [];
+		for (var i = 0; i < se.length && edges.length < 2; i++) {
+			if (KNOWN[se[i]] && edges.indexOf(se[i]) === -1) {
+				edges.push(se[i]);
+			}
+		}
+		return edges.length > 0 ? edges : ["left"];
+	}
+	// One Gate per start edge. The gate hugs its edge with a fixed depth (GATE_DEPTH)
+	// and spans the full width/height of the opposite axis. Gate stores true
+	// dimensions, so these rects are correct on any edge.
+	buildStartingGates(startEdges) {
+		var W = this.world.width, H = this.world.height, D = GATE_DEPTH;
+		var rects = {
+			left: [0, 0, D, H],
+			right: [W - D, 0, D, H],
+			top: [0, 0, W, D],
+			bottom: [0, H - D, W, D]
+		};
+		var gates = [];
+		for (var i = 0; i < startEdges.length; i++) {
+			var r = rects[startEdges[i]];
+			if (r == null) { continue; }
+			var gate = new Gate(r[0], r[1], r[2], r[3]);
+			gate.edge = startEdges[i];
+			gates.push(gate);
+		}
+		if (gates.length === 0) {
+			var fallback = new Gate(0, 0, D, H);
+			fallback.edge = "left";
+			gates.push(fallback);
+		}
+		return gates;
 	}
 	startCollapse(loc) {
 		this.collapseLoc = loc;
@@ -1827,12 +1891,38 @@ class GameBoard {
 		this.resetPlayers(currentState);
 	}
 	gatePlayers() {
+		// Balanced alternating split: with two gates (opposite-edge maps), even
+		// spawn-order players go to gate 0 and odd to gate 1, so neither edge is
+		// stacked. Single-gate maps put everyone at gate 0.
+		var i = 0;
+		var gateCount = this.startingGates.length || 1;
 		for (var playerID in this.playerList) {
-			this.gatePlayer(this.playerList[playerID]);
+			this.gatePlayer(this.playerList[playerID], i % gateCount);
+			i++;
 		}
 	}
-	gatePlayer(player) {
-		var loc = this.startingGate.findFreeLoc(player);
+	// Pick the gate currently holding the fewest players, so mid-sequence joins
+	// (the AI grid fill happens AFTER gatePlayers, and late human joins arrive via
+	// determineGameState) keep opposite-edge maps balanced. `exclude` skips the
+	// player being placed so it doesn't count its own stale default gate.
+	leastPopulatedGateIndex(exclude) {
+		var counts = [];
+		for (var i = 0; i < this.startingGates.length; i++) { counts.push(0); }
+		for (var pid in this.playerList) {
+			if (this.playerList[pid] === exclude) { continue; }
+			var gi = this.playerList[pid].gateIndex || 0;
+			if (gi >= 0 && gi < counts.length) { counts[gi]++; }
+		}
+		var best = 0;
+		for (var k = 1; k < counts.length; k++) { if (counts[k] < counts[best]) { best = k; } }
+		return best;
+	}
+	gatePlayer(player, gateIndex) {
+		if (gateIndex == null) { gateIndex = this.leastPopulatedGateIndex(player); }
+		if (gateIndex >= this.startingGates.length) { gateIndex = 0; }
+		player.gateIndex = gateIndex;
+		var gate = this.startingGates[gateIndex];
+		var loc = gate.findFreeLoc(player);
 		player.x = loc.x;
 		player.y = loc.y;
 		// Sync the engine's integration position too. The engine advances newX/newY

--- a/server/utils.js
+++ b/server/utils.js
@@ -454,8 +454,40 @@ exports.validateMap = function (vMap, config) {
             }
         }
     }
+    // startEdges: optional; absent => default ["left"] (legacy maps). One edge for
+    // a single start, or an OPPOSITE pair (left+right / top+bottom) for a two-sided
+    // start. Adjacent pairs (e.g. left+top) and repeats are rejected.
+    if (vMap.startEdges != null) {
+        var startEdgeCheck = validateStartEdges(vMap.startEdges);
+        if (!startEdgeCheck.valid) {
+            return startEdgeCheck;
+        }
+    }
     return { valid: true };
 }
+// Shared start-edge rule used by validateMap on both sides. Kept as a standalone
+// so the client editor can mirror it exactly.
+function validateStartEdges(startEdges) {
+    var OPPOSITE = { left: "right", right: "left", top: "bottom", bottom: "top" };
+    if (!Array.isArray(startEdges) || startEdges.length < 1 || startEdges.length > 2) {
+        return { valid: false, reason: "startEdges must list 1 or 2 edges." };
+    }
+    for (var i = 0; i < startEdges.length; i++) {
+        if (OPPOSITE[startEdges[i]] == null) {
+            return { valid: false, reason: "startEdges has an unknown edge." };
+        }
+    }
+    if (startEdges.length === 2) {
+        if (startEdges[0] === startEdges[1]) {
+            return { valid: false, reason: "startEdges can't repeat the same edge." };
+        }
+        if (OPPOSITE[startEdges[0]] !== startEdges[1]) {
+            return { valid: false, reason: "Two start edges must be opposite (left+right or top+bottom)." };
+        }
+    }
+    return { valid: true };
+}
+exports.validateStartEdges = validateStartEdges;
 exports.getContentCount = function () {
     return mapListing.length + soundListing.length + imgListing.length;
 }


### PR DESCRIPTION
Map authors can now choose which edge the race starts from — **left / right / top / bottom** — or an **opposite-edge combo** (left+right, top+bottom) that splits the racers across two gates for a head-on dash to the middle. Implements the bundled `docs/spikes/map-start-edges.md` design (items A–I, build order §6).

New map-JSON field **`startEdges`** (1 entry, or an opposite pair). Legacy maps with no field default to `["left"]` — **zero migration**, behaviour unchanged for every committed map.

## What changed

**Data model (the spine)**
- `GameBoard.startingGates[]` built from `currentMap.startEdges`; a `startingGate` getter aliases gate 0 so existing single-gate readers keep working. Players carry `gateIndex`.
- `Gate` now stores **true dimensions** (overrides `getVertices`/`getSafeLoc`) so it sits on any edge correctly. This keeps `preventEscape` (`x+width`), the AI front edge, the compressor payload, and client rendering consistent **without touching `engine.js`**; `Gate(0,0,75,H)` keeps its exact prior meaning.

**Server**
- `gatePlayers` distributes players across gates (balanced alternating; least-populated for the mid-sequence AI grid fill and late joins, so opposite-edge maps stay even). Per-gate hold in `collectGatedCollisionObjects`; all gates pushed as collapse barriers.
- `validateMap` (server + editor mirror) accepts `startEdges` — 1–2 known edges, opposite pairs only (adjacent/repeat/unknown rejected).
- AI gated steering generalized to a per-gate front edge + perpendicular lane axis; each bot presses its assigned gate's safe (non-lava) lanes (works for vertical L/R and horizontal T/B gates).
- Par-time samples along the start edge's axis (combos symmetric).

**Network + client (lockstep)**
- `gameState` gate payload now carries N gates `[x,y,w,h,edge]`; the `gameboard.js` decoder mirrors it in the same change. `drawGate`/`drawGateLine` iterate and draw each release line on its gate's inner edge.

**Editor**
- Gamepad-navigable start-edge picker (single edges + the two combos), draws the gate(s) where you picked, reserves cell strips per edge, saves `startEdges`, and shows a "centered goal" hint for two-sided maps. The previewed gate(s) and the server's `setupMap` gates use the same geometry (`GATE_DEPTH=75`, world 1366×768), so preview matches play.

## Testing
- New headless `\.github/scripts/start-edges-test.js` (wired into CI): for each single edge **and** each combo it ticks gated→racing→collapsing and asserts the multi-gate `gameState` payload round-trips, players are held in their own gate, bots split across gates and settle on non-lava lanes, and no throws / malformed payloads.
- `smoke-test.js` (50 maps) and `validate-content.js` pass; all server/client files `node --check` clean. Rebased onto `origin/main` (v0.8.4).

Player-facing CHANGELOG entry added under `## Unreleased` (game-mechanic change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)