### PR TITLE
feat(perf): device graphics-detail profiles + motion interpolation + reduced map cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 ### General
 
 - The game now picks a graphics-detail level to match your device, dialing back heavy effects (particles, glows, the crowd, trail length) on phones and small or low-powered screens so it runs smoother — desktops keep the full show. A new "Graphics detail" control in the top bar (and in the controller Settings panel) lets you override it: Auto, High, Balanced, or Low. Your choice is remembered.
+- Movement is smoother across the board — karts, bumpers and other moving things now glide between updates instead of stepping, so motion looks fluid even on high-refresh and mobile screens.
 
 ## v0.15.0 — 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- The game now picks a graphics-detail level to match your device, dialing back heavy effects (particles, glows, the crowd, trail length) on phones and small or low-powered screens so it runs smoother — desktops keep the full show. A new "Graphics detail" control in the top bar (and in the controller Settings panel) lets you override it: Auto, High, Balanced, or Low. Your choice is remembered.
 
 ## v0.15.0 — 2026-05-27
 

--- a/build.js
+++ b/build.js
@@ -5,6 +5,7 @@ const path = require('path');
 const bundles = {
     'play.bundle.min.js': [
         'client/scripts/game.js',
+        'client/scripts/perf.js',
         'client/scripts/client.js',
         'client/scripts/audio.js',
         'client/scripts/input.js',

--- a/client/play.html
+++ b/client/play.html
@@ -42,6 +42,8 @@
             color: inherit;"><i class="music-btn fas fa-video" aria-hidden="true"></i> [<i class="music-btn fa fa-check" aria-hidden="true"></i>]</a>
             <a id="colorblindControl" class="nav-toggle" role="button" tabindex="0" aria-label="Toggle colour-blind assist (distinct kart colours)" style="cursor:pointer; text-decoration: inherit;
             color: inherit;"><i class="music-btn fas fa-eye" aria-hidden="true"></i> [<i class="music-btn fa fa-ban" aria-hidden="true"></i>]</a>
+            <a id="performanceControl" class="nav-toggle" role="button" tabindex="0" aria-label="Graphics detail level" style="cursor:pointer; text-decoration: inherit;
+            color: inherit;"><i class="music-btn fas fa-bolt" aria-hidden="true"></i> [Auto]</a>
           </nav>
         <section>
             <!-- Game enclosed here -->
@@ -82,6 +84,7 @@
         <script defer src="scripts/auth.js"></script>
         <!-- BUILD: bundle-start -->
         <script src="scripts/game.js"></script>
+        <script src="scripts/perf.js"></script>
         <script src="scripts/client.js"></script>
         <script src="scripts/audio.js"></script>
         <script src="scripts/input.js"></script>

--- a/client/scripts/audience.js
+++ b/client/scripts/audience.js
@@ -106,7 +106,15 @@ function audiencePopulated() {
 // frame budget, and a near-16:9 fullscreen phone has little/no letterbox anyway.
 // isTouchScreen is the game's shared touch/coarse-pointer flag (input.js).
 function audienceDisabled() {
-    return (typeof isTouchScreen !== "undefined" && isTouchScreen === true);
+    if (typeof isTouchScreen !== "undefined" && isTouchScreen === true) {
+        return true;
+    }
+    // Low-end performance profiles drop the crowd to reclaim its frame budget
+    // (e.g. a small desktop window that auto-resolved to LOW).
+    if (typeof perfAudienceAllowed === "function" && !perfAudienceAllowed()) {
+        return true;
+    }
+    return false;
 }
 
 // Pre-render the fan sprites once: every palette colour x depth bucket x

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -306,8 +306,11 @@ function registerScoreHandlers(server) {
 			// Remember where/when they fell: a dead local player can press attack
 			// to ping every dead player's spot, and the floating skull fades from
 			// deathAt — see updateDeathPings()/drawDeathMessage() in draw.js.
-			playerList[id].deathX = playerList[id].x;
-			playerList[id].deathY = playerList[id].y;
+			// Use the authoritative server position (tx/ty), not the eased render
+			// position (x/y), so the death skull/ping lands where the kart actually
+			// died (x/y lags by ~tau, noticeable for a fast death into lava).
+			playerList[id].deathX = (playerList[id].tx != null) ? playerList[id].tx : playerList[id].x;
+			playerList[id].deathY = (playerList[id].ty != null) ? playerList[id].ty : playerList[id].y;
 			playerList[id].deathAt = Date.now();
 		}
 		recapMarkHighlight('death', [id]); // flag an elimination moment for the recap

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -545,6 +545,13 @@ function drawObjects(dt) {
     }
     syncColorblind();
 
+    // Ease entity render positions toward their latest 30Hz server targets, so
+    // motion is smooth at 60fps instead of stepping at the tick rate. Runs before
+    // the camera so it tracks the smoothed local kart. (see gameboard.js)
+    if (typeof smoothEntities === "function") {
+        smoothEntities(dt);
+    }
+
     updateWorldCamera(dt);
     applyCanvasTransform();
     drawBackground(dt);

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -718,7 +718,9 @@ function drawOffscreenGoalIndicator() {
     gameContext.rotate(ang);                            // tip (+x) points outward toward the goal
     gameContext.translate(bob, 0);                      // local +x = toward the goal, so it bobs along the aim
     gameContext.shadowColor = goalColor;
-    gameContext.shadowBlur = 12 + 12 * pulse;
+    // Skip the per-frame glow on profiles that disable it (the arrow still reads
+    // via its bright fill + dark outline).
+    gameContext.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? (12 + 12 * pulse) : 0;
     // Same chunky block arrow as the lobby arrows, tip at origin pointing +x.
     gameContext.beginPath();
     gameContext.moveTo(0, 0);
@@ -1264,7 +1266,7 @@ function spawnSlashEffect(x, y, angleDeg, color) {
             ctx.strokeStyle = color || "white";
             ctx.lineWidth = (10 * (1 - t)) + 2;
             ctx.shadowColor = color || "white";
-            ctx.shadowBlur = 12 * (1 - t);
+            ctx.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? (12 * (1 - t)) : 0;
             ctx.beginPath();
             ctx.moveTo(x - dx, y - dy);
             ctx.lineTo(x + dx, y + dy);
@@ -1313,10 +1315,11 @@ function spawnExplosion(x, y, radius, color) {
             ctx.beginPath();
             ctx.arc(0, 0, radius * (0.6 + 1.0 * p), 0, 2 * Math.PI);
             ctx.stroke();
-            // Debris sparks.
+            // Debris sparks — count scales with the performance profile.
             ctx.fillStyle = color;
-            for (var i = 0; i < 10; i++) {
-                var a = (i / 10) * Math.PI * 2 + 0.2;
+            var sparks = (typeof perfExplosionSparks === "function") ? perfExplosionSparks() : 10;
+            for (var i = 0; i < sparks; i++) {
+                var a = (i / sparks) * Math.PI * 2 + 0.2;
                 var r = radius * (0.3 + 1.1 * p);
                 ctx.globalAlpha = (1 - t);
                 ctx.beginPath();
@@ -1333,6 +1336,7 @@ function spawnExplosion(x, y, radius, color) {
 function spawnScreenFlash(color, peakAlpha, maxAge) {
     addEffect({
         screen: true,
+        keep: true,   // gameplay telegraph (e.g. brutal-round start) — never evicted by the perf cap
         x: 0,
         y: 0,
         maxAge: maxAge || 250,
@@ -2337,7 +2341,7 @@ function drawCutAimer(x, y, angle, color) {
         gameContext.strokeStyle = color;
     }
     gameContext.shadowColor = color;
-    gameContext.shadowBlur = 12;
+    gameContext.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? 12 : 0;
     gameContext.lineWidth = 4;
     gameContext.beginPath();
     gameContext.moveTo(bwd.x, bwd.y);
@@ -2392,15 +2396,48 @@ function drawArmedRing(x, y, color, radius) {
 }
 
 function drawTrail(player) {
-    if (player.trail.canvas != null) {
-        // Fade other players' trails so your own line stays legible in the pack.
+    var trail = player.trail;
+    if (trail == null) {
+        return;
+    }
+    // Direct trail mode (low-end profile): stroke the capped recent tail straight
+    // onto the main canvas. The vertices are world coords (same space as the
+    // canvas blit's origin), so this aligns identically under the world pass —
+    // but with no per-kart world-sized texture to re-upload to the GPU each frame.
+    if ((typeof perfTrailDirect === "function") && perfTrailDirect()) {
+        var verts = trail.vertices;
+        if (verts == null || verts.length < 2) {
+            return;
+        }
+        var maxN = (typeof perfTrailDirectMax === "function") ? perfTrailDirectMax() : 240;
+        var start = Math.max(0, verts.length - maxN);
         var dim = !isLocalId(player.id);
+        gameContext.save();
         if (dim) {
+            gameContext.globalAlpha = NONLOCAL_TRAIL_ALPHA;
+        }
+        gameContext.strokeStyle = player.color;
+        gameContext.lineWidth = 5;
+        gameContext.lineCap = "round";
+        gameContext.lineJoin = "round";
+        gameContext.beginPath();
+        gameContext.moveTo(verts[start].x, verts[start].y);
+        for (var i = start + 1; i < verts.length; i++) {
+            gameContext.lineTo(verts[i].x, verts[i].y);
+        }
+        gameContext.stroke();
+        gameContext.restore();
+        return;
+    }
+    if (trail.canvas != null) {
+        // Fade other players' trails so your own line stays legible in the pack.
+        var dimC = !isLocalId(player.id);
+        if (dimC) {
             gameContext.save();
             gameContext.globalAlpha = NONLOCAL_TRAIL_ALPHA;
         }
-        gameContext.drawImage(player.trail.canvas, player.trail.canvasOriginX, player.trail.canvasOriginY);
-        if (dim) {
+        gameContext.drawImage(trail.canvas, trail.canvasOriginX, trail.canvasOriginY);
+        if (dimC) {
             gameContext.restore();
         }
     }
@@ -2421,6 +2458,7 @@ var DEATH_SKULL_FADE_MS = 4000;
 function spawnDeathPingEffect(x, y, color) {
     var ringColor = color || "rgb(255, 215, 0)";
     addEffect({
+        keep: true,   // deliberate death-spot reveal — never evicted by the perf cap
         x: x,
         y: y,
         maxAge: 1100,

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -2853,7 +2853,10 @@ function drawMap() {
         mapDirty = false;
     }
     if (mapCanvas != null) {
-        gameContext.drawImage(mapCanvas, world.x - mapCanvasPad, world.y - mapCanvasPad);
+        // Stretch the (possibly reduced-resolution) cache back over the full world
+        // region; at scale 1 this is a 1:1 blit (unchanged on High/Balanced).
+        gameContext.drawImage(mapCanvas, world.x - mapCanvasPad, world.y - mapCanvasPad,
+            world.width + mapCanvasPad * 2, world.height + mapCanvasPad * 2);
     }
     if (Object.keys(hazardList).length > 0) {
         for (var id in hazardList) {
@@ -2969,15 +2972,28 @@ function renderMapToCache() {
     if (world == null) {
         return;
     }
+    // The map cache is re-rendered AND re-uploaded to the GPU on every tile change
+    // (ability pickup, bomb, tileSwap, collapse). On low-end GPUs that big-texture
+    // upload is the dominant paint stutter, so render the cache at a reduced
+    // resolution there (perfMapScale < 1) — fewer bytes per upload, slightly softer
+    // terrain. Rebuild from scratch if the scale changed (profile toggled).
+    var scale = (typeof perfMapScale === "function") ? perfMapScale() : 1;
+    if (mapCanvas != null && mapCanvas._mapScale !== scale) {
+        mapCanvas = null;
+    }
     if (mapCanvas == null) {
         mapCanvas = document.createElement("canvas");
-        mapCanvas.width = world.width + mapCanvasPad * 2;
-        mapCanvas.height = world.height + mapCanvasPad * 2;
+        mapCanvas.width = Math.max(1, Math.ceil((world.width + mapCanvasPad * 2) * scale));
+        mapCanvas.height = Math.max(1, Math.ceil((world.height + mapCanvasPad * 2) * scale));
+        mapCanvas._mapScale = scale;
         mapCtx = mapCanvas.getContext("2d");
     } else {
         mapCtx.clearRect(0, 0, mapCanvas.width, mapCanvas.height);
     }
     mapCtx.save();
+    if (scale !== 1) {
+        mapCtx.scale(scale, scale);   // render world-coord cells into the smaller texture
+    }
     mapCtx.translate(-world.x + mapCanvasPad, -world.y + mapCanvasPad);
 
     var cells = currentMap.cells;

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -389,11 +389,22 @@ function animloop() {
     }
 }
 function gameLoop(dt) {
+    // performance.now() splits the frame into input / render / rest phases for the
+    // perf diagnostics. Four now() calls/frame is negligible; the tick helpers
+    // below no-op unless ?fps=1 / ?diag=1 is set, so normal play is unaffected.
+    var t0 = performance.now();
     pollGamepad(dt);
+    var t1 = performance.now();
     drawObjects(dt);
+    var t2 = performance.now();
     updateGameboard(dt);
     // Crowd in the letterbox (own canvas; no-op until audience.js is loaded).
     if (typeof drawAudience === "function") { drawAudience(dt); }
+    var t3 = performance.now();
+    // Diagnostic FPS/frame-time overlay (only when ?fps=1; no-op otherwise).
+    if (typeof perfHudTick === "function") { perfHudTick(dt); }
+    // Diagnostic perf telemetry to the server (only when ?diag=1; no-op otherwise).
+    if (typeof perfDiagTick === "function") { perfDiagTick(dt, t1 - t0, t2 - t1, t3 - t2); }
 }
 
 
@@ -430,11 +441,13 @@ function resize() {
     overlayCanvas.style.height = newHeight + "px";
 
     // Backing store: render at device resolution so the game (and its text) is
-    // sharp on Retina/phone displays. Cap dpr at 2 to avoid over-rendering on
-    // 3x phones. The logical 1366x768 space is unchanged; applyCanvasTransform()
-    // scales drawing into the backing store each frame, so no gameplay math
-    // moves to device pixels.
-    var dpr = Math.min(window.devicePixelRatio || 1, 2);
+    // sharp on Retina/phone displays. The dpr ceiling avoids over-rendering on
+    // 3x phones; the active performance profile can drop it further on low-end
+    // devices (perfDprCap, default 2). The logical 1366x768 space is unchanged;
+    // applyCanvasTransform() scales drawing into the backing store each frame, so
+    // no gameplay math moves to device pixels.
+    var dprCap = (typeof perfDprCap === "function") ? perfDprCap() : 2;
+    var dpr = Math.min(window.devicePixelRatio || 1, dprCap);
     gameCanvas.width = Math.round(newWidth * dpr);
     gameCanvas.height = Math.round(newHeight * dpr);
     overlayCanvas.width = Math.round(newWidth * dpr);

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -157,7 +157,19 @@ function resetTrails() {
 	}
 }
 
+// Trail vertices are sampled at ~30Hz regardless of render rate. Motion smoothing
+// (smoothEntities) now nudges x/y every frame, so without this gate the trail
+// would record at 60fps — doubling the stroke/memory work on desktop and halving
+// the kept-tail duration of the direct-trail cap on Low. 30Hz matches the server
+// tick (the cadence the trail recorded at before smoothing existed).
+var TRAIL_SAMPLE_MS = 33;
+var lastTrailSampleAt = 0;
 function updateTrails() {
+	var now = Date.now();
+	if (now - lastTrailSampleAt < TRAIL_SAMPLE_MS) {
+		return;
+	}
+	lastTrailSampleAt = now;
 	for (var id in playerList) {
 		var player = playerList[id];
 		if (player.alive == false || player.infected == true) {
@@ -970,7 +982,12 @@ function addEffect(effect) {
 		while (ei < effectsList.length && effectsList[ei].keep) {
 			ei++;
 		}
-		effectsList.splice(ei < effectsList.length ? ei : 0, 1);
+		// Evict the oldest non-keep effect. If EVERY live effect is a telegraph,
+		// let the list exceed the cap rather than dropping one — telegraphs are
+		// few and short-lived, so "keep" truly means never evicted.
+		if (ei < effectsList.length) {
+			effectsList.splice(ei, 1);
+		}
 	}
 	effectsList.push(effect);
 	return effect;

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -212,6 +212,8 @@ function createPlayer(dataArray) {
 	playerList[index].id = dataArray[0];
 	playerList[index].x = dataArray[1];
 	playerList[index].y = dataArray[2];
+	playerList[index].tx = dataArray[1];   // seed render-smoothing target (see smoothEntities)
+	playerList[index].ty = dataArray[2];
 	playerList[index].color = dataArray[3];
 	playerList[index].alive = dataArray[4];
 	playerList[index].notches = dataArray[5];
@@ -234,6 +236,61 @@ function createPlayer(dataArray) {
 	};
 }
 
+// --- Client-side motion smoothing -------------------------------------------
+// The server ticks positions at 30Hz (serverTickSpeed 33.33ms); without this,
+// entities snap to those 30Hz positions and visibly STEP at 60fps render (the
+// "bumper jumping frames", and choppy motion overall — most obvious on a crisp/
+// high-refresh display). Each frame we ease the RENDER position (x/y) toward the
+// latest server target (tx/ty): the local kart eases fast (snappy controls),
+// remote karts and hazards ease slower (smooth). A jump larger than
+// SMOOTH_SNAP_DIST (respawn, swap-teleport, inactive park at -100,-100) snaps
+// instantly instead of sliding across the map. Easing (not velocity
+// extrapolation) is deliberate: the sim is server-authoritative and
+// collision-heavy, so extrapolating would overshoot into walls/bumpers and
+// rubber-band. Always on — a universal smoothness win, independent of the perf
+// profile. A kart travels <=~27px per 30Hz tick (playerMaxSpeed), so 120px
+// cleanly separates real motion from a teleport.
+var SMOOTH_TAU_LOCAL = 22;    // ms — local kart catches up in ~2-3 frames
+var SMOOTH_TAU_REMOTE = 60;   // ms — remote karts / hazards glide over ~5 frames
+var SMOOTH_SNAP_DIST = 120;   // px — beyond this is a teleport, not motion → snap
+function smoothPos(o, tau, dt) {
+	if (o == null || o.tx == null) {
+		return;
+	}
+	if (o.x == null || o.y == null) {   // first sight: snap onto the target
+		o.x = o.tx; o.y = o.ty;
+		return;
+	}
+	var dx = o.tx - o.x, dy = o.ty - o.y;
+	if (dx * dx + dy * dy > SMOOTH_SNAP_DIST * SMOOTH_SNAP_DIST) {
+		o.x = o.tx; o.y = o.ty;          // teleport/respawn/park → snap, don't slide
+		return;
+	}
+	var a = 1 - Math.exp(-dt / tau);     // dt>>tau (tab refocus) → a→1 → full snap, no overshoot
+	o.x += dx * a;
+	o.y += dy * a;
+}
+// Ease every moving entity toward its latest server target. Called once per
+// render frame, BEFORE drawing (and before the camera reads the local kart).
+function smoothEntities(dt) {
+	if (!(dt > 0)) {
+		return;
+	}
+	var id;
+	for (id in playerList) {
+		var p = playerList[id];
+		if (p == null) {
+			continue;
+		}
+		smoothPos(p, isLocalId(id) ? SMOOTH_TAU_LOCAL : SMOOTH_TAU_REMOTE, dt);
+	}
+	if (typeof hazardList !== "undefined" && hazardList) {
+		for (id in hazardList) {
+			smoothPos(hazardList[id], SMOOTH_TAU_REMOTE, dt);
+		}
+	}
+}
+
 function updatePlayerList(packet) {
 	if (packet == null) {
 		return;
@@ -242,8 +299,11 @@ function updatePlayerList(packet) {
 		var player = packet[i];
 		if (playerList[player[0]] != null) {
 			playerList[player[0]].id = player[0];
-			playerList[player[0]].x = player[1];
-			playerList[player[0]].y = player[2];
+			// Server position is the SMOOTHING TARGET (tx/ty); smoothEntities eases
+			// the render position (x/y) toward it each frame so 30Hz ticks don't
+			// render as visible stepping. (See smoothEntities.)
+			playerList[player[0]].tx = player[1];
+			playerList[player[0]].ty = player[2];
 			playerList[player[0]].velX = player[3];
 			playerList[player[0]].velY = player[4];
 			playerList[player[0]].angle = player[5];
@@ -303,8 +363,10 @@ function updateHazardList(packet) {
 	for (var i = 0; i < packet.length; i++) {
 		var hazard = packet[i];
 		if (hazardList[hazard[0]] != null) {
-			hazardList[hazard[0]].x = hazard[1];
-			hazardList[hazard[0]].y = hazard[2];
+			// Smoothing target (eased toward in smoothEntities) — stops moving
+			// bumpers from stepping at the 30Hz tick rate.
+			hazardList[hazard[0]].tx = hazard[1];
+			hazardList[hazard[0]].ty = hazard[2];
 		}
 	}
 }
@@ -463,6 +525,8 @@ function applyHazards(payload) {
 		hazardList[hazard[0]].id = hazard[1];
 		hazardList[hazard[0]].x = hazard[2];
 		hazardList[hazard[0]].y = hazard[3];
+		hazardList[hazard[0]].tx = hazard[2];   // seed render-smoothing target (see smoothEntities)
+		hazardList[hazard[0]].ty = hazard[3];
 		hazardList[hazard[0]].angle = hazard[4];
 
 		hazardList[hazard[0]].railX = hazardList[hazard[0]].x;

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -890,6 +890,24 @@ function addEffect(effect) {
 	if (effect.maxAge == null) {
 		effect.maxAge = 300;
 	}
+	// Bound the live effect list per the performance profile. At the cap, an
+	// ordinary cosmetic effect is simply DROPPED (O(1), no array churn / GC) —
+	// the cheap path, since this runs hardest on the low-end device the cap is
+	// for. A gameplay telegraph (tagged `keep` — death ping, brutal-round flash)
+	// is always admitted, making room by evicting the oldest non-keep effect, so
+	// a flood of cosmetic FX can never crowd out something the player must see.
+	// The safe default is evictable: a new cosmetic spawner needs no flag.
+	// HIGH's cap is effectively unbounded, so this never trims on desktop.
+	if (typeof perfMaxEffects === "function" && effectsList.length >= perfMaxEffects()) {
+		if (!effect.keep) {
+			return null;
+		}
+		var ei = 0;
+		while (ei < effectsList.length && effectsList[ei].keep) {
+			ei++;
+		}
+		effectsList.splice(ei < effectsList.length ? ei : 0, 1);
+	}
 	effectsList.push(effect);
 	return effect;
 }
@@ -1029,7 +1047,7 @@ function tileIdAt(x, y) {
 // `count` flecks kicked up behind a moving player, coloured by the terrain and
 // scattered a little so they read as a puff rather than a single dot.
 function spawnTerrainParticle(p, color, minSize, count) {
-	count = count || 1;
+	count = (typeof perfCount === "function") ? perfCount(count || 1) : (count || 1);
 	var dir = Math.atan2(p.velY, p.velX);
 	for (var i = 0; i < count; i++) {
 		var bx = p.x - Math.cos(dir) * p.radius + (Math.random() * 2 - 1) * p.radius * 0.5;
@@ -1078,7 +1096,8 @@ function spawnIceTrail(p) {
 // direction of travel, coloured by the terrain underfoot.
 function spawnSkid(p, color) {
 	var dir = Math.atan2(p.prevVelY, p.prevVelX);
-	for (var i = 0; i < 4; i++) {
+	var n = (typeof perfCount === "function") ? perfCount(4) : 4;
+	for (var i = 0; i < n; i++) {
 		var spread = (Math.random() * 2 - 1) * 0.04;
 		var vx = Math.cos(dir) * 0.02 + Math.cos(dir + Math.PI / 2) * spread;
 		var vy = Math.sin(dir) * 0.02 + Math.sin(dir + Math.PI / 2) * spread;
@@ -1090,6 +1109,9 @@ function updateMovementParticles(dt) {
 	if (config == null) {
 		return;
 	}
+	// Spawn-cooldown helper: the performance profile stretches the gaps between
+	// particle bursts (>1x => rarer) so a low-end device emits fewer over time.
+	var cd = (typeof perfCooldown === "function") ? perfCooldown : function (ms) { return ms; };
 	var maxSpeed = config.playerMaxSpeed;
 	var fastThresh = maxSpeed * 0.55;
 	var walkThresh = maxSpeed * 0.08;
@@ -1114,7 +1136,7 @@ function updateMovementParticles(dt) {
 				var dot = (p.velX * p.prevVelX + p.velY * p.prevVelY) / (speed * prevSpeed);
 				if (dot < 0.6) {
 					spawnSkid(p, terrainParticleColor(tileIdAt(p.x, p.y)));
-					p.skidCD = 140;
+					p.skidCD = cd(140);
 				}
 			}
 		}
@@ -1127,31 +1149,32 @@ function updateMovementParticles(dt) {
 				// Skate trails only when actually gliding fast across the ice.
 				if (speed > fastThresh) {
 					spawnIceTrail(p);
-					p.dustCD = 40;
+					p.dustCD = cd(40);
 				} else {
-					p.dustCD = 60;
+					p.dustCD = cd(60);
 				}
 			} else if (tile == config.tileMap.fast.id) {
 				// Grass dialed back ~20% (smaller flecks) — it read a touch strong.
 				spawnTerrainParticle(p, grassColor(), 1.8, 2);
-				p.dustCD = speed > fastThresh ? 45 : 70;
+				p.dustCD = cd(speed > fastThresh ? 45 : 70);
 			} else if (tile == config.tileMap.slow.id) {
 				spawnTerrainParticle(p, sandColor(), 3, 2);
-				p.dustCD = speed > fastThresh ? 45 : 70;
+				p.dustCD = cd(speed > fastThresh ? 45 : 70);
 			} else if (speed > fastThresh) {
 				spawnTerrainParticle(p, dustColor(), 2.5, 2);
-				p.dustCD = 50;
+				p.dustCD = cd(50);
 			} else {
 				// Bare dirt at a walk: nothing to emit; recheck shortly (keeps the
 				// per-frame nearest-cell lookup throttled).
-				p.dustCD = 60;
+				p.dustCD = cd(60);
 			}
 		}
 
-		// Burning -> rising embers.
-		if (p.onFire > 0 && p.emberCD <= 0) {
+		// Burning -> rising embers. Shed entirely on low-end profiles (the flame
+		// sprite still draws, so a burning kart still reads).
+		if (p.onFire > 0 && p.emberCD <= 0 && (typeof perfEmbers !== "function" || perfEmbers())) {
 			spawnEmber(p.x + (Math.random() * 2 - 1) * p.radius, p.y + (Math.random() * 2 - 1) * p.radius);
-			p.emberCD = 70;
+			p.emberCD = cd(70);
 		}
 
 		p.prevVelX = p.velX;
@@ -1222,7 +1245,9 @@ class Trail {
 	}
 	_applyStrokeStyle(color, dashed) {
 		this.ctx.lineWidth = dashed ? 6 : 5;
-		this.ctx.shadowBlur = 3;
+		// shadowBlur on every trail segment is a per-frame fill cost; drop it on
+		// profiles that disable glow (the trail still reads as a solid stroke).
+		this.ctx.shadowBlur = (typeof perfGlow === "function" && !perfGlow()) ? 0 : 3;
 		this.ctx.shadowColor = "black";
 		this.ctx.strokeStyle = color;
 		this.ctx.setLineDash(dashed ? [20, 3, 3, 3, 3, 3, 3, 3] : []);
@@ -1263,6 +1288,22 @@ class Trail {
 				}
 				this._redrawAll(player.color, nvStill);
 				this.wasNearVictory = nvStill;
+				this.lastColor = player.color;
+			}
+			return;
+		}
+		// Direct trail mode (low-end profile): keep only a capped recent tail and
+		// let drawTrail stroke it onto the main canvas each frame. Avoids the
+		// per-kart world-sized offscreen canvas whose every-frame mutation forces a
+		// full-texture GPU re-upload — the source of the paint stutter on weak
+		// devices. No _ensureCanvas, no incremental stroke, no growing _redrawAll.
+		if ((typeof perfTrailDirect === "function") && perfTrailDirect()) {
+			var dcap = (typeof perfTrailDirectMax === "function") ? perfTrailDirectMax() : 240;
+			while (this.vertices.length >= dcap) {
+				this.vertices.shift();
+			}
+			this.vertices.push(currentPosition);
+			if (player != null) {
 				this.lastColor = player.color;
 			}
 			return;

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -1025,6 +1025,9 @@ function settingsRowDefs() {
         { id: "musicControl",      icon: "fas fa-music",  label: "Music",          on: function () { return typeof musicVolume !== "undefined" && musicVolume > 0; } },
         { id: "cameraControl",     icon: "fas fa-video",  label: "Dynamic camera", on: function () { return typeof cameraZoomEnabled !== "undefined" && cameraZoomEnabled; } },
         { id: "colorblindControl", icon: "fas fa-eye",    label: "Colour-blind",   on: function () { return typeof colorblindEnabled !== "undefined" && colorblindEnabled; } },
+        // Graphics detail cycles auto/high/balanced/low via the navbar
+        // #performanceControl (perf.js). `value` shows the current tier, like Theme.
+        { id: "performanceControl", icon: "fas fa-bolt",  label: "Graphics detail", value: function () { return (typeof perfProfileLabel === "function") ? perfProfileLabel() : "Auto"; } },
         // Theme is tri-state (auto/light/dark) — A cycles it via theme.js's injected
         // #themeToggle. `value` (vs `on`) makes the row show the mode instead of On/Off.
         { id: "themeToggle",       icon: "fas fa-adjust", label: "Theme",          value: function () { return themePrefLabel(); } }

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -240,7 +240,13 @@ function keyUp(evt) {
 
 function determineMovement() {
     if (playerList[myID] != null) {
-        var curAngle = angle(playerList[myID].x, playerList[myID].y, mousex, mousey);
+        // Aim from the AUTHORITATIVE server position (the smoothing target), not the
+        // eased render position (x/y), which lags by ~tau — otherwise mouse-drive
+        // direction is computed from a stale spot and can pick the wrong cone.
+        var mp = playerList[myID];
+        var ax = (mp.tx != null) ? mp.tx : mp.x;
+        var ay = (mp.ty != null) ? mp.ty : mp.y;
+        var curAngle = angle(ax, ay, mousex, mousey);
         var rightCone = (curAngle >= 330 || curAngle <= 30);
         var rfwdCone = (curAngle >= 300 && curAngle <= 330);
         var forwardCone = (curAngle >= 240 && curAngle <= 300);

--- a/client/scripts/perf.js
+++ b/client/scripts/perf.js
@@ -30,6 +30,7 @@ var PERF_PROFILES = {
         explosionSparks: 10,     // debris sparks per explosion
         audience: true,          // letterbox crowd
         trailDirect: false,      // false = full per-kart offscreen trail canvas; true = stroke a capped tail straight to the main canvas (avoids re-uploading a world-sized texture/kart/frame on weak GPUs)
+        mapScale: 1,             // resolution of the cached map texture (1 = full); <1 shrinks it so each re-upload on a tile change moves fewer bytes (the GPU-paint stutter on weak GPUs)
         dprCap: 2                // device-pixel-ratio ceiling for the backing store
     },
     // Tablets / small desktop windows: trim particle volume, keep the glow and
@@ -43,6 +44,7 @@ var PERF_PROFILES = {
         explosionSparks: 7,
         audience: true,
         trailDirect: false,
+        mapScale: 1,
         dprCap: 2
     },
     // Phones / low-end: shed the fill-rate-heavy work — glow passes, the crowd,
@@ -57,6 +59,7 @@ var PERF_PROFILES = {
         explosionSparks: 4,
         audience: false,
         trailDirect: true,
+        mapScale: 0.6,
         dprCap: 1.5
     }
 };
@@ -174,6 +177,11 @@ function applyPerfProfile() {
     if (PERF.dprCap !== prevDprCap && typeof resize === "function") {
         try { resize(); } catch (e) { /* canvas not ready yet */ }
     }
+    // The map cache resolution (mapScale) is baked in; force a rebuild so a tier
+    // change re-bakes it at the new resolution instead of waiting for a tile change.
+    if (typeof invalidateMapCache === "function") {
+        invalidateMapCache();
+    }
     updatePerformanceToggleUI();
     if (typeof renderSettingsRows === "function") {
         try { renderSettingsRows(); } catch (e) { /* settings panel not open */ }
@@ -229,6 +237,7 @@ function perfGlow() { return !!PERF.glow; }
 function perfEmbers() { return !!PERF.embers; }
 function perfTrailDirect() { return !!PERF.trailDirect; }
 function perfTrailDirectMax() { return PERF_TRAIL_DIRECT_MAX; }
+function perfMapScale() { return PERF.mapScale || 1; }
 function perfExplosionSparks() { return PERF.explosionSparks; }
 function perfMaxEffects() { return PERF.maxEffects; }
 function perfDprCap() { return PERF.dprCap; }
@@ -294,7 +303,7 @@ var pdWinStart = 0, pdLastSpikeEmit = 0, pdLoaf = [];
 var PD_WINDOW_MS = 3000, PD_SPIKE_MS = 60, PD_SPIKE_EMIT_GAP = 1500;
 // Bump this whenever the perf code changes meaningfully, so a device reporting an
 // old value tells us it loaded a stale (cached) bundle rather than the new fix.
-var PERF_DIAG_VERSION = "td1";
+var PERF_DIAG_VERSION = "td2";
 
 function perfDiagEnabled() {
     if (perfDiagOn === null) {
@@ -353,6 +362,7 @@ function perfDiagEmit(reason) {
         tier: perfTier, pref: getPerfPref(),
         v: PERF_DIAG_VERSION,                                   // build marker: confirms the device ran THIS code (not a cached old bundle)
         td: (typeof perfTrailDirect === "function") ? perfTrailDirect() : null, // is the direct-trail fix active this frame?
+        ms: (typeof perfMapScale === "function") ? perfMapScale() : null,       // map-cache resolution scale (1 = full, <1 = reduced)
         st: (typeof currentState !== "undefined") ? currentState : null,
         karts: (typeof playerList !== "undefined") ? perfDiagCount(playerList) : 0,
         fx: (typeof effectsList !== "undefined") ? perfDiagCount(effectsList) : 0,

--- a/client/scripts/perf.js
+++ b/client/scripts/perf.js
@@ -177,10 +177,11 @@ function applyPerfProfile() {
     if (PERF.dprCap !== prevDprCap && typeof resize === "function") {
         try { resize(); } catch (e) { /* canvas not ready yet */ }
     }
-    // The map cache resolution (mapScale) is baked in; force a rebuild so a tier
-    // change re-bakes it at the new resolution instead of waiting for a tile change.
-    if (typeof invalidateMapCache === "function") {
-        invalidateMapCache();
+    // The map cache resolution (mapScale) is baked into the cached canvas, so a
+    // tier change must discard it (not just mark it dirty) to re-bake at the new
+    // resolution rather than re-rendering into the old-sized canvas.
+    if (typeof discardMapCache === "function") {
+        discardMapCache();
     }
     updatePerformanceToggleUI();
     if (typeof renderSettingsRows === "function") {

--- a/client/scripts/perf.js
+++ b/client/scripts/perf.js
@@ -1,0 +1,461 @@
+// Device / screen-size performance profiles.
+//
+// Small phones and weak GPUs can't afford the same FX budget as a desktop, so a
+// "profile" is a small bag of rendering-detail knobs (particle counts, effect
+// caps, glow passes, trail length, the device-pixel-ratio cap, the audience
+// crowd) that the render loop reads each frame. Three named quality tiers, plus
+// an AUTO mode that picks one from screen size + known devices + hardware hints.
+//
+// The HIGH tier is tuned to be a byte-for-byte no-op versus the pre-profile
+// renderer, so desktop players (the bulk of the audience) see no change; only
+// small/low-end screens shed detail. The chosen tier is persisted in
+// localStorage and exposed both as a navbar control (#performanceControl) and a
+// row in the in-game controller Settings panel.
+//
+// `PERF` is the live resolved knob bag, read by draw.js / gameboard.js /
+// game.js (resize) / audience.js via the small perf*() accessors below. It's
+// initialised eagerly to HIGH so those reads are always valid even before the
+// first detection pass runs.
+
+// Named quality tiers. Anything not listed here falls back to HIGH.
+var PERF_PROFILES = {
+    // Roomy desktop / laptop: everything on. Values mirror the old hard-coded
+    // renderer exactly, so selecting HIGH is indistinguishable from no profile.
+    high: {
+        particleCount: 1.0,      // multiplier on per-spawn particle counts
+        cooldownMul: 1.0,        // multiplier on particle spawn cooldowns (>1 = rarer)
+        maxEffects: 100000,      // cap on simultaneous transient effects (huge => unbounded)
+        glow: true,              // per-frame shadowBlur glow passes (goal arrow, ability beam, trail, cut)
+        embers: true,            // rising embers off burning karts
+        explosionSparks: 10,     // debris sparks per explosion
+        audience: true,          // letterbox crowd
+        trailDirect: false,      // false = full per-kart offscreen trail canvas; true = stroke a capped tail straight to the main canvas (avoids re-uploading a world-sized texture/kart/frame on weak GPUs)
+        dprCap: 2                // device-pixel-ratio ceiling for the backing store
+    },
+    // Tablets / small desktop windows: trim particle volume, keep the glow and
+    // crowd (they read well on a mid device).
+    balanced: {
+        particleCount: 0.6,
+        cooldownMul: 1.4,
+        maxEffects: 280,
+        glow: true,
+        embers: true,
+        explosionSparks: 7,
+        audience: true,
+        trailDirect: false,
+        dprCap: 2
+    },
+    // Phones / low-end: shed the fill-rate-heavy work — glow passes, the crowd,
+    // embers — cap effects hard, and drop the DPR a notch so the backing store
+    // isn't over-rendered on dense panels.
+    low: {
+        particleCount: 0.4,
+        cooldownMul: 2.2,
+        maxEffects: 120,
+        glow: false,
+        embers: false,
+        explosionSparks: 4,
+        audience: false,
+        trailDirect: true,
+        dprCap: 1.5
+    }
+};
+
+// Max trail vertices kept/stroked per kart in direct mode (~last few seconds of
+// tail). Bounds both memory and the per-frame re-stroke, and — unlike the old
+// offscreen canvas — never triggers a full-world texture upload or an unbounded
+// _redrawAll, so it kills both the GPU-paint and the main-thread trail spikes.
+var PERF_TRAIL_DIRECT_MAX = 240;
+
+var PERF_STORAGE_KEY = "perfPref";
+var PERF_ORDER = ["auto", "high", "balanced", "low"];
+var PERF_LABEL = { auto: "Auto", high: "High", balanced: "Balanced", low: "Low" };
+
+// In-memory preference ("auto" | "high" | "balanced" | "low"), seeded lazily
+// from storage. Held separately from PERF so AUTO can re-resolve each load (and
+// on resize/orientation change) while a pinned tier stays put.
+var perfPref = null;
+// The resolved tier name currently in effect ("high" | "balanced" | "low").
+var perfTier = "high";
+// The live knob bag the renderer reads. Eagerly valid (see file header).
+var PERF = clonePerfProfile(PERF_PROFILES.high);
+
+function clonePerfProfile(p) {
+    var out = {};
+    for (var k in p) {
+        if (Object.prototype.hasOwnProperty.call(p, k)) {
+            out[k] = p[k];
+        }
+    }
+    return out;
+}
+
+function readStoredPerfPref() {
+    try {
+        var p = localStorage.getItem(PERF_STORAGE_KEY);
+        return (p === "high" || p === "balanced" || p === "low" || p === "auto") ? p : "auto";
+    } catch (e) {
+        return "auto";
+    }
+}
+
+function getPerfPref() {
+    if (perfPref === null) {
+        perfPref = readStoredPerfPref();
+    }
+    return perfPref;
+}
+
+function setPerfPref(pref) {
+    perfPref = pref;
+    try { localStorage.setItem(PERF_STORAGE_KEY, pref); } catch (e) { /* storage disabled */ }
+}
+
+// Named profiles tuned for specific target devices. A UA match here wins over
+// the generic screen/hardware heuristic below, so a known phone always lands on
+// LOW even on a high-DPR panel that might otherwise read as "big".
+function namedDeviceTier(ua) {
+    if (/iPhone|iPod/i.test(ua)) { return "low"; }        // iPhones: shed FX
+    if (/iPad/i.test(ua)) { return "balanced"; }           // iPads: mid detail
+    if (/Android/i.test(ua)) {
+        return /Mobile/i.test(ua) ? "low" : "balanced";    // android phone vs tablet
+    }
+    // Note: iPadOS 13+ Safari reports a desktop "Macintosh" UA with no iPad
+    // token, so it falls through here — but it's a coarse-pointer device, so the
+    // touch branch in detectPerfTier still lands it on BALANCED (same as above).
+    return null;
+}
+
+// Resolve AUTO to a concrete tier from the device & viewport. Conservative:
+// when signals conflict it steps down a notch rather than risking a stutter.
+function detectPerfTier() {
+    var w = window.innerWidth || (screen && screen.width) || 1366;
+    var h = window.innerHeight || (screen && screen.height) || 768;
+    var minDim = Math.min(w, h);
+    var touch = (typeof isTouchScreen !== "undefined" && isTouchScreen === true);
+    var cores = (typeof navigator !== "undefined" && navigator.hardwareConcurrency) || 0;
+    var mem = (typeof navigator !== "undefined" && navigator.deviceMemory) || 0; // GB, Chromium-only
+    var ua = (typeof navigator !== "undefined" && navigator.userAgent) || "";
+
+    var named = namedDeviceTier(ua);
+    if (named) { return named; }
+
+    // Coarse-pointer (touch) screens: bucket by physical size. LOW is reserved
+    // for phone-sized touch screens — a mouse/desktop never auto-drops to LOW,
+    // so the desktop audience keeps the full show (CHANGELOG promise).
+    if (touch) {
+        return (minDim <= 480) ? "low" : "balanced"; // phone vs tablet/large-touch
+    }
+
+    // Desktop / laptop. Only genuinely weak machines (a couple of cores, or
+    // ~2GB RAM) or cramped windows step down to BALANCED; 4-core/8GB and up,
+    // at a normal window size, stay HIGH.
+    if ((cores && cores <= 2) || (mem && mem <= 2)) { return "balanced"; }
+    if (w < 900 || h < 560) { return "balanced"; }
+
+    return "high";
+}
+
+// Recompute the active tier from the preference and copy its knobs into PERF.
+// Re-applies the DPR cap (via resize) and refreshes any visible UI.
+function applyPerfProfile() {
+    var pref = getPerfPref();
+    var prevDprCap = (PERF && PERF.dprCap != null) ? PERF.dprCap : null;
+    perfTier = (pref === "auto") ? detectPerfTier() : pref;
+    if (!PERF_PROFILES[perfTier]) {
+        perfTier = "high";
+    }
+    PERF = clonePerfProfile(PERF_PROFILES[perfTier]);
+    // The particle/glow/effect knobs are read live each frame, so they take
+    // effect on the next frame with no extra work. Only the DPR cap feeds the
+    // backing-store size (set in resize), so re-fit ONLY when it actually
+    // changes — toggling e.g. High<->Balanced (same cap) shouldn't reallocate
+    // the canvas or reset the camera.
+    if (PERF.dprCap !== prevDprCap && typeof resize === "function") {
+        try { resize(); } catch (e) { /* canvas not ready yet */ }
+    }
+    updatePerformanceToggleUI();
+    if (typeof renderSettingsRows === "function") {
+        try { renderSettingsRows(); } catch (e) { /* settings panel not open */ }
+    }
+}
+
+// Cycle auto -> high -> balanced -> low -> auto (navbar click / settings row).
+function cyclePerfProfile() {
+    var next = PERF_ORDER[(PERF_ORDER.indexOf(getPerfPref()) + 1) % PERF_ORDER.length];
+    setPerfPref(next);
+    applyPerfProfile();
+}
+
+// Label for the navbar/settings UI. AUTO shows the tier it resolved to, e.g.
+// "Auto (Low)", so players can see what the detector picked.
+function perfProfileLabel() {
+    var pref = getPerfPref();
+    if (pref === "auto") {
+        return "Auto (" + (PERF_LABEL[perfTier] || "High") + ")";
+    }
+    return PERF_LABEL[pref] || "High";
+}
+
+function updatePerformanceToggleUI() {
+    var el = (typeof document !== "undefined") ? document.getElementById("performanceControl") : null;
+    if (!el) {
+        return;
+    }
+    el.innerHTML = '<i class="music-btn fas fa-bolt" aria-hidden="true"></i> [' + perfProfileLabel() + ']';
+    el.setAttribute("title", "Graphics detail: " + perfProfileLabel() + " (click to change)");
+    el.setAttribute("aria-label", "Graphics detail: " + perfProfileLabel() + ". Click to change.");
+}
+
+// --- Renderer-facing accessors, read every frame. PERF is eagerly initialised
+// above and never cleared, so these read it directly; renderer call sites guard
+// `typeof perfX === "function"` to cover perf.js being absent entirely (in which
+// case these functions don't exist either). Keep them cheap. ---
+// Scale a requested particle burst. A burst that was going to spawn (n >= 1)
+// always keeps at least one fleck — profiles thin particles, they don't make
+// terrain feedback vanish entirely (full removal is an explicit knob, e.g.
+// perfEmbers). n == 0 stays 0.
+function perfCount(n) {
+    return Math.max(n >= 1 ? 1 : 0, Math.round(n * PERF.particleCount));
+}
+function perfCooldown(ms) {
+    return ms * PERF.cooldownMul;
+}
+// Gates the per-frame shadowBlur glow passes in the racing hot path (the
+// off-screen goal arrow, the ability/aim beam, the kart trail, the cut slash).
+// One-shot, cached (halo/sprite), lobby and HUD glows are intentionally left
+// alone — they're not in the per-frame racing budget the LOW tier targets.
+function perfGlow() { return !!PERF.glow; }
+function perfEmbers() { return !!PERF.embers; }
+function perfTrailDirect() { return !!PERF.trailDirect; }
+function perfTrailDirectMax() { return PERF_TRAIL_DIRECT_MAX; }
+function perfExplosionSparks() { return PERF.explosionSparks; }
+function perfMaxEffects() { return PERF.maxEffects; }
+function perfDprCap() { return PERF.dprCap; }
+function perfAudienceAllowed() { return PERF.audience !== false; }
+
+// --- Optional on-screen frame-time HUD (diagnostic) ---
+// Enabled with ?fps=1 in the URL (or localStorage perfHud=1). Shows smoothed FPS
+// plus the WORST frame in each ~0.5s window — the worst-frame number is the
+// stutter signal: if FPS reads ~50 but worst spikes to 80ms+, that's hitching,
+// not a low average. Off by default; pure overlay, never touches gameplay.
+var perfHudOn = null, perfHudEl = null, perfHudAccum = 0, perfHudFrames = 0, perfHudWorst = 0;
+function perfHudEnabled() {
+    if (perfHudOn === null) {
+        perfHudOn = false;
+        try {
+            perfHudOn = /[?&]fps=1\b/.test(window.location.search || "") ||
+                (localStorage.getItem("perfHud") === "1");
+        } catch (e) { /* no location/storage */ }
+    }
+    return perfHudOn;
+}
+function perfHudTick(dt) {
+    if (!perfHudEnabled() || !(dt > 0)) {
+        return;
+    }
+    if (dt > perfHudWorst) { perfHudWorst = dt; }
+    perfHudFrames++;
+    perfHudAccum += dt;
+    if (perfHudAccum < 500) {
+        return;
+    }
+    var fps = Math.round(1000 * perfHudFrames / perfHudAccum);
+    var worst = Math.round(perfHudWorst);
+    if (!perfHudEl && typeof document !== "undefined" && document.body) {
+        perfHudEl = document.createElement("div");
+        perfHudEl.id = "perfHud";
+        perfHudEl.style.cssText = "position:fixed;top:4px;left:4px;z-index:99999;" +
+            "font:bold 12px monospace;background:rgba(0,0,0,.6);color:#0f0;" +
+            "padding:3px 6px;border-radius:4px;pointer-events:none;white-space:pre;";
+        document.body.appendChild(perfHudEl);
+    }
+    if (perfHudEl) {
+        perfHudEl.textContent = fps + " fps   worst " + worst + "ms   [" + perfProfileLabel() + "]";
+        // Red = a real stutter spike this window; amber = low average; green = smooth.
+        perfHudEl.style.color = worst > 40 ? "#ff5555" : (fps < 45 ? "#ffdd00" : "#00ff66");
+    }
+    perfHudAccum = 0; perfHudFrames = 0; perfHudWorst = 0;
+}
+
+// --- Optional perf telemetry to the server (diagnostic) ---
+// Enabled with ?diag=1 (or localStorage perfDiag=1). Streams compact render-perf
+// samples over the existing socket so a stutter on a real device can be read from
+// the SERVER log ([perf-diag] lines): rolling frame-time stats, a coarse phase
+// split (input / render / rest), device class + current game-state counts, and —
+// on Chromium — Long Animation Frame attribution (script vs render blocking),
+// which is the clearest signal for whether spikes are JS/GC or rendering. Off by
+// default; sends only technical data (no PII beyond the UA string), and a spike
+// frame triggers an immediate (throttled) report so the stutter is captured.
+var perfDiagOn = null, perfDiagInited = false;
+var pdFrames = 0, pdSum = 0, pdWorst = 0, pdDrop = 0, pdSpike = 0;
+var pdInSum = 0, pdInWorst = 0, pdRnSum = 0, pdRnWorst = 0, pdRsSum = 0, pdRsWorst = 0;
+var pdWinStart = 0, pdLastSpikeEmit = 0, pdLoaf = [];
+var PD_WINDOW_MS = 3000, PD_SPIKE_MS = 60, PD_SPIKE_EMIT_GAP = 1500;
+// Bump this whenever the perf code changes meaningfully, so a device reporting an
+// old value tells us it loaded a stale (cached) bundle rather than the new fix.
+var PERF_DIAG_VERSION = "td1";
+
+function perfDiagEnabled() {
+    if (perfDiagOn === null) {
+        perfDiagOn = false;
+        try {
+            perfDiagOn = /[?&]diag=1\b/.test(window.location.search || "") ||
+                (localStorage.getItem("perfDiag") === "1");
+        } catch (e) { /* no location/storage */ }
+    }
+    return perfDiagOn;
+}
+
+function perfDiagInit() {
+    if (perfDiagInited || !perfDiagEnabled()) {
+        return;
+    }
+    perfDiagInited = true;
+    pdWinStart = Date.now();
+    // Chromium: attribute long frames (script/style/layout/paint blocking). Tells
+    // us whether a spike was JS execution (incl. GC) or rendering. No-op elsewhere.
+    try {
+        if (window.PerformanceObserver && PerformanceObserver.supportedEntryTypes &&
+            PerformanceObserver.supportedEntryTypes.indexOf("long-animation-frame") !== -1) {
+            var po = new PerformanceObserver(function (list) {
+                var es = list.getEntries();
+                for (var i = 0; i < es.length; i++) {
+                    pdLoaf.push({ d: Math.round(es[i].duration), b: Math.round(es[i].blockingDuration || 0) });
+                    if (pdLoaf.length > 8) { pdLoaf.shift(); }
+                }
+            });
+            po.observe({ type: "long-animation-frame", buffered: true });
+        }
+    } catch (e) { /* observer unsupported */ }
+}
+
+function perfDiagCount(obj) {
+    if (obj == null) { return 0; }
+    if (typeof obj.length === "number") { return obj.length; }
+    var n = 0; for (var k in obj) { if (Object.prototype.hasOwnProperty.call(obj, k)) { n++; } }
+    return n;
+}
+
+function perfDiagEmit(reason) {
+    var sock = (typeof server !== "undefined") ? server : null;
+    if (!sock || typeof sock.emit !== "function") {
+        return;
+    }
+    var frames = pdFrames || 1;
+    var nav = (typeof navigator !== "undefined") ? navigator : {};
+    var payload = {
+        r: reason,
+        ua: (nav.userAgent || "").slice(0, 180),
+        dpr: window.devicePixelRatio || 1,
+        iw: window.innerWidth, ih: window.innerHeight,
+        cores: nav.hardwareConcurrency || 0, mem: nav.deviceMemory || 0,
+        tier: perfTier, pref: getPerfPref(),
+        v: PERF_DIAG_VERSION,                                   // build marker: confirms the device ran THIS code (not a cached old bundle)
+        td: (typeof perfTrailDirect === "function") ? perfTrailDirect() : null, // is the direct-trail fix active this frame?
+        st: (typeof currentState !== "undefined") ? currentState : null,
+        karts: (typeof playerList !== "undefined") ? perfDiagCount(playerList) : 0,
+        fx: (typeof effectsList !== "undefined") ? perfDiagCount(effectsList) : 0,
+        proj: (typeof projectileList !== "undefined") ? perfDiagCount(projectileList) : 0,
+        fps: Math.round(1000 * pdFrames / Math.max(1, pdSum)),
+        avg: +(pdSum / frames).toFixed(1), worst: Math.round(pdWorst),
+        drop33: pdDrop, spike60: pdSpike,
+        ph: {
+            in: { a: +(pdInSum / frames).toFixed(1), w: +pdInWorst.toFixed(1) },
+            rn: { a: +(pdRnSum / frames).toFixed(1), w: +pdRnWorst.toFixed(1) },
+            rs: { a: +(pdRsSum / frames).toFixed(1), w: +pdRsWorst.toFixed(1) }
+        },
+        loaf: pdLoaf.slice(-5)
+    };
+    try { sock.emit("clientPerfDiag", JSON.stringify(payload)); } catch (e) { /* socket not ready */ }
+}
+
+function perfDiagReset() {
+    pdFrames = 0; pdSum = 0; pdWorst = 0; pdDrop = 0; pdSpike = 0;
+    pdInSum = 0; pdInWorst = 0; pdRnSum = 0; pdRnWorst = 0; pdRsSum = 0; pdRsWorst = 0;
+    pdWinStart = Date.now();
+}
+
+// Per-frame sample. inputMs/renderMs/restMs are the gameLoop phase splits.
+function perfDiagTick(dt, inputMs, renderMs, restMs) {
+    if (!perfDiagEnabled() || !(dt > 0)) {
+        return;
+    }
+    // Ignore non-render stalls: a backgrounded/locked tab or an asset-load gap
+    // produces multi-second "frames" that aren't rendering and would swamp the
+    // stats (the 5–6s "frames" seen in early captures). Real render spikes are
+    // well under this.
+    if (dt > 2000 || (typeof document !== "undefined" && document.hidden)) {
+        return;
+    }
+    if (!perfDiagInited) { perfDiagInit(); }
+    pdFrames++; pdSum += dt;
+    if (dt > pdWorst) { pdWorst = dt; }
+    if (dt > 33) { pdDrop++; }            // missed 30fps
+    if (dt > PD_SPIKE_MS) { pdSpike++; }  // a stutter spike
+    pdInSum += inputMs; if (inputMs > pdInWorst) { pdInWorst = inputMs; }
+    pdRnSum += renderMs; if (renderMs > pdRnWorst) { pdRnWorst = renderMs; }
+    pdRsSum += restMs; if (restMs > pdRsWorst) { pdRsWorst = restMs; }
+
+    var now = Date.now();
+    // Capture a single bad spike promptly (throttled) so we see what coincided.
+    if (dt > PD_SPIKE_MS && now - pdLastSpikeEmit > PD_SPIKE_EMIT_GAP) {
+        pdLastSpikeEmit = now;
+        perfDiagEmit("spike");
+    }
+    if (now - pdWinStart >= PD_WINDOW_MS) {
+        perfDiagEmit("interval");
+        perfDiagReset();
+    }
+}
+
+// Wire the navbar control and run the first detection pass once the DOM is up.
+// Re-resolve AUTO on viewport changes (rotate / resize) so going landscape on a
+// tablet, say, can step the tier up or down.
+function initPerf() {
+    var el = (typeof document !== "undefined") ? document.getElementById("performanceControl") : null;
+    if (el && !el._perfWired) {
+        el._perfWired = true;
+        el.addEventListener("click", cyclePerfProfile);
+        el.addEventListener("keydown", function (e) {
+            if (e.key === "Enter" || e.key === " " || e.keyCode === 13 || e.keyCode === 32) {
+                e.preventDefault();
+                e.stopPropagation();
+                cyclePerfProfile();
+            }
+        });
+    }
+    if (typeof window !== "undefined" && !window._perfResizeWired) {
+        window._perfResizeWired = true;
+        // Re-resolve AUTO on viewport changes (rotate / resize), but DEBOUNCED:
+        // mobile browsers fire 'resize' rapidly as the address bar shows/hides on
+        // scroll, and re-applying (a possible canvas re-fit) on each would stutter.
+        // Collapse a burst into one settled check, and only re-apply on a genuine
+        // tier change (applyPerfProfile itself re-fits only if the DPR cap moved).
+        var resizeTimer = null;
+        window.addEventListener("resize", function () {
+            if (getPerfPref() !== "auto") {
+                return;
+            }
+            if (resizeTimer) {
+                clearTimeout(resizeTimer);
+            }
+            resizeTimer = setTimeout(function () {
+                resizeTimer = null;
+                if (getPerfPref() === "auto" && detectPerfTier() !== perfTier) {
+                    applyPerfProfile();
+                }
+            }, 300);
+        });
+    }
+    perfDiagInit();
+    applyPerfProfile();
+}
+
+if (typeof document !== "undefined") {
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", initPerf);
+    } else {
+        initPerf();
+    }
+}

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -99,6 +99,24 @@ function checkForMail(client) {
 		client.emit("config", c);
 	});
 
+	// Diagnostic only: a client running with ?diag=1 streams render-perf samples
+	// (frame times, phase split, device class, game-state counts) so a stutter on
+	// a real device can be diagnosed from server logs. Untrusted input — accept
+	// only a small object, log one compact line, never act on it or echo it.
+	client.on("clientPerfDiag", function (payload) {
+		try {
+			var d = (typeof payload === "string") ? JSON.parse(payload) : payload;
+			if (d == null || typeof d !== "object") {
+				return;
+			}
+			var s = JSON.stringify(d);
+			if (s.length > 4000) {
+				s = s.slice(0, 4000) + "…";
+			}
+			console.log("[perf-diag] " + client.id + " " + s);
+		} catch (e) { /* ignore malformed diag payloads */ }
+	});
+
 	client.on('submitNewMap', function (package) {
 		var vMap;
 		try {

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -101,19 +101,26 @@ function checkForMail(client) {
 
 	// Diagnostic only: a client running with ?diag=1 streams render-perf samples
 	// (frame times, phase split, device class, game-state counts) so a stutter on
-	// a real device can be diagnosed from server logs. Untrusted input — accept
-	// only a small object, log one compact line, never act on it or echo it.
+	// a real device can be diagnosed from server logs. Untrusted input from any
+	// client, so it's hardened against abuse: reject anything but a small string,
+	// rate-limit per client, and log one truncated line. Never parse a large
+	// payload (avoids a main-thread JSON.parse DoS) and never act on it.
+	var lastPerfDiagAt = 0;
 	client.on("clientPerfDiag", function (payload) {
 		try {
-			var d = (typeof payload === "string") ? JSON.parse(payload) : payload;
+			if (typeof payload !== "string" || payload.length > 4000) {
+				return;   // the legit client sends a small JSON string; ignore anything else
+			}
+			var now = Date.now();
+			if (now - lastPerfDiagAt < 500) {
+				return;   // rate-limit: the real client emits every ~1.5-3s
+			}
+			lastPerfDiagAt = now;
+			var d = JSON.parse(payload);
 			if (d == null || typeof d !== "object") {
 				return;
 			}
-			var s = JSON.stringify(d);
-			if (s.length > 4000) {
-				s = s.slice(0, 4000) + "…";
-			}
-			console.log("[perf-diag] " + client.id + " " + s);
+			console.log("[perf-diag] " + client.id + " " + payload);
 		} catch (e) { /* ignore malformed diag payloads */ }
 	});
 


### PR DESCRIPTION
## Summary

Makes the game run and *feel* smoother on phones, tablets and low-end screens, without touching the desktop experience. Three independent improvements (each its own commit):

### 1. Device / screen-size graphics-detail profiles
Auto-picks a rendering-detail tier from screen size + known devices + hardware hints, and sheds expensive FX on small/low-end screens. Named tiers **High / Balanced / Low** plus **Auto**, exposed as a top-bar **⚡ Graphics detail** control and a row in the controller Settings panel, persisted in `localStorage`.

The profile gates: particle counts + spawn cooldowns, the transient-effect cap (telegraphs flagged `keep` are never evicted), per-frame `shadowBlur` glow passes, ember particles, explosion debris, the audience crowd, the **device-pixel-ratio cap**, the **trail renderer** (Low strokes a capped tail directly instead of a per-kart world-sized texture), and the **map-cache resolution** (Low renders it smaller so each re-upload on a tile change moves far fewer bytes).

- **High is a byte-for-byte no-op** vs the previous renderer — desktop sees no change.
- **Auto never drops a non-touch desktop below Balanced** — the desktop audience keeps the full show.

### 2. Client-side motion interpolation (all devices)
The server ticks positions at 30 Hz; the client snapped entities straight to those positions, so motion *stepped* at 60 fps (the "bumper jumping frames"). Now the render position eases toward the latest server target each frame — local kart fast, remote karts + hazards smooth — snapping on a real teleport (respawn / swap). Easing (not extrapolation) is deliberate: the sim is server-authoritative and collision-heavy, so extrapolation would overshoot into walls. **Authoritative reads (mouse-drive aim, death position) use the un-eased server target**, so control feel is unaffected.

### 3. Diagnostics (off by default)
`?fps=1` shows an on-screen FPS + worst-frame overlay. `?diag=1` streams compact render-perf samples (frame stats, input/render/rest phase split, device class, game-state counts, Chromium Long-Animation-Frame attribution) over the socket to a **hardened** `clientPerfDiag` log handler (rejects non-string/oversized payloads before parsing; rate-limited per client). Useful for on-device profiling; for broad always-on prod tracking, GA4 (`trackEvent`) is the better long-term vehicle.

## Why
Real-device testing surfaced mobile stutter that a frame-rate counter couldn't see — it was GPU texture re-uploads (per-kart trail canvas + the world-sized map cache re-uploaded on every tile change) plus 30 Hz→60 fps motion stepping. This PR addresses all of it. Validated on a real Android phone (now "very smooth" on Low) and an iPad (worst frame 81 → 53 ms, ≥60 ms spikes 5 → 0 on Low).

## Test plan
- `npm run build` — clean
- `.github/scripts/smoke-test.js` — boots + ticks all maps, passes
- Browser-verified: profile cycling/persistence/detection, DPR re-fit, telegraph-protecting effect cap, interpolation (ease curve, teleport snap), reduced-res map cache (1382 → 830 px on Low), trail throttled to ~30 Hz; 0 console errors
- `/code-review xhigh` run; findings fixed (see final commit)

## Notes
- Client-only except a guarded diagnostic log handler in `server/messenger.js`.
- New file `client/scripts/perf.js` (added to the play bundle in `build.js` + `play.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
