### PR TITLE
feat(learn): in-game Codex / Learn page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+- New **Learn** page, reachable from the landing screen — an in-game Codex that explains every tile, ability, brutal round, and medal, each with a plain-English "how it works and feels" description and a little live animated example built from the real in-game effects. Search the codex or filter it by category, and browse it all with a controller or by touch.
 
 ## v0.13.0 — 2026-05-27
 

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1370,3 +1370,208 @@ body.osk-open .gamepad-prompts {
         margin-top: 0.5rem;
     }
 }
+
+/* ============================================================================
+   Codex / Learn page (learn.html + scripts/learn.js).
+   Master/detail: a scrolling list of entries on the left, a detail pane on the
+   right that is sticky on wide screens and stacks below on narrow/touch.
+   All colours come from the theme tokens so light/dark "just work".
+   GOTCHA: the ability/brutal icons are BLACK SILHOUETTE SVGs — .codex-icon--svg
+   gives them a fixed light chip so they never disappear in dark theme.
+   ============================================================================ */
+.learn-shell {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 1rem calc(1rem + var(--safe-left)) 3rem calc(1rem + var(--safe-right));
+}
+.learn-header {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+.learn-header h1 {
+    margin: 0;
+    font-size: clamp(1.8rem, 6vw, 2.6rem);
+    color: var(--text);
+}
+.learn-sub {
+    margin: 0.25rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+/* --- search + category filter toolbar --- */
+.learn-toolbar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin-bottom: 1.1rem;
+    /* Stay reachable while the long grid scrolls. Sits just under the navbar;
+       the negative-margin + padding trick keeps cards from peeking above it. */
+    position: sticky;
+    top: calc(var(--navbar-height) + var(--safe-top));
+    z-index: 4;
+    background: var(--bg);
+    padding: 0.75rem 0 0.6rem;
+    margin-top: -0.5rem;
+}
+.learn-search {
+    width: 100%;
+    min-height: 44px;            /* touch target */
+    padding: 0.5rem 0.9rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font-size: 0.95rem;
+}
+.learn-search::placeholder {
+    color: var(--text-muted);
+}
+.learn-search:focus {
+    outline: none;
+    border-color: #c87f8a;
+    box-shadow: 0 0 0 3px rgba(200, 127, 138, 0.3);
+}
+.learn-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+.learn-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;            /* touch target */
+    padding: 0.35rem 0.95rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text-soft);
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.learn-chip:hover {
+    background: var(--surface-2);
+}
+.learn-chip.is-active {
+    background: #c87f8a;
+    border-color: #c87f8a;
+    color: #fff;
+}
+
+/* applyFilter() toggles this on hidden entries/headings */
+.is-hidden {
+    display: none !important;
+}
+.learn-empty {
+    color: var(--text-muted);
+    padding: 1rem 0.25rem;
+}
+
+/* --- card grid, grouped by category --- */
+.codex-group {
+    margin-bottom: 1.6rem;
+}
+.codex-group-title {
+    font-size: 0.74rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin: 0 0 0.6rem;
+    padding-left: 0.15rem;
+}
+.codex-grid {
+    display: grid;
+    /* responsive: ~3 cols desktop, 2 iPad, 1 phone — auto from min card width */
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1rem;
+    align-items: start;
+}
+.codex-card {
+    display: flex;
+    flex-direction: column;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0px 0px 6px var(--card-shadow);
+    outline: none;
+}
+.codex-card.is-anchored {
+    border-color: #c87f8a;
+    box-shadow: 0 0 0 3px rgba(200, 127, 138, 0.35);
+}
+/* the live animation canvas: full width, keeps its 240x140 aspect.
+   position:static OVERRIDES the global unscoped `canvas { position:absolute }`
+   rule, which would otherwise rip the canvas out to fill the viewport. */
+.codex-card-anim {
+    position: static;
+    display: block;
+    width: 100%;
+    height: auto;
+    background: var(--surface-2);
+    border-bottom: 1px solid var(--border);
+}
+.codex-card-body {
+    padding: 0.85rem 1rem 1rem;
+}
+.codex-card-head {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-bottom: 0.5rem;
+}
+.codex-card-head h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--text);
+}
+.codex-card-body p {
+    color: var(--text-soft);
+    line-height: 1.55;
+    font-size: 0.9rem;
+    margin: 0 0 0.6rem;
+}
+.codex-card-body p:last-child {
+    margin-bottom: 0;
+}
+
+/* --- icon chips in card heads --- */
+.codex-icon {
+    flex: 0 0 auto;
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+.codex-icon--emoji {
+    font-size: 20px;
+    line-height: 1;
+}
+.codex-icon--swatch {
+    border: 1px solid var(--border);
+}
+.codex-icon--texture img,
+.codex-icon--art canvas {
+    position: static;            /* beat the global canvas{position:absolute} */
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+.codex-icon--art {
+    background: var(--surface-2);
+}
+/* Black-silhouette SVGs sit on a FIXED light chip so they're visible in dark
+   theme too — do not remove the background. */
+.codex-icon--svg {
+    background: #f0f0f0;
+    border: 1px solid var(--border);
+}
+.codex-icon--svg img {
+    width: 62%;
+    height: 62%;
+    object-fit: contain;
+}

--- a/client/learn.html
+++ b/client/learn.html
@@ -27,8 +27,10 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="css/styles.css">
     <link rel="stylesheet" type="text/css" href="assets/css/all.css">
+    <!-- on-screen keyboard styles, so the search box is typeable with a controller -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/css/index.css">
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
-    <title>Chao Chao</title>
+    <title>Chao Chao — Codex</title>
   </head>
   <body>
     <nav class="d-flex align-items-center px-3">
@@ -37,38 +39,41 @@
         color: inherit;" href="./index.html">ChaoChao</a>
       </div>
     </nav>
-    <section>
-      <div id="main">
-        <div class="container d-flex h-100 align-items-center">
-          <div class="row justify-content-center align-self-center mx-auto w-100">
-            <div class="landing-stack">
-              <div class="play-container">
-                <span id="version"><b><!-- VERSION --></b></span>
-                <span id="game-title">Chao Chao</span>
-                <a href="./play.html" id="playButton" data-gp-nav class="btn btn-outline-success w-100 mt-3" onclick="trackEvent('cta_click', { target: 'play' })">Play</a>
-                <a href="./join.html" id="joinButton" data-gp-nav class="btn btn-outline-info w-100 mt-2" onclick="trackEvent('cta_click', { target: 'join' })">Join</a>
-                <a href="./create.html" id="createButton" data-gp-nav class="btn btn-outline-warning w-100 mt-2" onclick="trackEvent('cta_click', { target: 'create' })">Create</a>
-                <a href="./learn.html" id="learnButton" data-gp-nav class="btn btn-outline-primary w-100 mt-2" onclick="trackEvent('cta_click', { target: 'learn' })">Learn</a>
-                <!-- NEWS_BANNER -->
-              </div>
-              <p class="tagline">Slow-paced multiplayer arena racing.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
 
-    <!-- Load bootstrap -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <!-- Codex: full-info card grid of mechanics, tiles, abilities, brutal rounds
+         and medals. Built by scripts/learn.js; each card's live animation by
+         scripts/learnScenes.js. Uses a plain scrolling container (NOT <section>,
+         whose global rule is fixed-height and would clip it). The fixed-navbar
+         offset comes from body { padding-top }. -->
+    <main class="learn-shell">
+      <header class="learn-header">
+        <h1>Codex</h1>
+        <p class="learn-sub">How everything in Chao Chao works — and feels.</p>
+      </header>
+      <!-- Sticky search + category filter. Both are data-gp-nav (controller-
+           reachable); the search input pops the on-screen keyboard when activated
+           by a pad (menuGamepad routes to osk.js). Chips are built by learn.js. -->
+      <div class="learn-toolbar">
+        <input type="search" id="learnSearch" class="learn-search" data-gp-nav
+               placeholder="Search the codex…" aria-label="Search the codex" autocomplete="off">
+        <div class="learn-filters" id="learnFilters" role="group" aria-label="Filter by category"><!-- chips built by learn.js --></div>
+      </div>
+      <!-- Card groups built by learn.js (one .codex-group per category). -->
+      <div class="codex-groups" id="codexGroups"></div>
+    </main>
+
+    <!-- Menu-page script set (same as index/join): controller identity must load
+         before menuGamepad; learn.js builds the [data-gp-nav] entries it walks.
+         osk.js (after the simple-keyboard lib, before menuGamepad) gives the
+         search box pad-driven text entry; it falls back to plain focus if the
+         CDN is blocked. -->
     <script src="scripts/controllerIdentity.js"></script>
+    <script src="scripts/learnScenes.js"></script>
+    <script src="scripts/learn.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/index.js"></script>
+    <script src="scripts/osk.js"></script>
     <script src="scripts/menuGamepad.js"></script>
     <script src="scripts/controllerHeader.js"></script>
     <script src="scripts/theme.js"></script>
-    <!-- Auth: browser-safe Supabase config injected server-side; stripped when disabled. -->
-    <!-- SUPABASE_CONFIG -->
-    <!-- deferred (non-render-blocking); run in order before DOMContentLoaded. -->
-    <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script defer src="scripts/auth.js"></script>
   </body>
 </html>

--- a/client/scripts/learn.js
+++ b/client/scripts/learn.js
@@ -1,0 +1,467 @@
+// ============================================================================
+// learn.js — the Codex / "Learn" page (client-only, no game loop, no socket).
+//
+// LAYOUT: a responsive full-info CARD GRID grouped by category. Each card shows
+// a live in-game animation (drawn by learnScenes.js), an icon + name, and the
+// full plain-English description. A sticky toolbar at the top has a search box
+// and category-filter chips. Chosen over master-detail because it fills the
+// width (no whitespace), needs no modal, and degrades to 1 column on phones.
+//
+// DUAL PURPOSE — keep both in mind when editing:
+//   1. PLAYER REFERENCE: how every mechanic/tile/ability/brutal round/medal
+//      WORKS AND FEELS. Deliberately NO numbers / percentages / durations —
+//      describe the feel ("a short fuse", "skates", "briefly"), never the value.
+//   2. AGENT KNOWLEDGE BASE: the CODEX array is the canonical plain-English
+//      description of what the game does. When you change a mechanic in
+//      server/config.json / game.js / engine.js, update the matching entry here
+//      in the SAME change. (Contract recorded in MEMORY.md → "Learn/Codex page".)
+//
+// SOURCING + GOTCHAS:
+//   • Behaviour confirmed in server/engine.js, game.js, entities/player.js,
+//     achievements.js (medals; note the source typo "Resouceful" → shown
+//     "Resourceful"). Tuning lives in server/config.json.
+//   • PUNCH entry reflects the rework on branch worktree-feat-punch-rework
+//     (momentum + hold-to-charge + stamina ring + overcharge + clashes). If that
+//     changes / doesn't ship, reconcile with live player.js + config punch*.
+//   • Each entry has `anim`: a scene name registered in learnScenes.js. Add a
+//     card → add a SCENES[name] there too. Scenes reuse the REAL game art (kart
+//     disc, fire sprites, bumper disc+ring, terrain PNGs, gold goal).
+//   • Icons: ability/brutal SVGs are BLACK SILHOUETTES → shown on a light chip
+//     (.codex-icon--svg) so they survive dark theme. The bumper head-icon is
+//     drawn procedurally via LearnAnim.staticIcon (matches in-game).
+//   • Only brutal rounds active:true are shown; parked ones (gravity/fiesta/
+//     golden) stay in CODEX with show:false so the knowledge survives.
+//   • Page is socket-free / no config fetch (static, instant, can't error).
+//
+// CONTROLLER / TOUCH:
+//   • Search box + chips + every card carry data-gp-nav; shared menuGamepad.js
+//     does 2D-spatial focus (A=activate, B=back). Cards are focusable so a pad
+//     can scroll the whole grid. osk.js gives pad-driven typing in the search.
+//   • Tap targets (search, chips) are >=44px; see styles.css.
+// ============================================================================
+
+(function () {
+    "use strict";
+
+    var IMG = "assets/img/";
+    function svg(file) { return { kind: "svg", src: IMG + file }; }
+    function tex(file) { return { kind: "texture", src: IMG + file }; }
+    function swatch(color) { return { kind: "swatch", color: color }; }
+    function emoji(glyph) { return { kind: "emoji", glyph: glyph }; }
+    function art(name) { return { kind: "art", art: name }; }   // procedural in-game art
+
+    // ------------------------------------------------------------------------
+    // THE CODEX. `blurb` = short line (also fuels search). `detail` = full prose
+    // (string or array of paragraphs) shown on the card. `anim` = scene name in
+    // learnScenes.js. `id` must be unique (used for the deep-link hash).
+    // ------------------------------------------------------------------------
+    var CODEX = [
+        {
+            id: "basics",
+            label: "Basics",
+            entries: [
+                {
+                    id: "winning", name: "Winning a Match", icon: swatch("#FFD700"), anim: "goalRun",
+                    blurb: "Reach the goal to score — first to enough wins.",
+                    detail: [
+                        "Every round is a dash to the glowing goal zone. Cross into it and you bank a notch — your tally of round wins. String enough notches together before anyone else and you take the whole match.",
+                        "The more racers in the room, the fewer notches it takes, so a packed lobby crowns a champion faster than a quiet one. And being the one everybody's chasing is dangerous: fall just short of the win and rivals will gun for you, hungry to knock the leader down a peg."
+                    ]
+                },
+                {
+                    id: "collapse", name: "The Collapse", icon: tex("lava.png"), anim: "collapse",
+                    blurb: "The floor turns to lava and squeezes everyone inward.",
+                    detail: [
+                        "Once the front-runners are home, the arena starts turning to lava from the edges inward, shrinking the safe ground and herding everyone toward the middle. Linger too long and you'll be swimming in fire.",
+                        "It's the game's clock — it guarantees every round ends and turns the final moments into a frantic scramble for solid footing. When a single racer is all that's left, the lava eases up to give them a fair shot at the goal."
+                    ]
+                },
+                {
+                    id: "punching", name: "Punching", icon: emoji("👊"), anim: "punch",
+                    blurb: "Timing and positioning, not mashing.",
+                    detail: [
+                        "Punching is about how you commit, not how fast you tap. A standing tap barely nudges someone; driving into them at full speed lands a real shove — your punch hits as hard as the speed you carry into it. A glow in front of your kart previews how hard you'd connect right now.",
+                        "Hold the button to wind up a heavier hit: a fist rears back in front of you and your view rumbles. Everyone can see the haymaker coming, so a big one can be dodged or beaten to the punch. Hold too long, though, and you overcharge and fizzle — left winded and sluggish with nothing to show for it.",
+                        "Every punch draws from a stamina ring around your kart. Spam it and you run dry, then have to recover before you can swing again, so mashing no longer pays off. And punches clash: swing back into an incoming fist at the right moment and an even match sends both of you flying — but a clearly stronger punch bowls straight through a weak one, so over-committing a charge can backfire spectacularly."
+                    ]
+                },
+                {
+                    id: "fire", name: "Fire & Killstreaks", icon: tex("redFire.png"), anim: "fire",
+                    blurb: "Kills set you ablaze and hit harder.",
+                    detail: [
+                        "Knock a rival into the lava and you catch fire — flames trail your kart and your hits land meaner. Keep the kills coming without cooling off and the whole arena hears about it: a Killing Spree, then a Rampage, then truly Godlike.",
+                        "Fire makes you faster and deadlier, but the flames paint a target on your back — every burning streak invites someone to put you out."
+                    ]
+                },
+                {
+                    id: "pickups", name: "Ability Pickups", icon: svg("toolbox-solid.svg"), anim: "pickup",
+                    blurb: "Roll over a pad to pocket a single-use power.",
+                    detail: [
+                        "Some maps scatter ability pads around the track. Roll over one and you pocket a single-use power — anything from a lobbed bomb to a blinding fog to a swap of places with a rival.",
+                        "You hold one at a time, so grabbing a new pad means committing to what you're carrying. Save it for the perfect moment, or burn it to bail yourself out of trouble. A pad goes quiet for a bit after someone takes it, then re-arms."
+                    ]
+                }
+            ]
+        },
+        {
+            id: "terrain",
+            label: "Terrain",
+            entries: [
+                { id: "tile-normal", name: "Normal Ground", icon: tex("dirt.png"), anim: "terrainNormal",
+                  blurb: "The default footing — your baseline.",
+                  detail: "Plain dirt with predictable grip and steady acceleration. This is the feel every other surface is measured against — nothing surprising, just honest traction." },
+                { id: "tile-fast", name: "Fast Ground", icon: tex("grass.png"), anim: "terrainFast",
+                  blurb: "Slick and speedy — easy to overshoot.",
+                  detail: "Grass that lets you accelerate harder and carry more speed. Brilliant for overtakes and breakaways, but all that pace makes it easy to blow straight past a tight turn." },
+                { id: "tile-slow", name: "Slow Ground", icon: tex("sand.png"), anim: "terrainSlow",
+                  blurb: "Draggy sand that saps your momentum.",
+                  detail: "Sand grabs at your wheels and bleeds off speed the moment you touch it. Plowing through a patch costs you, so it's often worth the longer line around it." },
+                { id: "tile-ice", name: "Ice", icon: tex("ice.png"), anim: "terrainIce",
+                  blurb: "Almost no grip — you keep sliding.",
+                  detail: "Ice barely bites. You keep gliding long after you ease off, steering only suggests where you'd like to go, and any shove sends you skating helplessly. It turns precise driving into a guessing game." },
+                { id: "tile-lava", name: "Lava", icon: tex("lava.png"), anim: "lavaBurn",
+                  blurb: "Touch it and you burn out of the round.",
+                  detail: "A fiery dunk and you're done — burned out and respawned, out of the round. The collapse turns the whole arena into this, and a well-aimed punch can post a rival straight into it." },
+                { id: "tile-goal", name: "Goal", icon: swatch("#FFCB30"), anim: "goalRun",
+                  blurb: "Reach it to bank a notch.",
+                  detail: "The finish zone, glowing gold. Reaching it banks you a notch toward the match win. It's the one tile everyone is racing toward, every single round." },
+                { id: "tile-ability", name: "Ability Pad", icon: swatch("#C8C8C8"), anim: "pickup",
+                  blurb: "Grab a random single-use power.",
+                  detail: "A pickup pad. Roll across it to grab a random single-use power. It goes dormant briefly after someone claims it, then lights back up for the next racer." },
+                { id: "tile-bumper", name: "Bumpers", icon: art("bumper"), anim: "bumper",
+                  blurb: "Springy obstacles that fling you back.",
+                  detail: "Bump a bumper and you're flung away from it — maddening when you're in a hurry, but a clever way to launch a chasing rival clean off their line. Some maps add moving bumpers that sweep across the track like windscreen wipers, so the safe lane keeps shifting." },
+                { id: "tile-random", name: "Random Ground", icon: swatch("#7c3aed"), anim: "randomTile",
+                  blurb: "A wildcard disguised as another surface.",
+                  detail: "A trickster tile. It masquerades as one of the ordinary surfaces, so you won't know whether you're about to hit speedy grass or draggy sand until you're already committed to it." }
+            ]
+        },
+        {
+            id: "abilities",
+            label: "Abilities",
+            entries: [
+                { id: "ability-blindfold", name: "Blindfold", icon: svg("low-vision.svg"), anim: "blindfold",
+                  blurb: "Blinds the whole room but you.",
+                  detail: "Drops a blackout over everyone's view except your own. For a few seconds the entire room is driving blind while you see just fine — pure chaos when you spring it right before the goal." },
+                { id: "ability-swap", name: "Swap", icon: svg("random.svg"), anim: "swap",
+                  blurb: "Trade places with a nearby racer.",
+                  detail: "Marks the ground with a growing ring everyone can see, then trades your position with a racer caught inside it. Steal a leader's safe spot at the last instant, or yank yourself out of the lava's path and dump someone else into it." },
+                { id: "ability-bomb", name: "Bomb", icon: svg("bomb.svg"), anim: "bomb",
+                  blurb: "Lob an explosive that flings karts.",
+                  detail: "Lobs an explosive that sits for a short fuse and then erupts, flinging every kart caught in the blast — including you, if you hang around. Wherever it goes off it scorches the ground into a patch of slow, draggy sand, so it both clears a crowd off the goal and gums up the spot they were fighting for." },
+                { id: "ability-speedbuff", name: "Speed Burst", icon: svg("wind-solid.svg"), anim: "speedBurst",
+                  blurb: "A burst of extra speed for you.",
+                  detail: "A shot of extra pace for a short while. Pop it to run down a leader, outrun the closing lava, or simply blitz a long straightaway before anyone reacts." },
+                { id: "ability-speeddebuff", name: "Slowdown", icon: svg("hourglass-start-solid.svg"), anim: "slowdown",
+                  blurb: "Bogs down everyone but you.",
+                  detail: "Saps the speed of every other racer at once, miring the whole pack in molasses while you carry on at full clip. Drop it as you make your break and watch the field bog down behind you." },
+                { id: "ability-tileswap", name: "Tile Swap", icon: svg("copy-regular.svg"), anim: "tileSwap",
+                  blurb: "Flips the fast and icy patches.",
+                  detail: "After a wind-up everyone can see, the arena's fast lanes and icy patches trade places — the speedy grass you were counting on turns to treacherous ice, and vice versa. Time it to flip a rival's safe line out from under them as they commit." },
+                { id: "ability-icecannon", name: "Ice Cannon", icon: svg("snowflake-solid.svg"), anim: "iceCannon",
+                  blurb: "Freeze the ground where it lands.",
+                  detail: "Fires a frozen shot that turns the patch where it lands into slick ice. Lay a trap on a tight corner and watch chasers skate helplessly off the track." },
+                { id: "ability-cut", name: "Cut", icon: svg("scissors-solid.svg"), anim: "cut",
+                  blurb: "A short-range swipe that shoves rivals aside.",
+                  detail: "A quick, close-range swipe that carves a line through the pack and flings every nearby racer away from that line — anyone on one side is thrown one way, anyone on the other side the opposite way. No wind-up and no aiming, just an instant shove to clear bodies off you or fling a clinging rival off course." }
+            ]
+        },
+        {
+            id: "brutal",
+            label: "Brutal Rounds",
+            entries: [
+                { id: "brutal-what", name: "What Is a Brutal Round?", icon: emoji("🔥"), anim: "brutalIntro",
+                  blurb: "Special rounds where the arena turns nasty.",
+                  detail: [
+                      "Now and then a round goes brutal: the arena bends a rule, throws a twist into the mix, and dares everyone to survive it. The music shifts, the icon flashes up, and the usual race becomes a fight to last.",
+                      "The closer the match is to ending, the more likely a brutal round is to appear — and sometimes several twists stack on the same round. Here's what each one does."
+                  ] },
+                { id: "brutal-ability", name: "Ability", icon: svg("toolbox-solid.svg"), anim: "abilityRain",
+                  blurb: "Every racer starts holding an ability.",
+                  detail: "Every racer starts the round already holding a random ability, so powers come flying from the opening moment instead of having to be hunted down. Expect bombs, blinds, swaps and freezes going off back to back — it's an instant free-for-all of effects." },
+                { id: "brutal-cloudy", name: "Cloudy", icon: svg("cloud-solid.svg"), anim: "cloudy",
+                  blurb: "Drifting clouds hide the track.",
+                  detail: "Banks of cloud roll across the arena, blotting out patches of the track as they drift. Hazards and rivals vanish into the fog and reappear without warning — you're racing half-blind through the gaps." },
+                { id: "brutal-lightning", name: "Lightning", icon: svg("bolt-solid.svg"), anim: "lightning",
+                  blurb: "Every racer is sped up.",
+                  detail: "Everyone gets a jolt: every racer is given a big speed boost for the whole round, and the hazards whip around faster too. You cover ground in a blink, so the pace turns twitchy and unforgiving — there's far less time to read the track and react before you've overshot it." },
+                { id: "brutal-volcano", name: "Volcano", icon: svg("volcano-solid.svg"), anim: "volcano",
+                  blurb: "The ground erupts mid-round.",
+                  detail: "Partway through, the arena erupts — lava blooms out and floods inward with only a brief warning before it blows. Read the rumble, get clear of where it's about to open, and ride out the eruption to claim the goal." },
+                { id: "brutal-infection", name: "Infection", icon: svg("biohazard-solid.svg"), anim: "infection",
+                  blurb: "Get tagged and you join the horde.",
+                  detail: [
+                      "One racer starts infected, and their touch spreads it. Get tagged and you turn too, joining a horde that hunts down whoever's left. The last clean racer standing wins the round.",
+                      "Once you're infected there's no winning the round — your only job is to drag everyone else down with you. So survivors run and scatter while the horde closes in."
+                  ] },
+                { id: "brutal-hockey", name: "Air Hockey", icon: svg("hockey-puck-solid.svg"), anim: "hockey",
+                  blurb: "A puck rockets around, launching karts.",
+                  detail: "A giant puck ricochets around the arena, picking up frightening speed with every wall it slams into. Get clipped and you're launched across the map. Smack it to redirect it into rivals — and stay well clear of its line, because it only gets faster." },
+                { id: "brutal-explosive", name: "Explosive", icon: svg("explosion-solid.svg"), anim: "explosive",
+                  blurb: "Every death blasts a crater of lava.",
+                  detail: "Every kart is a walking powder keg. When a racer goes down, the spot they died swells with a warning and then detonates — flinging everyone nearby and scorching the ground around it into lava. Each death eats away the safe floor and can chain into the next, so a crowded scramble can erupt into a string of blasts that leaves the arena pocked with fire." },
+                { id: "brutal-blackout", name: "Blackout", icon: svg("moon-solid.svg"), anim: "blackout",
+                  blurb: "The lights go out.",
+                  detail: "The arena goes dark and you can only see a small pool of light around your own kart. The goal, the lava and your rivals all lurk in the black until you're nearly on top of them — every move is a gamble into the unknown." },
+                // --- Parked brutal modes (active:false in config today). Flip show:true when re-enabled. ---
+                { id: "brutal-gravity", name: "Gravity", icon: svg("infinity-solid.svg"), anim: "_blank", show: false,
+                  blurb: "(disabled) Pull warps your movement.",
+                  detail: "Currently disabled. A gravity twist that warps how karts drift across the arena." },
+                { id: "brutal-fiesta", name: "Fiesta", icon: svg("cake-candles-solid.svg"), anim: "_blank", show: false,
+                  blurb: "(disabled) A party-themed twist.",
+                  detail: "Currently disabled. A celebratory chaos round." },
+                { id: "brutal-golden", name: "Golden", icon: svg("sack-dollar-solid.svg"), anim: "_blank", show: false,
+                  blurb: "(disabled) A high-stakes gold round.",
+                  detail: "Currently disabled. A high-value scoring twist." }
+            ]
+        },
+        {
+            id: "medals",
+            label: "Medals",
+            entries: [
+                { id: "medal-intro", name: "About Medals", icon: emoji("🏅"), anim: "medalShine",
+                  blurb: "Honours handed out when the match ends.",
+                  detail: "When the match wraps, the game looks back over everything that happened and hands out medals for how each racer played — who racked up kills, who kept reaching the goal, who couldn't catch a break. They're bragging rights, awarded automatically." },
+                { id: "medal-serialkiller", name: "Serial Killer", icon: emoji("🔪"), anim: "medalShine",
+                  blurb: "Most kills across the whole match.",
+                  detail: "Goes to the racer who knocked out the most rivals over the entire match. The arena's apex predator — more interested in the body count than the finish line." },
+                { id: "medal-savior", name: "Savior", icon: emoji("🛡️"), anim: "medalShine",
+                  blurb: "Took down a rival on the brink of winning.",
+                  detail: "Earned by eliminating someone who was one step from taking the match, snatching victory out of their hands at the last possible second. The crowd loves a spoiler." },
+                { id: "medal-survivalist", name: "Survivalist", icon: emoji("🏁"), anim: "medalShine",
+                  blurb: "Reached the goal the most times.",
+                  detail: "For the racer who crossed into the goal the most often — slippery, relentless, and somehow always still alive when it counts." },
+                { id: "medal-brutalist", name: "Brutalist", icon: emoji("🔥"), anim: "medalShine",
+                  blurb: "Most finishes during brutal rounds.",
+                  detail: "Like Survivalist, but earned the hard way: the most goals reached during brutal rounds, when the arena is throwing everything it has at you and just finishing is an achievement." },
+                { id: "medal-pickedon", name: "Picked On", icon: emoji("🎯"), anim: "medalShine",
+                  blurb: "Killed the most by a single rival.",
+                  detail: "The unlucky one — knocked out more times by the same rival than anyone else. Somebody clearly had a vendetta, and you were it." },
+                { id: "medal-resourceful", name: "Resourceful", icon: emoji("🧰"), anim: "medalShine",
+                  blurb: "Used the most abilities.",
+                  detail: "For the racer who leaned hardest on pickups, always with a trick in their back pocket. Why win a fair fight when you can swap, bomb, or freeze your way through it?" },
+                { id: "medal-bully", name: "Bully", icon: emoji("👊"), anim: "medalShine",
+                  blurb: "Threw the most punches.",
+                  detail: "Awarded for throwing more punches than anyone else — less interested in racing, more interested in shoving. Whether they connected is beside the point." },
+                { id: "medal-multikill", name: "Multi-Kills", icon: emoji("💥"), anim: "medalShine",
+                  blurb: "Double, Triple and Mega Kills.",
+                  detail: "For stacking eliminations in a single breath: take out two in quick succession for a Double Kill, three for a Triple, and four or more for a Mega Kill. The more you fell before the dust settles, the louder the call-out." }
+            ]
+        }
+    ];
+
+    // ------------------------------------------------------------------------
+    // Rendering + filtering. Cards are shown/hidden in place (display:none) so
+    // focus and the menuGamepad cursor stay stable and off-screen canvases stop
+    // animating (the IntersectionObserver in learnScenes.js handles that).
+    // ------------------------------------------------------------------------
+    var groupsEl, searchInput, filtersEl, emptyEl;
+    var allRecords = [];     // [{ entry, card, catId, groupEl }]
+    var groupEls = {};       // catId -> group wrapper element
+    var activeCat = "all";
+    var query = "";
+
+    function paragraphs(detail) { return Array.isArray(detail) ? detail : [detail]; }
+
+    function buildIcon(icon) {
+        var wrap = document.createElement("span");
+        wrap.className = "codex-icon";
+        if (!icon) { return wrap; }
+        if (icon.kind === "emoji") {
+            wrap.classList.add("codex-icon--emoji");
+            wrap.textContent = icon.glyph;
+        } else if (icon.kind === "swatch") {
+            wrap.classList.add("codex-icon--swatch");
+            wrap.style.background = icon.color;
+        } else if (icon.kind === "texture") {
+            wrap.classList.add("codex-icon--texture");
+            var t = document.createElement("img");
+            t.src = icon.src; t.alt = ""; t.setAttribute("aria-hidden", "true");
+            wrap.appendChild(t);
+        } else if (icon.kind === "art") {
+            // Procedural in-game art (e.g. the bumper disc + ring) drawn to a
+            // tiny canvas so the list icon matches what's rendered in-game.
+            wrap.classList.add("codex-icon--art");
+            var cv = document.createElement("canvas");
+            cv.setAttribute("aria-hidden", "true");
+            wrap.appendChild(cv);
+            if (typeof LearnAnim !== "undefined" && LearnAnim.staticIcon) { LearnAnim.staticIcon(cv, icon.art); }
+        } else { // "svg" — black silhouette, needs the light chip to stay visible
+            wrap.classList.add("codex-icon--svg");
+            var s = document.createElement("img");
+            s.src = icon.src; s.alt = ""; s.setAttribute("aria-hidden", "true");
+            wrap.appendChild(s);
+        }
+        return wrap;
+    }
+
+    function buildCard(entry) {
+        var card = document.createElement("article");
+        card.className = "codex-card";
+        card.id = "card-" + entry.id;
+        card.setAttribute("data-entry-id", entry.id);
+        card.setAttribute("data-gp-nav", "");        // pad can scroll through cards
+        card.setAttribute("tabindex", "-1");
+
+        var canvas = document.createElement("canvas");
+        canvas.className = "codex-card-anim";
+        canvas.setAttribute("aria-hidden", "true");
+        card.appendChild(canvas);
+
+        var body = document.createElement("div");
+        body.className = "codex-card-body";
+
+        var head = document.createElement("div");
+        head.className = "codex-card-head";
+        head.appendChild(buildIcon(entry.icon));
+        var h = document.createElement("h3");
+        h.textContent = entry.name;
+        head.appendChild(h);
+        body.appendChild(head);
+
+        paragraphs(entry.detail).forEach(function (text) {
+            var p = document.createElement("p");
+            p.textContent = text;
+            body.appendChild(p);
+        });
+        card.appendChild(body);
+
+        // Clicking a card anchors it (shareable deep-link) without a modal.
+        card.addEventListener("click", function () {
+            try { history.replaceState(null, "", "#" + entry.id); } catch (e) { /* ignore */ }
+        });
+
+        // Wire the live animation (only runs while on-screen; see learnScenes.js).
+        if (typeof LearnAnim !== "undefined" && LearnAnim.attach) {
+            LearnAnim.attach(canvas, entry.anim, { glyph: entry.icon && entry.icon.glyph });
+        }
+        return card;
+    }
+
+    function buildFilters() {
+        if (!filtersEl) { return; }
+        var cats = [{ id: "all", label: "All" }];
+        CODEX.forEach(function (g) { cats.push({ id: g.id, label: g.label }); });
+        cats.forEach(function (c) {
+            var chip = document.createElement("button");
+            chip.type = "button";
+            chip.className = "learn-chip" + (c.id === activeCat ? " is-active" : "");
+            chip.setAttribute("data-gp-nav", "");
+            chip.setAttribute("data-cat", c.id);
+            chip.setAttribute("aria-pressed", c.id === activeCat ? "true" : "false");
+            chip.textContent = c.label;
+            chip.addEventListener("click", function () {
+                activeCat = c.id;
+                var chips = filtersEl.querySelectorAll(".learn-chip");
+                for (var i = 0; i < chips.length; i++) {
+                    var on = chips[i] === chip;
+                    chips[i].classList.toggle("is-active", on);
+                    chips[i].setAttribute("aria-pressed", on ? "true" : "false");
+                }
+                applyFilter();
+            });
+            filtersEl.appendChild(chip);
+        });
+    }
+
+    function matchesQuery(entry) {
+        if (!query) { return true; }
+        var hay = (entry.name + " " + entry.blurb + " " + paragraphs(entry.detail).join(" ")).toLowerCase();
+        return hay.indexOf(query) !== -1;
+    }
+
+    function applyFilter() {
+        var anyVisible = false;
+        var visibleByCat = {};
+        allRecords.forEach(function (r) {
+            var vis = (activeCat === "all" || r.catId === activeCat) && matchesQuery(r.entry);
+            r.card.classList.toggle("is-hidden", !vis);
+            if (vis) { anyVisible = true; visibleByCat[r.catId] = true; }
+        });
+        Object.keys(groupEls).forEach(function (catId) {
+            groupEls[catId].classList.toggle("is-hidden", !visibleByCat[catId]);
+        });
+        if (emptyEl) { emptyEl.classList.toggle("is-hidden", anyVisible); }
+    }
+
+    function build() {
+        groupsEl = document.getElementById("codexGroups");
+        searchInput = document.getElementById("learnSearch");
+        filtersEl = document.getElementById("learnFilters");
+        if (!groupsEl) { return; }
+
+        CODEX.forEach(function (group) {
+            var groupEl = document.createElement("div");
+            groupEl.className = "codex-group";
+            groupEl.setAttribute("data-cat", group.id);
+
+            var title = document.createElement("h2");
+            title.className = "codex-group-title";
+            title.textContent = group.label;
+            groupEl.appendChild(title);
+
+            var grid = document.createElement("div");
+            grid.className = "codex-grid";
+            group.entries.forEach(function (entry) {
+                if (entry.show === false) { return; }
+                var card = buildCard(entry);
+                grid.appendChild(card);
+                allRecords.push({ entry: entry, card: card, catId: group.id, groupEl: groupEl });
+            });
+            groupEl.appendChild(grid);
+            groupsEl.appendChild(groupEl);
+            groupEls[group.id] = groupEl;
+        });
+
+        emptyEl = document.createElement("p");
+        emptyEl.className = "learn-empty is-hidden";
+        emptyEl.textContent = "No matches — try a different search or category.";
+        groupsEl.appendChild(emptyEl);
+
+        buildFilters();
+        if (searchInput) {
+            searchInput.addEventListener("input", function () {
+                query = (searchInput.value || "").trim().toLowerCase();
+                applyFilter();
+            });
+        }
+
+        // Deep-link: if the URL has #entry-id, scroll that card into view + flash.
+        focusHashCard();
+        window.addEventListener("hashchange", focusHashCard);
+    }
+
+    function focusHashCard() {
+        var id = (location.hash || "").replace(/^#/, "");
+        if (!id) { return; }
+        var el = document.getElementById("card-" + id);
+        if (!el) { return; }
+        // If an active filter/search is hiding the target, clear it so the
+        // deep-link actually lands (scrollIntoView no-ops on a display:none card).
+        if (el.classList.contains("is-hidden")) { resetFilters(); }
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        el.classList.add("is-anchored");
+        setTimeout(function () { el.classList.remove("is-anchored"); }, 1600);
+    }
+
+    function resetFilters() {
+        activeCat = "all";
+        query = "";
+        if (searchInput) { searchInput.value = ""; }
+        if (filtersEl) {
+            var chips = filtersEl.querySelectorAll(".learn-chip");
+            for (var i = 0; i < chips.length; i++) {
+                var on = chips[i].getAttribute("data-cat") === "all";
+                chips[i].classList.toggle("is-active", on);
+                chips[i].setAttribute("aria-pressed", on ? "true" : "false");
+            }
+        }
+        applyFilter();
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", build);
+    } else {
+        build();
+    }
+})();

--- a/client/scripts/learnScenes.js
+++ b/client/scripts/learnScenes.js
@@ -1,0 +1,797 @@
+// ============================================================================
+// learnScenes.js — live mini-animations for the Codex cards (learn.html).
+//
+// FAITHFUL TO THE GAME: the effects here are PORTED VERBATIM from the real
+// renderer, not re-invented. The effects engine (addEffect), the spawn functions
+// (punch / hit / teleport-puff / slash / explosion / screen-flash / muzzle), the
+// terrain dust system (spawnDustParticle / spawnTerrainParticle / spawnIceTrail /
+// spawnEmber, coloured per surface), drawSpeedFx, and the fire SpriteSheet are
+// copied from client/scripts/draw.js + client/scripts/gameboard.js with only
+// these adaptations: the draw context is passed in (the game uses a global
+// `gameContext`) and there's no camera transform. Each scene drives a fake kart
+// (`p`) through the same code paths the game uses, so a card shows the ACTUAL
+// in-game effect (e.g. grass/sand/ice kick up the real flecks/skate-marks; the
+// fire uses the real flame sprite sheet; punch/swap/bomb use the real bursts).
+//
+// >>> KEEP IN SYNC: if those functions change in draw.js/gameboard.js, update the
+//     ports below. They're marked "PORT:" with their source. <<<
+//
+// PERFORMANCE (~30 canvases, mobile/iPad): ONE shared rAF; an IntersectionObserver
+// starts/stops each canvas as it scrolls in/out (filter-hidden display:none cards
+// auto-stop); prefers-reduced-motion → one static frame, no loop; DPR capped at 2;
+// logical canvas is small (W×H). Each card has its OWN effects list (its own `fx`).
+//
+// FIRE GOTCHA: the *Fire.png sheets are 32×128 = 4 frames stacked VERTICALLY
+// (rows=4, columns=1). Slicing them horizontally produces garbage — use SpriteSheet.
+// ============================================================================
+
+var LearnAnim = (function () {
+    "use strict";
+
+    var BASE = "assets/img/";
+    var W = 240, H = 140;
+    var MAXSPEED = 500;                 // mirrors config.playerMaxSpeed for dust thresholds
+    var SCENES = {};
+    var reduceMotion = !!(window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+
+    // ---- lazy image cache ----
+    var imgCache = {};
+    function img(file) {
+        if (imgCache[file] !== undefined) { return imgCache[file]; }
+        var i = new Image();
+        // In reduced-motion mode cards draw once; refresh them as images decode.
+        i.addEventListener("load", function () { if (reduceMotion) { redrawVisibleStatic(); } });
+        i.src = BASE + file; imgCache[file] = i; return i;
+    }
+    function ready(i) { return i && i.complete && i.naturalWidth > 0; }
+
+    // ---- math (PORT: draw.js helpers) ----
+    function clamp01(v) { return v < 0 ? 0 : (v > 1 ? 1 : v); }
+    function clamp(v, a, b) { return v < a ? a : (v > b ? b : v); }
+    function easeOutCubic(t) { return 1 - Math.pow(1 - t, 3); }
+    function lerp(a, b, t) { return a + (b - a) * t; }
+    function loop(t, period) { return (t % period) / period; }
+    function ease(t) { return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2; }
+    function ping(t, period) { var p = loop(t, period); return p < 0.5 ? p * 2 : (1 - p) * 2; }
+    function rnd() { return Math.random(); }
+
+    var BLUE = "#3a9bff", RED = "#ff5b5b", GREEN = "#54d18c", YELLOW = "#ffd23a", PURPLE = "#9b6bff";
+
+    // ========================================================================
+    // EFFECTS ENGINE (PORT: draw.js effectsList/addEffect/drawEffects). Each card
+    // owns its list; addEffect targets the "active" list set before a scene runs.
+    // ========================================================================
+    function makeFX() { return { list: [] }; }
+    var _fx = null;                     // active effects list (set per card per frame)
+    function addEffect(e) { e.age = 0; if (_fx) { _fx.list.push(e); } }
+    function updateFX(fx, dt) {
+        for (var i = fx.list.length - 1; i >= 0; i--) {
+            fx.list[i].age += dt;
+            if (fx.list[i].age >= fx.list[i].maxAge) { fx.list.splice(i, 1); }
+        }
+    }
+    function drawFX(fx, ctx) {
+        for (var i = 0; i < fx.list.length; i++) {
+            var e = fx.list[i];
+            var t = clamp01(e.age / e.maxAge);
+            ctx.save();
+            e.draw(ctx, t, e);
+            ctx.restore();
+        }
+    }
+
+    // ---- terrain particles (PORT: gameboard.js) ----
+    function spawnDustParticle(x, y, vx, vy, size, color) {
+        addEffect({ x: x, y: y, maxAge: 430, draw: function (ctx, t, e) {
+            var a = 1 - t, r = size * (1 - 0.35 * t);
+            ctx.beginPath();
+            ctx.arc(x + vx * e.age, y + vy * e.age, r, 0, 2 * Math.PI);
+            ctx.globalAlpha = a * 0.85; ctx.fillStyle = color; ctx.fill();
+            ctx.globalAlpha = a * 0.4; ctx.lineWidth = 1; ctx.strokeStyle = "rgba(0,0,0,1)"; ctx.stroke();
+        } });
+    }
+    function spawnEmber(x, y) {
+        var vx = (rnd() * 2 - 1) * 0.015, vy = -(0.03 + rnd() * 0.03);
+        var hue = 18 + rnd() * 32, maxAge = 500 + rnd() * 300;
+        addEffect({ x: x, y: y, maxAge: maxAge, draw: function (ctx, t, e) {
+            ctx.globalAlpha = (1 - t) * 0.9;
+            ctx.fillStyle = "hsl(" + hue + ", 100%, " + (62 - 22 * t) + "%)";
+            ctx.beginPath(); ctx.arc(x + vx * e.age, y + vy * e.age, 2.5 * (1 - t) + 0.5, 0, 2 * Math.PI); ctx.fill();
+        } });
+    }
+    function dustColor() { return "rgba(170, 150, 120, 1)"; }
+    function grassColor() { return "rgba(150, 230, 70, 1)"; }
+    function sandColor() { return "rgba(250, 238, 205, 1)"; }
+    function iceColor() { return "rgba(70, 165, 220, 1)"; }
+    function spawnTerrainParticle(p, color, minSize, count) {
+        count = count || 1;
+        var dir = Math.atan2(p.velY, p.velX);
+        for (var i = 0; i < count; i++) {
+            var bx = p.x - Math.cos(dir) * p.radius + (rnd() * 2 - 1) * p.radius * 0.5;
+            var by = p.y - Math.sin(dir) * p.radius + (rnd() * 2 - 1) * p.radius * 0.5;
+            var spread = (rnd() * 2 - 1) * 0.03;
+            var vx = -Math.cos(dir) * 0.013 + Math.cos(dir + Math.PI / 2) * spread;
+            var vy = -Math.sin(dir) * 0.013 + Math.sin(dir + Math.PI / 2) * spread;
+            spawnDustParticle(bx, by, vx, vy, minSize + rnd() * 2, color);
+        }
+    }
+    function addIceStreak(bx, by, ex, ey) {
+        addEffect({ x: bx, y: by, maxAge: 700, draw: function (ctx, t) {
+            ctx.globalAlpha = (1 - t) * 0.6; ctx.strokeStyle = iceColor(); ctx.lineWidth = 3; ctx.lineCap = "round";
+            ctx.beginPath(); ctx.moveTo(bx, by); ctx.lineTo(ex, ey); ctx.stroke();
+        } });
+    }
+    function spawnIceTrail(p) {
+        var dir = Math.atan2(p.velY, p.velX), len = p.radius * 1.7, perp = dir + Math.PI / 2, gap = p.radius * 0.5;
+        for (var s = -1; s <= 1; s += 2) {
+            var bx = p.x + Math.cos(perp) * gap * s, by = p.y + Math.sin(perp) * gap * s;
+            addIceStreak(bx, by, bx - Math.cos(dir) * len, by - Math.sin(dir) * len);
+        }
+    }
+    function spawnSkid(p, color) {
+        var dir = Math.atan2(p.prevVelY, p.prevVelX);
+        for (var i = 0; i < 4; i++) {
+            var spread = (rnd() * 2 - 1) * 0.04;
+            var vx = Math.cos(dir) * 0.02 + Math.cos(dir + Math.PI / 2) * spread;
+            var vy = Math.sin(dir) * 0.02 + Math.sin(dir + Math.PI / 2) * spread;
+            spawnDustParticle(p.x, p.y, vx, vy, 2.5 + rnd() * 2, color);
+        }
+    }
+    // PORT: gameboard.js updateMovementParticles — surface comes from p.surface
+    // (the game does a Voronoi tile lookup; here each scene sets it explicitly).
+    function updateMovementParticles(p, dt) {
+        if (p.alive === false || p.velX == null) { return; }
+        var fastThresh = MAXSPEED * 0.55, walkThresh = MAXSPEED * 0.08;
+        var speed = Math.sqrt(p.velX * p.velX + p.velY * p.velY);
+        if (p.dustCD == null) { p.dustCD = 0; } if (p.skidCD == null) { p.skidCD = 0; } if (p.emberCD == null) { p.emberCD = 0; }
+        p.dustCD -= dt; p.skidCD -= dt; p.emberCD -= dt;
+        if (p.prevVelX != null && p.skidCD <= 0 && speed > fastThresh * 0.5) {
+            var prevSpeed = Math.sqrt(p.prevVelX * p.prevVelX + p.prevVelY * p.prevVelY);
+            if (prevSpeed > 1) {
+                var dot = (p.velX * p.prevVelX + p.velY * p.prevVelY) / (speed * prevSpeed);
+                if (dot < 0.6) { spawnSkid(p, surfaceColor(p.surface)); p.skidCD = 140; }
+            }
+        }
+        if (speed > walkThresh && p.dustCD <= 0) {
+            if (p.surface === "ice") { if (speed > fastThresh) { spawnIceTrail(p); p.dustCD = 40; } else { p.dustCD = 60; } }
+            else if (p.surface === "fast") { spawnTerrainParticle(p, grassColor(), 1.8, 2); p.dustCD = speed > fastThresh ? 45 : 70; }
+            else if (p.surface === "slow") { spawnTerrainParticle(p, sandColor(), 3, 2); p.dustCD = speed > fastThresh ? 45 : 70; }
+            else if (speed > fastThresh) { spawnTerrainParticle(p, dustColor(), 2.5, 2); p.dustCD = 50; }
+            else { p.dustCD = 60; }
+        }
+        if (p.onFire > 0 && p.emberCD <= 0) {
+            spawnEmber(p.x + (rnd() * 2 - 1) * p.radius, p.y + (rnd() * 2 - 1) * p.radius); p.emberCD = 70;
+        }
+        p.prevVelX = p.velX; p.prevVelY = p.velY;
+    }
+    function surfaceColor(s) { return s === "fast" ? grassColor() : s === "slow" ? sandColor() : s === "ice" ? iceColor() : dustColor(); }
+
+    // ---- ability / impact bursts (PORT: draw.js spawn* functions) ----
+    function spawnPunchEffect(px, py, baseRadius, color, angleDeg) {
+        addEffect({ x: px, y: py, maxAge: 220, draw: function (ctx, t) {
+            var grow = easeOutCubic(t); ctx.lineCap = "round";
+            ctx.globalAlpha = (1 - t) * 0.5; ctx.fillStyle = color;
+            ctx.beginPath(); ctx.arc(px, py, baseRadius * (0.55 + 0.75 * grow), 0, 2 * Math.PI); ctx.fill();
+            ctx.globalAlpha = (1 - t); ctx.lineWidth = 2 * (1 - t) + 1; ctx.strokeStyle = color;
+            ctx.beginPath(); ctx.arc(px, py, baseRadius * (0.8 + 0.8 * grow), 0, 2 * Math.PI); ctx.stroke();
+            if (angleDeg != null && t < 0.6) {
+                var st = clamp01(t / 0.6), center = angleDeg * Math.PI / 180, half = 0.95 * (1 - st * 0.4), reach = baseRadius * (1.1 + 0.7 * st);
+                ctx.globalAlpha = (1 - st) * 0.85; ctx.lineWidth = baseRadius * 0.45 * (1 - st) + 1.5;
+                ctx.beginPath(); ctx.arc(px, py, reach, center - half, center + half); ctx.stroke();
+            }
+        } });
+    }
+    function spawnHitEffect(x, y, color) {
+        addEffect({ x: x, y: y, maxAge: 220, draw: function (ctx, t) {
+            var p = easeOutCubic(t); ctx.translate(x, y); ctx.lineCap = "round";
+            ctx.globalAlpha = (1 - t); ctx.strokeStyle = "white"; ctx.lineWidth = 3 * (1 - t) + 1;
+            ctx.beginPath(); ctx.arc(0, 0, 6 + 22 * p, 0, 2 * Math.PI); ctx.stroke();
+            ctx.strokeStyle = color || "white"; ctx.lineWidth = 2 * (1 - t) + 1;
+            for (var i = 0; i < 6; i++) { var a = (i / 6) * Math.PI * 2 + 0.3, r0 = 2.8 + 8.4 * p, r1 = 8.4 + 18.2 * p;
+                ctx.beginPath(); ctx.moveTo(Math.cos(a) * r0, Math.sin(a) * r0); ctx.lineTo(Math.cos(a) * r1, Math.sin(a) * r1); ctx.stroke(); }
+        } });
+    }
+    function spawnTeleportPuff(x, y, color) {
+        addEffect({ x: x, y: y, maxAge: 360, draw: function (ctx, t) {
+            var p = easeOutCubic(t); ctx.translate(x, y);
+            ctx.globalAlpha = (1 - t) * 0.9; ctx.strokeStyle = color || "white"; ctx.lineWidth = 3 * (1 - t) + 1;
+            ctx.beginPath(); ctx.arc(0, 0, 8 + 38 * p, 0, 2 * Math.PI); ctx.stroke();
+            ctx.fillStyle = color || "white";
+            for (var i = 0; i < 8; i++) { var a = (i / 8) * Math.PI * 2 + t * 3, r = 6 + 30 * p; ctx.globalAlpha = (1 - t);
+                ctx.beginPath(); ctx.arc(Math.cos(a) * r, Math.sin(a) * r, 2.5 * (1 - t) + 0.5, 0, 2 * Math.PI); ctx.fill(); }
+        } });
+    }
+    function spawnSlashEffect(x, y, angleDeg, color) {
+        var a = angleDeg * Math.PI / 180, len = W, dx = Math.cos(a) * len, dy = Math.sin(a) * len;
+        addEffect({ x: x, y: y, maxAge: 280, draw: function (ctx, t) {
+            ctx.lineCap = "round";
+            ctx.globalAlpha = (1 - t) * 0.6; ctx.strokeStyle = color || "white"; ctx.lineWidth = (10 * (1 - t)) + 2;
+            ctx.shadowColor = color || "white"; ctx.shadowBlur = 12 * (1 - t);
+            ctx.beginPath(); ctx.moveTo(x - dx, y - dy); ctx.lineTo(x + dx, y + dy); ctx.stroke();
+            ctx.globalAlpha = (1 - t); ctx.strokeStyle = "white"; ctx.lineWidth = (4 * (1 - t)) + 1; ctx.shadowBlur = 0;
+            ctx.beginPath(); ctx.moveTo(x - dx, y - dy); ctx.lineTo(x + dx, y + dy); ctx.stroke();
+        } });
+    }
+    function spawnExplosion(x, y, radius, color) {
+        color = color || "#ff7a18"; radius = radius || 70;
+        addEffect({ x: x, y: y, maxAge: 430, draw: function (ctx, t) {
+            var p = easeOutCubic(t); ctx.translate(x, y);
+            var coreR = radius * (0.4 + 0.9 * p);
+            var grad = ctx.createRadialGradient(0, 0, 0, 0, 0, coreR);
+            grad.addColorStop(0, "rgba(255,245,200," + (1 - t) + ")"); grad.addColorStop(0.5, color); grad.addColorStop(1, "rgba(0,0,0,0)");
+            ctx.globalAlpha = (1 - t) * 0.85; ctx.fillStyle = grad;
+            ctx.beginPath(); ctx.arc(0, 0, coreR, 0, 2 * Math.PI); ctx.fill();
+            ctx.globalAlpha = (1 - t); ctx.strokeStyle = "rgba(255,255,255,0.9)"; ctx.lineWidth = 3 * (1 - t) + 1;
+            ctx.beginPath(); ctx.arc(0, 0, radius * (0.6 + 1.0 * p), 0, 2 * Math.PI); ctx.stroke();
+            ctx.fillStyle = color;
+            for (var i = 0; i < 10; i++) { var a = (i / 10) * Math.PI * 2 + 0.2, r = radius * (0.3 + 1.1 * p); ctx.globalAlpha = (1 - t);
+                ctx.beginPath(); ctx.arc(Math.cos(a) * r, Math.sin(a) * r, 2.5 * (1 - t) + 0.5, 0, 2 * Math.PI); ctx.fill(); }
+        } });
+    }
+    function spawnScreenFlash(color, peakAlpha, maxAge) {
+        addEffect({ x: 0, y: 0, maxAge: maxAge || 250, draw: function (ctx, t) {
+            ctx.globalAlpha = (1 - t) * (peakAlpha || 0.35); ctx.fillStyle = color || "red";
+            ctx.fillRect(-10, -10, W + 20, H + 20);
+        } });
+    }
+    function spawnMuzzleFlash(x, y, angleDeg, color) {
+        var a = angleDeg * Math.PI / 180;
+        addEffect({ x: x, y: y, maxAge: 160, draw: function (ctx, t) {
+            var p = easeOutCubic(t), reach = 8 + 20 * p, spread = 6 * (1 - t) + 3;
+            ctx.translate(x, y); ctx.rotate(a);
+            ctx.globalAlpha = (1 - t) * 0.9; ctx.fillStyle = color;
+            ctx.beginPath(); ctx.moveTo(0, 0); ctx.lineTo(reach, -spread); ctx.lineTo(reach + 6, 0); ctx.lineTo(reach, spread); ctx.closePath(); ctx.fill();
+            ctx.globalAlpha = (1 - t); ctx.strokeStyle = "white"; ctx.lineCap = "round"; ctx.lineWidth = 2 * (1 - t) + 0.5;
+            for (var i = -1; i <= 1; i++) { ctx.beginPath(); ctx.moveTo(2, i * 3); ctx.lineTo(reach * 0.8, i * 4); ctx.stroke(); }
+        } });
+    }
+    // PORT: draw.js drawSpeedFx — buff wind-streaks / debuff ripple. now = elapsed ms.
+    function drawSpeedFx(ctx, p, now) {
+        if (p.speedBuffUntil != null && now < p.speedBuffUntil) {
+            var speed = Math.sqrt(p.velX * p.velX + p.velY * p.velY);
+            if (speed > 0.5) {
+                var dirA = Math.atan2(p.velY, p.velX);
+                ctx.save(); ctx.translate(p.x, p.y); ctx.rotate(dirA);
+                ctx.strokeStyle = "rgba(255,255,255,0.6)"; ctx.lineCap = "round"; ctx.lineWidth = 2;
+                var phase = (now / 60) % 12;
+                for (var i = 0; i < 3; i++) { var off = (i - 1) * p.radius * 0.7, back = p.radius + 4 + ((phase + i * 4) % 12);
+                    ctx.beginPath(); ctx.moveTo(-back, off); ctx.lineTo(-back - 10, off); ctx.stroke(); }
+                ctx.restore();
+            }
+        }
+        if (p.speedDebuffUntil != null && now < p.speedDebuffUntil) {
+            var rp = (now / 700) % 1;
+            ctx.save(); ctx.globalAlpha = (1 - rp) * 0.4; ctx.strokeStyle = "rgba(80,80,160,1)"; ctx.lineWidth = 2;
+            ctx.beginPath(); ctx.arc(p.x, p.y, p.radius + 2 + rp * 12, 0, 2 * Math.PI); ctx.stroke(); ctx.restore();
+        }
+    }
+
+    // ---- fire (PORT: draw.js SpriteSheet + drawFire/drawFlameColor) ----
+    // Frame index is derived from a shared wall-clock (below), NOT a per-instance
+    // accumulator: the sheets are module singletons shared by every fire card, so
+    // a per-instance update(dt) called once per visible card would advance the
+    // frame N× per tick (chatter). A clock-based index is idempotent across cards.
+    var FIRE_FRAMES = 4, FIRE_FRAME_MS = 1000 / 24;
+    function SpriteSheet(image, frameW, frameH, rows) {
+        this.image = image; this.frameW = frameW; this.frameH = frameH; this.rows = rows;
+    }
+    SpriteSheet.prototype.draw = function (ctx, frameIdx, w, h) {
+        if (!ready(this.image)) { return; }
+        ctx.drawImage(this.image, 0, frameIdx * this.frameH, this.frameW, this.frameH, -w / 2, -h / 2, w, h);
+    };
+    var FIRE_FILES = ["redFire.png", "orangeFire.png", "yellowFire.png", "greenFire.png", "blueFire.png", "purpleFire.png"];
+    var fireSheets = {};
+    function fireSheet(idx) {
+        var f = FIRE_FILES[idx];
+        if (!fireSheets[f]) { fireSheets[f] = new SpriteSheet(img(f), 32, 32, 4); }
+        return fireSheets[f];
+    }
+    // In-game (draw.js) the flame is drawn at 55px for the 7.5px player radius and
+    // offset 5px to the trailing edge — keep those RATIOS so the flame scales with
+    // our larger codex kart instead of looking shrunken.
+    var FLAME_RATIO = 55 / 7.5;       // ≈ 7.33
+    var FLAME_OFFSET = 5 / 7.5;       // ≈ 0.67
+    function drawFlame(ctx, p) {
+        var ms = p.onFire;
+        var idx = ms < 1000 ? 0 : ms < 2000 ? 1 : ms < 3000 ? 2 : ms < 4000 ? 3 : ms < 5000 ? 4 : 5;
+        var sh = fireSheet(idx); if (!ready(sh.image)) { return; }
+        var frame = Math.floor(performance.now() / FIRE_FRAME_MS) % FIRE_FRAMES;  // shared clock
+        var size = p.radius * FLAME_RATIO;
+        ctx.save();
+        var ar = p.angle * (Math.PI / 180);
+        ctx.translate(p.x - p.radius * FLAME_OFFSET * Math.cos(ar), p.y - p.radius * FLAME_OFFSET * Math.sin(ar));
+        ctx.rotate((p.angle - 90) * (Math.PI / 180));
+        sh.draw(ctx, frame, size, size);
+        ctx.restore();
+    }
+
+    // ---- floor + kart + tile primitives ----
+    var TILE_FALLBACK = { "dirt.png": "#6b5640", "grass.png": "#4f9e57", "sand.png": "#c9b483", "ice.png": "#bfe9f0", "lava.png": "#cf1020" };
+    function floor(ctx, file, tile) {
+        var im = img(file);
+        if (ready(im)) { for (var y = 0; y < H; y += tile) { for (var x = 0; x < W; x += tile) { ctx.drawImage(im, x, y, tile, tile); } } }
+        else { ctx.fillStyle = TILE_FALLBACK[file] || "#555"; ctx.fillRect(0, 0, W, H); }
+    }
+    // PORT (look): getPlayerSprite — glossy procedural disc.
+    function kart(ctx, x, y, r, color, opts) {
+        opts = opts || {};
+        ctx.save();
+        ctx.beginPath(); ctx.arc(x, y, r, 0, 2 * Math.PI);
+        ctx.fillStyle = color; ctx.shadowColor = color; ctx.shadowBlur = 4; ctx.fill(); ctx.shadowBlur = 0;
+        var g = ctx.createRadialGradient(x - r * 0.34, y - r * 0.42, r * 0.1, x, y, r);
+        g.addColorStop(0, "rgba(255,255,255,0.6)"); g.addColorStop(0.5, "rgba(255,255,255,0)"); g.addColorStop(1, "rgba(0,0,0,0.35)");
+        ctx.fillStyle = g; ctx.beginPath(); ctx.arc(x, y, r, 0, 2 * Math.PI); ctx.fill();
+        ctx.lineWidth = Math.max(1, r * 0.18); ctx.strokeStyle = opts.outline || "#141414";
+        ctx.beginPath(); ctx.arc(x, y, r, 0, 2 * Math.PI); ctx.stroke();
+        ctx.restore();
+    }
+    // Infected kart (PORT look: draw.js drawPlayer infected branch) — a red disc
+    // with the biohazard mark and a green outline, the game's infection artwork.
+    function infectedKart(ctx, x, y, r) {
+        ctx.save();
+        ctx.beginPath(); ctx.arc(x, y, r, 0, 2 * Math.PI); ctx.fillStyle = "#c0231b"; ctx.fill();
+        var bio = img("biohazard-solid.svg");
+        if (ready(bio)) { var sz = r * 1.5; ctx.drawImage(bio, x - sz / 2, y - sz / 2, sz, sz); }
+        ctx.lineWidth = 2; ctx.strokeStyle = "green"; ctx.beginPath(); ctx.arc(x, y, r, 0, 2 * Math.PI); ctx.stroke();
+        ctx.restore();
+    }
+    function bumper(ctx, x, y, r) {
+        ctx.save();
+        ctx.beginPath(); ctx.arc(x, y, r * 1.6, 0, 2 * Math.PI); ctx.strokeStyle = "#E5392B"; ctx.lineWidth = 3; ctx.stroke();
+        ctx.beginPath(); ctx.arc(x, y, r, 0, 2 * Math.PI); ctx.fillStyle = "orange"; ctx.fill();
+        ctx.restore();
+    }
+    function goalZone(ctx, x, y, w, h) {
+        ctx.save(); ctx.fillStyle = "#FFCB30"; ctx.strokeStyle = "#756300"; ctx.lineWidth = 4;
+        ctx.fillRect(x, y, w, h); ctx.strokeRect(x, y, w, h); ctx.restore();
+    }
+    function pad(ctx, x, y, r, iconFile, dim) {
+        ctx.save(); var d = img("dirt.png");
+        ctx.beginPath(); ctx.arc(x, y, r, 0, 2 * Math.PI); ctx.clip();
+        if (ready(d)) { ctx.drawImage(d, x - r, y - r, r * 2, r * 2); } else { ctx.fillStyle = "#6b5640"; ctx.fillRect(x - r, y - r, r * 2, r * 2); }
+        ctx.restore();
+        ctx.save(); ctx.beginPath(); ctx.arc(x, y, r, 0, 2 * Math.PI); ctx.strokeStyle = "#cfcfcf"; ctx.lineWidth = 2; ctx.stroke();
+        var ic = iconFile && img(iconFile);
+        if (ic && ready(ic)) { ctx.globalAlpha = dim ? 0.25 : 1; var s = r * 1.1; ctx.drawImage(ic, x - s / 2, y - s / 2, s, s); }
+        ctx.restore();
+    }
+
+    // ---- helper: move a fake kart and set velocity for the dust thresholds ----
+    // velMag drives the particle thresholds (vs MAXSPEED); visSpeed is how fast it
+    // visibly crosses the canvas (decoupled so cards read at a calm pace).
+    function drive(p, dirX, dirY, velMag, visSpeed, dt) {
+        p.velX = dirX * velMag; p.velY = dirY * velMag;
+        p.angle = Math.atan2(dirY, dirX) * 180 / Math.PI;
+        p.x += dirX * visSpeed * dt / 1000; p.y += dirY * visSpeed * dt / 1000;
+    }
+
+    var env = { W: W, H: H, img: img, ready: ready, loop: loop, lerp: lerp, ease: ease, ping: ping, clamp: clamp,
+        floor: floor, kart: kart, bumper: bumper, goalZone: goalZone, pad: pad, drive: drive, drawFlame: drawFlame,
+        drawSpeedFx: drawSpeedFx, updateMovementParticles: updateMovementParticles,
+        spawnPunchEffect: spawnPunchEffect, spawnHitEffect: spawnHitEffect, spawnTeleportPuff: spawnTeleportPuff,
+        spawnSlashEffect: spawnSlashEffect, spawnExplosion: spawnExplosion, spawnScreenFlash: spawnScreenFlash,
+        spawnMuzzleFlash: spawnMuzzleFlash,
+        BLUE: BLUE, RED: RED, GREEN: GREEN, YELLOW: YELLOW, PURPLE: PURPLE };
+
+    // Fire a one-shot spawn once per loop cycle. `key` namespaces each spawn so a
+    // scene can schedule several (e.g. bomb's muzzle + explosion) without them
+    // clobbering each other's last-cycle marker. `t` may be offset to fire mid-cycle.
+    function onCycle(mem, t, period, key, fn) {
+        var c = Math.floor(t / period), k = "_c_" + key;
+        // Baseline on the first sighting (e.g. the t=0 attach frame, where a
+        // negative offset gives c=-1) WITHOUT firing — otherwise a punch/bomb/
+        // explosion burst pops at scene start before the karts are in position.
+        // The next real cycle crossing fires at the intended beat.
+        if (mem[k] === undefined) { mem[k] = c; return; }
+        if (mem[k] !== c) { mem[k] = c; fn(); }
+    }
+
+    // ========================= SCENES =========================
+    // s = { ctx, t, dt, mem, opts, p }. Background already cleared. Effects in
+    // s' card list are advanced + drawn ON TOP after the scene returns.
+
+    function terrain(surface, file, tile, velMag, visSpeed, wobble) {
+        return function (s) {
+            floor(s.ctx, file, tile);
+            var p = s.p; p.surface = surface; p.radius = 12; p.alive = true;
+            var span = W + 60;
+            // wrap horizontally
+            if (p.x == null || p.x > W + 30) { p.x = -30; p.y = H / 2; }
+            drive(p, 1, 0, velMag, visSpeed, s.dt);
+            if (wobble) { p.y = H / 2 + Math.sin(s.t / 180) * 16; p.velY = Math.cos(s.t / 180) * velMag * 0.5; }
+            updateMovementParticles(p, s.dt);
+            kart(s.ctx, p.x, p.y, p.radius, BLUE);
+        };
+    }
+    SCENES["terrainNormal"] = terrain("normal", "dirt.png", 60, MAXSPEED * 0.62, 95, false);
+    SCENES["terrainFast"] = terrain("fast", "grass.png", 70, MAXSPEED * 0.72, 120, false);
+    SCENES["terrainSlow"] = terrain("slow", "sand.png", 60, MAXSPEED * 0.22, 42, false);
+    SCENES["terrainIce"] = terrain("ice", "ice.png", 80, MAXSPEED * 0.72, 115, true);
+
+    SCENES["lavaBurn"] = function (s) {
+        floor(s.ctx, "lava.png", 80);
+        var p = s.p; p.radius = 12; p.alive = true; p.surface = "normal";
+        if (p.x == null || p.x > W * 0.7) { p.x = -22; p.y = H / 2; p.onFire = 0; }
+        drive(p, 1, 0, MAXSPEED * 0.5, 70, s.dt);
+        if (p.x > W * 0.4) { p.onFire = 4000; }       // ignite mid-screen
+        updateMovementParticles(p, s.dt);
+        // flame BEHIND the kart, matching draw.js drawPlayer (drawFire before sprite)
+        if (p.onFire > 0) { drawFlame(s.ctx, p); }
+        kart(s.ctx, p.x, p.y, p.radius, BLUE);
+    };
+
+    // The collapse: lava floods in from all edges; a lava-red shockwave ring
+    // (PORT: draw.js drawCollapseShockwaves) pulses out; the kart scrambles for
+    // the shrinking centre.
+    SCENES["collapse"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var inset = lerp(0, 50, ease(ping(s.t, 5000)));
+        var lv = img("lava.png");
+        s.ctx.save();
+        var pat = ready(lv) ? s.ctx.createPattern(lv, "repeat") : null;
+        s.ctx.fillStyle = pat || "#cf1020";
+        s.ctx.fillRect(0, 0, W, inset); s.ctx.fillRect(0, H - inset, W, inset);
+        s.ctx.fillRect(0, 0, inset, H); s.ctx.fillRect(W - inset, 0, inset, H);
+        s.ctx.strokeStyle = "#7a1500"; s.ctx.lineWidth = 3; s.ctx.strokeRect(inset, inset, W - inset * 2, H - inset * 2);
+        s.ctx.restore();
+        var sw = loop(s.t, 1600);                       // expanding shockwave ring
+        s.ctx.save(); s.ctx.globalAlpha = 0.6 * (1 - sw); s.ctx.strokeStyle = "#cf1020"; s.ctx.lineWidth = 6;
+        s.ctx.beginPath(); s.ctx.arc(W / 2, H / 2, sw * 90, 0, 2 * Math.PI); s.ctx.stroke(); s.ctx.restore();
+        var safeW = Math.max(8, (W / 2 - inset) - 18), safeH = Math.max(6, (H / 2 - inset) - 14);
+        kart(s.ctx, W / 2 + Math.cos(s.t / 420) * safeW, H / 2 + Math.sin(s.t / 320) * safeH, 12, BLUE);
+    };
+
+    SCENES["fire"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var p = s.p; p.radius = 12; p.alive = true; p.surface = "normal";
+        if (p.x == null || p.x > W + 30) { p.x = -30; p.y = H / 2; }
+        drive(p, 1, 0, MAXSPEED * 0.45, 70, s.dt);
+        p.onFire = 500 + loop(s.t, 6000) * 5200;       // escalate red→purple
+        updateMovementParticles(p, s.dt);
+        drawFlame(s.ctx, p);                      // flame behind, kart on top (matches game)
+        kart(s.ctx, p.x, p.y, p.radius, BLUE);
+    };
+
+    SCENES["goalRun"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        goalZone(s.ctx, W - 46, 18, 34, H - 36);
+        var p = s.p; p.radius = 12; p.surface = "normal"; p.alive = true;
+        if (p.x == null || p.x > W - 30) { p.x = -20; p.y = H / 2; }
+        drive(p, 1, 0, MAXSPEED * 0.62, 95, s.dt);
+        updateMovementParticles(p, s.dt);
+        kart(s.ctx, p.x, p.y, p.radius, BLUE);
+    };
+
+    SCENES["pickup"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var p = s.p; p.radius = 12; p.surface = "normal"; p.alive = true;
+        var ph = loop(s.t, 3000), grabbed = ph > 0.5;
+        pad(s.ctx, W / 2, H / 2, 18, "bomb.svg", grabbed);
+        if (p.x == null || p.x > W + 20) { p.x = -20; p.y = H / 2; }
+        drive(p, 1, 0, MAXSPEED * 0.45, 80, s.dt);
+        updateMovementParticles(p, s.dt);
+        onCycle(s.mem, s.t, 3000, "grab", function () { spawnTeleportPuff(W / 2, H / 2, "#ffffff"); });
+        kart(s.ctx, p.x, p.y, p.radius, BLUE);
+    };
+
+    SCENES["bumper"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var bx = W * 0.66, by = H / 2, p = s.p; p.radius = 11; p.surface = "normal"; p.alive = true;
+        var ph = ping(s.t, 2400), x = lerp(-20, bx - 26, ease(ph));
+        p.velX = (ph < 0.5 ? 1 : -1) * MAXSPEED * 0.5; p.velY = 0; p.angle = ph < 0.5 ? 0 : 180;
+        p.x = x; p.y = by;
+        updateMovementParticles(p, s.dt);
+        kart(s.ctx, x, by, p.radius, BLUE);
+        bumper(s.ctx, bx, by, 11);
+        // fire the knockback burst at the bounce apex (ping peaks at t%2400 ≈ 1200)
+        onCycle(s.mem, s.t - 1200, 2400, "bounce", function () { spawnPunchEffect(bx - 16, by, 14, "#E5392B", 180); });
+    };
+
+    SCENES["randomTile"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var tiles = ["grass.png", "ice.png", "sand.png"], which = Math.floor(s.t / 700) % tiles.length;
+        var px = W / 2 - 28, py = H / 2 - 24, pw = 56, ph = 48, im = img(tiles[which]);
+        s.ctx.save(); s.ctx.beginPath(); s.ctx.rect(px, py, pw, ph); s.ctx.clip();
+        if (ready(im)) { s.ctx.drawImage(im, px, py, pw, ph); } else { s.ctx.fillStyle = "#888"; s.ctx.fillRect(px, py, pw, ph); }
+        s.ctx.restore();
+        s.ctx.save(); s.ctx.strokeStyle = "#7c3aed"; s.ctx.lineWidth = 3; s.ctx.strokeRect(px, py, pw, ph);
+        s.ctx.fillStyle = "#7c3aed"; s.ctx.font = "bold 22px sans-serif"; s.ctx.textAlign = "center"; s.ctx.textBaseline = "middle";
+        s.ctx.globalAlpha = 0.85; s.ctx.fillText("?", W / 2, H / 2); s.ctx.restore();
+    };
+
+    SCENES["punch"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var ph = loop(s.t, 2400), hit = ease(clamp(ph / 0.5, 0, 1));
+        var rx = lerp(W * 0.12, W * 0.44, hit), contact = ph >= 0.5;
+        var bx = W * 0.56 + (contact ? ease(clamp((ph - 0.5) / 0.4, 0, 1)) * 38 : 0);
+        kart(s.ctx, rx, H / 2, 12, RED); kart(s.ctx, bx, H / 2, 12, BLUE);
+        onCycle(s.mem, s.t - 1200, 2400, "punch", function () {
+            spawnPunchEffect(W * 0.5, H / 2, 14, RED, 0); spawnHitEffect(W * 0.5, H / 2, "#fff");
+        });
+    };
+
+    SCENES["swap"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var ph = loop(s.t, 3000), ax = W * 0.25, bx = W * 0.75, y = H / 2;
+        var sMove = ph > 0.45 ? ease(clamp((ph - 0.45) / 0.4, 0, 1)) : 0;
+        var x1 = lerp(ax, bx, sMove), x2 = lerp(bx, ax, sMove);
+        if (ph < 0.5) { var rr = 8 + ease(loop(s.t, 1500)) * 18; s.ctx.save(); s.ctx.globalAlpha = 0.6; s.ctx.strokeStyle = RED; s.ctx.lineWidth = 2; s.ctx.beginPath(); s.ctx.arc(ax, y, rr, 0, 2 * Math.PI); s.ctx.stroke(); s.ctx.restore(); }
+        onCycle(s.mem, s.t - 1350, 3000, "swap", function () { spawnTeleportPuff(ax, y, BLUE); spawnTeleportPuff(bx, y, RED); });
+        kart(s.ctx, x1, y, 12, BLUE); kart(s.ctx, x2, y, 12, RED);
+    };
+
+    SCENES["bomb"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var ph = loop(s.t, 3200), land = 0.5, bxp = W * 0.6, byp = H / 2;
+        // After the blast the ground there is scorched into SLOW SAND (game:
+        // explodeBomb sets cells to tileMap.slow). Bloom a sand patch post-explosion.
+        if (ph >= land) {
+            var se = clamp((ph - land) / 0.25, 0, 1), rr = ease(se) * 34, sand = img("sand.png");
+            s.ctx.save(); s.ctx.beginPath(); s.ctx.arc(bxp, byp, rr, 0, 2 * Math.PI); s.ctx.clip();
+            if (ready(sand)) { s.ctx.drawImage(sand, bxp - rr, byp - rr, rr * 2, rr * 2); } else { s.ctx.fillStyle = "#c9b483"; s.ctx.fillRect(bxp - rr, byp - rr, rr * 2, rr * 2); }
+            s.ctx.restore();
+        }
+        if (ph < land) { var pp = ph / land, x = lerp(20, bxp, pp), y = lerp(H * 0.6, byp, pp) - Math.sin(pp * Math.PI) * 50;
+            var bi = img("bomb.svg");                   // the real bomb art (draw.js bombImage)
+            if (ready(bi)) { s.ctx.save(); s.ctx.translate(x, y); s.ctx.rotate(s.t / 200); var bs = 20; s.ctx.drawImage(bi, -bs / 2, -bs / 2, bs, bs); s.ctx.restore(); }
+            else { s.ctx.fillStyle = "#222"; s.ctx.beginPath(); s.ctx.arc(x, y, 7, 0, 2 * Math.PI); s.ctx.fill(); }
+            onCycle(s.mem, s.t, 3200, "fire", function () { spawnMuzzleFlash(20, H * 0.6, -60, "#ffd23a"); });
+        } else { var e = (ph - land) / (1 - land); kart(s.ctx, lerp(bxp + 6, bxp + 40, ease(e)), byp, 11, RED);
+            onCycle(s.mem, s.t - 1600, 3200, "boom", function () { spawnExplosion(bxp, byp, 60, "#ff7a18"); }); }
+        kart(s.ctx, bxp, byp, 12, BLUE);
+    };
+
+    SCENES["speedBurst"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var p = s.p; p.radius = 12; p.surface = "normal"; p.alive = true; p.speedBuffUntil = 1e15;
+        if (p.x == null || p.x > W + 30) { p.x = -30; p.y = H / 2; }
+        drive(p, 1, 0, MAXSPEED * 0.9, 150, s.dt);
+        updateMovementParticles(p, s.dt);
+        drawSpeedFx(s.ctx, p, s.t);
+        kart(s.ctx, p.x, p.y, p.radius, BLUE);
+    };
+
+    SCENES["slowdown"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var fast = loop(s.t, 1500), slow = loop(s.t, 5200);
+        kart(s.ctx, lerp(-20, W + 20, fast), H * 0.32, 12, BLUE);
+        var a = { x: lerp(-20, W + 20, slow), y: H * 0.6, radius: 11, velX: MAXSPEED * 0.2, velY: 0, speedDebuffUntil: 1e15 };
+        var b = { x: lerp(-60, W - 20, slow), y: H * 0.82, radius: 11, velX: MAXSPEED * 0.2, velY: 0, speedDebuffUntil: 1e15 };
+        drawSpeedFx(s.ctx, a, s.t); drawSpeedFx(s.ctx, b, s.t);
+        kart(s.ctx, a.x, a.y, 11, RED); kart(s.ctx, b.x, b.y, 11, GREEN);
+    };
+
+    SCENES["tileSwap"] = function (s) {
+        var ph = ping(s.t, 3400), a = img("grass.png"), b = img("ice.png");
+        function half(im, x, alpha) { s.ctx.save(); s.ctx.globalAlpha = alpha; s.ctx.beginPath(); s.ctx.rect(x, 0, W / 2, H); s.ctx.clip();
+            if (ready(im)) { for (var yy = 0; yy < H; yy += 70) { for (var xx = x; xx < x + W / 2; xx += 70) { s.ctx.drawImage(im, xx, yy, 70, 70); } } } s.ctx.restore(); }
+        half(a, 0, 1 - ease(ph)); half(b, 0, ease(ph)); half(b, W / 2, 1 - ease(ph)); half(a, W / 2, ease(ph));
+        s.ctx.strokeStyle = "rgba(255,255,255,0.5)"; s.ctx.lineWidth = 1; s.ctx.beginPath(); s.ctx.moveTo(W / 2, 0); s.ctx.lineTo(W / 2, H); s.ctx.stroke();
+        kart(s.ctx, W / 2, H / 2, 12, BLUE);
+    };
+
+    SCENES["iceCannon"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var ph = loop(s.t, 3200), land = 0.4, lx = W * 0.66, ly = H / 2;
+        if (ph >= land) { var e = clamp((ph - land) / 0.3, 0, 1), rr = ease(e) * 30, ice = img("ice.png");
+            s.ctx.save(); s.ctx.beginPath(); s.ctx.arc(lx, ly, rr, 0, 2 * Math.PI); s.ctx.clip();
+            if (ready(ice)) { s.ctx.drawImage(ice, lx - rr, ly - rr, rr * 2, rr * 2); } else { s.ctx.fillStyle = "#bfe9f0"; s.ctx.fillRect(lx - rr, ly - rr, rr * 2, rr * 2); }
+            s.ctx.restore();
+            onCycle(s.mem, s.t - 1280, 3200, "ice", function () { spawnExplosion(lx, ly, 34, "#9fe8ff"); });
+        } else { var pp = ph / land, sx = lerp(W * 0.2 + 8, lx, pp); s.ctx.fillStyle = "#9fe8ff"; s.ctx.beginPath(); s.ctx.arc(sx, ly - Math.sin(pp * Math.PI) * 22, 5, 0, 2 * Math.PI); s.ctx.fill();
+            onCycle(s.mem, s.t, 3200, "fire", function () { spawnMuzzleFlash(W * 0.2 + 8, ly, 0, "#bfeaff"); }); }
+        kart(s.ctx, W * 0.2, ly, 12, BLUE);
+    };
+
+    SCENES["cut"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        // One slash line through the cutter; rivals are flung AWAY from that line
+        // (perpendicular), each to whichever side they were on.
+        var ph = loop(s.t, 2600), ang = 18 * Math.PI / 180, perp = ang + Math.PI / 2;
+        var push = ease(clamp((ph - 0.35) / 0.4, 0, 1)) * 40, cols = [RED, GREEN, YELLOW, PURPLE];
+        var along = [-36, 36, -14, 14], side = [1, 1, -1, -1];
+        for (var i = 0; i < 4; i++) {
+            var bx = W / 2 + Math.cos(ang) * along[i], by = H / 2 + Math.sin(ang) * along[i], d = (10 + push) * side[i];
+            kart(s.ctx, bx + Math.cos(perp) * d, by + Math.sin(perp) * d, 9, cols[i]);
+        }
+        onCycle(s.mem, s.t - 910, 2600, "cut", function () { spawnSlashEffect(W / 2, H / 2, 18, "#cfe"); });
+        kart(s.ctx, W / 2, H / 2, 12, BLUE);
+    };
+
+    SCENES["blindfold"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        kart(s.ctx, W * 0.3, H / 2, 11, RED); kart(s.ctx, W * 0.68, H * 0.6, 11, GREEN);
+        var ux = W * 0.5, uy = H / 2; kart(s.ctx, ux, uy, 12, BLUE);
+        var dark = ping(s.t, 3200);
+        s.ctx.save(); s.ctx.globalAlpha = ease(dark) * 0.92;
+        s.ctx.fillStyle = "#000"; s.ctx.fillRect(0, 0, W, H);
+        s.ctx.globalCompositeOperation = "destination-out";
+        var g = s.ctx.createRadialGradient(ux, uy, 14, ux, uy, 46); g.addColorStop(0, "rgba(0,0,0,1)"); g.addColorStop(1, "rgba(0,0,0,0)");
+        s.ctx.fillStyle = g; s.ctx.beginPath(); s.ctx.arc(ux, uy, 46, 0, 2 * Math.PI); s.ctx.fill(); s.ctx.restore();
+    };
+
+    SCENES["brutalIntro"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var icons = ["bolt-solid.svg", "cloud-solid.svg", "hockey-puck-solid.svg", "biohazard-solid.svg"], which = Math.floor(s.t / 800) % icons.length;
+        onCycle(s.mem, s.t, 1600, "flash", function () { spawnScreenFlash("#b3261e", 0.4, 600); });
+        var ic = img(icons[which]);
+        if (ready(ic)) { s.ctx.save(); s.ctx.fillStyle = "rgba(255,255,255,0.9)"; s.ctx.beginPath(); s.ctx.arc(W / 2, H / 2, 30, 0, 2 * Math.PI); s.ctx.fill(); s.ctx.drawImage(ic, W / 2 - 22, H / 2 - 22, 44, 44); s.ctx.restore(); }
+    };
+
+    // EVERY racer starts the round already holding an ability (game:
+    // applyBrutalAbilityRound gives each player one) — show karts with a held-
+    // ability badge, and a power going off now and then.
+    SCENES["abilityRain"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var icons = ["bomb.svg", "snowflake-solid.svg", "scissors-solid.svg"];
+        var spots = [{ x: W * 0.25, y: H * 0.58, c: BLUE }, { x: W * 0.52, y: H * 0.4, c: RED }, { x: W * 0.78, y: H * 0.62, c: GREEN }];
+        for (var i = 0; i < spots.length; i++) {
+            var sp = spots[i]; kart(s.ctx, sp.x, sp.y, 12, sp.c);
+            var ic = img(icons[i]), bob = Math.sin(s.t / 320 + i) * 3, by = sp.y - 24 + bob;
+            s.ctx.save(); s.ctx.fillStyle = "rgba(255,255,255,0.92)"; s.ctx.beginPath(); s.ctx.arc(sp.x, by, 11, 0, 2 * Math.PI); s.ctx.fill();
+            if (ready(ic)) { s.ctx.drawImage(ic, sp.x - 8, by - 8, 16, 16); } s.ctx.restore();
+        }
+        onCycle(s.mem, s.t, 1800, "fx", function () { spawnExplosion(W * 0.52, H * 0.4, 34, "#ff7a18"); });
+    };
+
+    SCENES["cloudy"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        kart(s.ctx, W * 0.4, H * 0.6, 11, BLUE); kart(s.ctx, W * 0.7, H * 0.4, 11, RED);
+        var cl = img("cloud.svg");                      // the real cloud art (draw.js cloudImage)
+        for (var i = 0; i < 3; i++) {
+            var x = lerp(-80, W + 80, loop(s.t + i * 1700, 6500)), y = 22 + i * 42, cw = 96, ch = 60;
+            if (ready(cl)) { s.ctx.save(); s.ctx.globalAlpha = 0.92; s.ctx.drawImage(cl, x - cw / 2, y - ch / 2, cw, ch); s.ctx.restore(); }
+            else { s.ctx.save(); s.ctx.fillStyle = "rgba(225,228,235,0.85)"; s.ctx.beginPath(); s.ctx.ellipse(x, y, 38, 18, 0, 0, 2 * Math.PI); s.ctx.fill(); s.ctx.restore(); }
+        }
+    };
+
+    SCENES["lightning"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        // EVERY racer is sped up (game: applyBrutalLightningRound gives all a big
+        // speed bonus) — show the whole field tearing across with streaks.
+        var lanes = [{ y: H * 0.3, c: BLUE, sp: 200 }, { y: H * 0.55, c: RED, sp: 230 }, { y: H * 0.8, c: GREEN, sp: 180 }];
+        for (var i = 0; i < lanes.length; i++) {
+            var x = lerp(-20, W + 20, loop(s.t + i * 700, 1100));
+            s.ctx.save(); s.ctx.strokeStyle = "rgba(255,255,255,0.6)"; s.ctx.lineCap = "round"; s.ctx.lineWidth = 2;
+            for (var k = 1; k <= 4; k++) { s.ctx.globalAlpha = 0.5 / k; s.ctx.beginPath(); s.ctx.moveTo(x - 12, lanes[i].y); s.ctx.lineTo(x - 12 - k * 11, lanes[i].y); s.ctx.stroke(); }
+            s.ctx.restore();
+            kart(s.ctx, x, lanes[i].y, 11, lanes[i].c);
+        }
+        onCycle(s.mem, s.t, 1800, "bolt", function () { spawnScreenFlash("#ffffff", 0.5, 180); });
+        s.ctx.save(); s.ctx.strokeStyle = "#ffe23a"; s.ctx.lineWidth = 2; s.ctx.globalAlpha = loop(s.t, 1800) < 0.12 ? 1 : 0;
+        s.ctx.beginPath(); s.ctx.moveTo(W * 0.5, 0); s.ctx.lineTo(W * 0.44, 40); s.ctx.lineTo(W * 0.54, 60); s.ctx.lineTo(W * 0.46, H); s.ctx.stroke(); s.ctx.restore();
+    };
+
+    SCENES["volcano"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var ph = loop(s.t, 3600), cx = W / 2, cy = H / 2;
+        if (ph < 0.45) { var rr = 6 + ease(ph / 0.45) * 26; s.ctx.save(); s.ctx.globalAlpha = 0.8; s.ctx.strokeStyle = "#ff8a3a"; s.ctx.lineWidth = 2; s.ctx.beginPath(); s.ctx.arc(cx, cy, rr, 0, 2 * Math.PI); s.ctx.stroke(); s.ctx.restore(); }
+        onCycle(s.mem, s.t - 1620, 3600, "erupt", function () { spawnExplosion(cx, cy, 70, "#cf1020"); });
+    };
+
+    SCENES["infection"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var ph = loop(s.t, 4000), carrierX = lerp(W * 0.1, W * 0.9, ph);
+        var spots = [{ x: W * 0.35, y: H * 0.4 }, { x: W * 0.6, y: H * 0.65 }, { x: W * 0.8, y: H * 0.4 }];
+        for (var i = 0; i < spots.length; i++) { var turned = carrierX > spots[i].x; if (turned) { infectedKart(s.ctx, spots[i].x, spots[i].y, 12); } else { kart(s.ctx, spots[i].x, spots[i].y, 11, BLUE); } }
+        infectedKart(s.ctx, carrierX, H * 0.55, 12);
+    };
+
+    SCENES["hockey"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var px = 20 + Math.abs(((s.t / 4) % (2 * (W - 40))) - (W - 40));
+        var py = 18 + Math.abs(((s.t / 3.1) % (2 * (H - 36))) - (H - 36));
+        kart(s.ctx, W * 0.5, H * 0.5, 11, BLUE);
+        s.ctx.save(); s.ctx.fillStyle = "#111"; s.ctx.beginPath(); s.ctx.arc(px, py, 8, 0, 2 * Math.PI); s.ctx.fill(); s.ctx.strokeStyle = "rgba(255,255,255,0.6)"; s.ctx.lineWidth = 1; s.ctx.stroke(); s.ctx.restore();
+    };
+
+    SCENES["explosive"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        var ph = loop(s.t, 3000), cx = W / 2, cy = H / 2;
+        // after the blast the crater is LAVA (game: explodeLava turns cells to lava on death)
+        if (ph >= 0.45) {
+            var le = clamp((ph - 0.45) / 0.25, 0, 1), lr = ease(le) * 40, lv = img("lava.png");
+            s.ctx.save(); s.ctx.beginPath(); s.ctx.arc(cx, cy, lr, 0, 2 * Math.PI); s.ctx.clip();
+            if (ready(lv)) { s.ctx.drawImage(lv, cx - lr, cy - lr, lr * 2, lr * 2); } else { s.ctx.fillStyle = "#cf1020"; s.ctx.fillRect(cx - lr, cy - lr, lr * 2, lr * 2); }
+            s.ctx.restore();
+            s.ctx.save(); s.ctx.strokeStyle = "#7a1500"; s.ctx.lineWidth = 2; s.ctx.beginPath(); s.ctx.arc(cx, cy, lr, 0, 2 * Math.PI); s.ctx.stroke(); s.ctx.restore();
+        }
+        if (ph < 0.45) { var rr = 6 + ease(ph / 0.45) * 20; s.ctx.save(); s.ctx.globalAlpha = 0.85; s.ctx.strokeStyle = "#ff5b3a"; s.ctx.lineWidth = 2; s.ctx.beginPath(); s.ctx.arc(cx, cy, rr, 0, 2 * Math.PI); s.ctx.stroke(); s.ctx.restore(); kart(s.ctx, cx, cy, 11, RED); }
+        else { var e = (ph - 0.45) / 0.55, sp = ease(clamp(e, 0, 1)) * 44; kart(s.ctx, cx - 18 - sp, cy - 8, 10, BLUE); kart(s.ctx, cx + 18 + sp, cy + 8, 10, GREEN); }
+        onCycle(s.mem, s.t - 1350, 3000, "boom", function () { spawnExplosion(cx, cy, 60, "#ff7a18"); });
+    };
+
+    SCENES["blackout"] = function (s) {
+        floor(s.ctx, "dirt.png", 60);
+        goalZone(s.ctx, W - 40, 30, 26, H - 60);
+        var ux = lerp(W * 0.15, W * 0.7, ping(s.t, 4000)), uy = H / 2;
+        kart(s.ctx, W * 0.5, H * 0.3, 10, RED); kart(s.ctx, ux, uy, 12, BLUE);
+        s.ctx.save(); s.ctx.fillStyle = "rgba(0,0,0,0.93)"; s.ctx.fillRect(0, 0, W, H);
+        s.ctx.globalCompositeOperation = "destination-out";
+        var g = s.ctx.createRadialGradient(ux, uy, 8, ux, uy, 40); g.addColorStop(0, "rgba(0,0,0,1)"); g.addColorStop(1, "rgba(0,0,0,0)");
+        s.ctx.fillStyle = g; s.ctx.beginPath(); s.ctx.arc(ux, uy, 40, 0, 2 * Math.PI); s.ctx.fill(); s.ctx.restore();
+    };
+
+    SCENES["medalShine"] = function (s) {
+        var ctx = s.ctx;
+        var grd = ctx.createLinearGradient(0, 0, W, H); grd.addColorStop(0, "rgba(255,255,255,0.06)"); grd.addColorStop(1, "rgba(255,255,255,0)");
+        ctx.fillStyle = grd; ctx.fillRect(0, 0, W, H);
+        var glyph = (s.opts && s.opts.glyph) || "🏅", pulse = 1 + ping(s.t, 2200) * 0.08;
+        ctx.font = Math.round(56 * pulse) + "px sans-serif"; ctx.textAlign = "center"; ctx.textBaseline = "middle";
+        ctx.fillText(glyph, W / 2, H / 2 + 2);
+        var sx = lerp(-30, W + 30, loop(s.t, 2600)); var sg = ctx.createLinearGradient(sx - 30, 0, sx + 30, 0);
+        sg.addColorStop(0, "rgba(255,255,255,0)"); sg.addColorStop(0.5, "rgba(255,255,255,0.35)"); sg.addColorStop(1, "rgba(255,255,255,0)");
+        ctx.fillStyle = sg; ctx.fillRect(sx - 30, 0, 60, H);
+        for (var i = 0; i < 4; i++) { var a = ping(s.t + i * 500, 2000); ctx.globalAlpha = a; ctx.fillStyle = "#ffe9a8";
+            ctx.beginPath(); ctx.arc(W / 2 + Math.cos(i * 1.7) * 46, H / 2 + Math.sin(i * 2.3) * 34, 2 + a * 2, 0, 2 * Math.PI); ctx.fill(); ctx.globalAlpha = 1; }
+    };
+
+    SCENES["_blank"] = function (s) { floor(s.ctx, "dirt.png", 60); };
+
+    // ========================= engine =========================
+    var items = [];   // { canvas, ctx, scene, opts, fx, p, mem, t, last, visible }
+    var rafId = null;
+
+    function drawItem(it, ts) {
+        if (!it.last) { it.last = ts; }
+        var dt = clamp(ts - it.last, 0, 50); it.last = ts; it.t += dt;
+        _fx = it.fx;
+        var ctx = it.ctx;
+        ctx.clearRect(0, 0, W, H);
+        // save/restore isolates any canvas state a scene leaves (globalAlpha, font,
+        // a stray transform) from the effects layer and the next frame.
+        ctx.save();
+        try { it.scene({ ctx: ctx, t: it.t, dt: dt, mem: it.mem, opts: it.opts, p: it.p }); } catch (err) { /* one bad scene must not kill the loop */ }
+        ctx.restore();
+        try { updateFX(it.fx, dt); drawFX(it.fx, ctx); } catch (err2) { /* */ }
+        _fx = null;
+    }
+    // Reduced-motion draws each card only once (no rAF), so a texture/flame/icon
+    // that decodes AFTER that single draw would never appear. Redraw visible cards
+    // when an image finishes loading to fill them in.
+    function redrawVisibleStatic() {
+        if (!reduceMotion) { return; }
+        for (var i = 0; i < items.length; i++) { if (items[i].visible) { drawItem(items[i], performance.now()); } }
+    }
+    function frame(ts) {
+        rafId = null; var any = false;
+        for (var i = 0; i < items.length; i++) { if (!items[i].visible) { continue; } any = true; drawItem(items[i], ts); }
+        if (any && !reduceMotion) { rafId = requestAnimationFrame(frame); }
+    }
+    function ensureLoop() { if (rafId == null) { rafId = requestAnimationFrame(frame); } }
+    function find(canvas) { for (var i = 0; i < items.length; i++) { if (items[i].canvas === canvas) { return items[i]; } } return null; }
+
+    var io = window.IntersectionObserver ? new IntersectionObserver(function (entries) {
+        for (var i = 0; i < entries.length; i++) {
+            var it = find(entries[i].target); if (!it) { continue; }
+            it.visible = entries[i].isIntersecting;
+            if (it.visible) { if (reduceMotion) { it.last = 0; drawItem(it, performance.now()); } else { ensureLoop(); } }
+        }
+    }, { root: null, threshold: 0.05 }) : null;
+
+    function attach(canvas, sceneName, opts) {
+        if (!canvas) { return; }
+        var scene = SCENES[sceneName] || SCENES["_blank"];
+        var dpr = Math.min(2, window.devicePixelRatio || 1);
+        canvas.width = Math.round(W * dpr); canvas.height = Math.round(H * dpr);
+        var ctx = canvas.getContext("2d"); ctx.scale(dpr, dpr);
+        var it = { canvas: canvas, ctx: ctx, scene: scene, opts: opts || {}, fx: makeFX(), p: { radius: 12, alive: true }, mem: {}, t: 0, last: 0, visible: false };
+        items.push(it);
+        drawItem(it, performance.now());          // one frame so it's never blank
+        if (io) { io.observe(canvas); } else { it.visible = true; if (!reduceMotion) { ensureLoop(); } }
+    }
+
+    function staticIcon(canvas, name) {
+        if (!canvas) { return; }
+        var dpr = Math.min(2, window.devicePixelRatio || 1), size = 40;
+        canvas.width = Math.round(size * dpr); canvas.height = Math.round(size * dpr);
+        var ctx = canvas.getContext("2d"); ctx.scale(dpr, dpr); ctx.clearRect(0, 0, size, size);
+        var c = size / 2;
+        if (name === "bumper") {
+            ctx.beginPath(); ctx.arc(c, c, 15, 0, 2 * Math.PI); ctx.strokeStyle = "#E5392B"; ctx.lineWidth = 3; ctx.stroke();
+            ctx.beginPath(); ctx.arc(c, c, 9, 0, 2 * Math.PI); ctx.fillStyle = "orange"; ctx.fill();
+        }
+    }
+
+    return { attach: attach, staticIcon: staticIcon, SCENES: SCENES, W: W, H: H };
+})();


### PR DESCRIPTION
## What

Adds a **Learn** button to the landing page that opens `learn.html` — an in-game **Codex**: a responsive card grid documenting every mechanic, tile, ability, brutal round, and medal. Each card has a plain-English "how it works and feels" description (deliberately no numbers) plus a **live canvas animation** of that mechanic.

It also doubles as an **agent knowledge base**: the `CODEX` array in `learn.js` is the canonical plain-English description of game behaviour, with `// PORT:` / `KEEP IN SYNC` comments so it's updated alongside future mechanic changes.

## How it works

- **Card grid** (`learn.js`): responsive `auto-fill` grid (3 cols desktop / 2 iPad / 1 phone), grouped by category, with a **sticky search box + category-filter chips**. Deep-linkable (`#card-<id>`).
- **Live animations** (`learnScenes.js`): a small shared-rAF engine that **ports the game's real effects verbatim** from `draw.js` / `gameboard.js` — the glossy kart, the fire sprite sheet, terrain dust/skate-marks, and the real `spawnPunchEffect` / `spawnTeleportPuff` / `spawnSlashEffect` / `spawnExplosion` / `spawnScreenFlash` / `spawnMuzzleFlash` bursts — plus the real texture PNGs and bumper disc-and-ring. Each scene drives a fake kart through those code paths. Only on-screen cards animate (IntersectionObserver); honours `prefers-reduced-motion`; DPR capped.
- Mechanics are accurate to the engine: bomb leaves slow sand, cut flings racers perpendicular off the slash line, lightning speeds up every racer, infection uses the red biohazard artwork, explosive craters the floor to lava, the ability round starts everyone holding an ability. The punch entry matches the v0.13.0 punch rework.

## Scope / safety

- **Client-only** — no `server/` / `config.json` / `game.js` / `engine.js` changes.
- **Not bundled** — `learn.html` loads raw `<script>` tags like `index.html` (no `build.js` / prod-rewriter change needed).
- Controller-navigable (`data-gp-nav` + `osk.js` for search) and touch-compliant (≥44px targets); light/dark themed.
- Adds a player-facing CHANGELOG entry → **suggest the `release:minor` label**.

## Verification

- Browser-verified across all categories, light + dark, responsive 3/2/1, no console errors.
- `/code-review` (5 angles) run; fixed 5 issues: spurious first-frame effect (`onCycle` baseline), flame frame double-advance (clock-based), reduced-motion cold-cache blank cards, deep-link to a filtered-out card, and scene canvas-state isolation.

## Known follow-ups (not in this PR)

- The navbar **sign-in control** (from the auth feature that merged after this branch began) isn't wired into `learn.html` yet — the page predates it.
- CI `button-gate` / `button-lint` page lists don't include `learn.html`, so its controls aren't gated — worth adding.
- Pre-existing: `--card-shadow: var(--card-shadow)` is self-referential in the light `:root`, so light-theme cards have no drop shadow (affects all pages, not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)