### PR TITLE
Controller menu nav: data-gp-nav source of truth + map-editor dialog fixes

### DIFF
--- a/client/create.html
+++ b/client/create.html
@@ -329,7 +329,7 @@
             <button id="exportButton" data-gp-nav class="btn btn-block">Copy to Clipboard<i class="fa fa-clipboard ml-2" aria-hidden="true"></i></button>
             <button id="exportStatus" class="btn btn-block" disabled style="display:none;"><span></span></button>
             <button id="submitButton" data-gp-nav class="btn btn-block">Upload to Github<i class="fa fa-cloud-upload ml-2"></i></button>
-            <button id="submitStatus" class="btn btn-block" disabled ><span>Submitting..</span></button>
+            <button id="submitStatus" class="btn btn-block" disabled style="display:none;"><span>Submitting..</span></button>
           </div>
         </div>
       </div>

--- a/client/create.html
+++ b/client/create.html
@@ -262,20 +262,20 @@
       <div id="mapEditor">
         <div id="controlPanel" class="bg-light">
           <div id="editorToolbar" class="d-flex align-items-center justify-content-between">
-            <button id="loadButton" class="btn bg-light p-0" title="Back to map list"><i class="fa fa-arrow-left fa-2x" aria-hidden="true"></i></button>
-            <button id="rebuildButton" class="btn bg-light p-0" title="Wipe map and start over"><i class="fa fa-trash fa-2x" aria-hidden="true"></i></button>
-            <button id="deleteSelectedButton" class="btn bg-light p-0" title="Delete selected hazard" disabled><i class="fa fa-times fa-2x" aria-hidden="true"></i></button>
-            <button id="rotateButton" class="btn bg-light p-0" title="Rotate selected hazard 15°"><i class="fa fa-rotate-right fa-2x" aria-hidden="true"></i></button>
-            <button id="mouseButton" class="btn bg-light p-0" title="Switch to selection cursor"><i class="fa fa-mouse-pointer fa-2x" aria-hidden="true"></i></button>
+            <button id="loadButton" data-gp-nav class="btn bg-light p-0" title="Back to map list"><i class="fa fa-arrow-left fa-2x" aria-hidden="true"></i></button>
+            <button id="rebuildButton" data-gp-nav class="btn bg-light p-0" title="Wipe map and start over"><i class="fa fa-trash fa-2x" aria-hidden="true"></i></button>
+            <button id="deleteSelectedButton" data-gp-nav class="btn bg-light p-0" title="Delete selected hazard" disabled><i class="fa fa-times fa-2x" aria-hidden="true"></i></button>
+            <button id="rotateButton" data-gp-nav class="btn bg-light p-0" title="Rotate selected hazard 15°"><i class="fa fa-rotate-right fa-2x" aria-hidden="true"></i></button>
+            <button id="mouseButton" data-gp-nav class="btn bg-light p-0" title="Switch to selection cursor"><i class="fa fa-mouse-pointer fa-2x" aria-hidden="true"></i></button>
           </div>
           <div id="inputBar" class="mb-3">
             <div class="h5">
               Details
             </div>
             <hr />
-            <input class="editor-inputs form-control" type="text" id="author" name="author" placeholder="Author" maxlength="15"></input>
-            <input class="editor-inputs form-control" type="text" id="name" name="name" placeholder="Map Name" maxlength="15"></input>
-            <input class="editor-inputs form-control" type="text" id="email" name="email" placeholder="Email" maxlength="50"></input>
+            <input class="editor-inputs form-control" data-gp-nav type="text" id="author" name="author" placeholder="Author" maxlength="15"></input>
+            <input class="editor-inputs form-control" data-gp-nav type="text" id="name" name="name" placeholder="Map Name" maxlength="15"></input>
+            <input class="editor-inputs form-control" data-gp-nav type="text" id="email" name="email" placeholder="Email" maxlength="50"></input>
           </div>
           <div class="palette mb-3">
             <div class="h5">
@@ -283,14 +283,14 @@
             </div>
             <hr />
             <div>
