### PR TITLE
Touch overhaul: reliable punch, fullscreen, settings + lobby camera on tablets/iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- Touch: the camera now follows you in the lobby (like it does during a race), instead of showing the whole lobby zoomed out — so you're not a tiny dot on a phone screen while walking to a station.
+- Touch: a translucent settings (gear) button now appears at the top of the screen while you're in fullscreen, opening the same Settings panel the controller's Start button does (sound, music, camera, colour-blind, theme) — tap a row to change it and **Done** to close. Previously fullscreen touch players had no way to reach Settings.
+
+### Bug fixes
+
+- Touch: the Fullscreen button now actually enters fullscreen. It was firing the request the instant your finger touched down, which browsers reject (fullscreen must be requested as your finger lifts) — so it silently did nothing. It now triggers on release.
+- Touch: tapping the screen no longer fires a phantom punch, and double-tapping no longer flips on the desktop "mouse-drive" mode (which could send your kart driving off on its own to its death). Tablets/phones were quietly delivering simulated mouse clicks on top of every tap, so taps — including on the Fullscreen button — were also registering as clicks.
+- Touch: the on-screen buttons now line up exactly with where you tap, even when the browser renders the play area at a slightly different size than expected (which made the top-right Fullscreen button especially easy to miss into a punch on iPad).
+- Touch: punching now works on tablets and iPads. There's a clear **Attack** button in the lower-right corner that lights up when you press it, and tapping anywhere on the right side of the screen throws a punch — previously the punch target was a small invisible circle stuck in the screen's middle, so on bigger screens a thumb resting in the corner missed it every time.
+- Touch: the top-corner Fullscreen and Emoji buttons are bigger and have a visible backing, and tapping near them no longer throws a punch by mistake.
+- Touch: the on-screen controls no longer vanish during the Blackout brutal round — they now stay visible on top of the darkness.
 
 ## v0.16.0 — 2026-05-27
 

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1218,6 +1218,50 @@ body.osk-open .gamepad-prompts {
     font-size: 0.8rem;
     color: var(--muted, #999);
 }
+/* Touch-only "Done" button in the settings footer (touch can't press a pad's B
+   to close, and the modal's transparent backdrop passes taps through). */
+.settings-foot .settings-done {
+    pointer-events: auto;
+    padding: 0.5rem 1.4rem;
+    font-size: 1rem;
+    font-weight: 700;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+}
+/* Translucent settings (gear) button — shown only on touch while in fullscreen,
+   where the navbar (and its settings controls) is hidden and there's no pad
+   Start button. Sits above the settings modal so it can also toggle it closed. */
+#touchSettingsBtn {
+    position: fixed;
+    top: max(8px, env(safe-area-inset-top));
+    left: 50%;
+    transform: translateX(-50%);
+    width: 48px;
+    height: 48px;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    font-size: 22px;
+    line-height: 1;
+    color: #fff;
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 50%;
+    cursor: pointer;
+    z-index: 3001;            /* above .settings-modal (3000) so it can close it */
+    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(4px);
+}
+#touchSettingsBtn.visible {
+    display: inline-flex;
+}
+#touchSettingsBtn:active {
+    background: rgba(0, 0, 0, 0.62);
+}
 /* Reuse the hint-bar chip look so the footer matches the rest of the game's
    controller glyphs (the bare .gp-glyph rules are all parent-scoped). */
 .settings-foot .gp-hint {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -835,12 +835,17 @@ function computeWorldViewTarget(dt) {
         worldViewFocusedElapsed = 0;
         return wholeMap;
     }
-    // Focus once the round is live (gate countdown + race);
-    // lobby / overview / game-over keep the whole map so the goal + player and
-    // the arena are all visible at the start.
+    // Focus once the round is live (gate countdown + race); plus the LOBBY on
+    // touch, where the whole-map view leaves the player a tiny dot on a phone —
+    // a follow camera keeps them readable while they walk to a station. (Desktop
+    // lobby stays whole-map; touch lobby taps are inverse-mapped through the zoom
+    // in onTouchStart so station hit-testing still lines up.)
+    var inLobbyTouch = (currentState === config.stateMap.lobby &&
+        typeof isTouchScreen !== "undefined" && isTouchScreen);
     var focused = (currentState === config.stateMap.gated ||
         currentState === config.stateMap.racing ||
-        currentState === config.stateMap.collapsing);
+        currentState === config.stateMap.collapsing ||
+        inLobbyTouch);
     if (!focused) {
         worldViewFocusedElapsed = 0;
         return wholeMap;
@@ -3303,10 +3308,15 @@ function drawVirtualButtons() {
     }
 }
 
