### PR TITLE
Add client-side GA4 gameplay event instrumentation

### DIFF
--- a/client/create.html
+++ b/client/create.html
@@ -14,6 +14,12 @@
     gtag('js', new Date());
 
     gtag('config', 'G-832XFC4F84');
+
+    // Fire-and-forget analytics helper, shared across pages. No-ops if gtag is
+    // unavailable (e.g. blocked by an ad/tracker blocker) so it can never throw.
+    function trackEvent(name, params) {
+      if (typeof gtag === 'function') { gtag('event', name, params || {}); }
+    }
   </script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">

--- a/client/index.html
+++ b/client/index.html
@@ -15,6 +15,12 @@
       gtag('js', new Date());
 
       gtag('config', 'G-832XFC4F84');
+
+      // Fire-and-forget analytics helper, shared across pages. No-ops if gtag is
+      // unavailable (e.g. blocked by an ad/tracker blocker) so it can never throw.
+      function trackEvent(name, params) {
+        if (typeof gtag === 'function') { gtag('event', name, params || {}); }
+      }
     </script>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
@@ -39,9 +45,9 @@
               <div class="play-container">
                 <span id="version"><b><!-- VERSION --></b></span>
                 <span id="game-title">Chao Chao</span>
-                <a href="./play.html" id="playButton" data-gp-nav class="btn btn-outline-success w-100 mt-3">Play</a>
-                <a href="./join.html" id="joinButton" data-gp-nav class="btn btn-outline-info w-100 mt-2">Join</a>
-                <a href="./create.html" id="createButton" data-gp-nav class="btn btn-outline-warning w-100 mt-2">Create</a>
+                <a href="./play.html" id="playButton" data-gp-nav class="btn btn-outline-success w-100 mt-3" onclick="trackEvent('cta_click', { target: 'play' })">Play</a>
+                <a href="./join.html" id="joinButton" data-gp-nav class="btn btn-outline-info w-100 mt-2" onclick="trackEvent('cta_click', { target: 'join' })">Join</a>
+                <a href="./create.html" id="createButton" data-gp-nav class="btn btn-outline-warning w-100 mt-2" onclick="trackEvent('cta_click', { target: 'create' })">Create</a>
                 <!-- NEWS_BANNER -->
               </div>
               <p class="tagline">Slow-paced multiplayer arena racing.</p>

--- a/client/join.html
+++ b/client/join.html
@@ -12,6 +12,12 @@
             gtag('js', new Date());
 
             gtag('config', 'G-832XFC4F84');
+
+            // Fire-and-forget analytics helper, shared across pages. No-ops if gtag is
+            // unavailable (e.g. blocked by an ad/tracker blocker) so it can never throw.
+            function trackEvent(name, params) {
+                if (typeof gtag === 'function') { gtag('event', name, params || {}); }
+            }
         </script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">

--- a/client/play.html
+++ b/client/play.html
@@ -14,6 +14,12 @@
             gtag('js', new Date());
 
             gtag('config', 'G-832XFC4F84');