-              <button id="slowTileButton" style="background-color: #f6d7b0;" title="Sand" class="mapEditorTile"><span>Sand</span></button>
-              <button id="normalTileButton" style="background-color: #523A28" title="Dirt" class="mapEditorTile"><span>Dirt</span></button>
-              <button id="fastTileButton" style="background-color: #90ee90" title="Grass" class="mapEditorTile"><span>Grass</span></button>
-              <button id="lavaTileButton" style="background-color: #cf1020" title="Lava" class="mapEditorTile"><span>Lava</span></button>
-              <button id="iceTileButton" style="background-color: #A5F2F3" title="Ice" class="mapEditorTile"><span>Ice</span></button>
-              <button id="abilityTileButton" style="background-color: #C8C8C8" title="Ability" class="mapEditorTile"><span>Ability</span></button>
-              <button id="randomTileButton" style="background-color: #020DFE" title="Random" class="mapEditorTile"><span>Random</span></button>
-              <button id="goalTileButton" style="background-color: #FFD700" title="Goal" class="mapEditorTile"><span>Goal</span></button>
+              <button id="slowTileButton" data-gp-nav style="background-color: #f6d7b0;" title="Sand" class="mapEditorTile"><span>Sand</span></button>
+              <button id="normalTileButton" data-gp-nav style="background-color: #523A28" title="Dirt" class="mapEditorTile"><span>Dirt</span></button>
+              <button id="fastTileButton" data-gp-nav style="background-color: #90ee90" title="Grass" class="mapEditorTile"><span>Grass</span></button>
+              <button id="lavaTileButton" data-gp-nav style="background-color: #cf1020" title="Lava" class="mapEditorTile"><span>Lava</span></button>
+              <button id="iceTileButton" data-gp-nav style="background-color: #A5F2F3" title="Ice" class="mapEditorTile"><span>Ice</span></button>
+              <button id="abilityTileButton" data-gp-nav style="background-color: #C8C8C8" title="Ability" class="mapEditorTile"><span>Ability</span></button>
+              <button id="randomTileButton" data-gp-nav style="background-color: #020DFE" title="Random" class="mapEditorTile"><span>Random</span></button>
+              <button id="goalTileButton" data-gp-nav style="background-color: #FFD700" title="Goal" class="mapEditorTile"><span>Goal</span></button>
             </div>
           </div>
           <div class="palette mb-3">
@@ -299,8 +299,8 @@
             </div>
             <hr />
             <div>
-              <button id="bumperButton" style="background-color: orange" title="Bumper" class="mapEditorTile"><span>Bumper</span></button>
-              <button id="movingBumperButton" style="background-color: orange" title="Moving Bumper" class="mapEditorTile"><span>Moving Bumper</span></button>
+              <button id="bumperButton" data-gp-nav style="background-color: orange" title="Bumper" class="mapEditorTile"><span>Bumper</span></button>
+              <button id="movingBumperButton" data-gp-nav style="background-color: orange" title="Moving Bumper" class="mapEditorTile"><span>Moving Bumper</span></button>
             </div>
           </div>
           <div id="startEdgePalette" class="palette mb-3">
@@ -309,12 +309,12 @@
             </div>
             <hr />
             <div>
-              <button data-edges="left" class="mapEditorTile startEdgeButton"><span>Left</span></button>
-              <button data-edges="right" class="mapEditorTile startEdgeButton"><span>Right</span></button>
-              <button data-edges="top" class="mapEditorTile startEdgeButton"><span>Top</span></button>
-              <button data-edges="bottom" class="mapEditorTile startEdgeButton"><span>Bottom</span></button>
-              <button data-edges="left+right" class="mapEditorTile startEdgeButton"><span>Left + Right</span></button>
-              <button data-edges="top+bottom" class="mapEditorTile startEdgeButton"><span>Top + Bottom</span></button>
+              <button data-edges="left" data-gp-nav class="mapEditorTile startEdgeButton"><span>Left</span></button>
+              <button data-edges="right" data-gp-nav class="mapEditorTile startEdgeButton"><span>Right</span></button>
+              <button data-edges="top" data-gp-nav class="mapEditorTile startEdgeButton"><span>Top</span></button>
+              <button data-edges="bottom" data-gp-nav class="mapEditorTile startEdgeButton"><span>Bottom</span></button>
+              <button data-edges="left+right" data-gp-nav class="mapEditorTile startEdgeButton"><span>Left + Right</span></button>
+              <button data-edges="top+bottom" data-gp-nav class="mapEditorTile startEdgeButton"><span>Top + Bottom</span></button>
             </div>
           </div>
           <div id="actionsSection">
@@ -322,12 +322,13 @@
               Actions
             </div>
             <hr />
