### PR TITLE
Fix AI corner-freeze + improve ice navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- AI racers no longer sit frozen forever in a lava-walled corner. A bot that gets wedged with no way forward — most often boxed in near the starting edge — now commits straight toward the goal to break out instead of loitering in one spot for the whole race (it either threads back onto the track or goes down trying).
 
 ## v0.14.0 — 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
+### General
+
+- AI racers handle ice a lot better. They now slow down before sliding onto an icy stretch and look much farther ahead while on it, so they curve around lava instead of skating straight into it — they make it across slippery, lava-lined maps far more often than before.
+
 ### Bug fixes
 
 - AI racers no longer sit frozen forever in a lava-walled corner. A bot that gets wedged with no way forward — most often boxed in near the starting edge — now commits straight toward the goal to break out instead of loitering in one spot for the whole race (it either threads back onto the track or goes down trying).

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -48,7 +48,8 @@ var FEELER_BOXED_NEAR = 0.6;    // both-sides "boxed in" brakes only when lava i
 // farther ahead on ice (and allow more samples + a bigger cap so the long ray still
 // catches lava) so the perpendicular push starts curving the slide while there's room.
 var ICE_FEELER_MULT = 2.6;      // feeler reach/cap multiplier while on ice
-var ICE_FEELER_SAMPLES = 16;    // more ray samples on ice so the longer feeler doesn't step over lava
+var ICE_FEELER_SAMPLES = 24;    // ray samples on ice: keep ~13px spacing (=FEELER_STEP) over the
+                                // ~2.6x-longer feeler so a thin lava finger isn't stepped over
 // Pre-ice speed control: a kart can only brake on a GRIPPY tile (ice brake is 0.0001),
 // so the time to bleed speed for the ice is BEFORE crossing onto it. When grippy and ice
 // is imminent dead ahead, brake down to a controllable entry speed so the weak ice-steering
@@ -911,7 +912,10 @@ function steerBot(bot, ctx, dt) {
         // Final ladder rung: stuck (no real headway) past BEELINE_AFTER_MS regardless of
         // the soft/committed escape — it's sealed in. The steer below abandons the path
         // and beelines the nearest goal with avoidance off (thread out, or die clearing it).
-        beelining = (nowProbe - ai.headwayAt) >= BEELINE_AFTER_MS;
+        // Not during a collapse — there the no-path branch already flees toward the safe
+        // center (collapseLoc), which beats charging a goal tile with lava avoidance off
+        // into the advancing collapse front.
+        beelining = !ctx.collapsing && (nowProbe - ai.headwayAt) >= BEELINE_AFTER_MS;
     }
 
     // --- Re-path on a throttle (and immediately if we have no path) ---
