### PR TITLE
Refresh map tile visuals: cohesive palette, region borders, accents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- The maps got a visual refresh: terrain colours are re-graded into one cohesive palette so tiles no longer clash (the neon grass and washed-out ice are gone), every region now has a crisp edge so tiles read more clearly, the random tile is purple instead of harsh electric blue, bumpers and the goal sit better with everything else, and the arena has a subtle vignette around the edges.
 
 ## v0.12.0 — 2026-05-26
 

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -195,14 +195,15 @@ function tryStart() {
 
 function loadPatterns() {
 
-    //Tiles
-    patterns[config.tileMap.lava.id] = makeSeamlessPattern(lava);
-    patterns[config.tileMap.ice.id] = makeSeamlessPattern(ice);
-    patterns[config.tileMap.fast.id] = makeSeamlessPattern(grass);
-    patterns[config.tileMap.normal.id] = makeSeamlessPattern(dirt);
-    patterns[config.tileMap.slow.id] = makeSeamlessPattern(sand);
+    //Tiles — grade the terrain textures through the shared palette (utils.js)
+    // so the editing surface matches the in-game look.
+    patterns[config.tileMap.lava.id] = makeSeamlessPattern(gradeTexture(lava, "lava"));
+    patterns[config.tileMap.ice.id] = makeSeamlessPattern(gradeTexture(ice, "ice"));
+    patterns[config.tileMap.fast.id] = makeSeamlessPattern(gradeTexture(grass, "grass"));
+    patterns[config.tileMap.normal.id] = makeSeamlessPattern(gradeTexture(dirt, "dirt"));
+    patterns[config.tileMap.slow.id] = makeSeamlessPattern(gradeTexture(sand, "sand"));
     patterns[config.tileMap.random.id] = makePattern(random, config.tileMap.random.color);
-    patterns[config.tileMap.ability.id] = makePattern(bombIcon, makeSeamlessPattern(dirt));
+    patterns[config.tileMap.ability.id] = makePattern(bombIcon, makeSeamlessPattern(gradeTexture(dirt, "dirt")));
 
     brushColor = patterns[config.tileMap.normal.id];
 }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -371,28 +371,42 @@ tileImagesReady.then(function () {
 });
 
 
+// Terrain texture colour grading (TILE_GRADE / gradeTexture) lives in
+// client/scripts/utils.js so both the game (this file) and the map editor
+// (create.js) grade from the same single source of truth.
+
 function loadPatterns() {
+    // Grade the terrain textures once into a shared palette (see TILE_GRADE),
+    // then build every pattern from the graded canvases so the board reads as
+    // one cohesive set (the dirt underlay for ability tiles included).
+    var gGrass = gradeTexture(grass, "grass");
+    var gDirt = gradeTexture(dirt, "dirt");
+    var gSand = gradeTexture(sand, "sand");
+    var gIce = gradeTexture(ice, "ice");
+    var gLava = gradeTexture(lava, "lava");
+    var gPoison = gradeTexture(poison, "poison");
+
     //Abilities
-    patterns[config.tileMap.abilities.blindfold.id] = makePattern(blindfoldIcon, makeSeamlessPattern(dirt));
-    patterns[config.tileMap.abilities.swap.id] = makePattern(transferIcon, makeSeamlessPattern(dirt));
-    patterns[config.tileMap.abilities.bomb.id] = makePattern(bombIcon, makeSeamlessPattern(dirt));
-    patterns[config.tileMap.abilities.speedBuff.id] = makePattern(windIcon, makeSeamlessPattern(dirt));
-    patterns[config.tileMap.abilities.speedDebuff.id] = makePattern(hourglassIcon, makeSeamlessPattern(dirt));
-    patterns[config.tileMap.abilities.tileSwap.id] = makePattern(copyIcon, makeSeamlessPattern(dirt));
-    patterns[config.tileMap.abilities.iceCannon.id] = makePattern(snowFlakeIcon, makeSeamlessPattern(dirt));
-    patterns[config.tileMap.abilities.cut.id] = makePattern(scissorsIcon, makeSeamlessPattern(dirt));
+    patterns[config.tileMap.abilities.blindfold.id] = makePattern(blindfoldIcon, makeSeamlessPattern(gDirt));
+    patterns[config.tileMap.abilities.swap.id] = makePattern(transferIcon, makeSeamlessPattern(gDirt));
+    patterns[config.tileMap.abilities.bomb.id] = makePattern(bombIcon, makeSeamlessPattern(gDirt));
+    patterns[config.tileMap.abilities.speedBuff.id] = makePattern(windIcon, makeSeamlessPattern(gDirt));
+    patterns[config.tileMap.abilities.speedDebuff.id] = makePattern(hourglassIcon, makeSeamlessPattern(gDirt));
+    patterns[config.tileMap.abilities.tileSwap.id] = makePattern(copyIcon, makeSeamlessPattern(gDirt));
+    patterns[config.tileMap.abilities.iceCannon.id] = makePattern(snowFlakeIcon, makeSeamlessPattern(gDirt));
+    patterns[config.tileMap.abilities.cut.id] = makePattern(scissorsIcon, makeSeamlessPattern(gDirt));
     patterns[config.brutalRounds.infection.id] = makePattern(infectionIcon, "red");
 
     //Tiles
     if (infection == true) {
-        patterns[config.tileMap.lava.id] = makeSeamlessPattern(poison);
+        patterns[config.tileMap.lava.id] = makeSeamlessPattern(gPoison);
     } else {
-        patterns[config.tileMap.lava.id] = makeSeamlessPattern(lava);
+        patterns[config.tileMap.lava.id] = makeSeamlessPattern(gLava);
     }
-    patterns[config.tileMap.ice.id] = makeSeamlessPattern(ice);
-    patterns[config.tileMap.fast.id] = makeSeamlessPattern(grass);
-    patterns[config.tileMap.normal.id] = makeSeamlessPattern(dirt);
-    patterns[config.tileMap.slow.id] = makeSeamlessPattern(sand);
+    patterns[config.tileMap.ice.id] = makeSeamlessPattern(gIce);
+    patterns[config.tileMap.fast.id] = makeSeamlessPattern(gGrass);
+    patterns[config.tileMap.normal.id] = makeSeamlessPattern(gDirt);
+    patterns[config.tileMap.slow.id] = makeSeamlessPattern(gSand);
 
 
 
@@ -564,6 +578,7 @@ function drawObjects(dt) {
         currentState == config.stateMap.collapsing) {
         drawGate();
         drawMap();
+        drawArenaVignette();
         drawPendingSwap();
         drawPingCircles();
         drawCollapseShockwaves();
@@ -2671,8 +2686,29 @@ function renderMapToCache() {
         mapCtx.fill();
         mapCtx.stroke();
     }
+    drawTileBorders(mapCtx);
     drawLavaBorders(mapCtx);
     mapCtx.restore();
+}
+
+// A subtle dark vignette over the play area, so the flat background reads as an
+// intentional frame rather than dead space. Drawn in world coords right after
+// the map (under players/FX) so it never dims karts. Cheap: one gradient fill.
+function drawArenaVignette() {
+    if (world == null) {
+        return;
+    }
+    var cx = world.x + world.width / 2;
+    var cy = world.y + world.height / 2;
+    var inner = Math.min(world.width, world.height) * 0.45;
+    var outer = Math.sqrt(world.width * world.width + world.height * world.height) / 2;
+    var g = gameContext.createRadialGradient(cx, cy, inner, cx, cy, outer);
+    g.addColorStop(0, "rgba(0, 0, 0, 0)");
+    g.addColorStop(1, "rgba(8, 6, 14, 0.26)");
+    gameContext.save();
+    gameContext.fillStyle = g;
+    gameContext.fillRect(world.x, world.y, world.width, world.height);
+    gameContext.restore();
 }
 
 // Trace a dark-red rim around every lava grouping. The map is a Voronoi diagram
@@ -2682,7 +2718,56 @@ function renderMapToCache() {
 // tiles. Runs only on cache rebuilds (map load / tile change), so it's free
 // per-frame. Keys off cell.id, so it tracks bombs/tileSwap/collapse and still
 // works when lava renders as poison in infection rounds.
-var lavaBorderColor = "#7a0000";
+// Outline every terrain region's perimeter with a subtle dark edge so tiles
+// read as crisp, designed shapes instead of soft Voronoi blobs. Like
+// drawLavaBorders, each Voronoi edge knows the two cells it separates, so we
+// stroke only edges where the tile TYPE changes (or the map/background edge) —
+// internal seams between same-type cells are skipped, avoiding a busy mesh.
+// Lava edges are left to drawLavaBorders (its red rim owns them). Runs only on
+// cache rebuilds, so it's free per-frame.
+var tileBorderColor = "rgba(18, 16, 24, 0.42)";
+function drawTileBorders(ctx) {
+    if (currentMap == null || currentMap.cells == null) {
+        return;
+    }
+    var cells = currentMap.cells;
+    var bgId = config.tileMap.background.id;
+    var lavaId = config.tileMap.lava.id;
+    var idByVoronoi = {};
+    for (var i = 0; i < cells.length; i++) {
+        idByVoronoi[cells[i].site.voronoiId] = cells[i].id;
+    }
+    ctx.save();
+    ctx.beginPath();
+    for (var c = 0; c < cells.length; c++) {
+        var cell = cells[c];
+        if (cell.id == bgId || cell.id == lavaId) {
+            continue; // background draws nothing; lava has its own rim
+        }
+        var halfedges = cell.halfedges;
+        for (var h = 0; h < halfedges.length; h++) {
+            var he = halfedges[h];
+            var neighbor = compareSite(he.edge.lSite, he.site) ? he.edge.rSite : he.edge.lSite;
+            var nid = neighbor != null ? idByVoronoi[neighbor.voronoiId] : null;
+            if (nid === cell.id || nid === lavaId) {
+                continue; // same-type internal seam, or lava's edge — skip
+            }
+            var sp = getStartpoint(he);
+            var ep = getEndpoint(he);
+            ctx.moveTo(sp.x, sp.y);
+            ctx.lineTo(ep.x, ep.y);
+        }
+    }
+    ctx.setLineDash([]);
+    ctx.lineWidth = 2.5;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.strokeStyle = tileBorderColor;
+    ctx.stroke();
+    ctx.restore();
+}
+
+var lavaBorderColor = "#7a1500";
 function drawLavaBorders(ctx) {
     if (currentMap == null || currentMap.cells == null) {
         return;
@@ -2731,10 +2816,11 @@ function drawHazard(hazard) {
     }
 }
 
+var bumperRingColor = "#E5392B";
 function drawBumper(x, y) {
     gameContext.save();
     gameContext.beginPath();
-    gameContext.strokeStyle = "red";
+    gameContext.strokeStyle = bumperRingColor;
     gameContext.lineWidth = 3;
     gameContext.arc(x, y, config.hazards.bumper.attackRadius, 0, 2 * Math.PI);
     gameContext.stroke();
@@ -2756,7 +2842,7 @@ function drawMovingBumper(x, y, railX, railY, angle) {
 
     gameContext.save();
     gameContext.beginPath();
-    gameContext.strokeStyle = "red";
+    gameContext.strokeStyle = bumperRingColor;
     gameContext.lineWidth = 3;
     gameContext.arc(x, y, config.hazards.movingBumper.attackRadius, 0, 2 * Math.PI);
     gameContext.stroke();

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -340,7 +340,7 @@ function lobbyProjectToScreen(wx, wy) {
 // (drawLobbyFloor), and the interactive accent is the game's goal gold — warm,
 // already part of the palette, and high-contrast on the green/brown/blue/ice map.
 // Walking into a zone lights it up gold (see the active state below).
-var HUB_ACCENT = "#FFD700"; // goal gold — the "interactive / active" accent
+var HUB_ACCENT = "#FFCB30"; // goal gold (matches config.tileMap.goal.color) — the "interactive / active" accent
 function hubInk() {
     return (typeof themeColor === "function") ? themeColor("ink", "#ffffff") : "#ffffff";
 }

--- a/client/scripts/utils.js
+++ b/client/scripts/utils.js
@@ -101,3 +101,147 @@ function easeOutBack(t) {
     var c3 = c1 + 1;
     return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
 }
+
+// --- Terrain texture colour grading -------------------------------------
+// Shared by the game (draw.js) and the map editor (create.js) so both render
+// terrain from the same palette. The six terrain textures (grass/dirt/sand/
+// lava/ice/poison) were authored independently, so their saturation and
+// brightness clash hard — neon-lime grass beside washed-out pale sand and ice.
+// gradeTexture() bakes them ONCE at load into a shared band: tame saturation,
+// pull the over-bright tiles down, gently flatten contrast. HUE IS PRESERVED,
+// so every tile stays just as recognisable (green is still green, lava red).
+//
+// Per-texture knobs: sat = saturation multiplier, light = lightness
+// multiplier, contrast = pull toward mid (<1 = calmer/flatter); optional
+// tint = [r,g,b] master colour and tintAmt = 0..1 blend toward it (in RGB,
+// after the HSL pass). Applied per pixel; alpha untouched. Live-tunable.
+//
+// NOTE on ice: it's a near-white texture with tiny coloured sparkle pixels
+// baked in. MULTIPLYING saturation amplifies those into rainbow confetti, so
+// ice instead REDUCES saturation (to mute the speckles) and deepens its blue
+// with a tint blend — averaging toward one colour smooths noise out.
+var TILE_GRADE_ENABLED = true;
+var TILE_GRADE = {
+    grass:  { sat: 0.60, light: 0.90, contrast: 0.92 }, // kill the neon lime
+    dirt:   { sat: 0.90, light: 0.98, contrast: 0.96 }, // anchor tone, barely touched
+    sand:   { sat: 0.92, light: 0.86, contrast: 0.95 }, // drop the bright glow
+    ice:    { sat: 0.82, light: 0.97, contrast: 1.00, tint: [120, 200, 236], tintAmt: 0.20 }, // deepen blue via tint, mute sparkle noise
+    lava:   { sat: 0.92, light: 0.96, contrast: 1.00 }, // still hot, a touch less fluorescent
+    poison: { sat: 0.92, light: 0.96, contrast: 1.00 }  // lava's infection-round swap
+};
+
+function _rgbToHsl(r, g, b) {
+    r /= 255; g /= 255; b /= 255;
+    var max = Math.max(r, g, b), min = Math.min(r, g, b);
+    var h, s, l = (max + min) / 2;
+    if (max === min) {
+        h = s = 0;
+    } else {
+        var d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        switch (max) {
+            case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+            case g: h = (b - r) / d + 2; break;
+            default: h = (r - g) / d + 4; break;
+        }
+        h /= 6;
+    }
+    return [h, s, l];
+}
+function _hue2rgb(p, q, t) {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+}
+function _hslToRgb(h, s, l) {
+    var r, g, b;
+    if (s === 0) {
+        r = g = b = l;
+    } else {
+        var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+        var p = 2 * l - q;
+        r = _hue2rgb(p, q, h + 1 / 3);
+        g = _hue2rgb(p, q, h);
+        b = _hue2rgb(p, q, h - 1 / 3);
+    }
+    return [r * 255, g * 255, b * 255];
+}
+
+// Grade `image` by `key` into an offscreen canvas, memoised on the image so
+// repeat loadPatterns() calls (infection toggle, theme change) don't re-grade.
+// Returns the graded canvas — a drawable usable anywhere the raw image was. Any
+// `image.scale` is copied onto the canvas so callers that scale by it (the
+// editor's makeSeamlessPattern) keep working.
+function gradeTexture(image, key) {
+    var spec = TILE_GRADE_ENABLED ? TILE_GRADE[key] : null;
+    if (image._gradeKey === key && image._gradeOn === !!spec && image._gradedCanvas != null) {
+        return image._gradedCanvas;
+    }
+    // Size the tile by the DECLARED dimensions (image.width/height), matching the
+    // original makeSeamlessPattern: the source PNGs can be larger than their
+    // `new Image(256,256)` hint (grass/dirt/ice/sand are natively 512), and the
+    // patterns were tuned for the declared size — naturalWidth here would double
+    // the tiling. drawImage scales the larger source down into w×h.
+    var w = image.width || image.naturalWidth || 0;
+    var h = image.height || image.naturalHeight || 0;
+    // A mid-game joiner can call loadPatterns() before the textures decode
+    // (see draw.js comment near requiredImages). When not decoded, return an
+    // un-memoised throwaway canvas so the tileImagesReady/newMap self-heal can
+    // re-grade once the image lands — caching a blank here would be permanent.
+    var ready = image.complete && image.naturalWidth > 0;
+    var canvas = document.createElement("canvas");
+    canvas.width = w || 1;
+    canvas.height = h || 1;
+    if (image.scale != null) {
+        canvas.scale = image.scale;
+    }
+    var ctx = canvas.getContext("2d");
+    if (ready && w > 0 && h > 0) {
+        ctx.drawImage(image, 0, 0, w, h);
+    }
+    var finish = function () {
+        // Only cache once the source is decoded; otherwise a later call must be
+        // free to re-grade (don't pin a transparent canvas).
+        if (ready) {
+            image._gradeKey = key;
+            image._gradeOn = !!spec;
+            image._gradedCanvas = canvas;
+        }
+        return canvas;
+    };
+    if (spec == null || !ready || w === 0 || h === 0) {
+        return finish();
+    }
+    var sat = spec.sat != null ? spec.sat : 1;
+    var light = spec.light != null ? spec.light : 1;
+    var contrast = spec.contrast != null ? spec.contrast : 1;
+    var tint = spec.tint || null;
+    var tintAmt = tint != null && spec.tintAmt != null ? spec.tintAmt : 0;
+    var data;
+    try {
+        data = ctx.getImageData(0, 0, w, h);
+    } catch (e) {
+        // Tainted canvas (shouldn't happen for same-origin assets) — fall back
+        // to the ungraded texture rather than breaking the board.
+        return finish();
+    }
+    var px = data.data;
+    for (var i = 0; i < px.length; i += 4) {
+        var hsl = _rgbToHsl(px[i], px[i + 1], px[i + 2]);
+        var s = clamp01(hsl[1] * sat);
+        var l = clamp01(0.5 + (hsl[2] * light - 0.5) * contrast);
+        var rgb = _hslToRgb(hsl[0], s, l);
+        if (tintAmt > 0) {
+            rgb[0] = rgb[0] * (1 - tintAmt) + tint[0] * tintAmt;
+            rgb[1] = rgb[1] * (1 - tintAmt) + tint[1] * tintAmt;
+            rgb[2] = rgb[2] * (1 - tintAmt) + tint[2] * tintAmt;
+        }
+        px[i] = rgb[0]; px[i + 1] = rgb[1]; px[i + 2] = rgb[2];
+        // alpha (px[i + 3]) left untouched
+    }
+    ctx.putImageData(data, 0, 0);
+    return finish();
+}

--- a/server/config.json
+++ b/server/config.json
@@ -113,17 +113,17 @@
             "dragCoeff": 0.10,
             "acel": 450,
             "canBeRandomed": false,
-            "color": "#FFD700"
+            "color": "#FFCB30"
         },
         "bumper": {
             "id": 7,
             "canBeRandomed": false,
-            "color": "#FF7900"
+            "color": "#F07B36"
         },
         "random": {
             "id": 8,
             "canBeRandomed": false,
-            "color": "#020DFE"
+            "color": "#7E57C2"
         },
         "background": {
             "id": 9,
@@ -277,14 +277,14 @@
     "hazards": {
         "bumper": {
             "id": 900,
-            "color": "orange",
+            "color": "#F07B36",
             "attackRadius": 15,
             "radius": 10,
             "punchBonus": 10
         },
         "movingBumper": {
             "id": 901,
-            "color": "orange",
+            "color": "#F07B36",
             "speed": 2000,
             "width": 100,
             "height": 5,


### PR DESCRIPTION
Re-grades the six terrain textures (grass/dirt/sand/lava/ice/poison) into one cohesive palette and cleans up the surrounding map visuals.

**What players see**
- Terrain no longer clashes — neon-lime grass and washed-out ice are pulled into a shared, muted band; lava/goal stay the bright "danger/win" accents.
- Each terrain region has a crisp dark edge, so tiles read as designed shapes.
- The random tile is purple instead of harsh electric blue; goal/bumper colors harmonized.
- A subtle vignette frames the arena.

**How it works**
- Hue-preserving HSL grade pass (`gradeTexture`/`TILE_GRADE` in `utils.js`), shared by the game and the map editor; baked once at load, so zero per-frame cost. Ice uses a tint blend rather than a saturation boost to avoid amplifying its baked-in sparkle noise.
- `drawTileBorders` strokes only Voronoi type-boundary edges (reusing the `drawLavaBorders` neighbor walk); `drawArenaVignette` is one gradient fill.
- Flat accents + overlay/FX colors (lava rim, bumper rings) moved into the palette via `config.json` and `draw.js`.

**Verification:** build passes (all 3 bundles), smoke test ran the engine across all 51 maps, and confirmed live in-game + editor. A `/code-review` pass caught and fixed two real bugs pre-merge (a memoized-blank-canvas case that would've left mid-game joiners with transparent terrain, and a 2× texture-scale regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