-function drawTouchControls() {
+function drawTouchControls(ctx) {
     if (isTouchScreen == false) {
         return;
     }
+    // Draw on the OVERLAY canvas (top layer) by default so the controls sit ABOVE
+    // everything the game draws — including the blackout brutal round, which fills
+    // the overlay with darkness. The control UI must never be hidden by a gameplay
+    // effect. (Both canvases share the same transform; see applyCanvasTransform.)
+    ctx = ctx || overlayContext;
 
     var exitToUse = exitIcon;
     var fullScreenToUse = fullscreenIcon;
@@ -3326,77 +3336,77 @@ function drawTouchControls() {
 
 
     if (joystickMovement != null && joystickMovement.isVisible()) {
-        gameContext.save();
-        gameContext.beginPath();
-        gameContext.lineWidth = 3;
-        gameContext.strokeStyle = themeColor('ink', 'black');
-        gameContext.arc(joystickMovement.baseX, joystickMovement.baseY, joystickMovement.baseRadius, 0, Math.PI * 2, false);
-        gameContext.stroke();
-        gameContext.beginPath();
-        gameContext.arc(joystickMovement.baseX, joystickMovement.baseY, joystickMovement.stickRadius, 0, Math.PI * 2, false);
-        gameContext.stroke();
+        ctx.save();
+        ctx.beginPath();
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = themeColor('ink', 'black');
+        ctx.arc(joystickMovement.baseX, joystickMovement.baseY, joystickMovement.baseRadius, 0, Math.PI * 2, false);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(joystickMovement.baseX, joystickMovement.baseY, joystickMovement.stickRadius, 0, Math.PI * 2, false);
+        ctx.stroke();
 
 
-        gameContext.beginPath();
-        gameContext.arc(joystickMovement.stickX, joystickMovement.stickY, joystickMovement.stickRadius, 0, Math.PI * 2, true);
-        gameContext.fillStyle = "rgba(255, 0, 0, 0.2)";
-        gameContext.fill();
-        gameContext.stroke();
-        gameContext.restore();
-        drawTouchLabel("Move", joystickMovement.baseX, joystickMovement.baseY + joystickMovement.baseRadius + 20);
+        ctx.beginPath();
+        ctx.arc(joystickMovement.stickX, joystickMovement.stickY, joystickMovement.stickRadius, 0, Math.PI * 2, true);
+        ctx.fillStyle = "rgba(255, 0, 0, 0.2)";
+        ctx.fill();
+        ctx.stroke();
+        ctx.restore();
+        drawTouchLabel("Move", joystickMovement.baseX, joystickMovement.baseY + joystickMovement.baseRadius + 20, ctx);
     }
     if (joystickCamera != null && joystickCamera.isVisible()) {
-        gameContext.save();
+        ctx.save();
 
-        gameContext.beginPath();
-        gameContext.lineWidth = 3;
-        gameContext.strokeStyle = themeColor('ink', 'black');
-        gameContext.arc(joystickCamera.baseX, joystickCamera.baseY, joystickCamera.baseRadius, 0, Math.PI * 2, false);
-        gameContext.stroke();
-        gameContext.beginPath();
-        gameContext.arc(joystickCamera.baseX, joystickCamera.baseY, joystickCamera.stickRadius, 0, Math.PI * 2, false);
-        gameContext.stroke();
+        ctx.beginPath();
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = themeColor('ink', 'black');
+        ctx.arc(joystickCamera.baseX, joystickCamera.baseY, joystickCamera.baseRadius, 0, Math.PI * 2, false);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(joystickCamera.baseX, joystickCamera.baseY, joystickCamera.stickRadius, 0, Math.PI * 2, false);
+        ctx.stroke();
 
-        gameContext.beginPath();
-        gameContext.fillStyle = "rgba(0, 255, 0, 0.2)";
-        gameContext.arc(joystickCamera.stickX, joystickCamera.stickY, joystickCamera.stickRadius, 0, Math.PI * 2, true);
-        gameContext.fill();
-        gameContext.stroke();
-        gameContext.restore();
+        ctx.beginPath();
+        ctx.fillStyle = "rgba(0, 255, 0, 0.2)";
+        ctx.arc(joystickCamera.stickX, joystickCamera.stickY, joystickCamera.stickRadius, 0, Math.PI * 2, true);
+        ctx.fill();
+        ctx.stroke();
+        ctx.restore();
     }
     if (attackButton != null && attackButton.isVisible()) {
-        gameContext.save();
-        gameContext.beginPath();
-        gameContext.lineWidth = 1;
-        gameContext.strokeStyle = themeColor('ink', 'black');
-        gameContext.fillStyle = "rgba(0, 0, 255, 0.2)";
-
-        //gameContext.rect(attackButton.baseX, attackButton.baseY, attackButton.width, attackButton.height);
-        gameContext.arc(attackButton.baseX, attackButton.baseY, attackButton.radius, 0, Math.PI * 2, true);
-        gameContext.fill();
-        gameContext.stroke();
-        gameContext.restore();
-        drawTouchLabel("Attack", attackButton.baseX, attackButton.baseY + attackButton.radius + 20);
+        ctx.save();
+        ctx.beginPath();
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = themeColor('ink', 'black');
+        // Punch-red so it reads as the attack control (mirrors the move ring on
+        // the left); brighten the fill while held for tap/charge feedback.
+        ctx.fillStyle = attackButton.pressed ? "rgba(255, 72, 56, 0.5)" : "rgba(255, 72, 56, 0.26)";
+        ctx.arc(attackButton.baseX, attackButton.baseY, attackButton.radius, 0, Math.PI * 2, false);
+        ctx.fill();
+        ctx.stroke();
+        ctx.restore();
+        drawTouchLabel("Attack", attackButton.baseX, attackButton.baseY + attackButton.radius + 20, ctx);
     }
     if (exitButton != null && exitButton.isVisible() && fullscreenSupported()) {
         var exitSize = exitButton.iconSize || 34;
         if (window.document.fullscreenElement) {
-            gameContext.save();
-            gameContext.drawImage(exitToUse, exitButton.baseX - exitSize / 2, exitButton.baseY - exitSize / 2, exitSize, exitSize);
-            gameContext.restore();
+            ctx.save();
+            ctx.drawImage(exitToUse, exitButton.baseX - exitSize / 2, exitButton.baseY - exitSize / 2, exitSize, exitSize);
+            ctx.restore();
         } else {
-            gameContext.save();
-            gameContext.drawImage(fullScreenToUse, exitButton.baseX - exitSize / 2, exitButton.baseY - exitSize / 2, exitSize, exitSize);
-            gameContext.restore();
+            ctx.save();
+            ctx.drawImage(fullScreenToUse, exitButton.baseX - exitSize / 2, exitButton.baseY - exitSize / 2, exitSize, exitSize);
+            ctx.restore();
         }
-        drawTouchLabel(window.document.fullscreenElement ? "Exit" : "Fullscreen", exitButton.baseX, exitButton.baseY + exitSize / 2 + 16);
+        drawTouchLabel(window.document.fullscreenElement ? "Exit" : "Fullscreen", exitButton.baseX, exitButton.baseY + exitSize / 2 + 16, ctx);
     }
     if (chatButton != null && chatButton.isVisible()) {
         var chatSize = chatButton.iconSize || 34;
-        gameContext.save();
-        gameContext.drawImage(chatToUse, chatButton.baseX - chatSize / 2, chatButton.baseY - chatSize / 2, chatSize, chatSize);
-        gameContext.restore();
-        drawTouchLabel("Emoji", chatButton.baseX, chatButton.baseY + chatSize / 2 + 16);
+        ctx.save();
+        ctx.drawImage(chatToUse, chatButton.baseX - chatSize / 2, chatButton.baseY - chatSize / 2, chatSize, chatSize);
+        ctx.restore();
+        drawTouchLabel("Emoji", chatButton.baseX, chatButton.baseY + chatSize / 2 + 16, ctx);
     }
 }
 
@@ -3420,23 +3430,24 @@ function drawMouseDriveIndicator() {
 }
 
 // Small caption under a touch control so mobile players know what it does.
-function drawTouchLabel(text, x, y) {
-    gameContext.save();
+function drawTouchLabel(text, x, y, ctx) {
+    ctx = ctx || overlayContext;
+    ctx.save();
     // The 1366x768 logical space is scaled down a lot on a phone, so a fixed
     // 16px label would render only a few CSS px tall. Size up as the fit ratio
     // shrinks to hold a roughly constant physical size (~15 CSS px), clamped so
     // it never goes below the original 16px or balloons on large displays.
     var fontPx = Math.round(Math.max(16, Math.min(40, 15 / (fitRatio || 1))));
-    gameContext.font = "bold " + fontPx + "px Arial";
-    gameContext.textAlign = "center";
-    gameContext.lineWidth = 4;
+    ctx.font = "bold " + fontPx + "px Arial";
+    ctx.textAlign = "center";
+    ctx.lineWidth = 4;
     // Theme-aware so the captions read correctly on the dark board too (matches
     // the rest of the renderer + the adjacent touch-control rings).
-    gameContext.strokeStyle = themeColor('inkOutline', 'white');
-    gameContext.fillStyle = themeColor('ink', 'black');
-    gameContext.strokeText(text, x, y);
-    gameContext.fillText(text, x, y);
-    gameContext.restore();
+    ctx.strokeStyle = themeColor('inkOutline', 'white');
+    ctx.fillStyle = themeColor('ink', 'black');
+    ctx.strokeText(text, x, y);
+    ctx.fillText(text, x, y);
+    ctx.restore();
 }
 
 function drawTitle() {

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -83,6 +83,7 @@ function initGamepad() {
     buildHintBar();
     buildLeaveModalUI();
     buildSettingsModalUI();
+    buildTouchSettingsButton();
     buildPadPlayersUI();
     // Start on the device's most likely method; live usage swaps it.
     setInputMethod((typeof isTouchScreen !== "undefined" && isTouchScreen) ? "touch" : "kbm");
@@ -1092,7 +1093,9 @@ function buildSettingsModalUI() {
         '<div class="settings-rows">' + rows + '</div>' +
         '<div class="settings-foot"></div>' +
         '</div>';
-    document.body.appendChild(el);
+    // Append inside #gameWindow so the panel is visible when opened in fullscreen
+    // (the fullscreen element only renders its own subtree); falls back to <body>.
+    (document.getElementById("gameWindow") || document.body).appendChild(el);
     settingsModalEl = el;
     // Mouse users can click a row directly.
     var btns = el.querySelectorAll(".settings-row");
@@ -1217,10 +1220,20 @@ function openSettingsModal(lp) {
     // adapt to the pad type (Xbox A/B vs PlayStation cross/circle).
     var foot = settingsModalEl.querySelector(".settings-foot");
     if (foot) {
-        foot.innerHTML =
-            '<span class="gp-hint"><span class="gp-glyph gp-stick">L</span><span class="gp-glyph gp-dpad">✛</span>Move</span>' +
-            '<span class="gp-hint"><span class="gp-glyph gp-face">' + attackGlyph() + '</span>Toggle</span>' +
-            '<span class="gp-hint"><span class="gp-glyph gp-face">' + leaveGlyph() + '</span>Close</span>';
+        if (typeof isTouchScreen !== "undefined" && isTouchScreen) {
+            // Touch: tap a row to toggle it; an explicit Done button closes the
+            // panel (the controller glyph hints below are meaningless on touch).
+            foot.innerHTML = '<button type="button" id="settingsDoneBtn" class="settings-done">Done</button>';
+            var done = foot.querySelector("#settingsDoneBtn");
+            if (done) {
+                done.addEventListener("click", function () { closeSettingsModal(); });
+            }
+        } else {
+            foot.innerHTML =
+                '<span class="gp-hint"><span class="gp-glyph gp-stick">L</span><span class="gp-glyph gp-dpad">✛</span>Move</span>' +
+                '<span class="gp-hint"><span class="gp-glyph gp-face">' + attackGlyph() + '</span>Toggle</span>' +
+                '<span class="gp-hint"><span class="gp-glyph gp-face">' + leaveGlyph() + '</span>Close</span>';
+        }
     }
     renderSettingsRows();
     settingsModalEl.className = "settings-modal visible";
@@ -1231,6 +1244,62 @@ function closeSettingsModal() {
     if (settingsModalEl) {
         settingsModalEl.className = "settings-modal hidden";
     }
+}
+
+// --- Touch settings (gear) button --------------------------------------------
+// On touch in fullscreen the navbar (and its settings controls) is hidden and
+// there's no pad Start button, so touch players had no way to reach Settings.
+// This translucent gear at the top opens the same panel and, because the panel's
+// backdrop is click-through (co-op keeps racing), also toggles it closed.
+var touchSettingsBtnEl = null;
+
+function inFullscreen() {
+    return !!(document.fullscreenElement || document.webkitFullscreenElement ||
+        document.mozFullScreenElement || document.msFullscreenElement);
+}
+
+function buildTouchSettingsButton() {
+    if (touchSettingsBtnEl || typeof document === "undefined" || !document.body) {
+        return;
+    }
+    var b = document.createElement("button");
+    b.id = "touchSettingsBtn";
+    b.type = "button";
+    b.setAttribute("aria-label", "Settings");
+    b.innerHTML = '<i class="fas fa-cog" aria-hidden="true"></i>';
+    b.addEventListener("click", function (e) {
+        if (e && e.preventDefault) { e.preventDefault(); }
+        toggleTouchSettings();
+    });
+    // Append INSIDE #gameWindow (the element that goes fullscreen), not <body>:
+    // in fullscreen the browser only renders the fullscreen element's subtree, so
+    // a button on <body> would be invisible exactly when this button is needed.
+    (document.getElementById("gameWindow") || document.body).appendChild(b);
+    touchSettingsBtnEl = b;
+    updateTouchSettingsButtonVisibility();
+    document.addEventListener("fullscreenchange", updateTouchSettingsButtonVisibility, false);
+    document.addEventListener("webkitfullscreenchange", updateTouchSettingsButtonVisibility, false);
+}
+
+// Show the gear only on a touch device AND while in fullscreen (otherwise the
+// navbar already exposes every setting). Called on fullscreen change.
+function updateTouchSettingsButtonVisibility() {
+    if (!touchSettingsBtnEl) {
+        return;
+    }
+    var touch = (typeof isTouchScreen !== "undefined" && isTouchScreen);
+    touchSettingsBtnEl.classList.toggle("visible", !!(touch && inFullscreen()));
+}
+
+function toggleTouchSettings() {
+    if (settingsModalIsOpen()) {
+        closeSettingsModal();
+        return;
+    }
+    // Settings affect the one shared screen/speakers, so they belong to the
+    // primary (P1) slot — same rule as the pad Start button.
+    var lp = (typeof localPlayers !== "undefined") ? localPlayers[primarySlot] : null;
+    openSettingsModal(lp);
 }
 
 function pollSettingsModal(pad, lp) {

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -48,7 +48,32 @@ function initEventHandlers() {
 
 }
 
+// Map a viewport client X/Y to the canvas' logical 1366x768 space using the
+// canvas' ACTUAL rendered size (rect.width/height) — which is what the drawing
+// transform scales into — so touch/mouse hit-tests line up with where controls
+// are actually drawn. Dividing by the computed newWidth/newHeight instead skews
+// the mapping whenever the rendered size differs from it (iOS visual-viewport
+// scaling, sub-pixel rounding, a resize that ran against a stale viewport): the
+// skew is ~0 at the left/top edge and grows toward the right/bottom, so a
+// top-right control can miss while a top-left one is dead-on.
+function canvasClientToLogicalX(clientX, rect) {
+    var w = (rect && rect.width) || newWidth || LOGICAL_WIDTH;
+    return ((clientX - rect.left) / w) * LOGICAL_WIDTH;
+}
+function canvasClientToLogicalY(clientY, rect) {
+    var h = (rect && rect.height) || newHeight || LOGICAL_HEIGHT;
+    return ((clientY - rect.top) / h) * LOGICAL_HEIGHT;
+}
+
 function calcMousePos(evt) {
+    // Touch devices synthesize mouse events from taps (mousemove/mousedown/
+    // click/dblclick), which would drive the DESKTOP mouse controls in parallel
+    // with the touch handlers. Ignore them on touch-first devices so a tap can't
+    // fire a synthetic mousedown->attack or a double-tap->mouse-drive. See the
+    // same guard in handleClick/handleUnClick/handleDblClick.
+    if (isTouchScreen) {
+        return;
+    }
     // Only suppress the default (text selection / drag) when the pointer is over
     // the game canvas, so selecting text elsewhere on the page isn't broken by
     // the global mousemove listener (item 8).
@@ -59,9 +84,11 @@ function calcMousePos(evt) {
     }
     if (myPlayer != null) {
         var rect = gameCanvas.getBoundingClientRect();
-        // screen -> logical (the un-zoomed 1366x768 canvas space)
-        var lx = ((evt.pageX - rect.left) / newWidth) * LOGICAL_WIDTH;
-        var ly = ((evt.pageY - rect.top) / newHeight) * LOGICAL_HEIGHT;
+        // screen -> logical (the un-zoomed 1366x768 canvas space). Client coords
+        // are viewport-relative, matching getBoundingClientRect and handleClick;
+        // map against the canvas' actual rendered size (see canvasClientToLogical*).
+        var lx = canvasClientToLogicalX(evt.clientX, rect);
+        var ly = canvasClientToLogicalY(evt.clientY, rect);
         // logical -> world: invert the dynamic-camera transform so aiming points
         // at the world spot under the cursor even while zoomed. No-op (identity)
         // when the camera isn't zoomed (worldView centre = LOGICAL/2, scale 1).
@@ -93,6 +120,12 @@ function primaryOwnsWheel() {
         (typeof emojiOwnerSlot === "undefined" || emojiOwnerSlot === primarySlot);
 }
 function handleClick(event) {
+    // Synthetic mouse event from a tap on a touch device — the touch handlers
+    // already handled it. Without this, every tap fires a mousedown->attack
+    // (e.g. tapping the fullscreen button also punched). See calcMousePos.
+    if (isTouchScreen) {
+        return;
+    }
     switch (event.which) {
         case 1: {
             // Lobby hub: a left click on the primary's prompt/panel opens it, hits a
@@ -136,6 +169,9 @@ function handleClick(event) {
     event.preventDefault();
 }
 function handleUnClick(event) {
+    if (isTouchScreen) {
+        return; // synthetic mouseup from a tap; touch handlers own input
+    }
     switch (event.which) {
         case 1: {
             if (!primaryOwnsWheel()) {
@@ -150,6 +186,12 @@ function handleUnClick(event) {
     }
 }
 function handleDblClick(event) {
+    // A double-TAP on a touch device fires a synthetic dblclick; without this it
+    // would toggle the desktop "mouse-drive" mode and send the kart driving on
+    // its own (often to its death). Mouse-drive is desktop-only. See calcMousePos.
+    if (isTouchScreen) {
+        return;
+    }
     claimPrimaryForKbm(); // mouse-move play claims P1 -> controllers are P2+
     if (movingByMouse) {
         cancelMovement(event);
@@ -316,15 +358,24 @@ function setupVirtualbuttons() {
 
     virtualButtonList = [];
     joystickMovement = new Joystick(0, 0, false, false);
-    attackButton = new Button(0, 0, 0, 0, 0, true, false);
+    // Attack is now a PERSISTENT, VISIBLE button (autoHide=false, visible=true).
+    // It used to be invisible, so on big-screen tablets — where the old centred
+    // hit-circle shrank to the screen middle — players had no on-screen target
+    // and tapping the natural lower-right thumb spot missed entirely (punch never
+    // fired on iPad). The hit target is now the whole right region; see onTouchStart.
+    attackButton = new Button(0, 0, 0, 0, 0, false, true);
     // radius is set in layoutTouchControls (single source of truth); no dead 12.5.
     exitButton = new Button(0, 0, 0, 0, 0, false);
     chatButton = new Button(0, 0, 0, 0, 0, false);
 
+    // Hit-test ORDER matters: onTouchStart claims the first control whose bound
+    // contains the touch, so the small top-corner icons (emoji/fullscreen) must
+    // come BEFORE the large move/attack regions they overlap — otherwise the
+    // right-side attack region would swallow taps on the fullscreen icon.
+    virtualButtonList.push({ button: chatButton, bound: upperLeftRect });
+    virtualButtonList.push({ button: exitButton, bound: upperRightRect });
     virtualButtonList.push({ button: joystickMovement, bound: leftRect });
     virtualButtonList.push({ button: attackButton, bound: rightRect });
-    virtualButtonList.push({ button: exitButton, bound: upperRightRect });
-    virtualButtonList.push({ button: chatButton, bound: upperLeftRect });
 
     layoutTouchControls();
 }
@@ -352,20 +403,44 @@ function layoutTouchControls() {
     joystickMovement.maxPullRadius = cssToLogical(45);
     joystickMovement.deadzone = cssToLogical(5);
 
-    // Attack: keep a large right-side tap circle, sized in physical units.
+    // Attack: a thumb-sized button drawn in the LOWER-right corner (where a
+    // thumb naturally rests). This circle is only the visible AFFORDANCE — the
+    // actual hit target is the whole right tap region (see onTouchStart) — so it
+    // no longer matters that a fixed physical radius looks small on a big tablet
+    // (that shrinking centre circle is what made punch impossible to land there).
     if (attackButton) {
-        attackButton.radius = cssToLogical(150);
+        attackButton.radius = cssToLogical(78);
     }
 
-    // Top-corner icon buttons: >=44px square tap zones matching the drawn icon,
-    // inset from the edges and dropped below the top strip (URL bar / notch).
-    var hit = Math.max(cssToLogical(52), 44);   // tap zone side (logical)
-    var icon = cssToLogical(34);                // drawn icon size (logical)
-    var margin = cssToLogical(12);
-    var topInset = cssToLogical(14);
+    // Top-corner icon buttons: generous tap zones (the fullscreen icon shares the
+    // top edge with the right-side attack region, so a small target was easy to
+    // miss into a punch — corner buttons are hit-tested first, see onTouchStart,
+    // and now get a comfortable thumb-sized zone + a visible button backing).
+    var hit = Math.max(cssToLogical(72), 48);   // tap zone side (logical)
+    var icon = cssToLogical(38);                // drawn icon size (logical)
+    var margin = cssToLogical(16);
+    var topInset = cssToLogical(16);
     // chat (emoji) -> top-left; exit (fullscreen) -> top-right.
     sizeCornerButton(chatButton, margin + hit / 2, topInset + hit / 2, hit, icon);
     sizeCornerButton(exitButton, world.width - margin - hit / 2, topInset + hit / 2, hit, icon);
+
+    // Reserve the top strip for the corner icons: drop the TOP of the move/attack
+    // regions below the corner buttons (+ a little buffer). Without this the attack
+    // region reaches all the way into the top-right corner, so a tap aimed at the
+    // fullscreen icon that lands even slightly off it throws a punch instead. Now
+    // the strip around the corner icons is a no-punch zone — the icon (or nothing).
+    var regionTop = topInset + hit + cssToLogical(10);
+    for (var t = 0; t < virtualButtonList.length; t++) {
+        var entry = virtualButtonList[t];
+        if (entry.button === joystickMovement || entry.button === attackButton) {
+            var r = entry.bound;
+            var keepBottom = r.y + r.height;
+            r.y = regionTop;
+            r.top = regionTop;
+            r.height = keepBottom - regionTop;
+            r.bottom = keepBottom;
+        }
+    }
 
     // Centre each button in its bound rect (the joystick base is overridden on
     // touch-down; this fixes the static buttons' positions).
@@ -376,6 +451,16 @@ function layoutTouchControls() {
         b.stickX = b.baseX;
         b.baseY = bound.y + bound.height / 2 - b.height / 2;
         b.stickY = b.baseY;
+    }
+
+    // Anchor the visible attack button in the lower-right thumb zone (the centring
+    // loop above left it at the region's vertical middle). The bottom margin leaves
+    // room for the "Attack" caption so it never clips off the bottom edge.
+    if (attackButton) {
+        attackButton.baseX = world.width - cssToLogical(28) - attackButton.radius;
+        attackButton.baseY = world.height - cssToLogical(48) - attackButton.radius;
+        attackButton.stickX = attackButton.baseX;
+        attackButton.stickY = attackButton.baseY;
     }
 }
 
@@ -414,10 +499,21 @@ function onTouchStart(evt) {
     }
     var rect = gameCanvas.getBoundingClientRect();
     var touch = evt.changedTouches[0];
-    var touchX = (((touch.pageX - rect.left) / newWidth) * LOGICAL_WIDTH);
-    var touchY = (((touch.pageY - rect.top) / newHeight) * LOGICAL_HEIGHT);
+    // Map against the canvas' ACTUAL on-screen box (getBoundingClientRect) using
+    // viewport-relative client coords. We divide by rect.width/height, NOT the
+    // computed newWidth/newHeight: if the canvas ever renders at a size that
+    // differs from newWidth (CSS, a stale resize, sub-pixel rounding), dividing
+    // by newWidth skews the mapping — and the skew grows toward the right/bottom
+    // edge while the left/top stay accurate (which is exactly how a top-right
+    // button can miss while a top-left one is fine).
+    var touchX = canvasClientToLogicalX(touch.clientX, rect);
+    var touchY = canvasClientToLogicalY(touch.clientY, rect);
     // Lobby hub taps win over the movement/attack tap regions so the prompt/panel
-    // is usable even where it overlaps a control zone (primary slot only).
+    // is usable even where it overlaps a control zone (primary slot only). Pass the
+    // SCREEN-logical touch coords directly: the hub HUD is drawn in screen space and
+    // its hit rects come from lobbyProjectToScreen() (which already bakes in the
+    // dynamic-camera zoom/pan), so no world conversion is needed — and adding one
+    // would offset hits once the lobby follow-camera zooms in on touch.
     if (typeof config !== "undefined" && config && currentState === config.stateMap.lobby &&
         typeof lobbyHubHandlePrimaryPointer === "function" && lobbyHubHandlePrimaryPointer(touchX, touchY)) {
         evt.preventDefault();
@@ -431,14 +527,19 @@ function onTouchStart(evt) {
                 button.onDown(touchX, touchY);
 
                 if (button == attackButton) {
-                    if (button.pressed) {
-                        attack = true;
-                        server.emit('movement', { turnLeft: turnLeft, moveForward: moveForward, turnRight: turnRight, moveBackward: moveBackward, attack: attack });
-                    }
+                    // The ENTIRE right tap region punches (not just the drawn
+                    // circle), so a thumb anywhere on the right reliably attacks
+                    // on every screen size.
+                    button.pressed = true;
+                    attack = true;
+                    server.emit('movement', { turnLeft: turnLeft, moveForward: moveForward, turnRight: turnRight, moveBackward: moveBackward, attack: attack });
                 }
-                if (button == exitButton) {
-                    goFullScreen();
-                }
+                // NOTE: fullscreen (exitButton) is requested in onTouchEnd, NOT
+                // here. requestFullscreen() needs "transient activation", which
+                // browsers grant on the gesture-COMPLETING event (touchend), not
+                // on touchstart — calling it here rejects with "Cannot request
+                // fullscreen without transient activation." The touch is still
+                // claimed above (touchIdx + break), so onTouchEnd can act on it.
                 if (button == chatButton) {
                     if (menuOpen) {
                         closeEmojiWindow();
@@ -447,6 +548,11 @@ function onTouchStart(evt) {
                         openEmojiWindow(window.innerWidth / 2, window.innerHeight / 2);
                     }
                 }
+                // One touch claims exactly one control (priority order set in
+                // setupVirtualbuttons), so overlapping bounds — e.g. the
+                // fullscreen icon sitting inside the right attack region — can't
+                // fire two actions from a single tap.
+                break;
             }
         }
 
@@ -468,6 +574,12 @@ function onTouchEnd(evt) {
                     attack = false;
                     server.emit('movement', { turnLeft: turnLeft, moveForward: moveForward, turnRight: turnRight, moveBackward: moveBackward, attack: attack });
                 }
+                if (button == exitButton) {
+                    // Fire fullscreen on finger-UP: touchend carries the transient
+                    // activation that requestFullscreen() requires (touchstart does
+                    // not). This is what makes the fullscreen button actually work.
+                    goFullScreen();
+                }
                 button.touchIdx = null;
                 button.onUp();
             }
@@ -486,8 +598,10 @@ function onTouchMove(evt) {
     var touch, touchX, touchY;
     for (var i = 0; i < touchList.length; i++) {
         touch = touchList[i];
-        var touchX = (((touch.pageX - rect.left) / newWidth) * LOGICAL_WIDTH);
-        var touchY = (((touch.pageY - rect.top) / newHeight) * LOGICAL_HEIGHT);
+        // Map against the canvas' actual rendered size (see onTouchStart / the
+        // canvasClientToLogical* helpers) so drags track the finger exactly.
+        var touchX = canvasClientToLogicalX(touch.clientX, rect);
+        var touchY = canvasClientToLogicalY(touch.clientY, rect);
         for (var j = 0; j < virtualButtonList.length; j++) {
             var button = virtualButtonList[j].button;
             if (touch.identifier == button.touchIdx) {

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -2,6 +2,30 @@ var menuOpen = false;
 
 var gamePadA = null;
 var movingByMouse = false;
+// Opt-in touch diagnostics. Enable with ?debugtouch=1 in the URL: the client then
+// streams a touch-lifecycle snapshot (which control claimed each touch, every
+// control's live touchIdx, fullscreen state, touchcancel events) to the server,
+// for diagnosing touch problems on devices that can't be remotely inspected
+// (e.g. iOS Chrome/Safari). Off by default and zero-cost when off; the server
+// only logs these when started with TOUCH_DEBUG=1 (see messenger.js).
+var touchDebug = false;
+function tdLog(ev, extra) {
+    if (!touchDebug || typeof server === "undefined" || !server) {
+        return;
+    }
+    var p = {
+        ev: ev,
+        fs: !!(document.fullscreenElement || document.webkitFullscreenElement),
+        idx: {
+            move: joystickMovement ? joystickMovement.touchIdx : "n/a",
+            attack: attackButton ? attackButton.touchIdx : "n/a",
+            exit: exitButton ? exitButton.touchIdx : "n/a",
+            chat: chatButton ? chatButton.touchIdx : "n/a"
+        }
+    };
+    if (extra) { for (var k in extra) { p[k] = extra[k]; } }
+    server.emit("touchDebugReport", p);
+}
 var isTouchScreen = false,
     virtualButtonList = null,
     joystickMovement = null,
@@ -10,24 +34,55 @@ var isTouchScreen = false,
     chatButton = null,
     attackButton = null;
 
+// initEventHandlers() can run more than once per session (init() is called at
+// page load AND from the gameState handler, which re-fires on reconnect/re-join),
+// so the window/document listeners are bound exactly once behind this flag to
+// avoid stacking duplicate handlers.
+var eventListenersBound = false;
+var wasFullscreen = false;
+function onFullscreenChange() {
+    var nowFs = !!(document.fullscreenElement || document.webkitFullscreenElement);
+    tdLog("fschange");
+    // Release any still-held touch control when LEAVING fullscreen — that exit is
+    // the transition that orphaned the joystick (a stuck touchIdx bricked it).
+    // We skip ENTER so a player holding the stick while tapping fullscreen isn't
+    // dropped; touchcancel handles genuinely-cancelled touches in either direction.
+    if (wasFullscreen && !nowFs) {
+        releaseHeldTouchControls();
+    }
+    wasFullscreen = nowFs;
+}
+
 function initEventHandlers() {
-    window.addEventListener("mousemove", calcMousePos, false);
-    window.addEventListener("mousedown", handleClick, false);
-    window.addEventListener("mouseup", handleUnClick, false);
-    window.addEventListener("keydown", keyDown, false);
-    window.addEventListener("keyup", keyUp, false);
-    window.addEventListener("dblclick", handleDblClick, false);
+    if (!eventListenersBound) {
+        eventListenersBound = true;
+        window.addEventListener("mousemove", calcMousePos, false);
+        window.addEventListener("mousedown", handleClick, false);
+        window.addEventListener("mouseup", handleUnClick, false);
+        window.addEventListener("keydown", keyDown, false);
+        window.addEventListener("keyup", keyUp, false);
+        window.addEventListener("dblclick", handleDblClick, false);
 
+        window.addEventListener('touchstart', onTouchStart, { passive: false });
+        window.addEventListener('touchend', onTouchEnd, { passive: false });
+        window.addEventListener('touchmove', onTouchMove, { passive: false });
+        // The OS can CANCEL in-flight touches (touchcancel) rather than end them —
+        // notably iOS does this for touches held across a fullscreen enter/exit.
+        // Without a handler the touched control's touchIdx stays set forever and it
+        // goes dead (the movement stick bricked after toggling fullscreen).
+        window.addEventListener('touchcancel', onTouchCancel, { passive: false });
+        // Backstop: leaving fullscreen can orphan a touch without firing
+        // touchend/cancel; onFullscreenChange releases any still-held control then.
+        document.addEventListener('fullscreenchange', onFullscreenChange, false);
+        document.addEventListener('webkitfullscreenchange', onFullscreenChange, false);
 
-    window.addEventListener('touchstart', onTouchStart, { passive: false });
-    window.addEventListener('touchend', onTouchEnd, { passive: false });
-    window.addEventListener('touchmove', onTouchMove, { passive: false });
-
-    window.addEventListener('contextmenu', function (ev) {
-        ev.preventDefault();
-        return false;
-    }, false);
+        window.addEventListener('contextmenu', function (ev) {
+            ev.preventDefault();
+            return false;
+        }, false);
+    }
     isTouchScreen = isTouchDevice();
+    try { touchDebug = /[?&]debugtouch/.test(window.location.search); } catch (e) { touchDebug = false; }
     // Experiment: dynamic camera defaults ON for every input method (still
     // toggleable via the navbar camera button). It auto-falls back to the
     // whole-map view when >1 local player is sharing the screen (see
@@ -519,12 +574,15 @@ function onTouchStart(evt) {
         evt.preventDefault();
         return;
     }
+    var claimedName = "none";   // for touch diagnostics (tdLog below)
     for (var i = 0; i < virtualButtonList.length; i++) {
         if (virtualButtonList[i].bound.pointInRect(touchX, touchY)) {
             var button = virtualButtonList[i].button;
             if (button.touchIdx == null) {
                 button.touchIdx = touch.identifier;
                 button.onDown(touchX, touchY);
+                claimedName = button === joystickMovement ? "MOVE" : button === attackButton ? "ATTACK" :
+                    button === exitButton ? "EXIT" : button === chatButton ? "CHAT" : "?";
 
                 if (button == attackButton) {
                     // The ENTIRE right tap region punches (not just the drawn
@@ -557,12 +615,18 @@ function onTouchStart(evt) {
         }
 
     }
+    tdLog("start", { id: touch.identifier, x: Math.round(touchX), y: Math.round(touchY), claimed: claimedName });
 }
 function onTouchEnd(evt) {
     if (!virtualButtonList) {
         return;
     }
     var touchList = evt.changedTouches;
+    if (touchDebug) {
+        var endIds = [];
+        for (var e = 0; e < touchList.length; e++) { endIds.push(touchList[e].identifier); }
+        tdLog("end", { ids: endIds });
+    }
     for (var i = 0; i < touchList.length; i++) {
         for (var j = 0; j < virtualButtonList.length; j++) {
             var button = virtualButtonList[j].button;
@@ -584,6 +648,57 @@ function onTouchEnd(evt) {
                 button.onUp();
             }
         }
+    }
+}
+// touchcancel: the OS interrupted these touches (no touchend will come). Release
+// the matched controls exactly like touchend does, but WITHOUT requesting
+// fullscreen — a cancelled exit-button touch must not toggle fullscreen.
+function onTouchCancel(evt) {
+    if (!virtualButtonList) {
+        return;
+    }
+    var touchList = evt.changedTouches;
+    if (touchDebug) {
+        var cids = [];
+        for (var c = 0; c < touchList.length; c++) { cids.push(touchList[c].identifier); }
+        tdLog("CANCEL", { ids: cids });
+    }
+    for (var i = 0; i < touchList.length; i++) {
+        for (var j = 0; j < virtualButtonList.length; j++) {
+            var button = virtualButtonList[j].button;
+            if (touchList[i].identifier == button.touchIdx) {
+                if (button == joystickMovement) {
+                    cancelMovement();
+                }
+                if (button == attackButton) {
+                    attack = false;
+                    server.emit('movement', { turnLeft: turnLeft, moveForward: moveForward, turnRight: turnRight, moveBackward: moveBackward, attack: attack });
+                }
+                button.touchIdx = null;
+                button.onUp();
+            }
+        }
+    }
+}
+// Release any control that still thinks it's being touched. Used as a fullscreen-
+// change backstop: a transition can orphan a touch (no touchend/cancel), leaving
+// a stuck touchIdx that bricks the control until reload. Clearing it lets the
+// next tap re-claim the control cleanly.
+function releaseHeldTouchControls() {
+    if (!virtualButtonList) {
+        return;
+    }
+    var any = false;
+    for (var i = 0; i < virtualButtonList.length; i++) {
+        var button = virtualButtonList[i].button;
+        if (button.touchIdx != null) {
+            button.touchIdx = null;
+            if (button.onUp) { button.onUp(); }
+            any = true;
+        }
+    }
+    if (any) {
+        cancelMovement(); // clears the movement/attack globals and emits a stop
     }
 }
 function onTouchMove(evt) {

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -99,6 +99,17 @@ function checkForMail(client) {
 		client.emit("config", c);
 	});
 
+	// Opt-in touch diagnostics: a client running with ?debugtouch=1 streams touch
+	// lifecycle snapshots here. We only log them when the server is started with
+	// TOUCH_DEBUG=1, so in production this is a no-op and can't be log-spammed.
+	client.on("touchDebugReport", function (data) {
+		if (process.env.TOUCH_DEBUG !== "1") {
+			return;
+		}
+		try { console.log("[touchDebug] " + JSON.stringify(data)); }
+		catch (e) { console.log("[touchDebug] (unserializable)"); }
+	});
+
 	// Diagnostic only: a client running with ?diag=1 streams render-perf samples
 	// (frame times, phase split, device class, game-state counts) so a stutter on
 	// a real device can be diagnosed from server logs. Untrusted input from any


### PR DESCRIPTION
Reworks touch input, which was broken in several ways on tablets/iPad. All changes are client-side except a gated, prod-inert diagnostics endpoint.

## Player-facing (see CHANGELOG)
- **Punch works on tablets/iPad.** Visible lower-right **Attack** button (brightens while held); the whole right side punches. The old target was a fixed-physical-radius invisible circle stuck in the screen middle that a corner-resting thumb missed on big screens.
- **Fullscreen button actually enters fullscreen** — it was requesting on finger-*down*, which browsers reject ("transient activation"); now fires on finger-*up*.
- **No more phantom punches / runaway karts** — touch devices deliver synthetic mouse events on every tap; the desktop handlers now ignore them (a tap was firing `mousedown→attack`, a double-tap `dblclick→mouse-drive`).
- **Touch buttons line up with where you tap** — map against the canvas' actual rendered size, not the computed `newWidth` (the top-right button mis-mapped into the attack region on iPad).
- **Controls stay visible during the Blackout brutal round** (drawn on the overlay layer).
- **Bigger top-corner buttons**; a reserved no-punch strip below them so a tap aimed at fullscreen/emoji can't punch.
- **Translucent settings gear** (touch + fullscreen only) opens the controller Settings panel (incl. the new Graphics-detail row), with a touch **Done** button.
- **Lobby follow-camera on touch** — the camera follows your kart instead of showing the whole map zoomed out.
- **Dead-stick fix** — toggling fullscreen no longer bricks the movement stick (the in-flight touch was being orphaned with no `touchcancel` handler; now released on cancel and on leaving fullscreen).

## Dev: opt-in touch diagnostics (prod-inert)
`?debugtouch=1` streams a touch-lifecycle snapshot (claimed control, every control's live `touchIdx`, fullscreen state, cancels) to the server, logged only when started with `TOUCH_DEBUG=1` — a no-op otherwise. For debugging touch issues on devices that can't be remotely inspected.

## Testing
Rebased onto `main` (v0.16.0); clean auto-merge + targeted delta review of the touch ↔ perf/interpolation integration (no defects). Two rounds of code review (findings fixed). Headless smoke test passes (51 maps); `vm` touch-harness 17/17; full build compiles. Verified on-device (iPad): punch, fullscreen, settings gear, lobby camera, dead-stick fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)