@@ -995,10 +999,9 @@ function steerBot(bot, ctx, dt) {
         // No path AND stuck for BEELINE_AFTER_MS: it's sealed off (the goal is lava-walled
         // from here and a re-path will keep returning null). Don't keep holding — that's
         // exactly the off-terrain corner freeze where the bot never moves and never dies.
-        // Beeline the nearest goal with avoidance off (below) to thread out or die clearing it.
-        var ngz = nearestGoalPoint(bot.x, bot.y, ctx.goalTiles);
-        var gzx = ngz.x - bot.x, gzy = ngz.y - bot.y, gzm = mag(gzx, gzy) || 1;
-        desiredX = gzx / gzm; desiredY = gzy / gzm;
+        // The unconditional beeline override below points `desired` straight at the nearest
+        // goal (with avoidance off) to thread out or die clearing it; just don't fall into
+        // the hold/return branch here.
     } else {
         // No path and not collapsing: hold position (don't drive blindly). A walled
         // bot isn't "stuck at a pinch", so clear any charging escape and re-anchor

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -42,6 +42,19 @@ var FEELER_AVOID_STRENGTH = 3.0;// weight of the predictive feeler push (stronge
 var FEELER_STEP = 13;           // px between samples along a feeler (catch thin lava fingers)
 var FEELER_MAX_SAMPLES = 8;     // cap samples per feeler so isLavaAt cost stays bounded at high speed
 var FEELER_BOXED_NEAR = 0.6;    // both-sides "boxed in" brakes only when lava is this near (frac of side reach)
+// ICE: on a slippery tile a kart can barely brake (0.0001 vs 0.235) OR steer (accel 15
+// vs 300), so its stopping/steering distance balloons — a normal-length feeler spots the
+// lava far too late to curve the glide away, and the bot skates straight in. Look much
+// farther ahead on ice (and allow more samples + a bigger cap so the long ray still
+// catches lava) so the perpendicular push starts curving the slide while there's room.
+var ICE_FEELER_MULT = 2.6;      // feeler reach/cap multiplier while on ice
+var ICE_FEELER_SAMPLES = 16;    // more ray samples on ice so the longer feeler doesn't step over lava
+// Pre-ice speed control: a kart can only brake on a GRIPPY tile (ice brake is 0.0001),
+// so the time to bleed speed for the ice is BEFORE crossing onto it. When grippy and ice
+// is imminent dead ahead, brake down to a controllable entry speed so the weak ice-steering
+// can still follow the path across instead of skating straight off into the lava.
+var ICE_ENTRY_LOOKAHEAD = 46;   // px ahead (plus a speed term) to sniff for upcoming ice
+var ICE_ENTRY_SPEED = 42;       // px/s: target speed to be at or below when entering ice
 // Anti-stuck escape: in a tight/looping corridor (sidewinder) over-cautious
 // soft-field repulsion can stall a momentum car at a narrow gap — it crawls or
 // slowly orbits one spot ("line up at the 1px pinch and wait"). When a bot loiters
@@ -265,9 +278,8 @@ function lavaRepulsion(bot, lavaCells) {
     return { x: rx, y: ry };
 }
 
-// True if the Voronoi cell containing (x,y) — the nearest site — is lava. Used by
-// the predictive feelers to catch a momentum car about to slide off the path.
-function isLavaAt(ctx, x, y) {
+// Tile id of the Voronoi cell containing (x,y) — i.e. the nearest site's id.
+function nearestTileId(ctx, x, y) {
     var cells = ctx.map.cells;
     var best = Infinity, bestId = -1;
     for (var i = 0; i < cells.length; i++) {
@@ -277,8 +289,11 @@ function isLavaAt(ctx, x, y) {
         var d = dx * dx + dy * dy;
         if (d < best) { best = d; bestId = cells[i].id; }
     }
-    return bestId === ctx.lavaId;
+    return bestId;
 }
+// True if the cell containing (x,y) is lava. Used by the predictive feelers to catch a
+// momentum car about to slide off the path.
+function isLavaAt(ctx, x, y) { return nearestTileId(ctx, x, y) === ctx.lavaId; }
 
 function rotate(x, y, deg) {
     var r = deg * Math.PI / 180, cs = Math.cos(r), sn = Math.sin(r);
@@ -291,10 +306,11 @@ function rotate(x, y, deg) {
 // thin lava fingers narrower than the feeler (so the bot drove straight into them);
 // stepping along the ray catches them, and the fraction lets callers tell "lava
 // right here" from "lava far down the feeler".
-function rayLavaFrac(bot, ctx, dirX, dirY, reach) {
+function rayLavaFrac(bot, ctx, dirX, dirY, reach, maxSamples) {
     var steps = Math.ceil(reach / FEELER_STEP);
     if (steps < 1) { steps = 1; }
-    if (steps > FEELER_MAX_SAMPLES) { steps = FEELER_MAX_SAMPLES; }
+    var cap = maxSamples || FEELER_MAX_SAMPLES;
+    if (steps > cap) { steps = cap; }
     for (var i = 1; i <= steps; i++) {
         var t = i / steps;
         if (isLavaAt(ctx, bot.x + dirX * reach * t, bot.y + dirY * reach * t)) { return t; }
@@ -307,23 +323,27 @@ function rayLavaFrac(bot, ctx, dirX, dirY, reach) {
 // and flag a hard brake. Returns { x, y, brake } where x/y is a steer push.
 function feelerAvoid(bot, ctx, headX, headY, speed) {
     var reach = FEELER_BASE + speed * FEELER_SPEED_K;
+    var cap = FEELER_MAX;
+    // On ice the kart can't brake or steer hard, so it needs to see lava much farther out.
+    var onIce = bot.brakeCoeff < c.playerBrakeCoeff;
+    var samples = onIce ? ICE_FEELER_SAMPLES : FEELER_MAX_SAMPLES;
+    if (onIce) { reach *= ICE_FEELER_MULT; cap *= ICE_FEELER_MULT; }
     // Lightning round speeds everyone up — look farther ahead to keep control.
-    if (ctx.lightning) { reach *= LIGHTNING_FEELER_MULT; }
-    var cap = FEELER_MAX * (ctx.lightning ? LIGHTNING_FEELER_MULT : 1);
+    if (ctx.lightning) { reach *= LIGHTNING_FEELER_MULT; cap *= LIGHTNING_FEELER_MULT; }
     if (reach > cap) { reach = cap; }
     // Risk: high-risk personalities use shorter feelers, cutting closer to lava.
     if (ctx.riskMult != null) { reach *= ctx.riskMult; }
     var px = 0, py = 0, brake = false;
     // Center feeler — lava anywhere ahead (within stopping distance) means slow down.
-    if (rayLavaFrac(bot, ctx, headX, headY, reach) < 1) {
+    if (rayLavaFrac(bot, ctx, headX, headY, reach, samples) < 1) {
         brake = true;
     }
     // Side feelers, slightly shorter. Lava on one side pushes toward the other.
     var sd = reach * 0.8;
     var lDir = rotate(headX, headY, FEELER_SIDE_DEG);
     var rDir = rotate(headX, headY, -FEELER_SIDE_DEG);
-    var lFrac = rayLavaFrac(bot, ctx, lDir.x, lDir.y, sd);
-    var rFrac = rayLavaFrac(bot, ctx, rDir.x, rDir.y, sd);
+    var lFrac = rayLavaFrac(bot, ctx, lDir.x, lDir.y, sd, samples);
+    var rFrac = rayLavaFrac(bot, ctx, rDir.x, rDir.y, sd, samples);
     var lLava = lFrac < 1, rLava = rFrac < 1;
     // Perpendicular to heading: right = (headY, -headX), left = (-headY, headX).
     if (lLava && !rLava) { px += headY; py += -headX; }        // push right
@@ -1133,12 +1153,31 @@ function steerBot(bot, ctx, dt) {
     // crawl, so it never builds the momentum to thread. A real lava-DEAD-AHEAD brake
     // (fl.brake) still bites, so this doesn't drive it straight into lava.
     if (escaping) { lavaField *= ESCAPE_LAVA_RELAX; }
-    if (fl.brake || lavaField > 1.2) {
+    // On ice the throttle IS the bot's steering authority (the engine scales accel by the
+    // targetDir magnitude, and accel is only 15 on ice) — and braking does nothing. So the
+    // usual "crawl when lava is ahead" makes an ice slide WORSE: it cuts the very accel the
+    // bot needs to curve its momentum off the lava. Keep throttle up on ice and lean on the
+    // longer ice feeler (steer away early) + the emergency punch-brake (kill a bad slide).
+    var onIce = bot.brakeCoeff < c.playerBrakeCoeff;
+    if ((fl.brake || lavaField > 1.2) && !onIce) {
         throttle = 0.42;
         if (speed > BRAKE_SPEED_MIN) { braking = true; }
     } else if (sharpTurn || lavaField > 0.6) {
-        throttle = 0.7;
-        if (sharpTurn && speed > BRAKE_SPEED_MIN * 1.3) { braking = true; }
+        if (!onIce) { throttle = 0.7; }
+        if (sharpTurn && !onIce && speed > BRAKE_SPEED_MIN * 1.3) { braking = true; }
+    }
+    // Pre-ice braking: bleed speed on the grippy approach so we enter the ice slow enough
+    // to actually steer across it. Only when grippy now (braking works), ice is imminent
+    // dead ahead, and we're carrying too much speed; skip during a beeline/escape (those
+    // deliberately commit) and when fleeing a collapse.
+    if (!onIce && !beelining && !escaping && !ctx.collapsing &&
+        speed > ICE_ENTRY_SPEED) {
+        var look = ICE_ENTRY_LOOKAHEAD + speed * 0.45;
+        var hX = headX, hY = headY; // heading already computed above for the feelers
+        if (nearestTileId(ctx, bot.x + hX * look, bot.y + hY * look) === ctx.iceId) {
+            braking = true;
+            if (throttle > 0.5) { throttle = 0.5; }
+        }
     }
     // Blinded racers feel their way forward more tentatively.
     if (blinded) { throttle *= BLIND_THROTTLE; }
@@ -1437,6 +1476,7 @@ function update(gameBoard, currentState, dt) {
     var ctx = {
         map: map,
         lavaId: LAVA,
+        iceId: c.tileMap.ice.id,
         siteById: buildSiteIndex(map),
         lavaCells: lavaCells,
         goalTiles: goalTiles, // for zombie intercept (prey are racing to a goal)

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -64,6 +64,16 @@ var ESCAPE_ESCALATE_WINDOW = 4000; // ms: re-trigger within this counts as a rep
 var ESCAPE_COMMIT_THROTTLE = 0.75; // stage-2 committed throttle floor
 var ESCAPE_COMMIT_FEELER = 0.3;    // stage-2: shrink the feeler PUSH so the bot drives toward the
                                    // route exit (carrot) instead of being bent back into the pocket
+// Last-resort "give up" beeline: when a bot has made NO real headway (continuous,
+// reset only by actually breaking STUCK_RADIUS) for this long, neither the soft
+// escape nor a committed thread freed it — it's genuinely sealed/wedged. The worst
+// offender is a bot pinned in a lava-walled corner or in the start-gate margin
+// OUTSIDE the terrain, where it's even immune to lava death (off every cell -> no
+// hit) and so orbits one spot for the whole race. When this fires, the steer below
+// abandons the path and drives STRAIGHT at the nearest goal with ALL avoidance OFF:
+// it either threads back onto terrain, or drives onto the lava that's walling it in
+// and dies, clearing the clog. Strictly a bot that's been frozen seconds already.
+var BEELINE_AFTER_MS = 4500;       // ms continuously stuck before the avoidance-off beeline
 // Steering low-pass. In a narrow lava-walled corridor the feeler + lava-field push
 // flips side every tick; undamped, that vibration grows until the momentum car
 // clips a wall (death) or cancels its own forward motion (the "stuck" crawl). We
@@ -95,6 +105,9 @@ function newBotState(profile) {
         gateY: null,       // gated-phase vertical jockey target
         progressAnchor: null,// {x,y}: spot the bot last made real headway from (anti-stuck)
         progressAt: 0,     // ms: when it last re-anchored there
+        headwayAt: null,   // ms: last time it broke STUCK_RADIUS (real headway). MONOTONIC —
+                           // unlike progressAt it is NOT reset when an escape fires or a route
+                           // momentarily vanishes, so now-headwayAt is true continuous-stuck time.
         prevSx: null,      // steering low-pass: previous tick's (unnormalized) steer vector
         prevSy: null,
         escapeUntil: 0,    // ms: end of an active stuck-escape (relax soft fields)
@@ -854,17 +867,19 @@ function steerBot(bot, ctx, dt) {
     // while the hard ray-sampled feeler brake still guards against driving INTO lava.
     // (Zombies skip this — they ignore the goal and chase prey.) ---
     var nowProbe = Date.now();
-    var escaping = false, committed = false;
+    var escaping = false, committed = false, beelining = false;
     if (!bot.isZombie) {
+        if (ai.headwayAt == null) { ai.headwayAt = nowProbe; }
         if (ai.progressAnchor == null || mag(bot.x - ai.progressAnchor.x, bot.y - ai.progressAnchor.y) > STUCK_RADIUS) {
             ai.progressAnchor = { x: bot.x, y: bot.y };
             ai.progressAt = nowProbe;
+            ai.headwayAt = nowProbe; // real headway -> reset the continuous-stuck clock
             ai.escapeUntil = 0; ai.escapeStage = 0; ai.lastEscapeAt = 0; // real headway -> escape over
         } else if ((nowProbe - ai.progressAt) / 1000 >= STUCK_TRIGGER && nowProbe >= ai.escapeUntil) {
             // Re-triggering after a previous escape that real progress never cleared
-            // means the gentle approach didn't free it -> escalate to a committed
-            // thread-or-die push (keyed off lastEscapeAt, which only survives if no
-            // re-anchor reset it — so a different, freshly-reached pinch starts at 1).
+            // means the gentle approach didn't free it -> escalate the push (keyed off
+            // lastEscapeAt, which only survives if no re-anchor reset it — so a different,
+            // freshly-reached pinch starts at 1). 1 gentle -> 2 committed -> stays 2.
             ai.escapeStage = (nowProbe - ai.lastEscapeAt) <= ESCAPE_ESCALATE_WINDOW ? 2 : 1;
             ai.lastEscapeAt = nowProbe;
             ai.escapeUntil = nowProbe + ESCAPE_MS;
@@ -873,6 +888,10 @@ function steerBot(bot, ctx, dt) {
         }
         escaping = nowProbe < ai.escapeUntil;
         committed = escaping && ai.escapeStage === 2;
+        // Final ladder rung: stuck (no real headway) past BEELINE_AFTER_MS regardless of
+        // the soft/committed escape — it's sealed in. The steer below abandons the path
+        // and beelines the nearest goal with avoidance off (thread out, or die clearing it).
+        beelining = (nowProbe - ai.headwayAt) >= BEELINE_AFTER_MS;
     }
 
     // --- Re-path on a throttle (and immediately if we have no path) ---
@@ -952,11 +971,21 @@ function steerBot(bot, ctx, dt) {
         // A zombie with no reachable goal path (it's lava-immune and often sits on
         // lava) still HUNTS — fall through to the intercept override below, which
         // sets desired toward the prey. Don't freeze in the no-path hold.
+    } else if (beelining && ctx.goalTiles && ctx.goalTiles.length > 0) {
+        // No path AND stuck for BEELINE_AFTER_MS: it's sealed off (the goal is lava-walled
+        // from here and a re-path will keep returning null). Don't keep holding — that's
+        // exactly the off-terrain corner freeze where the bot never moves and never dies.
+        // Beeline the nearest goal with avoidance off (below) to thread out or die clearing it.
+        var ngz = nearestGoalPoint(bot.x, bot.y, ctx.goalTiles);
+        var gzx = ngz.x - bot.x, gzy = ngz.y - bot.y, gzm = mag(gzx, gzy) || 1;
+        desiredX = gzx / gzm; desiredY = gzy / gzm;
     } else {
         // No path and not collapsing: hold position (don't drive blindly). A walled
         // bot isn't "stuck at a pinch", so clear any charging escape and re-anchor
         // here — otherwise it would silently escalate to a committed launch the
         // instant a route reappears, firing it off a standstill with brakes off.
+        // (headwayAt is left alone — it's the monotonic clock that eventually trips
+        // the beeline above for a bot that's genuinely sealed in here.)
         ai.escapeUntil = 0; ai.escapeStage = 0; ai.lastEscapeAt = 0;
         ai.progressAnchor = { x: bot.x, y: bot.y }; ai.progressAt = nowProbe;
         bot.targetDirX = 0; bot.targetDirY = 0; bot.braking = true; bot.attack = false;
@@ -1019,16 +1048,26 @@ function steerBot(bot, ctx, dt) {
     // Risk: tighter lines hug the lava (corner-cutting); cautious bots keep clear.
     ctx.riskMult = 1 - 0.45 * ai.risk;
 
+    // A last-resort beeline overrides the path/carrot heading and points STRAIGHT at the
+    // nearest goal, so a bot sealed in a corner drives decisively out (or into the walling
+    // lava). Avoidance is turned off just below so nothing bends it back into the pocket.
+    if (beelining && ctx.goalTiles && ctx.goalTiles.length > 0) {
+        var ngb = nearestGoalPoint(bot.x, bot.y, ctx.goalTiles);
+        var bgx = ngb.x - bot.x, bgy = ngb.y - bot.y, bgm = mag(bgx, bgy) || 1;
+        desiredX = bgx / bgm; desiredY = bgy / bgm;
+    }
+
     // --- Avoidance: predictive feelers (primary) + soft fields (secondary) ---
     // Heading the feelers look along: actual velocity when moving, else desired.
     var headX = desiredX, headY = desiredY;
     if (speed > 5) { headX = bot.velX / speed; headY = bot.velY / speed; }
 
-    // Zombies don't die on lava (and ignore the collapse) — they cut straight
-    // across it to chase prey, so a zombie bot turns OFF all lava avoidance.
-    var ignoreLava = bot.isZombie === true;
+    // Zombies don't die on lava (and ignore the collapse) — they cut straight across it
+    // to chase prey, so a zombie turns OFF all lava avoidance. A beelining bot likewise
+    // wants no avoidance bending its decisive line (it has been frozen for seconds).
+    var ignoreLava = bot.isZombie === true || beelining;
     var fl = ignoreLava ? { x: 0, y: 0, brake: false } : feelerAvoid(bot, ctx, headX, headY, speed);
-    var hz = hazardRepulsion(bot, ctx.hazardList);
+    var hz = beelining ? { x: 0, y: 0 } : hazardRepulsion(bot, ctx.hazardList);
     var lv = ignoreLava ? { x: 0, y: 0 } : lavaRepulsion(bot, ctx.lavaCells);
 
     // Lava dead ahead means the current line is bad — re-path next tick to find a
@@ -1067,9 +1106,9 @@ function steerBot(bot, ctx, dt) {
         // the stored history so a zombie->racer revert (infection round end) doesn't
         // blend in a stale pre-zombie vector.
         ai.prevSx = null; ai.prevSy = null;
-    } else if (committed) {
-        // A committed (thread-or-die) escape wants its decisive line undiluted, so
-        // snap the filter to it instead of blending in the pre-escape pocket vector.
+    } else if (committed || beelining) {
+        // A committed (thread-or-die) escape or last-resort beeline wants its decisive line
+        // undiluted, so snap the filter to it instead of blending the pre-escape pocket vector.
         ai.prevSx = sx; ai.prevSy = sy;
     } else {
         if (ai.prevSx == null) { ai.prevSx = sx; ai.prevSy = sy; }
@@ -1126,6 +1165,9 @@ function steerBot(bot, ctx, dt) {
         if (throttle < ESCAPE_COMMIT_THROTTLE) { throttle = ESCAPE_COMMIT_THROTTLE; }
         braking = false;
     }
+    // Last-resort beeline: full throttle, no brake, no lava crawl — drive the decisive
+    // line out of the pocket (avoidance is already off, so fl.brake never fires here).
+    if (beelining) { throttle = Math.max(throttle, 1.0); braking = false; }
 
     // A hunting zombie commits fully: it ignores lava and only wants to catch prey,
     // so skip the cautious governor, rubber-band easing, and braking — full chase.

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -987,7 +987,17 @@ class Player extends Circle {
 		// on the new map instead of steering toward old-map coordinates. Identity,
 		// personality knobs and the emote cooldown live on the Player/profile and
 		// are intentionally preserved.
-		if (this.ai != null) { this.ai.waypoints = null; this.ai.repathTimer = 0; this.ai.punchHoldUntil = null; this.ai.punchAngle = 0; }
+		if (this.ai != null) {
+			this.ai.waypoints = null; this.ai.repathTimer = 0; this.ai.punchHoldUntil = null; this.ai.punchAngle = 0;
+			// Clear the anti-stuck/escape state too. It persists on bot.ai across rounds, and
+			// the headwayAt "continuous-stuck" clock is stale from the previous round — if the
+			// bot's new-round spawn happens to fall within STUCK_RADIUS of its old anchor (the
+			// corner-stuck bots end near the gate and respawn there), a stale headwayAt would
+			// trip the avoidance-off beeline on the very first racing tick and fling it off the
+			// line. Reset so the first tick re-anchors fresh.
+			this.ai.progressAnchor = null; this.ai.progressAt = 0; this.ai.headwayAt = null;
+			this.ai.escapeUntil = 0; this.ai.escapeStage = 0; this.ai.lastEscapeAt = 0;
+		}
 		this.x = this.initialLoc.x;
 		this.y = this.initialLoc.y;
 		this.newX = this.x;


### PR DESCRIPTION
## What & why

Reported: AI racers getting stuck in TheIsland's upper-left corner, and running into / "confused by" bumpers. Investigation (headless, seeded) traced this to two real AI issues plus one map-design limit.

### Fixes

**1. Bots no longer freeze forever in a lava-walled corner.** On left-start maps the start gate places karts in the off-terrain margin / lava corners (terrain cells start past the gate). A bot there finds no lava-free route to the goal *and* takes no lava damage (it's off every cell), so it sat frozen for the whole race. Added a last-resort rung to the stuck-escape ladder: after ~4.5s of zero real headway, abandon pathfinding and drive straight at the nearest goal with avoidance off — it threads back onto the track or dies clearing the spot.
- Headless on TheIsland: bots still frozen at race end **20 → 2** (24 seeds).

**2. Much better ice navigation.** On ice a kart can barely brake (0.0001) or steer (accel 15), so it skates into the lava lining the lanes. Now bots (a) brake on the grippy approach *before* entering ice, (b) look ~2.6× farther ahead while on ice (with enough ray samples to keep ~13px spacing), and (c) don't uselessly crawl on ice (throttle is the only steering authority there).
- Finisher counts **without → with**, across maps (35 bots/map, no regressions anywhere):

  | Map | OFF → ON |
  |---|---|
  | IcyLake | 5 → 22 |
  | Damnation | 1 → 6 |
  | HellsHelix | 0 → 5 |
  | MurderRow | 0 → 3 |
  | FastandSlow | 9 → 15 |
  | async | 14 → 18 |
  | crossroads | 17 → 19 |
  | randomLakes | 18 → 18 |
  | ChooseAPath | 5 → 5 |

### Not changed (deliberately)
- **Bumper-avoidance tuning** was tried and reverted — it didn't reduce actual bumper hits and slightly increased stalling.
- **TheIsland stays uncompletable by the AI** (0/56 finish even before this PR — its central ice+lava+bumper density is beyond reactive navigation). The bumper-bonking is a symptom of that, not something an AI tweak fixes; finishing it would need a map revision or a much larger planner. Flagging, not blocking.

## Review
Ran `/code-review` (xhigh) on the diff. It caught a real ship-blocker — stale per-round bot stuck-state could trip the avoidance-off beeline on the first racing tick of a later round (flinging a bot off the start line) — plus a collapse/beeline interaction and ice-feeler under-sampling. **All three fixed** in this branch and re-validated.

## Validation
- smoke (51 maps) ✅, start-edges ✅
- stuck END-STUCK 0/12 ✅
- perf tick-budget on ice-heavy IcyLake (25 karts + 4 stacked brutals): p95 **0.685ms** vs 33ms budget (48× headroom) ✅
- CHANGELOG updated (General + Bug fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