+
+            // Fire-and-forget analytics helper, shared across pages. No-ops if gtag is
+            // unavailable (e.g. blocked by an ad/tracker blocker) so it can never throw.
+            function trackEvent(name, params) {
+                if (typeof gtag === 'function') { gtag('event', name, params || {}); }
+            }
         </script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -342,6 +342,7 @@ function registerStateHandlers(server) {
 		recapNewMatch(); // a fresh match is forming — drop last game's recap clips
 		// Set state first so loadNewMap doesn't run its gated-only goal-ping branch.
 		currentState = config.stateMap.lobby;
+		trackEvent('lobby_entered');
 		spawnLobbyStartButton(packet);
 		setLobbySfxDampen(true);
 		playSoundAfterFinish(lobbyMusic);
@@ -378,6 +379,13 @@ function registerStateHandlers(server) {
 		resetPlayerRanks();
 		recapReset(); // start a fresh recap buffer for this round's map
 		currentState = config.stateMap.racing;
+		// Fires once per round (racing state is re-entered each round), so this is a
+		// round-start signal. `players` counts humans only: clientList is the room's
+		// client roster and excludes bots (the per-tick compressor never sends isAI).
+		trackEvent('round_start', {
+			players: clientList ? Object.keys(clientList).length : 0,
+			map: (currentMap && currentMap.name) || 'unknown'
+		});
 	});
 	//Server-driven mood change (near-victory) or next track (previous one ended).
 	server.on("musicMood", function (packet) {
@@ -403,6 +411,7 @@ function registerStateHandlers(server) {
 		calculateNotchMoveAmt();
 		loadMapPreview(packet.nextMapID);
 		currentState = config.stateMap.overview;
+		trackEvent('round_complete');
 	});
 	server.on("startGameover", function (packet) {
 		// Match over (solo creator hit the winning notch) — schedule the editor
@@ -421,6 +430,7 @@ function registerStateHandlers(server) {
 			? Colors.decode((winner._serverColor != null) ? winner._serverColor : winner.color)
 			: "";
 		currentState = config.stateMap.gameOver;
+		trackEvent('match_end', { won: (packet.winner === myID) });
 	});
 	server.on("startCollapse", function (info) {
 		currentState = config.stateMap.collapsing;

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -143,6 +143,7 @@ function clientConnect() {
         submitStatus.css("color", "white");
         submitStatus.css("background-color", "green");
         submitStatus.text("Success");
+        trackEvent('map_submitted');
     });
 
     server.on('previewRoomCreated', function (payload) {

--- a/docs/analytics-instrumentation-plan.md
+++ b/docs/analytics-instrumentation-plan.md
@@ -1,0 +1,103 @@
+# Analytics Instrumentation & Data Hygiene Plan
+
+**Branch:** `worktree-analytics-instrumentation`
+**Status:** plan only — implement this.
+**Why this is the next step:** A GA4 review (2026-05-23) showed the all-time "1.8K users"
+topline is ~90% data-center/bot traffic (China ~50%, Singapore ~43%, both ~0s engagement).
+The real audience is ~300 genuinely-engaged **US desktop** players, but GA fires **only
+default/enhanced-measurement events** (`page_view`, `session_start`, `scroll`, `first_visit`,
+`form_submit`) — so we are blind to actual gameplay and retention. Before driving any traffic
+(portals/SEO), we must (A) clean the data and (B) instrument real gameplay events, so we can
+tell whether distribution actually produces players who play and return.
+
+**Scope:** client-side analytics events + GA config. Nothing else. No gameplay logic changes,
+no server changes.
+
+---
+
+## Constraints (read first)
+
+- **Stay client-side.** All events fire from the browser via `gtag('event', ...)`. Do NOT
+  touch `server/game.js`, `server/engine.js`, or `server/config.json` — those trigger the
+  release-notes-check workflow. (Note: `client/scripts/game.js` is the *client* file and is
+  fine to edit; the protected one is `server/game.js`.) This task needs no CHANGELOG entry.
+- **GA tag coverage:** the gtag snippet is currently confirmed only in `client/index.html`
+  (lines ~8-16, measurement ID `G-832XFC4F84`). It must be present on every page where we
+  want events — `play.html`, `join.html`, `create.html` — or events there silently no-op.
+  Add the same gtag snippet to those pages' `<head>` (or factor a shared include).
+- **Bundle rule:** if you add a new client script file (e.g. `analytics.js`), register it in
+  BOTH `build.js`'s bundle list for each page AND that page's `<!-- BUILD: bundle-start --> …
+  <!-- BUILD: bundle-end -->` block (per CLAUDE.md). Inline `gtag('event', …)` calls at the
+  hook points avoid this, but a tiny shared `trackEvent()` wrapper is cleaner — your call.
+- **Don't double-count / don't break gameplay.** Events are fire-and-forget; never block or
+  await them in the game loop. Guard for `typeof gtag === 'function'` so missing gtag can't
+  throw.
+
+---
+
+## Part A — Custom gameplay events (code)
+
+Add a thin helper, e.g. `function trackEvent(name, params){ if (typeof gtag==='function') gtag('event', name, params||{}); }`
+and call it at these hook points. Event names use GA4 snake_case.
+
+**Landing page (`client/index.html`):**
+- `cta_click` with `{ target: 'play' | 'join' | 'create' }` on the Play/Join/Create
+  buttons (`#playButton`, `#joinButton`, `#createButton`). Measures landing→game conversion.
+
+**In-game client (`client/scripts/client.js` socket handlers — these already exist):**
+- `match_start` — when the local player actually begins a match. Fire when the client enters
+  the racing state (find where `currentState` becomes `config.stateMap.racing`). Include
+  `{ players: <count if available>, map: <map name/id if available> }`.
+- `lobby_entered` — in the `startLobby` handler (`client.js:208`). Optional but useful for
+  funnel (joined a room vs. actually played).
+- `round_complete` — in the `startOverview` handler (round transition).
+- `match_end` — in the `startGameover` handler (`client.js:245`). Include
+  `{ won: (packet.winner === myID) }` so we can later distinguish winners. This is the key
+  retention signal (a completed match).
+
+**Map editor (`client/scripts/create.js`):**
+- `map_submitted` on a successful `submitNewMap` (distinct from the auto `form_submit`).
+
+Keep params minimal and non-PII. No player names, no IDs beyond what's already public.
+
+## Part B — GA4 data hygiene (operator does this in the GA UI; document it)
+
+The implementing agent can't do these (no GA access) — include them as a checklist in the PR
+description / a short README note so the repo owner can action them:
+
+1. **Internal/developer traffic:** Admin → Data Streams → (web stream) → Configure tag
+   settings → "Define internal traffic" → add the dev's IP. Then Admin → Data Settings →
+   Data Filters → set the **Internal Traffic** filter to **Active** (not just Testing).
+   Removes the dev's own testing from reports.
+2. **Known-bot filtering** is automatic in GA4 (IAB/MRC list, can't be disabled) — note that
+   the China/Singapore traffic is NOT on that list (it's data-center/headless), so:
+3. **Real-users comparison for ongoing analysis:** GA4 standard data filters only support
+   internal/developer exclusion, so the data-center spam can't be fully removed from reports.
+   Create a saved **Comparison** (or Exploration segment) such as `Engaged sessions > 0` or
+   `Country = United States` to analyze real users going forward.
+4. **Optional follow-up (not this task):** block the data-center spam at the edge
+   (Cloudflare/host rules) if it keeps polluting — flag it, don't build it here.
+5. **Mark a key event:** once `match_end` (or `match_start`) appears in Admin → Events,
+   toggle it as a **Key event** so engagement/retention reports populate on real gameplay.
+
+---
+
+## Verification
+
+1. `npm start`, open each page, perform the actions (click CTAs, play a match to gameOver,
+   submit a map). In GA4 **DebugView** (or Realtime) confirm each custom event fires with the
+   expected params. (Use the GA debug extension or `?_dbg=1`/`debug_mode` as needed.)
+2. Confirm no console errors when gtag is absent (e.g. ad-blocker) — the `typeof gtag` guard
+   must hold.
+3. Confirm gameplay is unaffected (events are non-blocking).
+
+## Done criteria
+
+- [ ] gtag snippet present on `play.html`, `join.html`, `create.html` (not just index).
+- [ ] `trackEvent` helper (or inline calls) added; guarded against missing gtag.
+- [ ] Events firing: `cta_click`, `match_start`, `round_complete`, `match_end` (+ `won`),
+      `lobby_entered`, `map_submitted`.
+- [ ] New script file (if any) registered in `build.js` + the page `<!-- BUILD -->` block.
+- [ ] No edits to `server/game.js` / `server/engine.js` / `server/config.json` (no CHANGELOG).
+- [ ] GA data-hygiene checklist (Part B) included in the PR description for the owner.
+- [ ] Verified via DebugView/Realtime; no console errors; gameplay unaffected.


### PR DESCRIPTION
## What & why

A GA4 review showed the all-time topline is ~90% data-center/bot traffic, and GA was firing **only** default events (`page_view`, `session_start`, …) — so we were blind to actual gameplay and retention. This adds custom **client-side** gameplay events via `gtag` so we can measure whether players actually play and return.

**Scope:** client-side analytics events only. No server changes, no gameplay-logic changes → no CHANGELOG entry needed (the release-notes workflow exempts this).

## Events added

A small guarded helper is added inline to the gtag `<head>` snippet on all four pages (no new script file, so `build.js` and the `<!-- BUILD -->` blocks are untouched):

```js
function trackEvent(name, params) {
  if (typeof gtag === 'function') { gtag('event', name, params || {}); }
}
```

| Event | Where | Params |
|---|---|---|
| `cta_click` | index.html Play/Join/Create links | `target` (`play`/`join`/`create`) |
| `lobby_entered` | `startLobby` handler | — |
| `round_start` | `startRace` handler | `players` (humans only), `map` |
| `round_complete` | `startOverview` handler | — |
| `match_end` | `startGameover` handler | `won` (did the local player win) |
| `map_submitted` | create.js `githubSuccess` | — |

Notes:
- `round_start` (not `match_start`): racing state is re-entered each round, so this is a per-round signal — named honestly.
- `players` counts **humans only** via `clientList` (the room's client roster excludes bots; the per-tick compressor never sends an `isAI` flag, so a player-list filter would miscount).
- The helper no-ops when `gtag` is blocked (ad-blocker), so it can never throw.

## Verification

- In-browser: `cta_click` reaches `/g/collect` (`en=cta_click&ep.target=play`); `lobby_entered` fires via the live socket handler; helper is safe when `gtag` is stripped (no console errors).
- `npm run build` succeeds; events present in the bundles.
- Headless server smoke test passes (51 maps), confirming no gameplay impact.
- `/code-review` (extra-high) found no crashes/security issues.

---

## ⚠️ Owner action needed — GA4 setup (requires GA UI access)

These can't be done in code. Do them at/around deploy so data captures from day one.

**1. Register custom dimensions/metrics** (do this anytime — even pre-deploy). Admin → Property → Data display → **Custom definitions**. Without these, the event *parameters* won't be selectable in standard reports/Explorations (they still show in DebugView/Realtime/BigQuery). They are **not retroactive** and take ~24–48h to appear in standard reports.
   - Custom **dimensions** (scope = Event): `target`, `won`, `map`
   - Custom **metric** (scope = Event, unit = Standard): `players`

**2. Mark `match_end` as a Key event** (after deploy). In this property's newer UI there is **no "create by name" button** — you mark it via the **star** next to the event, which only appears once the event has fired. So: deploy → play one match to the win screen to seed `match_end` → Admin → Property → Data display → Events → **Recent events** tab → click the **★** next to `match_end`. It's **not retroactive**, so do it the same day you deploy. (Ignore the blue **"Create event"** button — that builds a synthetic event and would fabricate junk.)

**3. Data hygiene.**
   - Exclude dev traffic: Admin → Data Streams → web stream → Configure tag settings → **Define internal traffic** (your IP); then Admin → Data Filters → set **Internal Traffic** to **Active**.
   - The China/Singapore data-center spam isn't on GA's known-bot list, so standard filters can't remove it — analyze real users via a saved **Comparison/segment** (`Country = United States` or `Engaged sessions > 0`).
   - Optional follow-up (not this PR): block the spam at the edge (Cloudflare/host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