-            <button id="enableAIButton" class="btn btn-block" aria-pressed="false"
+            <button id="enableAIButton" data-gp-nav class="btn btn-block" aria-pressed="false"
               title="Fill the grid with AI racers. Off = a solo, bot-free run of your map."><i class="fa fa-square-o mr-2" aria-hidden="true"></i><span>AI racers: off</span></button>
-            <button id="previewButton" class="btn btn-block">Preview / Playtest<i class="fa fa-play ml-2" aria-hidden="true"></i></button>
+            <button id="previewButton" data-gp-nav class="btn btn-block">Preview / Playtest<i class="fa fa-play ml-2" aria-hidden="true"></i></button>
             <button id="previewStatus" class="btn btn-block" disabled style="display:none;"><span></span></button>
-            <button id="exportButton" class="btn btn-block">Copy to Clipboard<i class="fa fa-clipboard ml-2" aria-hidden="true"></i></button>
-            <button id="submitButton" class="btn btn-block">Upload to Github<i class="fa fa-cloud-upload ml-2"></i></button>
+            <button id="exportButton" data-gp-nav class="btn btn-block">Copy to Clipboard<i class="fa fa-clipboard ml-2" aria-hidden="true"></i></button>
+            <button id="exportStatus" class="btn btn-block" disabled style="display:none;"><span></span></button>
+            <button id="submitButton" data-gp-nav class="btn btn-block">Upload to Github<i class="fa fa-cloud-upload ml-2"></i></button>
             <button id="submitStatus" class="btn btn-block" disabled ><span>Submitting..</span></button>
           </div>
         </div>
@@ -352,7 +353,7 @@
     </div>
     <div id="loadWindow">
       <div class="map-image">
-        <button id="createNew"><img id="createNewImage" src="">
+        <button id="createNew" data-gp-nav><img id="createNewImage" src="">
           <div class="desc">Create a new map</div>
         </button>
       </div>

--- a/client/create.html
+++ b/client/create.html
@@ -252,7 +252,7 @@
 <body>
   <nav class="d-flex align-items-center px-3">
     <div class="navbar-brand">
-      <a style="text-decoration: inherit;
+      <a data-gp-nav style="text-decoration: inherit;
       color: inherit;" href="./index.html">ChaoChao</a>
     </div>
   </nav>

--- a/client/index.html
+++ b/client/index.html
@@ -39,9 +39,9 @@
               <div class="play-container">
                 <span id="version"><b><!-- VERSION --></b></span>
                 <span id="game-title">Chao Chao</span>
-                <a href="./play.html" id="playButton" class="btn btn-outline-success w-100 mt-3">Play</a>
-                <a href="./join.html" id="joinButton" class="btn btn-outline-info w-100 mt-2">Join</a>
-                <a href="./create.html" id="createButton" class="btn btn-outline-warning w-100 mt-2">Create</a>
+                <a href="./play.html" id="playButton" data-gp-nav class="btn btn-outline-success w-100 mt-3">Play</a>
+                <a href="./join.html" id="joinButton" data-gp-nav class="btn btn-outline-info w-100 mt-2">Join</a>
+                <a href="./create.html" id="createButton" data-gp-nav class="btn btn-outline-warning w-100 mt-2">Create</a>
                 <!-- NEWS_BANNER -->
               </div>
               <p class="tagline">Slow-paced multiplayer arena racing.</p>

--- a/client/index.html
+++ b/client/index.html
@@ -27,7 +27,7 @@
   <body>
     <nav class="d-flex align-items-center px-3">
       <div class="navbar-brand">
-        <a style="text-decoration: inherit;
+        <a data-gp-nav style="text-decoration: inherit;
         color: inherit;" href="./index.html">ChaoChao</a>
       </div>
     </nav>

--- a/client/join.html
+++ b/client/join.html
@@ -32,7 +32,7 @@
         <div class="container join-container">
             <div class="join-header">
                 <h4 class="join-title">Available games</h4>
-                <button id="refreshButton" type="button" class="btn btn-outline-secondary btn-sm" title="Refresh game list">
+                <button id="refreshButton" type="button" data-gp-nav class="btn btn-outline-secondary btn-sm" title="Refresh game list">
                     <i class="fa fa-refresh" aria-hidden="true"></i> Refresh
                 </button>
             </div>
@@ -49,11 +49,11 @@
                 </div>
             </div>
             <div class="join-by-id">
-                <input id="joinByIdInput" type="text" inputmode="numeric" pattern="[0-9]*" class="form-control" placeholder="Have a Game ID? Enter it here">
-                <button id="joinByIdButton" type="button" class="btn btn-outline-info">Join</button>
+                <input id="joinByIdInput" type="text" inputmode="numeric" pattern="[0-9]*" data-gp-nav class="form-control" placeholder="Have a Game ID? Enter it here">
+                <button id="joinByIdButton" type="button" data-gp-nav class="btn btn-outline-info">Join</button>
             </div>
             <div class="start-new">
-                <a href="./play.html" class="btn btn-outline-success">Start a new game</a>
+                <a href="./play.html" data-gp-nav class="btn btn-outline-success">Start a new game</a>
             </div>
         </div>
     </section>

--- a/client/join.html
+++ b/client/join.html
@@ -24,7 +24,7 @@
 <body>
     <nav class="d-flex align-items-center px-3">
         <div class="navbar-brand">
-            <a style="text-decoration: inherit;
+            <a data-gp-nav style="text-decoration: inherit;
             color: inherit;" href="./index.html">ChaoChao</a>
           </div>
       </nav>

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -164,7 +164,7 @@ function clientConnect() {
         for (var i = 0; i < mapnames.length; i++) {
             $.getJSON("../maps/" + mapnames[i], function (data) {
                 maps.push(data);
-                $("#loadWindow").append('<div class="map-image"><button id="' + data.id + '"><img src="' + data.thumbnail + '"><div class="desc">' + data.name + ' | ' + data.author + '</div></button></div>');
+                $("#loadWindow").append('<div class="map-image"><button id="' + data.id + '" data-gp-nav><img src="' + data.thumbnail + '"><div class="desc">' + data.name + ' | ' + data.author + '</div></button></div>');
                 $("#" + data.id).on("click", function () {
                     for (var j = 0; j < maps.length; j++) {
                         if (maps[j].id == this.id) {
@@ -241,7 +241,7 @@ function makeSeamlessPattern(image) {
 
 function setupPage() {
     $("#createNew").on("click", function () {
-        $("#submitStatus").hide();
+        $("#submitStatus, #exportStatus").hide();
         showEditor();
     });
     $("#rebuildButton").on("click", function () {
@@ -393,7 +393,7 @@ function setupPage() {
     $("#loadButton").on("click", function () {
         setSelectedObject(null);
         $("#createNewImage").attr("src", createCanvas.toDataURL("image/jpeg", 0.1));
-        $("#submitStatus").hide();
+        $("#submitStatus, #exportStatus").hide();
         showLoadWindow();
 
         window.removeEventListener("mousemove", cellUnderMouse, false);
@@ -473,7 +473,7 @@ function validateEmail(mail) {
 }
 
 function rebuild() {
-    $("#submitStatus").hide();
+    $("#submitStatus, #exportStatus").hide();
     setSelectedObject(null);
     vMap = generateVMap();
     $('#author').val("");
@@ -947,13 +947,27 @@ function compareSite(siteA, siteB) {
     }
     return true;
 }
+// Transient feedback for the Export button. A native alert() steals focus and a
+// gamepad can't dismiss it, so write to the inline #exportStatus readout instead
+// (mirrors the #submitStatus pattern) and auto-hide after a moment.
+var exportStatusTimer = null;
+function showExportStatus(message, bg) {
+    var el = $("#exportStatus");
+    el.children("span").text(message);
+    el.css({ "color": "white", "background-color": bg });
+    el.show();
+    if (exportStatusTimer) {
+        clearTimeout(exportStatusTimer);
+    }
+    exportStatusTimer = setTimeout(function () { el.hide(); }, 2500);
+}
 function exportToJSON() {
     basicSanitize();
     navigator.clipboard.writeText(JSON.stringify(vMap)).then(function () {
-        alert("Copied to Clipboard!");
+        showExportStatus("Copied to clipboard!", "green");
     }, function (err) {
         console.log(err);
-        alert("Export failed");
+        showExportStatus("Copy failed — try again", "red");
     });
 }
 
@@ -966,7 +980,13 @@ function submitViaEmail() {
 function submitToGithub() {
     var email = $("#email").val();
     if (!validateEmail(email)) {
-        alert("You must enter a valid email address to submit to GitHub");
+        // Inline feedback instead of a focus-stealing alert() the gamepad can't close.
+        var submitStatus = $("#submitStatus");
+        submitStatus.show();
+        submitStatus.css("color", "white");
+        submitStatus.css("background-color", "red");
+        submitStatus.text("Enter a valid email to submit");
+        $("#email").focus();
         return false;
     }
     basicSanitize();

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -953,7 +953,7 @@ function compareSite(siteA, siteB) {
 var exportStatusTimer = null;
 function showExportStatus(message, bg) {
     var el = $("#exportStatus");
-    el.children("span").text(message);
+    el.text(message); // same write pattern as #submitStatus (the span is just a placeholder)
     el.css({ "color": "white", "background-color": bg });
     el.show();
     if (exportStatusTimer) {

--- a/client/scripts/editorGamepad.js
+++ b/client/scripts/editorGamepad.js
@@ -245,7 +245,7 @@ function egSetMode(mode) {
     } else {
         var items = egItems();
         if (items.length) {
-            egSetFocus(egIndexOf(items) === -1 ? items[0] : egFocusEl);
+            egSetFocus(egIndexOf(items) === -1 ? egDefaultFocus(items) : egFocusEl);
         }
     }
     egShowPrompt(true);
@@ -288,6 +288,19 @@ function egIndexOf(items) {
     return -1;
 }
 
+// The navbar (brand link + theme toggle) is first in document order but isn't the
+// primary action — don't make it the initial selection. Prefer the first navigable
+// control outside the navbar; those controls stay reachable by navigating up to
+// them. Falls back to the first item (e.g. inside the modal trap, none are in a nav).
+function egDefaultFocus(items) {
+    for (var i = 0; i < items.length; i++) {
+        if (!items[i].closest || !items[i].closest("nav")) {
+            return items[i];
+        }
+    }
+    return items[0];
+}
+
 function egSetFocus(el) {
     if (egFocusEl && egFocusEl !== el) {
         egFocusEl.classList.remove("gp-focus");
@@ -313,7 +326,7 @@ function egMove(dir) {
         return;
     }
     if (!egFocusEl || egIndexOf(items) === -1) {
-        egSetFocus(items[0]);
+        egSetFocus(egDefaultFocus(items));
         return;
     }
     var f = egCenter(egFocusEl);
@@ -346,7 +359,7 @@ function egMove(dir) {
 function egActivate() {
     var items = egItems();
     if (egIndexOf(items) === -1) {
-        egSetFocus(items[0]);
+        egSetFocus(egDefaultFocus(items));
         return;
     }
     if (!egFocusEl) {

--- a/client/scripts/editorGamepad.js
+++ b/client/scripts/editorGamepad.js
@@ -42,10 +42,15 @@ var EG_DPAD_DOWN = 13;
 var EG_DPAD_LEFT = 14;
 var EG_DPAD_RIGHT = 15;
 
-// Every actionable control in whichever window is visible. Hidden ones (the
-// editor while the load grid is up, and vice versa) are filtered out by
-// egItems() via offsetParent, so the same selector serves both screens.
-var EG_NAV_SELECTOR = "#controlPanel button:not([disabled]), #controlPanel input, #loadWindow button:not([disabled])";
+// Single source of truth for gamepad-navigable editor controls: every such control
+// carries the data-gp-nav attribute (the toolbar, the tile/hazard/start-edge
+// palettes, the detail inputs, the action buttons, the map-list tiles, and the
+// navbar theme toggle). The disabled status readouts (#previewStatus/#submitStatus)
+// and the wipe-confirm modal buttons deliberately omit it — the latter are driven by
+// the modal focus trap, not this scan. Hidden controls (whichever window isn't
+// showing) are filtered out by egItems() via offsetParent, so one selector serves
+// both the editor and the load grid.
+var EG_NAV_SELECTOR = "[data-gp-nav]:not([disabled])";
 
 function initEditorGamepad() {
     window.addEventListener("gamepadconnected", egOnConnect, false);

--- a/client/scripts/join.js
+++ b/client/scripts/join.js
@@ -126,6 +126,7 @@ function buildCard(room, maxPlayers) {
     if (joinable) {
         joinBtn.href = './play.html?gameid=' + encodeURIComponent(room.gameID);
         joinBtn.className = 'btn btn-outline-info join-btn';
+        joinBtn.setAttribute('data-gp-nav', ''); // joinable rooms only; locked/full cards stay unfocusable
         joinBtn.textContent = 'Join';
     } else {
         // Not joinable: a started match reads "In progress"; a room that's merely

--- a/client/scripts/menuGamepad.js
+++ b/client/scripts/menuGamepad.js
@@ -8,10 +8,14 @@
 (function () {
     "use strict";
 
-    // Actionable elements, in document order. Covers the landing buttons, the
-    // join page's refresh / join-by-id / start-new controls, and the dynamically
-    // rendered room "Join" buttons (a.join-btn is also a.btn).
-    var NAV_SELECTOR = "a.btn, button.btn, input.form-control";
+    // Single source of truth for gamepad-navigable controls: every such control
+    // carries the data-gp-nav attribute. It's set in the page HTML and on the
+    // dynamically created elements (the theme toggle in theme.js, the room "Join"
+    // buttons in join.js). Decoupling navigability from styling classes is what
+    // lets the navbar theme toggle be reachable without abusing .btn, and makes
+    // "is this control reachable by a pad?" a single explicit, lintable contract.
+    // Disabled controls are skipped here; collectItems() also drops hidden ones.
+    var NAV_SELECTOR = "[data-gp-nav]:not([disabled])";
 
     var MOVE_DEADZONE = 0.5;   // stick must be pushed clearly to step focus
     var REPEAT_DELAY = 250;    // ms between focus steps while a direction is held

--- a/client/scripts/menuGamepad.js
+++ b/client/scripts/menuGamepad.js
@@ -153,6 +153,19 @@
         return -1;
     }
 
+    // The navbar theme toggle is first in document order but is a utility control,
+    // not the primary action — don't make it the initial selection on page load.
+    // Prefer the first navigable control outside the navbar; the toggle is still
+    // reachable by navigating to it. Falls back to the first item.
+    function defaultFocus(items) {
+        for (var i = 0; i < items.length; i++) {
+            if (!items[i].closest || !items[i].closest("nav")) {
+                return items[i];
+            }
+        }
+        return items[0];
+    }
+
     function setFocus(el) {
         if (focusEl && focusEl !== el) {
             focusEl.classList.remove("gp-focus");
@@ -178,7 +191,7 @@
         }
         if (!focusEl || indexOfFocus(items) === -1) {
             // nothing focused yet (or it was re-rendered away) — land on the first
-            setFocus(items[0]);
+            setFocus(defaultFocus(items));
             return;
         }
         var f = center(focusEl);
@@ -211,7 +224,7 @@
     function activate() {
         var items = collectItems();
         if (indexOfFocus(items) === -1) {
-            setFocus(items[0]);
+            setFocus(defaultFocus(items));
             return;
         }
         if (!focusEl) {

--- a/client/scripts/theme.js
+++ b/client/scripts/theme.js
@@ -87,6 +87,7 @@
         btn.id = 'themeToggle';
         btn.type = 'button';
         btn.className = 'theme-toggle';
+        btn.setAttribute('data-gp-nav', ''); // make the toggle reachable by gamepad menu nav
         btn.addEventListener('click', cycle);
         nav.appendChild(btn);
         updateButton(getPref());


### PR DESCRIPTION
## Summary
Audited controller support across all menu surfaces; found 2 gaps and fixed both, hardening the navigability contract.

## Gaps fixed
1. **Map-editor native `alert()`s** — Export ("Copied!"/"Export failed") and the email-validation message used `alert()`, which steals focus and a gamepad can't dismiss. Replaced with inline status text (`#exportStatus` mirrors the existing `#submitStatus` readout; invalid email shows a red `#submitStatus` and focuses the field). The wipe/rebuild confirm was already a DOM modal.
2. **Theme toggle unreachable by controller** on landing/join/editor — navigability was inferred from styling classes (`.btn`/`.form-control`) and `#controlPanel` scope, so the navbar `.theme-toggle` fell outside.

## The fix (source of truth)
- Introduced **`data-gp-nav`** as the single source of truth for gamepad-navigable DOM controls; `menuGamepad.js` and `editorGamepad.js` now select `[data-gp-nav]:not([disabled])`. Decouples navigability from styling → "reachable by a pad?" is an explicit, lintable contract.
- Tagged every navigable control (static + JS-injected: theme toggle, joinable room cards, map thumbnails). Disabled status readouts and modal-trapped confirm buttons are intentionally untagged.
- **Initial focus skips the navbar** (`defaultFocus`/`egDefaultFocus`): load lands on primary content; the navbar — now including the **"ChaoChao" brand → home** link — is reachable only via a deliberate "up".

## Verification
`npm run build` ✅ (3 bundles) · smoke ✅ (51 maps) · `/code-review` extra-high ✅ no bugs · manual controller pass on landing/join/editor.

## Notes
Client-only → CHANGELOG/release-notes exempt. `play.html` intentionally unchanged (racing-only input; B-to-leave already returns home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
