### PR TITLE
Map editor rebuild: responsive MS-Paint layout, touch, undo, textured swatches

### DIFF
--- a/.github/scripts/lint-button-input.js
+++ b/.github/scripts/lint-button-input.js
@@ -25,7 +25,10 @@ const repoRoot = path.join(__dirname, '..', '..');
 const clientDir = path.join(repoRoot, 'client');
 
 const MENU_PAGES = new Set(['index.html', 'join.html']); // load menuGamepad (global selector)
-const KNOWN_CLASSES = ['btn', 'mapEditorTile', 'nav-toggle', 'form-control', 'confirm-btn'];
+const KNOWN_CLASSES = ['btn', 'mapEditorTile', 'nav-toggle', 'form-control', 'confirm-btn',
+    // Map-editor rebuild styling classes (create.html): topbar icon/action buttons
+    // and the tool-rail Select/Eraser tools.
+    'ed-icon-btn', 'ed-btn', 'ed-tool'];
 
 // Allowlist: pre-existing controls that intentionally skip a rule. Each entry
 // documents WHY. New controls are not allowlisted — they must comply.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 - **Right-click** a hazard to delete it, or right-drag to erase tiles back to dirt.
 - The map list now has a **search box** to filter by name or author, a responsive grid, and the "Create a new map" tile is relabelled **"Continue editing"** while you have an in-progress map.
 - Copy/Upload now tell you when the author or map name is missing (they used to silently fall back to "anonymous"/"unknown"), and status messages clear themselves instead of lingering.
+- The tile and hazard buttons now show the **actual texture** they paint (grass, lava, ice, dirt, sand, the bomb tile, etc.) instead of flat colours — the tile's name shows on hover.
+- Opening a different map while you have **unsaved edits** now asks for confirmation first, so you can't lose your work by clicking back and picking another map.
 
 ## v0.17.0 — 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Map editor
+
+- The map editor has been rebuilt with an MS-Paint-style layout: a top action bar, a left tool rail (Select, Eraser, tiles, hazards, start edge), and the canvas filling the rest. On phones and tablets it reflows to a top tool strip and a bottom action bar, and — for the first time — the editor is fully usable by **touch** (the tools used to disappear entirely on small screens).
+- Added **Undo/Redo** (Ctrl+Z / Ctrl+Shift+Z) covering tile painting, hazard placement, deletion, and rotation.
+- Added **keyboard shortcuts**: `S` select, `E` eraser, `1`–`8` tiles, `B`/`M` hazards, `R` / `Shift+R` rotate, `Delete` to remove a selected hazard.
+- Selected hazards now show on-canvas handles you can grab to **rotate** (any angle) or **delete**, plus toolbar buttons to rotate in 15° steps either direction (it only rotated one way before).
+- **Right-click** a hazard to delete it, or right-drag to erase tiles back to dirt.
+- The map list now has a **search box** to filter by name or author, a responsive grid, and the "Create a new map" tile is relabelled **"Continue editing"** while you have an in-progress map.
+- Copy/Upload now tell you when the author or map name is missing (they used to silently fall back to "anonymous"/"unknown"), and status messages clear themselves instead of lingering.
 
 ## v0.17.0 — 2026-05-27
 

--- a/backlog.md
+++ b/backlog.md
@@ -56,7 +56,7 @@ Tracked work that is known and intentionally deferred. The currently-in-progress
 
 ### Bugs
 
-- **Duplicate-hazard selection collisions.** `updateSelectedObject` and `removeSelectedObject` match by `id + x + y`, so two same-type hazards stacked at identical coordinates can only be edited/deleted as the first one found. Track the array index of the selected hazard instead.
+<!-- ✅ RESOLVED (editor rebuild) — selection now tracks the hazard's array index, not `id + x + y`. `locateObject`/`hazardIndexUnderPoint` store `selectedObject.index`, and `updateSelectedObject`/`removeSelectedObject` act on that index, so stacked duplicates at identical coords are no longer ambiguous. Original: - **Duplicate-hazard selection collisions.** `updateSelectedObject` and `removeSelectedObject` match by `id + x + y`, so two same-type hazards stacked at identical coordinates can only be edited/deleted as the first one found. Track the array index of the selected hazard instead. -->
 - **Map JSON is larger than it needs to be.** `vMap.cells` is the raw voronoi structure with `edge` objects shared (and serialized) twice per pair of cells, plus per-halfedge `angle`. Existing maps in `client/maps/` are hundreds of KB largely from this. A minimal export — site coords + tile id, with the voronoi recomputed on load (or just edge endpoints stored once) — would shrink JSON dramatically.
 <!-- ✅ RESOLVED — validated headlessly (real getMaps handler via a fake socket): added `utils.getEditorMapListings()` (filters `lobbyOnly` maps out, lockstep with `mapListing`/`maps`) and the `getMaps` handler now emits that instead of the full list. `contentDelivery` still sends the full list so the play client preloads the lobby map for rendering, and the lobby still loads it via `loadMaps()`→`lobbyOnly` filter. Asserted: editor listing excludes `_lobbyTutorial.json`; full listing still includes it; lobby still resolves LobbyTutorial. Original: - **Lobby/tutorial map shows up in the editor's map list.** `loadMaps` (`utils.js:474`) returns every file in `client/maps/` — including `_lobbyTutorial.json` — and `messenger.js:47` (`getMaps`) hands that raw list to the editor (`create.js:155`). The `lobbyOnly` filter only applies to the race rotation (`game.js:809`), not to the listing the editor receives. Filter `lobbyOnly` maps out of the editor list. -->
 - **Preview/Playtest breaks with local co-op (2+ controllers).** Preview launches a single-human room (`play.html?preview=1`); `previewReturnToEditor` only tracks the primary slot, and a second hot-joining gamepad (`addLocalPlayer`, `client.js:871`) isn't accounted for, so co-op preview is effectively unsupported. Either wire local co-op into the preview game or block extra pads from joining while previewing. <!-- PENDING OPERATOR CONTROLLER TEST: FULL co-op-in-preview now implemented on branch batch/controller-coop-fixes (superseded the earlier client-only block). Server: `createPreviewRoom` capacity 1→4 (PREVIEW_COOP_CAP) + `findARoom` now skips `isPreview` so the room is never matchmade into even after game-over unlock. Client: removed the `addLocalPlayer` preview block (pads hot-join during gated like a normal couch game); preview returns to the editor after each round, and P1 leaving (or any teardown) routes to create.html instead of the menu; per-player B→leave drops just that player. Validated headlessly (4 join, 5th rejected, matchmaking-privacy, gated→race tick). Awaiting 2+ controller validation before resolving. -->
@@ -64,13 +64,22 @@ Tracked work that is known and intentionally deferred. The currently-in-progress
 
 ### UX
 
+<!-- ✅ ALL RESOLVED in the map-editor rebuild (MS-Paint-style responsive layout + unified tool model + touch support + styling pass; new `editorTools.js` module). Browser-verified on desktop + phone-width, light + dark themes.
+  - No feedback for missing inputs → `requireDetails()` gates Copy/Upload on author+name, flags the empty fields (`.field-required`), and auto-opens the Details panel; email still validated inline at upload.
+  - Submit status never resets → `showSubmitStatus()` auto-hides after 4s and `resetStatuses()` clears all status toasts on any Details input change.
+  - Rotate fixed at +15° → Rotate−/Rotate+ buttons (15° each way, `editorRotateSelected`), `R`/`Shift+R` shortcuts, and a drag-anywhere on-canvas rotate knob (free angle).
+  - No undo → generic command stack in `editorTools.js` (`pushCommand`/`editorUndo`/`editorRedo`, Ctrl+Z / Ctrl+Shift+Z); covers paint strokes (one step per stroke), hazard add/remove, and rotation. Destructive wipe/reshape clear history by design.
+  - No keyboard shortcuts → `installEditorShortcuts()`: S select, E eraser, 1–8 tiles, B/M hazards, R/Shift+R rotate, Delete, Esc.
+  - Right-click does nothing → right-click a hazard deletes it; right-drag erases tiles to dirt (`handleClick` case 3 + `erasing` stroke).
+  - No map-list search → `installMapSearch()` filters tiles by name/author (`data-search`); pinned New/Continue tile (`data-keep`) always shown; grid is now responsive.
+  Original items:
 - **No feedback for missing inputs.** Copy-to-clipboard silently substitutes `"anonymous"`/`"unknown"` for empty author/name. Email is only validated at submit time. Highlight required fields before allowing export.
 - **Submit status button never resets.** "Submitting…"/"Success"/"Failed" lingers indefinitely. Reset on any input change, on a fresh submit attempt, or after a short timeout.
 - **Rotate is fixed at +15° clockwise.** No counter-rotation, no finer step. Cheap upgrade: shift-click for -15°, or a number input for absolute angle.
 - **No undo.** A full undo stack across tile paints would be expensive, but at minimum "undo last hazard placement" is trivial and would prevent a lot of frustration.
 - **No keyboard shortcuts** for switching brushes/tools. Purely mouse-driven editing slows experienced users.
 - **Right-click is suppressed but does nothing useful.** Common expectation: right-click on a hazard deletes it; right-click drag erases to default tile.
-- **No search/filter for the map list.** The editor loads every map but offers no way to search or filter them; a filter input would scale as the library grows (pairs with the keyboard-shortcuts item).
+- **No search/filter for the map list.** The editor loads every map but offers no way to search or filter them; a filter input would scale as the library grows (pairs with the keyboard-shortcuts item). -->
 
 ### Features
 

--- a/build.js
+++ b/build.js
@@ -21,6 +21,7 @@ const bundles = {
     'create.bundle.min.js': [
         'client/scripts/rhill-voronoi-core.js',
         'client/scripts/create.js',
+        'client/scripts/editorTools.js',
         'client/scripts/osk.js',
         'client/scripts/editorGamepad.js',
         'client/scripts/utils.js',

--- a/client/create.html
+++ b/client/create.html
@@ -142,6 +142,15 @@
       border-color: rgba(207, 16, 32, 0.4);
       color: #cf1020;
     }
+    /* Rotate buttons use full-circle Unicode arrows (↺ ↻) so they read as
+       "rotate", clearly distinct from the undo/redo reply-style arrows — FA 4.7
+       aliases fa-rotate-left/right straight onto fa-undo/fa-repeat, so they'd
+       otherwise be the same glyph. */
+    .ed-rot-glyph {
+      font-size: 1.5rem;
+      line-height: 1;
+      font-weight: 700;
+    }
 
     /* Text action buttons (Details / Preview / Copy / Upload / AI). */
     .ed-btn {
@@ -588,8 +597,8 @@
           </div>
           <div class="ed-bar-divider"></div>
           <div class="ed-bar-group">
-            <button id="rotateLeftButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard -15° (Shift+R)"><i class="fa fa-rotate-left" aria-hidden="true"></i></button>
-            <button id="rotateButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard +15° (R)"><i class="fa fa-rotate-right" aria-hidden="true"></i></button>
+            <button id="rotateLeftButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard -15° (Shift+R)"><span class="ed-rot-glyph" aria-hidden="true">↺</span></button>
+            <button id="rotateButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard +15° (R)"><span class="ed-rot-glyph" aria-hidden="true">↻</span></button>
             <button id="deleteSelectedButton" data-gp-nav class="ed-icon-btn danger" title="Delete selected hazard (Del)" disabled><i class="fa fa-times" aria-hidden="true"></i></button>
           </div>
 

--- a/client/create.html
+++ b/client/create.html
@@ -441,14 +441,11 @@
       font-size: 0.95rem;
       outline: none;
     }
+    /* Uses .ed-icon-btn for a 40x40 hit target (clears the 24px WCAG floor) +
+       shared styling; only the muted glyph colour differs here. */
     #mapSearchClear {
-      border: 0;
-      background: transparent;
       color: var(--text-muted);
-      font-size: 1.1rem;
-      cursor: pointer;
-      padding: 4px 6px;
-      line-height: 1;
+      font-size: 1.2rem;
     }
     #mapSearchClear:hover {
       color: var(--text);
@@ -683,7 +680,7 @@
         <div class="map-search">
           <i class="fa fa-search" aria-hidden="true"></i>
           <input id="mapSearch" data-gp-nav type="text" placeholder="Search maps by name or author…" autocomplete="off">
-          <button id="mapSearchClear" data-gp-nav title="Clear search">&times;</button>
+          <button id="mapSearchClear" data-gp-nav class="ed-icon-btn" title="Clear search">&times;</button>
         </div>
       </div>
       <div class="map-image" data-keep="1">

--- a/client/create.html
+++ b/client/create.html
@@ -115,9 +115,9 @@
 
     /* Square icon buttons (back, wipe, undo/redo, rotate, delete). */
     .ed-icon-btn {
-      width: 40px;
-      height: 40px;
-      min-width: 40px;
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -154,7 +154,7 @@
 
     /* Text action buttons (Details / Preview / Copy / Upload / AI). */
     .ed-btn {
-      height: 40px;
+      height: 44px;
       padding: 0 14px;
       display: inline-flex;
       align-items: center;

--- a/client/create.html
+++ b/client/create.html
@@ -300,6 +300,44 @@
       mix-blend-mode: normal;
     }
 
+    /* Textured palette swatches (mirrors the lobby skin picker): rounded squares
+       showing the real terrain texture / hazard look, with the name on hover via
+       the button's title. JS (applyTileSwatches) paints the background-image. */
+    .ed-swatch-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 6px;
+    }
+    .ed-swatch-grid.hazards {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    #toolRail .mapEditorTile.swatch {
+      aspect-ratio: 1 / 1;
+      width: 100%;
+      height: auto;
+      min-width: 0;
+      padding: 0;
+      border-radius: 10px;
+      border: thin solid rgba(0, 0, 0, 0.18);
+      background-color: var(--surface-2);
+      background-size: cover;
+      background-position: center;
+      box-shadow: var(--ed-shadow-soft);
+    }
+    /* Hide the visible label (name lives in the title/hover). Keep it clipped in
+       the DOM so screen readers + the gamepad focus ring still announce it. */
+    #toolRail .mapEditorTile.swatch span {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
     /* Active selection ring shared by tools / tiles / hazards / edges. */
     .tool-active {
       outline: 3px solid var(--ed-accent) !important;
@@ -490,6 +528,20 @@
         min-width: 64px;
         padding: 0 12px;
       }
+      /* Swatches stay fixed squares in the horizontal dock. */
+      .ed-swatch-grid,
+      .ed-swatch-grid.hazards {
+        display: flex;
+        gap: 6px;
+      }
+      #toolRail .mapEditorTile.swatch {
+        width: 46px;
+        height: 46px;
+        aspect-ratio: auto;
+        min-width: 46px;
+        flex: 0 0 auto;
+        padding: 0;
+      }
       /* Action bar docks to the bottom and wraps. */
       #editorTopbar {
         border-bottom: 0;
@@ -575,7 +627,7 @@
           </div>
           <div class="ed-section">
             <div class="ed-section-title">Tiles</div>
-            <div class="ed-tool-grid">
+            <div class="ed-swatch-grid">
               <button id="slowTileButton" data-gp-nav style="background-color: #f6d7b0;" title="Sand (1)" class="mapEditorTile"><span>Sand</span></button>
               <button id="normalTileButton" data-gp-nav style="background-color: #523A28" title="Dirt (2)" class="mapEditorTile"><span>Dirt</span></button>
               <button id="fastTileButton" data-gp-nav style="background-color: #90ee90" title="Grass (3)" class="mapEditorTile"><span>Grass</span></button>
@@ -588,9 +640,9 @@
           </div>
           <div class="ed-section">
             <div class="ed-section-title">Hazards</div>
-            <div class="ed-tool-grid">
-              <button id="bumperButton" data-gp-nav style="background-color: orange" title="Bumper (B)" class="mapEditorTile"><span>Bumper</span></button>
-              <button id="movingBumperButton" data-gp-nav style="background-color: orange" title="Moving Bumper (M)" class="mapEditorTile"><span>Moving</span></button>
+            <div class="ed-swatch-grid">
+              <button id="bumperButton" data-gp-nav title="Bumper (B)" class="mapEditorTile"><span>Bumper</span></button>
+              <button id="movingBumperButton" data-gp-nav title="Moving Bumper (M)" class="mapEditorTile"><span>Moving Bumper</span></button>
             </div>
           </div>
           <div id="startEdgePalette" class="ed-section">
@@ -615,20 +667,6 @@
             <button id="submitStatus" class="btn" disabled style="display:none;"><span>Submitting..</span></button>
           </div>
         </main>
-
-        <!-- Controller-friendly confirm dialog (replaces native confirm(), which a
-             gamepad can't operate). Shares the leave-game modal's .confirm-* styling
-             (see styles.css). The editor gamepad traps focus to these buttons while
-             the modal is open. -->
-        <div id="wipeConfirmModal" class="confirm-modal hidden">
-          <div class="confirm-dialog">
-            <div class="confirm-title" id="wipeConfirmMessage">Are you sure?</div>
-            <div class="confirm-buttons">
-              <button type="button" id="wipeConfirmYes" class="confirm-btn confirm-leave">Delete</button>
-              <button type="button" id="wipeConfirmCancel" class="confirm-btn confirm-cancel">Cancel</button>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
     <div id="loadWindow">
@@ -643,6 +681,20 @@
         <button id="createNew" data-gp-nav><img id="createNewImage" src="">
           <div class="desc">Create a new map</div>
         </button>
+      </div>
+    </div>
+
+    <!-- Controller-friendly confirm dialog (replaces native confirm(), which a
+         gamepad can't operate). Shares the leave-game modal's .confirm-* styling
+         (see styles.css). Lives outside #createWindow / #loadWindow so it overlays
+         either screen — the editor gamepad traps focus to its buttons when open. -->
+    <div id="wipeConfirmModal" class="confirm-modal hidden">
+      <div class="confirm-dialog">
+        <div class="confirm-title" id="wipeConfirmMessage">Are you sure?</div>
+        <div class="confirm-buttons">
+          <button type="button" id="wipeConfirmYes" class="confirm-btn confirm-leave">Delete</button>
+          <button type="button" id="wipeConfirmCancel" class="confirm-btn confirm-cancel">Cancel</button>
+        </div>
       </div>
     </div>
   </section>

--- a/client/create.html
+++ b/client/create.html
@@ -29,6 +29,23 @@
   <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
   <title>Chao Chao Map Edit</title>
   <style>
+    /* ===========================================================================
+       Map editor layout. A single responsive CSS grid drives both forms:
+         desktop (>768px): top action bar + left tool rail + canvas
+         phone   (<=768px): top tool dock + canvas + bottom action dock
+       Same DOM in both — only the grid template + a few flex directions change —
+       so the editor gamepad's offsetParent-based focus ring stays correct and we
+       never hide tools on touch (the old layout did `display:none` on mobile).
+       =========================================================================== */
+
+    /* Editor-scoped accent + chrome tokens, layered on the site theme vars. */
+    #mapEditor {
+      --ed-accent: #2f8f4e;
+      --ed-accent-soft: rgba(47, 143, 78, 0.16);
+      --ed-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+      --ed-shadow-soft: 0 2px 6px rgba(0, 0, 0, 0.08);
+    }
+
     /* When the editor is visible, lock the page so the canvas can't be
        scrolled out of view. The load window flips this back to auto
        because the map grid needs to scroll. */
@@ -36,9 +53,9 @@
       overflow: hidden;
     }
 
-    /* Overrides styles.css `#createWindow { height: 100% }`, which would
-       otherwise force the editor to be a full viewport tall *below* the
-       navbar and overflow the page. */
+    /* Overrides styles.css `#createWindow { height: 100%; display: none }` — that
+       base rule was previously toggled by jQuery show/hide; we drive visibility
+       with the .editor-hidden class instead, so set display explicitly here. */
     #createWindow {
       position: fixed;
       top: var(--navbar-height);
@@ -48,208 +65,448 @@
       width: auto;
       height: auto;
       margin: 0;
-    }
-
-    #mapEditor {
-      position: relative;
-      width: 100%;
-      height: 100%;
-      margin: 0;
-    }
-
-    /* Overrides styles.css `#controlPanel { height: 90%; width: 9%; ... }`
-       so top/bottom take over for sizing. */
-    #controlPanel {
-      position: absolute;
-      top: 0;
-      left: 0;
-      bottom: 0;
-      width: 250px;
-      height: auto;
-      float: none;
-      z-index: 1002;
-      border-radius: 0;
-      border: 0;
-      border-right: thin solid #e6e6e6;
-      padding: 0 1rem;
-      box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
-      overflow-y: auto;
-    }
-
-    .mapEditorTile {
-      width: auto;
-      margin-left: 0;
-      margin-right: 4px;
-      border-radius: 100px;
-      padding: 4px 8px;
-      float: left;
-      margin-bottom: 2px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-wrap: wrap;
-      height: auto;
-      border: thin solid #e6e6e6;
-      font-size: 1rem;
-      font-weight: 500;
-      cursor: pointer;
-      min-width: 60px;
-      text-align: center !important;
-    }
-
-    #inputBar {
-      height: auto;
-    }
-
-    #inputBar .editor-inputs:last-child {
-      margin-bottom: 0;
-    }
-
-    .editor-inputs {
-      margin: 0;
-      margin-bottom: 1rem;
-    }
-
-    main {
-      position: absolute;
-      top: 0;
-      left: 250px;
-      right: 0;
-      bottom: 0;
-    }
-
-    /* Overrides styles.css `#canvasWindow { width: 80%; margin: 0 5%; ... }`
-       so the canvas-area uses the full width of <main> with the canvas
-       flex-centered inside it. */
-    #canvasWindow {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      width: auto;
-      height: auto;
-      margin: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    /* The global `canvas` rule in styles.css pins canvases to top-left;
-       inside the editor we want flex-centered, sized via JS. */
-    #canvasWindow #createCanvas {
-      position: static;
       display: block;
     }
 
-    .palette {
-      height: auto;
+    #mapEditor {
+      display: grid;
+      grid-template-columns: 268px 1fr;
+      grid-template-rows: auto 1fr;
+      grid-template-areas:
+        "topbar topbar"
+        "rail   canvas";
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      background: var(--board-bg);
+      color: var(--text);
     }
 
-    /* Keep the toolbar icons pinned to the top of the panel so they
-       stay visible when the rest of the panel content scrolls. */
-    #editorToolbar {
-      position: sticky;
-      top: 0;
-      background: #f8f9fa;
-      z-index: 1;
-      padding-top: 0.5rem;
-      padding-bottom: 0.5rem;
-      margin: 0 -1rem 0.5rem;
-      padding-left: 1rem;
-      padding-right: 1rem;
-      border-bottom: thin solid #e6e6e6;
+    /* --- top action bar ----------------------------------------------------- */
+    #editorTopbar {
+      grid-area: topbar;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      background: var(--surface);
+      border-bottom: thin solid var(--border);
+      box-shadow: var(--ed-shadow-soft);
+      z-index: 1003;
+      flex-wrap: wrap;
     }
 
-    /* Compact the panel so every control fits in a typical viewport
-       height without needing to scroll. */
-    #controlPanel .h5 {
-      font-size: 0.75rem;
+    .ed-bar-group {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .ed-bar-divider {
+      width: 1px;
+      align-self: stretch;
+      background: var(--border);
+      margin: 2px 4px;
+    }
+
+    .ed-bar-spacer {
+      flex: 1 1 auto;
+    }
+
+    /* Square icon buttons (back, wipe, undo/redo, rotate, delete). */
+    .ed-icon-btn {
+      width: 40px;
+      height: 40px;
+      min-width: 40px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: thin solid transparent;
+      border-radius: 10px;
+      background: transparent;
+      color: var(--text);
+      font-size: 1.1rem;
+      cursor: pointer;
+      transition: background 0.12s, border-color 0.12s, opacity 0.12s;
+    }
+    .ed-icon-btn:hover {
+      background: var(--surface-2);
+      border-color: var(--border);
+    }
+    .ed-icon-btn:disabled {
+      opacity: 0.35;
+      cursor: default;
+    }
+    .ed-icon-btn.danger:hover {
+      background: rgba(207, 16, 32, 0.12);
+      border-color: rgba(207, 16, 32, 0.4);
+      color: #cf1020;
+    }
+
+    /* Text action buttons (Details / Preview / Copy / Upload / AI). */
+    .ed-btn {
+      height: 40px;
+      padding: 0 14px;
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      border: thin solid var(--border);
+      border-radius: 10px;
+      background: var(--surface);
+      color: var(--text);
+      font-size: 0.9rem;
       font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.4px;
-      color: #6c757d;
-      margin: 0.4rem 0 0.25rem;
+      cursor: pointer;
+      transition: background 0.12s, border-color 0.12s, transform 0.06s;
     }
-    #controlPanel hr {
-      display: none;
+    .ed-btn:hover {
+      background: var(--surface-2);
     }
-    #controlPanel .mb-3 {
-      margin-bottom: 0.4rem !important;
+    .ed-btn:active {
+      transform: translateY(1px);
     }
-    #controlPanel .editor-inputs {
-      margin-bottom: 0.35rem !important;
-      padding: 0.25rem 0.5rem;
-      height: auto;
-      min-height: 0;
-      font-size: 0.85rem;
-    }
-    #controlPanel .btn-block {
-      padding: 0.3rem 0.5rem;
-      font-size: 0.85rem;
-      margin-bottom: 0.25rem;
-      margin-top: 0;
-    }
-    #controlPanel .mapEditorTile {
-      font-size: 0.85rem;
-      padding: 3px 7px;
-      min-width: 50px;
-    }
-    /* Compact the Start-edge picker so all six options fit in two rows (4 single
-       edges + 2 combos) and the section doesn't push the last row under the sticky
-       Actions footer. */
-    #controlPanel .startEdgeButton {
-      min-width: 0;
-      padding: 2px 6px;
-      font-size: 0.78rem;
-      margin: 0 3px 2px 0;
-    }
-    #startEdgePalette {
-      margin-bottom: 0.25rem !important;
-    }
-    #startEdgePalette .h5 {
-      margin: 0.25rem 0 0.2rem;
-    }
-
-    /* Pin the Actions section to the bottom of the panel — together
-       with the sticky toolbar, this guarantees the user can always
-       reach Copy/Upload regardless of viewport height. */
-    #actionsSection {
-      position: sticky;
-      bottom: 0;
-      background: #f8f9fa;
-      z-index: 1;
-      margin: 0.4rem -1rem 0;
-      padding: 0.5rem 1rem;
-      border-top: thin solid #e6e6e6;
-    }
-
-    /* "AI racers" preview toggle, styled as a full-width action button so it's
-       a large touch target and is reachable by the editor gamepad nav (A ->
-       click), unlike a tiny DOM checkbox. Off looks like the other Actions
-       buttons; on gets a brand-green fill (with a matching focus ring) so the
-       state reads at a glance in both light and dark. Two IDs keep this above
-       the [data-theme="dark"] #controlPanel .btn-block rule's specificity. */
-    #controlPanel #enableAIButton.ai-on {
-      background-color: #2f8f4e;
-      border-color: #2f8f4e;
+    .ed-btn.primary {
+      background: var(--ed-accent);
+      border-color: var(--ed-accent);
       color: #fff;
     }
-    /* Recolour the whole keyboard focus ring (outline + halo) green so the
-       on-state button doesn't show the global pink .btn:focus-visible outline
-       around a green fill. Gamepad nav keeps the shared .gp-focus ring. */
-    #controlPanel #enableAIButton.ai-on:focus-visible {
-      outline-color: #2f8f4e;
+    .ed-btn.primary:hover {
+      background: #267b42;
+    }
+    /* "AI racers" toggle: green fill when on, matching the primary actions. */
+    #enableAIButton.ai-on {
+      background: var(--ed-accent);
+      border-color: var(--ed-accent);
+      color: #fff;
+    }
+    #enableAIButton.ai-on:focus-visible {
+      outline-color: var(--ed-accent);
       box-shadow: 0 0 0 3px rgba(47, 143, 78, 0.5);
     }
 
-    @media screen and (max-width:768px) {
-      #controlPanel {
+    /* --- Details disclosure ------------------------------------------------- */
+    #detailsWrap {
+      position: relative;
+    }
+    #detailsPanel {
+      display: none;
+      position: absolute;
+      top: calc(100% + 8px);
+      right: 0;
+      width: 260px;
+      padding: 14px;
+      background: var(--surface);
+      border: thin solid var(--border);
+      border-radius: 12px;
+      box-shadow: var(--ed-shadow);
+      z-index: 1005;
+    }
+    #detailsPanel.open {
+      display: block;
+    }
+    #detailsPanel .ed-section-title {
+      margin-top: 0;
+    }
+    #detailsPanel .form-control {
+      margin-bottom: 8px;
+    }
+    .form-control.field-required {
+      border-color: #cf1020 !important;
+      box-shadow: 0 0 0 2px rgba(207, 16, 32, 0.18);
+    }
+    .ed-field-msg {
+      font-size: 0.75rem;
+      color: #cf1020;
+      min-height: 1em;
+      margin: -4px 0 6px;
+    }
+
+    /* --- left tool rail ----------------------------------------------------- */
+    #toolRail {
+      grid-area: rail;
+      background: var(--surface);
+      border-right: thin solid var(--border);
+      padding: 12px;
+      overflow-y: auto;
+      z-index: 1002;
+    }
+    .ed-section {
+      margin-bottom: 14px;
+    }
+    .ed-section-title {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-muted);
+      margin: 0 0 7px;
+    }
+    .ed-tool-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 6px;
+    }
+
+    /* Select / Eraser tools: icon over label. */
+    .ed-tool {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3px;
+      height: 56px;
+      border: thin solid var(--border);
+      border-radius: 10px;
+      background: var(--surface);
+      color: var(--text);
+      font-size: 0.78rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.12s, border-color 0.12s;
+    }
+    .ed-tool i {
+      font-size: 1.15rem;
+    }
+    .ed-tool:hover {
+      background: var(--surface-2);
+    }
+
+    /* Tile / hazard / start-edge chips. Override the float-based styles.css
+       base so they tile cleanly inside the rail's grid. */
+    #toolRail .mapEditorTile {
+      float: none;
+      width: 100%;
+      min-width: 0;
+      margin: 0;
+      height: 38px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 9px;
+      border: thin solid rgba(0, 0, 0, 0.12);
+      font-size: 0.82rem;
+      font-weight: 600;
+      cursor: pointer;
+      text-align: center;
+      box-shadow: var(--ed-shadow-soft);
+    }
+    #toolRail .startEdgeButton {
+      background: var(--surface);
+      color: var(--text);
+      box-shadow: none;
+    }
+    #toolRail .startEdgeButton span {
+      color: var(--text);
+      mix-blend-mode: normal;
+    }
+
+    /* Active selection ring shared by tools / tiles / hazards / edges. */
+    .tool-active {
+      outline: 3px solid var(--ed-accent) !important;
+      outline-offset: 1px;
+      box-shadow: 0 0 0 4px var(--ed-accent-soft) !important;
+    }
+
+    /* --- canvas area -------------------------------------------------------- */
+    main {
+      grid-area: canvas;
+      position: relative;
+      min-width: 0;
+      min-height: 0;
+    }
+    #canvasWindow {
+      position: absolute;
+      inset: 0;
+      width: auto;
+      height: auto;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 12px;
+    }
+    #canvasWindow #createCanvas {
+      position: static;
+      display: block;
+      border-radius: 8px;
+      box-shadow: var(--ed-shadow);
+      touch-action: none; /* we drive painting from touch events ourselves */
+    }
+
+    /* Floating status toasts over the canvas (preview/export/submit feedback).
+       Kept out of the topbar flow so status text can't reflow the buttons. */
+    #editorStatus {
+      position: absolute;
+      top: 18px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      align-items: center;
+      pointer-events: none;
+      z-index: 1004;
+    }
+    #editorStatus .btn {
+      pointer-events: auto;
+      border-radius: 999px;
+      font-weight: 600;
+      box-shadow: var(--ed-shadow);
+    }
+
+    /* --- map list ----------------------------------------------------------- */
+    #loadWindow {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 18px;
+      padding: 20px;
+      max-width: 1280px;
+      margin: 0 auto;
+      align-content: start;
+    }
+    #loadWindow.editor-hidden,
+    #createWindow.editor-hidden {
+      display: none !important;
+    }
+    #mapListHeader {
+      grid-column: 1 / -1;
+    }
+    .map-search {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      max-width: 480px;
+      padding: 0 14px;
+      height: 46px;
+      background: var(--surface);
+      border: thin solid var(--border);
+      border-radius: 12px;
+      box-shadow: var(--ed-shadow-soft);
+    }
+    .map-search i {
+      color: var(--text-muted);
+    }
+    .map-search input {
+      flex: 1 1 auto;
+      border: 0;
+      background: transparent;
+      color: var(--text);
+      font-size: 0.95rem;
+      outline: none;
+    }
+    #mapSearchClear {
+      border: 0;
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 1.1rem;
+      cursor: pointer;
+      padding: 4px 6px;
+      line-height: 1;
+    }
+    #mapSearchClear:hover {
+      color: var(--text);
+    }
+
+    div.map-image {
+      float: none;
+      width: 100%;
+      margin: 0;
+    }
+    div.map-image button {
+      width: 100%;
+      padding: 0;
+      border: thin solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      overflow: hidden;
+      cursor: pointer;
+      box-shadow: var(--ed-shadow-soft);
+      transition: transform 0.12s, box-shadow 0.12s, border-color 0.12s;
+    }
+    div.map-image button:hover {
+      transform: translateY(-3px);
+      box-shadow: var(--ed-shadow);
+      border-color: var(--ed-accent);
+    }
+    div.map-image img {
+      width: 100%;
+      height: auto;
+      aspect-ratio: 1366 / 768;
+      object-fit: cover;
+      display: block;
+      background: var(--surface-2);
+    }
+    /* The pinned New / Continue tile has no thumbnail until you've edited; give it
+       a friendly placeholder so it isn't a blank box on a fresh visit. */
+    #createNewImage[src=""],
+    #createNewImage:not([src]) {
+      min-height: 124px;
+    }
+    div.map-image .desc {
+      font-size: 0.82rem;
+      padding: 9px;
+      text-align: center;
+      color: var(--text);
+      border-top: thin solid var(--border);
+    }
+
+    /* --- responsive: phone reflow ------------------------------------------- */
+    @media screen and (max-width: 768px) {
+      #mapEditor {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr auto;
+        grid-template-areas:
+          "rail"
+          "canvas"
+          "topbar";
+      }
+      /* Tool rail becomes a horizontal scrolling dock at the top. */
+      #toolRail {
+        border-right: 0;
+        border-bottom: thin solid var(--border);
+        overflow-x: auto;
+        overflow-y: hidden;
+        display: flex;
+        gap: 14px;
+        padding: 8px 12px;
+        white-space: nowrap;
+      }
+      .ed-section {
+        margin-bottom: 0;
+        flex: 0 0 auto;
+      }
+      .ed-section-title {
+        display: none; /* save vertical space in the strip */
+      }
+      .ed-tool-grid {
+        display: flex;
+        gap: 6px;
+      }
+      .ed-tool {
+        width: 56px;
+      }
+      #toolRail .mapEditorTile {
+        width: auto;
+        min-width: 64px;
+        padding: 0 12px;
+      }
+      /* Action bar docks to the bottom and wraps. */
+      #editorTopbar {
+        border-bottom: 0;
+        border-top: thin solid var(--border);
+        justify-content: center;
+        padding-bottom: calc(8px + var(--safe-bottom));
+      }
+      .ed-bar-spacer {
         display: none;
       }
-
-      main {
-        left: 0;
+      #detailsPanel {
+        position: fixed;
+        left: 12px;
+        right: 12px;
+        bottom: 80px;
+        top: auto;
+        width: auto;
       }
     }
   </style>
@@ -264,101 +521,125 @@
   </nav>
   <!-- Game enclosed here -->
   <section>
-    <div id="createWindow">
+    <div id="createWindow" class="editor-hidden">
       <div id="mapEditor">
-        <div id="controlPanel" class="bg-light">
-          <div id="editorToolbar" class="d-flex align-items-center justify-content-between">
-            <button id="loadButton" data-gp-nav class="btn bg-light p-0" title="Back to map list"><i class="fa fa-arrow-left fa-2x" aria-hidden="true"></i></button>
-            <button id="rebuildButton" data-gp-nav class="btn bg-light p-0" title="Wipe map and start over"><i class="fa fa-trash fa-2x" aria-hidden="true"></i></button>
-            <button id="deleteSelectedButton" data-gp-nav class="btn bg-light p-0" title="Delete selected hazard" disabled><i class="fa fa-times fa-2x" aria-hidden="true"></i></button>
-            <button id="rotateButton" data-gp-nav class="btn bg-light p-0" title="Rotate selected hazard 15°"><i class="fa fa-rotate-right fa-2x" aria-hidden="true"></i></button>
-            <button id="mouseButton" data-gp-nav class="btn bg-light p-0" title="Switch to selection cursor"><i class="fa fa-mouse-pointer fa-2x" aria-hidden="true"></i></button>
+        <!-- Top action bar (reflows to a bottom dock on phones). -->
+        <div id="editorTopbar">
+          <div class="ed-bar-group">
+            <button id="loadButton" data-gp-nav class="ed-icon-btn" title="Back to map list"><i class="fa fa-arrow-left" aria-hidden="true"></i></button>
+            <button id="rebuildButton" data-gp-nav class="ed-icon-btn danger" title="Wipe map and start over"><i class="fa fa-trash" aria-hidden="true"></i></button>
           </div>
-          <div id="inputBar" class="mb-3">
-            <div class="h5">
-              Details
-            </div>
-            <hr />
-            <input class="editor-inputs form-control" data-gp-nav type="text" id="author" name="author" placeholder="Author" maxlength="15"></input>
-            <input class="editor-inputs form-control" data-gp-nav type="text" id="name" name="name" placeholder="Map Name" maxlength="15"></input>
-            <input class="editor-inputs form-control" data-gp-nav type="text" id="email" name="email" placeholder="Email" maxlength="50"></input>
+          <div class="ed-bar-divider"></div>
+          <div class="ed-bar-group">
+            <button id="undoButton" data-gp-nav class="ed-icon-btn" title="Undo (Ctrl+Z)" disabled><i class="fa fa-undo" aria-hidden="true"></i></button>
+            <button id="redoButton" data-gp-nav class="ed-icon-btn" title="Redo (Ctrl+Shift+Z)" disabled><i class="fa fa-repeat" aria-hidden="true"></i></button>
           </div>
-          <div class="palette mb-3">
-            <div class="h5">
-              Tiles
-            </div>
-            <hr />
-            <div>
-              <button id="slowTileButton" data-gp-nav style="background-color: #f6d7b0;" title="Sand" class="mapEditorTile"><span>Sand</span></button>
-              <button id="normalTileButton" data-gp-nav style="background-color: #523A28" title="Dirt" class="mapEditorTile"><span>Dirt</span></button>
-              <button id="fastTileButton" data-gp-nav style="background-color: #90ee90" title="Grass" class="mapEditorTile"><span>Grass</span></button>
-              <button id="lavaTileButton" data-gp-nav style="background-color: #cf1020" title="Lava" class="mapEditorTile"><span>Lava</span></button>
-              <button id="iceTileButton" data-gp-nav style="background-color: #A5F2F3" title="Ice" class="mapEditorTile"><span>Ice</span></button>
-              <button id="abilityTileButton" data-gp-nav style="background-color: #C8C8C8" title="Ability" class="mapEditorTile"><span>Ability</span></button>
-              <button id="randomTileButton" data-gp-nav style="background-color: #020DFE" title="Random" class="mapEditorTile"><span>Random</span></button>
-              <button id="goalTileButton" data-gp-nav style="background-color: #FFD700" title="Goal" class="mapEditorTile"><span>Goal</span></button>
-            </div>
+          <div class="ed-bar-divider"></div>
+          <div class="ed-bar-group">
+            <button id="rotateLeftButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard -15° (Shift+R)"><i class="fa fa-rotate-left" aria-hidden="true"></i></button>
+            <button id="rotateButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard +15° (R)"><i class="fa fa-rotate-right" aria-hidden="true"></i></button>
+            <button id="deleteSelectedButton" data-gp-nav class="ed-icon-btn danger" title="Delete selected hazard (Del)" disabled><i class="fa fa-times" aria-hidden="true"></i></button>
           </div>
-          <div class="palette mb-3">
-            <div class="h5">
-              Hazards
-            </div>
-            <hr />
-            <div>
-              <button id="bumperButton" data-gp-nav style="background-color: orange" title="Bumper" class="mapEditorTile"><span>Bumper</span></button>
-              <button id="movingBumperButton" data-gp-nav style="background-color: orange" title="Moving Bumper" class="mapEditorTile"><span>Moving Bumper</span></button>
+
+          <div class="ed-bar-spacer"></div>
+
+          <div class="ed-bar-group" id="detailsWrap">
+            <button id="detailsToggle" data-gp-nav class="ed-btn" title="Map details"><i class="fa fa-info-circle" aria-hidden="true"></i><span>Details</span></button>
+            <div id="detailsPanel">
+              <div class="ed-section-title">Map details</div>
+              <input class="form-control" data-gp-nav type="text" id="author" name="author" placeholder="Author" maxlength="15">
+              <div class="ed-field-msg" id="authorMsg"></div>
+              <input class="form-control" data-gp-nav type="text" id="name" name="name" placeholder="Map Name" maxlength="15">
+              <div class="ed-field-msg" id="nameMsg"></div>
+              <input class="form-control" data-gp-nav type="text" id="email" name="email" placeholder="Email (for upload)" maxlength="50">
+              <div class="ed-field-msg" id="emailMsg"></div>
             </div>
           </div>
-          <div id="startEdgePalette" class="palette mb-3">
-            <div class="h5">
-              Start edge
+          <div class="ed-bar-group">
+            <button id="enableAIButton" data-gp-nav class="ed-btn" aria-pressed="false"
+              title="Fill the grid with AI racers. Off = a solo, bot-free run of your map."><i class="fa fa-square-o" aria-hidden="true"></i><span>AI racers: off</span></button>
+            <button id="previewButton" data-gp-nav class="ed-btn primary" title="Play-test this map"><span>Preview</span><i class="fa fa-play" aria-hidden="true"></i></button>
+            <button id="exportButton" data-gp-nav class="ed-btn" title="Copy map JSON to clipboard"><i class="fa fa-clipboard" aria-hidden="true"></i><span>Copy</span></button>
+            <button id="submitButton" data-gp-nav class="ed-btn" title="Submit this map via GitHub"><i class="fa fa-cloud-upload" aria-hidden="true"></i><span>Upload</span></button>
+          </div>
+        </div>
+
+        <!-- Left tool rail (reflows to a horizontal dock on phones). -->
+        <div id="toolRail">
+          <div class="ed-section">
+            <div class="ed-section-title">Tools</div>
+            <div class="ed-tool-grid">
+              <button id="selectToolButton" data-gp-nav class="ed-tool" title="Select / move (S)"><i class="fa fa-mouse-pointer" aria-hidden="true"></i><span>Select</span></button>
+              <button id="eraserToolButton" data-gp-nav class="ed-tool" title="Erase to dirt (E)"><i class="fa fa-eraser" aria-hidden="true"></i><span>Eraser</span></button>
             </div>
-            <hr />
-            <div>
+          </div>
+          <div class="ed-section">
+            <div class="ed-section-title">Tiles</div>
+            <div class="ed-tool-grid">
+              <button id="slowTileButton" data-gp-nav style="background-color: #f6d7b0;" title="Sand (1)" class="mapEditorTile"><span>Sand</span></button>
+              <button id="normalTileButton" data-gp-nav style="background-color: #523A28" title="Dirt (2)" class="mapEditorTile"><span>Dirt</span></button>
+              <button id="fastTileButton" data-gp-nav style="background-color: #90ee90" title="Grass (3)" class="mapEditorTile"><span>Grass</span></button>
+              <button id="lavaTileButton" data-gp-nav style="background-color: #cf1020" title="Lava (4)" class="mapEditorTile"><span>Lava</span></button>
+              <button id="iceTileButton" data-gp-nav style="background-color: #A5F2F3" title="Ice (5)" class="mapEditorTile"><span>Ice</span></button>
+              <button id="abilityTileButton" data-gp-nav style="background-color: #C8C8C8" title="Ability (6)" class="mapEditorTile"><span>Ability</span></button>
+              <button id="randomTileButton" data-gp-nav style="background-color: #020DFE" title="Random (7)" class="mapEditorTile"><span>Random</span></button>
+              <button id="goalTileButton" data-gp-nav style="background-color: #FFD700" title="Goal (8)" class="mapEditorTile"><span>Goal</span></button>
+            </div>
+          </div>
+          <div class="ed-section">
+            <div class="ed-section-title">Hazards</div>
+            <div class="ed-tool-grid">
+              <button id="bumperButton" data-gp-nav style="background-color: orange" title="Bumper (B)" class="mapEditorTile"><span>Bumper</span></button>
+              <button id="movingBumperButton" data-gp-nav style="background-color: orange" title="Moving Bumper (M)" class="mapEditorTile"><span>Moving</span></button>
+            </div>
+          </div>
+          <div id="startEdgePalette" class="ed-section">
+            <div class="ed-section-title">Start edge</div>
+            <div class="ed-tool-grid">
               <button data-edges="left" data-gp-nav class="mapEditorTile startEdgeButton"><span>Left</span></button>
               <button data-edges="right" data-gp-nav class="mapEditorTile startEdgeButton"><span>Right</span></button>
               <button data-edges="top" data-gp-nav class="mapEditorTile startEdgeButton"><span>Top</span></button>
               <button data-edges="bottom" data-gp-nav class="mapEditorTile startEdgeButton"><span>Bottom</span></button>
-              <button data-edges="left+right" data-gp-nav class="mapEditorTile startEdgeButton"><span>Left + Right</span></button>
-              <button data-edges="top+bottom" data-gp-nav class="mapEditorTile startEdgeButton"><span>Top + Bottom</span></button>
+              <button data-edges="left+right" data-gp-nav class="mapEditorTile startEdgeButton"><span>L + R</span></button>
+              <button data-edges="top+bottom" data-gp-nav class="mapEditorTile startEdgeButton"><span>T + B</span></button>
             </div>
           </div>
-          <div id="actionsSection">
-            <div class="h5">
-              Actions
+        </div>
+
+        <main>
+          <div id="canvasWindow"><canvas id="createCanvas" width="1366" height="768"></canvas></div>
+          <!-- Floating status toasts; create.js shows/hides each as needed. -->
+          <div id="editorStatus">
+            <button id="previewStatus" class="btn" disabled style="display:none;"><span></span></button>
+            <button id="exportStatus" class="btn" disabled style="display:none;"><span></span></button>
+            <button id="submitStatus" class="btn" disabled style="display:none;"><span>Submitting..</span></button>
+          </div>
+        </main>
+
+        <!-- Controller-friendly confirm dialog (replaces native confirm(), which a
+             gamepad can't operate). Shares the leave-game modal's .confirm-* styling
+             (see styles.css). The editor gamepad traps focus to these buttons while
+             the modal is open. -->
+        <div id="wipeConfirmModal" class="confirm-modal hidden">
+          <div class="confirm-dialog">
+            <div class="confirm-title" id="wipeConfirmMessage">Are you sure?</div>
+            <div class="confirm-buttons">
+              <button type="button" id="wipeConfirmYes" class="confirm-btn confirm-leave">Delete</button>
+              <button type="button" id="wipeConfirmCancel" class="confirm-btn confirm-cancel">Cancel</button>
             </div>
-            <hr />
-            <button id="enableAIButton" data-gp-nav class="btn btn-block" aria-pressed="false"
-              title="Fill the grid with AI racers. Off = a solo, bot-free run of your map."><i class="fa fa-square-o mr-2" aria-hidden="true"></i><span>AI racers: off</span></button>
-            <button id="previewButton" data-gp-nav class="btn btn-block">Preview / Playtest<i class="fa fa-play ml-2" aria-hidden="true"></i></button>
-            <button id="previewStatus" class="btn btn-block" disabled style="display:none;"><span></span></button>
-            <button id="exportButton" data-gp-nav class="btn btn-block">Copy to Clipboard<i class="fa fa-clipboard ml-2" aria-hidden="true"></i></button>
-            <button id="exportStatus" class="btn btn-block" disabled style="display:none;"><span></span></button>
-            <button id="submitButton" data-gp-nav class="btn btn-block">Upload to Github<i class="fa fa-cloud-upload ml-2"></i></button>
-            <button id="submitStatus" class="btn btn-block" disabled style="display:none;"><span>Submitting..</span></button>
           </div>
         </div>
       </div>
-      <main>
-        <div id="canvasWindow"><canvas id="createCanvas" width="1366" height="768"></canvas></div>
-      </main>
-      <!-- Controller-friendly confirm dialog (replaces native confirm(), which a
-           gamepad can't operate). Shares the leave-game modal's .confirm-* styling
-           (see styles.css). The editor gamepad traps focus to these buttons while
-           the modal is open. -->
-      <div id="wipeConfirmModal" class="confirm-modal hidden">
-        <div class="confirm-dialog">
-          <div class="confirm-title" id="wipeConfirmMessage">Are you sure?</div>
-          <div class="confirm-buttons">
-            <button type="button" id="wipeConfirmYes" class="confirm-btn confirm-leave">Delete</button>
-            <button type="button" id="wipeConfirmCancel" class="confirm-btn confirm-cancel">Cancel</button>
-          </div>
-        </div>
-      </div>
-    </div>
     </div>
     <div id="loadWindow">
-      <div class="map-image">
+      <div id="mapListHeader">
+        <div class="map-search">
+          <i class="fa fa-search" aria-hidden="true"></i>
+          <input id="mapSearch" data-gp-nav type="text" placeholder="Search maps by name or author…" autocomplete="off">
+          <button id="mapSearchClear" data-gp-nav title="Clear search">&times;</button>
+        </div>
+      </div>
+      <div class="map-image" data-keep="1">
         <button id="createNew" data-gp-nav><img id="createNewImage" src="">
           <div class="desc">Create a new map</div>
         </button>
@@ -382,6 +663,7 @@
   <!-- BUILD: bundle-start -->
   <script src="scripts/rhill-voronoi-core.js"></script>
   <script src="scripts/create.js"></script>
+  <script src="scripts/editorTools.js"></script>
   <script src="scripts/osk.js"></script>
   <script src="scripts/editorGamepad.js"></script>
   <script src="scripts/utils.js"></script>

--- a/client/create.html
+++ b/client/create.html
@@ -597,8 +597,8 @@
           </div>
           <div class="ed-bar-divider"></div>
           <div class="ed-bar-group">
-            <button id="rotateLeftButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard -15° (Shift+R)"><span class="ed-rot-glyph" aria-hidden="true">↺</span></button>
-            <button id="rotateButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard +15° (R)"><span class="ed-rot-glyph" aria-hidden="true">↻</span></button>
+            <button id="rotateLeftButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard -15° (Shift+R)" disabled><span class="ed-rot-glyph" aria-hidden="true">↺</span></button>
+            <button id="rotateButton" data-gp-nav class="ed-icon-btn" title="Rotate selected hazard +15° (R)" disabled><span class="ed-rot-glyph" aria-hidden="true">↻</span></button>
             <button id="deleteSelectedButton" data-gp-nav class="ed-icon-btn danger" title="Delete selected hazard (Del)" disabled><i class="fa fa-times" aria-hidden="true"></i></button>
           </div>
 

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -27,6 +27,23 @@ var server,
     canvasWindow = document.getElementById("canvasWindow"),
     createContext;
 
+// Unified tool model. Every input method (mouse, touch, keyboard, gamepad) sets
+// `activeTool` through setTool(); the legacy render flags (drawBrushAimer/
+// drawObject/brushID/brushColor) are *derived* from it so the existing draw + paint
+// paths are unchanged. kind: 'select' | 'eraser' | 'tile' | 'hazard'.
+var activeTool = { kind: "select" };
+// Right-button erase-to-default stroke, kept distinct from a left-button paint.
+var erasing = false;
+// On-canvas hazard rotate handle: while dragging it the selected hazard's angle
+// tracks the cursor; rotateStartAngle keeps the pre-drag value to record one undo
+// command on release. touchActive guards the window-level touch move/end handlers.
+var rotatingHandle = false;
+var rotateStartAngle = 0;
+var touchActive = false;
+// Accumulates the cell changes of the in-progress paint/erase stroke so the whole
+// stroke collapses to one undo step (beginStroke/recordCellChange/commitStroke).
+var strokeChanges = null;
+
 var scale = 0.035;
 // Gate strip depth (px), matching server/game.js GATE_DEPTH so the previewed gate
 // lines up with where the server actually holds players.
@@ -106,21 +123,39 @@ window.onload = function () {
     }
 }
 
+// Visibility is toggled by class (not jQuery show/hide) so the load grid keeps its
+// CSS `display:grid` and the editor keeps its `display:grid` instead of jQuery
+// forcing them back to `block`.
 function showLoadWindow() {
-    $('#loadWindow').show();
-    $('#createWindow').hide();
+    document.getElementById('loadWindow').classList.remove('editor-hidden');
+    document.getElementById('createWindow').classList.add('editor-hidden');
     document.body.classList.remove('editor-open');
+    updateContinueTile();
 }
 
 function showEditor() {
-    $('#loadWindow').hide();
-    $('#createWindow').show();
+    document.getElementById('loadWindow').classList.add('editor-hidden');
+    document.getElementById('createWindow').classList.remove('editor-hidden');
     document.body.classList.add('editor-open');
-    var cp = document.getElementById('controlPanel');
-    if (cp != null) cp.scrollTop = 0;
+    closeDetailsPanel();
+    var rail = document.getElementById('toolRail');
+    if (rail != null) rail.scrollTop = 0;
     resize();
     addListeners();
 }
+
+// The pinned map-list tile doubles as "your work in progress" once a map has any
+// author work, so label it accordingly (non-destructive: clicking it re-enters the
+// in-memory map; only the wipe button clears it).
+function updateContinueTile() {
+    var desc = document.querySelector('#createNew .desc');
+    if (desc == null) { return; }
+    desc.textContent = mapHasContent() ? "Continue editing" : "Create a new map";
+}
+
+function openDetailsPanel() { var p = document.getElementById("detailsPanel"); if (p) { p.classList.add("open"); } }
+function closeDetailsPanel() { var p = document.getElementById("detailsPanel"); if (p) { p.classList.remove("open"); } }
+function toggleDetailsPanel() { var p = document.getElementById("detailsPanel"); if (p) { p.classList.toggle("open"); } }
 
 function clientConnect() {
     var server = io();
@@ -131,18 +166,12 @@ function clientConnect() {
     });
 
     server.on('githubFailure', function (error) {
-        var submitStatus = $("#submitStatus");
-        submitStatus.css("color", "white");
-        submitStatus.css("background-color", "red");
         console.log(error);
-        submitStatus.text("Failed");
+        showSubmitStatus("Upload failed — try again", "red", "white");
     });
     server.on('githubSuccess', function (url) {
         console.log(url);
-        var submitStatus = $("#submitStatus");
-        submitStatus.css("color", "white");
-        submitStatus.css("background-color", "green");
-        submitStatus.text("Success");
+        showSubmitStatus("Uploaded! Thanks 🎉", "green", "white");
         trackEvent('map_submitted');
     });
 
@@ -165,7 +194,8 @@ function clientConnect() {
         for (var i = 0; i < mapnames.length; i++) {
             $.getJSON("../maps/" + mapnames[i], function (data) {
                 maps.push(data);
-                $("#loadWindow").append('<div class="map-image"><button id="' + data.id + '" data-gp-nav><img src="' + data.thumbnail + '"><div class="desc">' + data.name + ' | ' + data.author + '</div></button></div>');
+                var searchAttr = ((data.name || "") + ' ' + (data.author || "")).replace(/"/g, '&quot;');
+                $("#loadWindow").append('<div class="map-image" data-search="' + searchAttr + '"><button id="' + data.id + '" data-gp-nav><img src="' + data.thumbnail + '"><div class="desc">' + data.name + ' | ' + data.author + '</div></button></div>');
                 $("#" + data.id).on("click", function () {
                     for (var j = 0; j < maps.length; j++) {
                         if (maps[j].id == this.id) {
@@ -243,7 +273,7 @@ function makeSeamlessPattern(image) {
 
 function setupPage() {
     $("#createNew").on("click", function () {
-        $("#submitStatus, #exportStatus").hide();
+        resetStatuses();
         showEditor();
     });
     $("#rebuildButton").on("click", function () {
@@ -272,103 +302,46 @@ function setupPage() {
     });
 
     $("#deleteSelectedButton").on("click", function () {
-        if (selectedObject != null) {
-            removeSelectedObject();
-        }
+        editorDeleteSelected();
         return false;
     });
-
     $("#rotateButton").on("click", function () {
-        drawObject = null;
-        drawBrushAimer = false;
-        if (selectedObject != null) {
-            selectedObject.angle += 15;
-            updateSelectedObject();
-            dirty = true;
-        }
+        editorRotateSelected(15);
         return false;
+    });
+    $("#rotateLeftButton").on("click", function () {
+        editorRotateSelected(-15);
+        return false;
+    });
+    $("#undoButton").on("click", function () { editorUndo(); return false; });
+    $("#redoButton").on("click", function () { editorRedo(); return false; });
+
+    $("#selectToolButton").on("click", function () { editorSelectTool("select"); return false; });
+    $("#eraserToolButton").on("click", function () { editorSelectTool("eraser"); return false; });
+
+    $("#detailsToggle").on("click", function () { toggleDetailsPanel(); return false; });
+    // Clear status toasts + field-required highlights as soon as the user edits any
+    // detail, so stale "Failed"/"required" feedback never lingers (backlog UX item).
+    $("#author, #name, #email").on("input", function () {
+        clearFieldErrors();
+        resetStatuses();
     });
 
-    $("#mouseButton").on("click", function () {
-        drawBrushAimer = false;
-        drawObject = null;
-        dirty = true;
-        return false;
-    });
-
-    $("#slowTileButton").on("click", function () {
-        brushID = config.tileMap.slow.id;
-        brushColor = patterns[config.tileMap.slow.id];
-        drawBrushAimer = true;
-        drawObject = null;
-        return false;
-    });
-    $("#normalTileButton").on("click", function () {
-        brushID = config.tileMap.normal.id;
-        brushColor = patterns[config.tileMap.normal.id];
-        drawBrushAimer = true;
-        drawObject = null;
-        return false;
-    });
-    $("#fastTileButton").on("click", function () {
-        brushID = config.tileMap.fast.id;
-        brushColor = patterns[config.tileMap.fast.id];
-        drawBrushAimer = true;
-        drawObject = null;
-        return false;
-    });
-    $("#lavaTileButton").on("click", function () {
-        brushID = config.tileMap.lava.id;
-        brushColor = patterns[config.tileMap.lava.id];
-        drawBrushAimer = true;
-        drawObject = null;
-        return false;
-    });
-    $("#iceTileButton").on("click", function () {
-        brushID = config.tileMap.ice.id;
-        brushColor = patterns[config.tileMap.ice.id];
-        drawBrushAimer = true;
-        drawObject = null;
-        return false;
-    });
-    $("#abilityTileButton").on("click", function () {
-        brushID = config.tileMap.ability.id;
-        brushColor = patterns[config.tileMap.ability.id];
-        drawBrushAimer = true;
-        drawObject = null;
-        return false;
-    });
-    $("#randomTileButton").on("click", function () {
-        brushID = config.tileMap.random.id;
-        brushColor = patterns[config.tileMap.random.id];
-        drawBrushAimer = true;
-        drawObject = null;
-        return false;
-    });
-    $("#goalTileButton").on("click", function () {
-        brushID = config.tileMap.goal.id;
-        brushColor = config.tileMap.goal.color;
-        drawBrushAimer = true;
-        drawObject = null;
-        return false;
-    });
+    $("#slowTileButton").on("click", function () { editorSelectTile("slow"); return false; });
+    $("#normalTileButton").on("click", function () { editorSelectTile("normal"); return false; });
+    $("#fastTileButton").on("click", function () { editorSelectTile("fast"); return false; });
+    $("#lavaTileButton").on("click", function () { editorSelectTile("lava"); return false; });
+    $("#iceTileButton").on("click", function () { editorSelectTile("ice"); return false; });
+    $("#abilityTileButton").on("click", function () { editorSelectTile("ability"); return false; });
+    $("#randomTileButton").on("click", function () { editorSelectTile("random"); return false; });
+    $("#goalTileButton").on("click", function () { editorSelectTile("goal"); return false; });
     $(".startEdgeButton").on("click", function () {
         var edges = ($(this).attr("data-edges") || "left").split("+");
         setStartEdges(edges);
         return false;
     });
-    $("#bumperButton").on("click", function () {
-        drawBrushAimer = false;
-        drawObject = null;
-        drawObject = config.hazards.bumper.id;
-        return false;
-    });
-    $("#movingBumperButton").on("click", function () {
-        drawBrushAimer = false;
-        drawObject = null;
-        drawObject = config.hazards.movingBumper.id;
-        return false;
-    });
+    $("#bumperButton").on("click", function () { editorSelectHazard("bumper"); return false; });
+    $("#movingBumperButton").on("click", function () { editorSelectHazard("movingBumper"); return false; });
     $("#previewButton").on("click", function () {
         previewMap();
         return false;
@@ -395,12 +368,10 @@ function setupPage() {
     $("#loadButton").on("click", function () {
         setSelectedObject(null);
         $("#createNewImage").attr("src", createCanvas.toDataURL("image/jpeg", 0.1));
-        $("#submitStatus, #exportStatus").hide();
+        resetStatuses();
+        closeDetailsPanel();
         showLoadWindow();
-
-        window.removeEventListener("mousemove", cellUnderMouse, false);
-        window.removeEventListener("mousedown", handleClick, false);
-        window.removeEventListener("mouseup", handleUnClick, false);
+        removeListeners();
         return false;
     });
     window.addEventListener('contextmenu', suppressContextMenu, false);
@@ -422,6 +393,27 @@ function addListeners() {
     window.addEventListener("mousemove", cellUnderMouse, false);
     window.addEventListener("mousedown", handleClick, false);
     window.addEventListener("mouseup", handleUnClick, false);
+    // Touch drives the same paint/place/select paths as the mouse. touchstart binds
+    // to the canvas (so taps on the tool docks don't paint); move/end bind to the
+    // window so a drag that strays off the canvas still tracks (touch capture).
+    if (createCanvas != null) {
+        createCanvas.addEventListener("touchstart", handleTouchStart, { passive: false });
+    }
+    window.addEventListener("touchmove", handleTouchMove, { passive: false });
+    window.addEventListener("touchend", handleTouchEnd, { passive: false });
+    window.addEventListener("touchcancel", handleTouchEnd, { passive: false });
+}
+
+function removeListeners() {
+    window.removeEventListener("mousemove", cellUnderMouse, false);
+    window.removeEventListener("mousedown", handleClick, false);
+    window.removeEventListener("mouseup", handleUnClick, false);
+    if (createCanvas != null) {
+        createCanvas.removeEventListener("touchstart", handleTouchStart);
+    }
+    window.removeEventListener("touchmove", handleTouchMove);
+    window.removeEventListener("touchend", handleTouchEnd);
+    window.removeEventListener("touchcancel", handleTouchEnd);
 }
 
 function suppressContextMenu(ev) {
@@ -431,8 +423,12 @@ function suppressContextMenu(ev) {
 
 function setSelectedObject(obj) {
     selectedObject = obj;
-    var btn = document.getElementById("deleteSelectedButton");
-    if (btn != null) btn.disabled = (obj == null);
+    var none = (obj == null);
+    var ids = ["deleteSelectedButton", "rotateButton", "rotateLeftButton"];
+    for (var i = 0; i < ids.length; i++) {
+        var btn = document.getElementById(ids[i]);
+        if (btn != null) { btn.disabled = none; }
+    }
     dirty = true;
 }
 
@@ -440,10 +436,11 @@ function setSelectedObject(obj) {
 // a non-default tile painted, or a hazard placed.
 function mapHasContent() {
     if (vMap == null || !Array.isArray(vMap.cells)) { return false; }
+    if (vMap.hazards && vMap.hazards.length > 0) { return true; }
+    if (config == null) { return false; } // can't compare tile ids until config arrives
     for (var i = 0; i < vMap.cells.length; i++) {
         if (vMap.cells[i].id != config.tileMap.normal.id) { return true; }
     }
-    if (vMap.hazards && vMap.hazards.length > 0) { return true; }
     return false;
 }
 
@@ -475,19 +472,26 @@ function validateEmail(mail) {
 }
 
 function rebuild() {
-    $("#submitStatus, #exportStatus").hide();
+    resetStatuses();
+    clearFieldErrors();
     setSelectedObject(null);
     vMap = generateVMap();
+    clearHistory(); // a fresh map starts with an empty undo history
     $('#author').val("");
     $('#name').val("");
     $("#createNewImage").attr("src", createCanvas.toDataURL("image/jpeg", 0.1));
+    updateContinueTile();
     resize();
 }
 
 function init() {
     initEditorGamepad();
+    installEditorShortcuts();
+    installMapSearch();
     recomputeStartLayout();
     updateStartEdgeButtons();
+    setTool({ kind: "select" }); // sensible default; pick a tile/hazard to start painting
+    updateUndoRedoButtons();
     animloop();
 }
 
@@ -500,13 +504,22 @@ function animloop() {
         mapReady = true;
         rebuild();
     }
-    if (drawBrushAimer) {
+    if (rotatingHandle && selectedObject != null) {
+        // Dragging the on-canvas rotate knob: angle tracks the cursor.
+        selectedObject.angle = Math.atan2(mousey - selectedObject.y, mousex - selectedObject.x) * (180 / Math.PI);
+        updateSelectedObject();
+        dirty = true;
+    }
+    if (drawBrushAimer || erasing) {
         var prev = currentCell;
         currentCell = cellIdFromPoint(mousex, mousey);
         if (prev !== currentCell) dirty = true;
     }
     if (brushing) {
         if (paintTile()) dirty = true;
+    }
+    if (erasing) {
+        if (paintTile(config.tileMap.normal.id)) dirty = true;
     }
     if (dirty) {
         drawEditor(dt);
@@ -608,6 +621,7 @@ function applyStartEdges(edges) {
     if (mapReady && vMap != null) {
         setSelectedObject(null);
         vMap = generateVMap();
+        clearHistory(); // the reshape replaced every cell — old undo steps are stale
     }
     if (vMap != null) { vMap.startEdges = startEdges.slice(); }
     updateStartEdgeButtons();
@@ -720,27 +734,338 @@ function drawMovingBumper(x, y, angle) {
 function handleClick(event) {
     switch (event.which) {
         case 1: {
-            if (drawBrushAimer) {
-                brushing = true;
-                break;
+            // On-canvas hazard handles take priority over painting/selecting.
+            if (selectedObject != null) {
+                if (overDeleteHandle(mousex, mousey)) { removeSelectedObject(); break; }
+                if (overRotateHandle(mousex, mousey)) {
+                    rotatingHandle = true;
+                    rotateStartAngle = selectedObject.angle || 0;
+                    break;
+                }
             }
-            if (drawObject != null) {
-                addObjectToMap(mousex, mousey, drawObject);
-                break;
-            }
+            if (drawBrushAimer) { brushing = true; beginStroke(); break; }
+            if (drawObject != null) { addObjectToMap(mousex, mousey, drawObject); break; }
             locateObject(mousex, mousey);
+            break;
+        }
+        case 3: {
+            // Right button: delete a hazard under the cursor, else erase to dirt
+            // (right-drag keeps erasing). Backlog UX item.
+            if (hazardUnderPoint(mousex, mousey)) {
+                removeHazardUnderPoint(mousex, mousey);
+                break;
+            }
+            erasing = true;
+            beginStroke();
+            break;
         }
     }
 }
 function handleUnClick(event) {
     switch (event.which) {
         case 1: {
-            if (drawBrushAimer) {
-                brushing = false;
+            if (rotatingHandle) {
+                rotatingHandle = false;
+                if (selectedObject != null) {
+                    pushRotateCommand(selectedHazardIndex(), rotateStartAngle, selectedObject.angle || 0);
+                }
                 break;
             }
+            if (brushing) { brushing = false; commitStroke(); break; }
+            break;
+        }
+        case 3: {
+            if (erasing) { erasing = false; commitStroke(); break; }
+            break;
         }
     }
+}
+
+// --- touch input --------------------------------------------------------------
+function canvasPointFromTouch(touch) {
+    var rect = createCanvas.getBoundingClientRect();
+    return {
+        x: ((touch.clientX - rect.left) / newWidth) * createCanvas.width,
+        y: ((touch.clientY - rect.top) / newHeight) * createCanvas.height
+    };
+}
+function handleTouchStart(event) {
+    if (event.touches.length === 0) { return; }
+    event.preventDefault();
+    touchActive = true;
+    var p = canvasPointFromTouch(event.touches[0]);
+    setMousePos(p.x, p.y);
+    // Resolve the touched cell up front so the first paint lands immediately
+    // (the animloop's per-frame recompute hasn't run yet for this point).
+    if (drawBrushAimer) { currentCell = cellIdFromPoint(p.x, p.y); }
+    handleClick({ which: 1 });
+}
+function handleTouchMove(event) {
+    if (!touchActive || event.touches.length === 0) { return; }
+    event.preventDefault();
+    var p = canvasPointFromTouch(event.touches[0]);
+    setMousePos(p.x, p.y);
+    dirty = true;
+}
+function handleTouchEnd(event) {
+    if (!touchActive) { return; }
+    if (event.cancelable) { event.preventDefault(); }
+    touchActive = false;
+    handleUnClick({ which: 1 });
+}
+
+// --- unified tool model -------------------------------------------------------
+// Every input path routes through setTool(); the legacy render flags are derived
+// here so draw/paint code is untouched.
+function setTool(tool) {
+    activeTool = tool;
+    drawBrushAimer = (tool.kind === "tile" || tool.kind === "eraser");
+    drawObject = (tool.kind === "hazard") ? tool.id : null;
+    if (tool.kind === "tile") {
+        brushID = tool.id;
+        brushColor = tool.color;
+    } else if (tool.kind === "eraser") {
+        brushID = config.tileMap.normal.id;
+        brushColor = patterns[config.tileMap.normal.id];
+    }
+    // A paint/place tool can't also keep a hazard selected (no handles to show).
+    if (tool.kind !== "select") {
+        setSelectedObject(null);
+    }
+    updateToolButtons();
+    dirty = true;
+}
+function editorSelectTool(kind) {
+    setTool({ kind: kind === "eraser" ? "eraser" : "select" });
+}
+function editorSelectTile(typeName) {
+    if (config == null) { return; }
+    var t = config.tileMap[typeName];
+    if (t == null) { return; }
+    var color = (patterns[t.id] != null) ? patterns[t.id] : t.color;
+    setTool({ kind: "tile", id: t.id, color: color, name: typeName });
+}
+function editorSelectHazard(typeName) {
+    if (config == null) { return; }
+    var h = config.hazards[typeName];
+    if (h == null) { return; }
+    setTool({ kind: "hazard", id: h.id, name: typeName });
+}
+function editorDeselect() {
+    if (selectedObject != null) { setSelectedObject(null); }
+}
+function editorRotateSelected(deg) {
+    if (selectedObject == null) { return; }
+    var from = selectedObject.angle || 0;
+    selectedObject.angle = from + deg;
+    updateSelectedObject();
+    pushRotateCommand(selectedHazardIndex(), from, selectedObject.angle);
+    dirty = true;
+}
+function editorDeleteSelected() {
+    if (selectedObject != null) { removeSelectedObject(); }
+}
+
+// Highlight the active tool/tile/hazard button.
+var TOOL_BUTTON_IDS = ["selectToolButton", "eraserToolButton", "slowTileButton",
+    "normalTileButton", "fastTileButton", "lavaTileButton", "iceTileButton",
+    "abilityTileButton", "randomTileButton", "goalTileButton", "bumperButton",
+    "movingBumperButton"];
+function updateToolButtons() {
+    for (var i = 0; i < TOOL_BUTTON_IDS.length; i++) {
+        var el = document.getElementById(TOOL_BUTTON_IDS[i]);
+        if (el != null) { el.classList.remove("tool-active"); }
+    }
+    var activeId = activeToolButtonId();
+    if (activeId != null) {
+        var a = document.getElementById(activeId);
+        if (a != null) { a.classList.add("tool-active"); }
+    }
+}
+function activeToolButtonId() {
+    if (activeTool.kind === "select") { return "selectToolButton"; }
+    if (activeTool.kind === "eraser") { return "eraserToolButton"; }
+    if (activeTool.kind === "tile") {
+        var tileMap = {
+            slow: "slowTileButton", normal: "normalTileButton", fast: "fastTileButton",
+            lava: "lavaTileButton", ice: "iceTileButton", ability: "abilityTileButton",
+            random: "randomTileButton", goal: "goalTileButton"
+        };
+        return tileMap[activeTool.name] || null;
+    }
+    if (activeTool.kind === "hazard") {
+        return activeTool.name === "movingBumper" ? "movingBumperButton" : "bumperButton";
+    }
+    return null;
+}
+
+// --- paint-stroke undo grouping ----------------------------------------------
+function beginStroke() { strokeChanges = {}; }
+function recordCellChange(idx, from, to) {
+    if (strokeChanges == null) { return; }
+    if (!Object.prototype.hasOwnProperty.call(strokeChanges, idx)) {
+        strokeChanges[idx] = { from: from };
+    }
+    strokeChanges[idx].to = to;
+}
+function commitStroke() {
+    if (strokeChanges == null) { return; }
+    var changes = [];
+    for (var k in strokeChanges) {
+        if (!Object.prototype.hasOwnProperty.call(strokeChanges, k)) { continue; }
+        var c = strokeChanges[k];
+        if (c.from !== c.to) { changes.push({ idx: +k, from: c.from, to: c.to }); }
+    }
+    strokeChanges = null;
+    if (changes.length === 0) { return; }
+    pushCommand({
+        undo: function () { for (var i = 0; i < changes.length; i++) { var cell = vMap.cells[changes[i].idx]; if (cell) { cell.id = changes[i].from; } } },
+        redo: function () { for (var i = 0; i < changes.length; i++) { var cell = vMap.cells[changes[i].idx]; if (cell) { cell.id = changes[i].to; } } }
+    });
+}
+
+// --- hazard helpers (index/reference based — also fixes the stacked-duplicate
+//     selection bug, since selection now tracks the array index, not x/y) -------
+function hazardConfigById(id) {
+    for (var type in config.hazards) {
+        if (config.hazards[type].id == id) { return config.hazards[type]; }
+    }
+    return null;
+}
+function selectedHazardIndex() {
+    return (selectedObject != null && selectedObject.index != null) ? selectedObject.index : -1;
+}
+function hazardIndexUnderPoint(x, y) {
+    if (outsideMapBounds(x, y, 0)) { return -1; }
+    var hazards = vMap.hazards || [];
+    for (var i = hazards.length - 1; i >= 0; i--) { // topmost (last drawn) first
+        var cfg = hazardConfigById(hazards[i].id);
+        if (cfg == null) { continue; }
+        if (getMagSq(x, y, hazards[i].x, hazards[i].y) < Math.pow(cfg.radius, 2)) { return i; }
+    }
+    return -1;
+}
+function hazardUnderPoint(x, y) { return hazardIndexUnderPoint(x, y) >= 0; }
+function removeHazardUnderPoint(x, y) {
+    var i = hazardIndexUnderPoint(x, y);
+    if (i < 0) { return; }
+    var removed = vMap.hazards[i];
+    vMap.hazards.splice(i, 1);
+    pushHazardRemoveCommand(removed, i);
+    setSelectedObject(null); // a splice shifts indices — drop any stale selection
+    dirty = true;
+}
+function pushHazardAddCommand(hazard) {
+    pushCommand({
+        undo: function () { var i = vMap.hazards.indexOf(hazard); if (i >= 0) { vMap.hazards.splice(i, 1); } },
+        redo: function () { if (vMap.hazards.indexOf(hazard) < 0) { vMap.hazards.push(hazard); } }
+    });
+}
+function pushHazardRemoveCommand(hazard, index) {
+    pushCommand({
+        undo: function () { vMap.hazards.splice(Math.min(index, vMap.hazards.length), 0, hazard); },
+        redo: function () { var i = vMap.hazards.indexOf(hazard); if (i >= 0) { vMap.hazards.splice(i, 1); } }
+    });
+}
+function pushRotateCommand(index, from, to) {
+    if (from === to) { return; }
+    var hz = (index >= 0 && vMap.hazards[index]) ? vMap.hazards[index] : null;
+    if (hz == null) { return; }
+    pushCommand({
+        undo: function () { hz.angle = from; },
+        redo: function () { hz.angle = to; }
+    });
+}
+
+// --- on-canvas hazard handles -------------------------------------------------
+function rotateHandlePos() {
+    var r = selectedObject.radius + 50;
+    return pos({ x: selectedObject.x, y: selectedObject.y }, r, selectedObject.angle || 0);
+}
+function deleteHandlePos() {
+    var d = selectedObject.radius + 28;
+    return { x: selectedObject.x + d, y: selectedObject.y - d };
+}
+function overRotateHandle(x, y) {
+    if (selectedObject == null) { return false; }
+    var p = rotateHandlePos();
+    return getMagSq(x, y, p.x, p.y) < 18 * 18;
+}
+function overDeleteHandle(x, y) {
+    if (selectedObject == null) { return false; }
+    var p = deleteHandlePos();
+    return getMagSq(x, y, p.x, p.y) < 18 * 18;
+}
+function drawHazardHandles() {
+    var rp = rotateHandlePos();
+    createContext.save();
+    createContext.beginPath();
+    createContext.arc(rp.x, rp.y, 12, 0, 2 * Math.PI);
+    createContext.fillStyle = "#1e90ff";
+    createContext.strokeStyle = "white";
+    createContext.lineWidth = 3;
+    createContext.fill();
+    createContext.stroke();
+    createContext.restore();
+
+    var dp = deleteHandlePos();
+    createContext.save();
+    createContext.beginPath();
+    createContext.arc(dp.x, dp.y, 13, 0, 2 * Math.PI);
+    createContext.fillStyle = "#cf1020";
+    createContext.strokeStyle = "white";
+    createContext.lineWidth = 3;
+    createContext.fill();
+    createContext.stroke();
+    createContext.beginPath();
+    createContext.moveTo(dp.x - 5, dp.y - 5); createContext.lineTo(dp.x + 5, dp.y + 5);
+    createContext.moveTo(dp.x + 5, dp.y - 5); createContext.lineTo(dp.x - 5, dp.y + 5);
+    createContext.lineWidth = 2.5;
+    createContext.strokeStyle = "white";
+    createContext.stroke();
+    createContext.restore();
+}
+
+// --- required-field validation + status reset --------------------------------
+function setFieldError(inputId, msgId, message) {
+    var input = document.getElementById(inputId);
+    var msg = document.getElementById(msgId);
+    if (input != null) { input.classList.add("field-required"); }
+    if (msg != null) { msg.textContent = message || ""; }
+}
+function clearFieldErrors() {
+    var fields = [["author", "authorMsg"], ["name", "nameMsg"], ["email", "emailMsg"]];
+    for (var i = 0; i < fields.length; i++) {
+        var input = document.getElementById(fields[i][0]);
+        var msg = document.getElementById(fields[i][1]);
+        if (input != null) { input.classList.remove("field-required"); }
+        if (msg != null) { msg.textContent = ""; }
+    }
+}
+// Author + name are required before export/upload (previously substituted with
+// "anonymous"/"unknown" silently). Flags the empty fields and opens the Details
+// panel so the feedback is visible. Returns true when both are present.
+function requireDetails() {
+    clearFieldErrors();
+    var ok = true;
+    if (($("#author").val() || "").trim() === "") { setFieldError("author", "authorMsg", "Author is required"); ok = false; }
+    if (($("#name").val() || "").trim() === "") { setFieldError("name", "nameMsg", "Map name is required"); ok = false; }
+    if (!ok) { openDetailsPanel(); }
+    return ok;
+}
+var submitStatusTimer = null;
+function showSubmitStatus(message, bg, color) {
+    var el = $("#submitStatus");
+    el.text(message);
+    el.css({ "color": color || "white", "background-color": bg });
+    el.show();
+    if (submitStatusTimer) { clearTimeout(submitStatusTimer); }
+    submitStatusTimer = setTimeout(function () { el.hide(); }, 4000);
+}
+function resetStatuses() {
+    $("#submitStatus, #exportStatus, #previewStatus").hide();
+    if (submitStatusTimer) { clearTimeout(submitStatusTimer); submitStatusTimer = null; }
+    if (exportStatusTimer) { clearTimeout(exportStatusTimer); exportStatusTimer = null; }
 }
 
 function setMousePos(x, y) {
@@ -748,76 +1073,58 @@ function setMousePos(x, y) {
     mousey = y;
 }
 
-function paintTile() {
+function paintTile(targetId) {
     if (currentCell == null) return false;
     var cell = vMap.cells[currentCell];
     if (cell == null) return false;
-    var newId = locateId(brushColor);
+    var newId = (targetId != null) ? targetId : locateId(brushColor);
     if (cell.id === newId) return false;
+    recordCellChange(currentCell, cell.id, newId);
     cell.id = newId;
     return true;
 }
 
 function addObjectToMap(x, y, obj) {
-    var radius = 0;
-    for (var hazard in config.hazards) {
-        if (obj == config.hazards[hazard].id) {
-            radius = config.hazards[hazard].attackRadius;
-        }
-    }
+    var cfg = hazardConfigById(obj);
+    var radius = (cfg != null) ? cfg.attackRadius : 0;
     if (outsideMapBounds(x, y, radius)) {
         return;
     }
     if (vMap.hazards == undefined) {
         vMap.hazards = [];
     }
-    vMap.hazards.push({ id: drawObject, x: x, y: y, angle: 0 });
+    var hazard = { id: obj, x: x, y: y, angle: 0 };
+    vMap.hazards.push(hazard);
+    pushHazardAddCommand(hazard);
     dirty = true;
 }
 
 function locateObject(x, y) {
-    if (outsideMapBounds(x, y, 0)) {
+    var i = hazardIndexUnderPoint(x, y);
+    if (i < 0) {
+        setSelectedObject(null);
         return;
     }
-    for (var hazard in vMap.hazards) {
-        var hazardObj = null;
-        for (var type in config.hazards) {
-            if (vMap.hazards[hazard].id == config.hazards[type].id) {
-                hazardObj = config.hazards[type];
-                break;
-            }
-        }
-        if (hazardObj == null) continue;
-        var distance = getMagSq(x, y, vMap.hazards[hazard].x, vMap.hazards[hazard].y);
-        if (distance < Math.pow(hazardObj.radius, 2)) {
-            setSelectedObject({ id: vMap.hazards[hazard].id, x: vMap.hazards[hazard].x, y: vMap.hazards[hazard].y, angle: vMap.hazards[hazard].angle, radius: hazardObj.radius });
-            return;
-        }
-    }
-    setSelectedObject(null);
+    var hz = vMap.hazards[i];
+    var cfg = hazardConfigById(hz.id);
+    setSelectedObject({ index: i, id: hz.id, x: hz.x, y: hz.y, angle: hz.angle, radius: cfg.radius });
 }
 
+// Write the selection's live angle back to its hazard (selection tracks the array
+// index, so stacked duplicates at the same x/y are no longer ambiguous).
 function updateSelectedObject() {
-    for (var i = 0; i < vMap.hazards.length; i++) {
-        if (vMap.hazards[i].id == selectedObject.id) {
-            if (vMap.hazards[i].x == selectedObject.x && vMap.hazards[i].y == selectedObject.y) {
-                vMap.hazards[i].angle = selectedObject.angle;
-                return;
-            }
-        }
-    }
+    var i = selectedHazardIndex();
+    if (i < 0 || vMap.hazards[i] == null) { return; }
+    vMap.hazards[i].angle = selectedObject.angle;
 }
 
 function removeSelectedObject() {
-    for (var i = 0; i < vMap.hazards.length; i++) {
-        if (vMap.hazards[i].id == selectedObject.id) {
-            if (vMap.hazards[i].x == selectedObject.x && vMap.hazards[i].y == selectedObject.y) {
-                vMap.hazards.splice(i, 1);
-                setSelectedObject(null);
-                return;
-            }
-        }
-    }
+    var i = selectedHazardIndex();
+    if (i < 0 || vMap.hazards[i] == null) { return; }
+    var removed = vMap.hazards[i];
+    vMap.hazards.splice(i, 1);
+    pushHazardRemoveCommand(removed, i);
+    setSelectedObject(null);
 }
 
 
@@ -964,6 +1271,10 @@ function showExportStatus(message, bg) {
     exportStatusTimer = setTimeout(function () { el.hide(); }, 2500);
 }
 function exportToJSON() {
+    if (!requireDetails()) {
+        showExportStatus("Add an author and map name first", "red");
+        return;
+    }
     basicSanitize();
     navigator.clipboard.writeText(JSON.stringify(vMap)).then(function () {
         showExportStatus("Copied to clipboard!", "green");
@@ -980,20 +1291,25 @@ function submitViaEmail() {
 }
 
 function submitToGithub() {
+    if (!requireDetails()) {
+        showSubmitStatus("Add an author and map name first", "red", "white");
+        return false;
+    }
     var email = $("#email").val();
     if (!validateEmail(email)) {
         // Inline feedback instead of a focus-stealing alert() the gamepad can't close.
-        var submitStatus = $("#submitStatus");
-        submitStatus.show();
-        submitStatus.css("color", "white");
-        submitStatus.css("background-color", "red");
-        submitStatus.text("Enter a valid email to submit");
+        setFieldError("email", "emailMsg", "Enter a valid email");
+        openDetailsPanel();
+        showSubmitStatus("Enter a valid email to submit", "red", "white");
         $("#email").focus();
         return false;
     }
     basicSanitize();
     vMap.email = email;
+    // Pending state stays put until githubSuccess/githubFailure replaces it (those
+    // use the auto-resetting showSubmitStatus); don't auto-hide the "Submitting.."
     var submitStatus = $("#submitStatus");
+    if (submitStatusTimer) { clearTimeout(submitStatusTimer); submitStatusTimer = null; }
     submitStatus.show();
     submitStatus.css("color", "black");
     submitStatus.css("background-color", "#ADD8E6");
@@ -1212,6 +1528,7 @@ function drawSelectedObject() {
         createContext.stroke();
         createContext.restore();
         drawRotationRing();
+        drawHazardHandles();
     }
 }
 

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -40,6 +40,7 @@ var erasing = false;
 var rotatingHandle = false;
 var rotateStartAngle = 0;
 var touchActive = false;
+var touchId = null; // identifier of the finger currently driving a touch stroke
 // Accumulates the cell changes of the in-progress paint/erase stroke so the whole
 // stroke collapses to one undo step (beginStroke/recordCellChange/commitStroke).
 var strokeChanges = null;
@@ -221,8 +222,11 @@ function clientConnect() {
         for (var i = 0; i < mapnames.length; i++) {
             $.getJSON("../maps/" + mapnames[i], function (data) {
                 maps.push(data);
-                var searchAttr = ((data.name || "") + ' ' + (data.author || "")).replace(/"/g, '&quot;');
-                $("#loadWindow").append('<div class="map-image" data-search="' + searchAttr + '"><button id="' + data.id + '" data-gp-nav><img src="' + data.thumbnail + '"><div class="desc">' + data.name + ' | ' + data.author + '</div></button></div>');
+                // Fully escape name/author before interpolating into innerHTML (both
+                // the data-search attribute and the visible caption) — quotes alone
+                // left & and < to corrupt the markup.
+                var nm = escapeHtml(data.name), au = escapeHtml(data.author);
+                $("#loadWindow").append('<div class="map-image" data-search="' + nm + ' ' + au + '"><button id="' + data.id + '" data-gp-nav><img src="' + data.thumbnail + '"><div class="desc">' + nm + ' | ' + au + '</div></button></div>');
                 $("#" + data.id).on("click", function () {
                     var id = this.id;
                     // Loading a different map replaces the in-memory map, so warn first
@@ -742,7 +746,10 @@ function applyStartEdges(edges) {
         setSelectedObject(null);
         vMap = generateVMap();
         clearHistory(); // the reshape replaced every cell — old undo steps are stale
-        mapModified = true; // a reshape is itself an unsaved edit
+        // The reshaped surface is blank again (no painted tiles/hazards), so there's
+        // nothing unsaved to warn about — matches a fresh map. Painting after this
+        // re-sets mapModified via pushCommand.
+        mapModified = false;
     }
     if (vMap != null) { vMap.startEdges = startEdges.slice(); }
     updateStartEdgeButtons();
@@ -769,11 +776,9 @@ function updateStartEdgeButtons() {
     var activeKey = startEdges.slice().sort().join("+");
     $(".startEdgeButton").each(function () {
         var edges = ($(this).attr("data-edges") || "").split("+").sort().join("+");
-        if (edges === activeKey) {
-            $(this).addClass("active-edge").css("outline", "3px solid #1e90ff");
-        } else {
-            $(this).removeClass("active-edge").css("outline", "");
-        }
+        // Use the shared .tool-active ring (same as tiles/hazards/tools) instead of a
+        // separate inline-blue outline, so the editor has one selection visual.
+        $(this).toggleClass("tool-active", edges === activeKey);
     });
 }
 
@@ -855,6 +860,7 @@ function drawMovingBumper(x, y, angle) {
 function handleClick(event) {
     switch (event.which) {
         case 1: {
+            if (erasing) { break; } // don't start a paint while a right-erase is in progress
             // On-canvas hazard handles take priority over painting/selecting.
             if (selectedObject != null) {
                 if (overDeleteHandle(mousex, mousey)) { removeSelectedObject(); break; }
@@ -870,6 +876,7 @@ function handleClick(event) {
             break;
         }
         case 3: {
+            if (brushing || rotatingHandle) { break; } // don't erase while painting/rotating
             // Right button: delete a hazard under the cursor, else erase to dirt
             // (right-drag keeps erasing). Backlog UX item.
             if (hazardUnderPoint(mousex, mousey)) {
@@ -903,18 +910,32 @@ function handleUnClick(event) {
 }
 
 // --- touch input --------------------------------------------------------------
+// Single-touch only: track the first finger's identifier and ignore extra fingers,
+// so a stray second touch can't snap the cursor or restart/commit the stroke.
 function canvasPointFromTouch(touch) {
     var rect = createCanvas.getBoundingClientRect();
+    // Map through the *live* displayed size, not the cached newWidth/newHeight which
+    // are 0 until a successful resize() — a tap during the first/reflow layout would
+    // otherwise divide by 0 and map to Infinity.
+    if (rect.width === 0 || rect.height === 0) { return { x: mousex, y: mousey }; }
     return {
-        x: ((touch.clientX - rect.left) / newWidth) * createCanvas.width,
-        y: ((touch.clientY - rect.top) / newHeight) * createCanvas.height
+        x: ((touch.clientX - rect.left) / rect.width) * createCanvas.width,
+        y: ((touch.clientY - rect.top) / rect.height) * createCanvas.height
     };
 }
+function findTrackedTouch(list) {
+    for (var i = 0; i < list.length; i++) {
+        if (list[i].identifier === touchId) { return list[i]; }
+    }
+    return null;
+}
 function handleTouchStart(event) {
-    if (event.touches.length === 0) { return; }
+    if (touchActive || event.changedTouches.length === 0) { return; } // ignore extra fingers
     event.preventDefault();
     touchActive = true;
-    var p = canvasPointFromTouch(event.touches[0]);
+    var t = event.changedTouches[0];
+    touchId = t.identifier;
+    var p = canvasPointFromTouch(t);
     setMousePos(p.x, p.y);
     // Resolve the touched cell up front so the first paint lands immediately
     // (the animloop's per-frame recompute hasn't run yet for this point).
@@ -922,16 +943,21 @@ function handleTouchStart(event) {
     handleClick({ which: 1 });
 }
 function handleTouchMove(event) {
-    if (!touchActive || event.touches.length === 0) { return; }
+    if (!touchActive) { return; }
+    var t = findTrackedTouch(event.touches);
+    if (t == null) { return; }
     event.preventDefault();
-    var p = canvasPointFromTouch(event.touches[0]);
+    var p = canvasPointFromTouch(t);
     setMousePos(p.x, p.y);
     dirty = true;
 }
 function handleTouchEnd(event) {
     if (!touchActive) { return; }
+    // End only when OUR finger lifts; touchcancel always ends the stroke.
+    if (event.type !== "touchcancel" && findTrackedTouch(event.changedTouches) == null) { return; }
     if (event.cancelable) { event.preventDefault(); }
     touchActive = false;
+    touchId = null;
     handleUnClick({ which: 1 });
 }
 
@@ -957,7 +983,14 @@ function setTool(tool) {
     dirty = true;
 }
 function editorSelectTool(kind) {
-    setTool({ kind: kind === "eraser" ? "eraser" : "select" });
+    // The eraser needs config (it paints the default tile id); guard like the
+    // tile/hazard selectors do. Select needs no config.
+    if (kind === "eraser") {
+        if (config == null) { return; }
+        setTool({ kind: "eraser" });
+        return;
+    }
+    setTool({ kind: "select" });
 }
 function editorSelectTile(typeName) {
     if (config == null) { return; }
@@ -1021,7 +1054,9 @@ function activeToolButtonId() {
 }
 
 // --- paint-stroke undo grouping ----------------------------------------------
-function beginStroke() { strokeChanges = {}; }
+// Idempotent: a second begin (e.g. button chording) must not clobber the
+// in-progress stroke's accumulated diff.
+function beginStroke() { if (strokeChanges == null) { strokeChanges = {}; } }
 function recordCellChange(idx, from, to) {
     if (strokeChanges == null) { return; }
     if (!Object.prototype.hasOwnProperty.call(strokeChanges, idx)) {
@@ -1105,7 +1140,12 @@ function rotateHandlePos() {
 }
 function deleteHandlePos() {
     var d = selectedObject.radius + 28;
-    return { x: selectedObject.x + d, y: selectedObject.y - d };
+    // Clamp inside the canvas so a hazard near the top-right edge still shows a
+    // clickable ✕ (the draw + hit-test both call this, so they stay in sync).
+    var m = 16;
+    var x = Math.max(m, Math.min(createCanvas.width - m, selectedObject.x + d));
+    var y = Math.max(m, Math.min(createCanvas.height - m, selectedObject.y - d));
+    return { x: x, y: y };
 }
 function overRotateHandle(x, y) {
     if (selectedObject == null) { return false; }
@@ -1175,7 +1215,11 @@ function requireDetails() {
     return ok;
 }
 var submitStatusTimer = null;
+// True between clicking Upload and the server's success/failure reply — so an
+// input-change reset doesn't wipe the in-flight "Submitting.." indicator.
+var submitPending = false;
 function showSubmitStatus(message, bg, color) {
+    submitPending = false; // a terminal status (success/failure/validation) clears pending
     var el = $("#submitStatus");
     el.text(message);
     el.css({ "color": color || "white", "background-color": bg });
@@ -1184,8 +1228,11 @@ function showSubmitStatus(message, bg, color) {
     submitStatusTimer = setTimeout(function () { el.hide(); }, 4000);
 }
 function resetStatuses() {
-    $("#submitStatus, #exportStatus, #previewStatus").hide();
-    if (submitStatusTimer) { clearTimeout(submitStatusTimer); submitStatusTimer = null; }
+    $("#exportStatus, #previewStatus").hide();
+    if (!submitPending) { // don't hide an in-flight upload
+        $("#submitStatus").hide();
+        if (submitStatusTimer) { clearTimeout(submitStatusTimer); submitStatusTimer = null; }
+    }
     if (exportStatusTimer) { clearTimeout(exportStatusTimer); exportStatusTimer = null; }
 }
 
@@ -1435,6 +1482,7 @@ function submitToGithub() {
     submitStatus.css("color", "black");
     submitStatus.css("background-color", "#ADD8E6");
     submitStatus.text("Submitting..");
+    submitPending = true; // protect this indicator from input-change resets until the reply
     server.emit('submitNewMap', JSON.stringify(vMap));
 }
 // Mirror of server/utils.js validateMap — gives fast inline feedback in the
@@ -1573,7 +1621,7 @@ function setPreviewAI(on) {
     btn.classList.toggle("ai-on", on);
     var icon = btn.querySelector("i");
     if (icon != null) {
-        icon.className = "fa mr-2 " + (on ? "fa-check-square" : "fa-square-o");
+        icon.className = "fa " + (on ? "fa-check-square" : "fa-square-o");
     }
     var label = btn.querySelector("span");
     if (label != null) {
@@ -1597,6 +1645,17 @@ function basicSanitize() {
     vMap.id = makeid(32);
     vMap.author = author.substring(0, 15);
     vMap.name = name.substring(0, 15);
+}
+
+// Escape HTML-significant chars before interpolating untrusted text (map name /
+// author) into innerHTML, for both attribute and element-content contexts.
+function escapeHtml(s) {
+    return String(s == null ? "" : s)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
 }
 
 function makeid(length) {

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -43,6 +43,13 @@ var touchActive = false;
 // Accumulates the cell changes of the in-progress paint/erase stroke so the whole
 // stroke collapses to one undo step (beginStroke/recordCellChange/commitStroke).
 var strokeChanges = null;
+// Graded terrain textures (keyed by tile type), cached at loadPatterns() so the
+// tile palette swatches can show the real painted texture, not a flat colour.
+var gradedTex = {};
+// True once the user has made an undoable edit (or a reshape) since the current
+// map was loaded/created/restored. Used to warn before loading a *different* map
+// (which would discard the in-progress work). Reset by load/rebuild.
+var mapModified = false;
 
 var scale = 0.035;
 // Gate strip depth (px), matching server/game.js GATE_DEPTH so the previewed gate
@@ -116,6 +123,7 @@ window.onload = function () {
         $('#author').val(vMap.author);
         $('#name').val(vMap.name);
         mapReady = true;
+        mapModified = true; // returning from preview = unsaved work to protect
         showEditor();
     } else {
         rebuild();
@@ -157,6 +165,25 @@ function openDetailsPanel() { var p = document.getElementById("detailsPanel"); i
 function closeDetailsPanel() { var p = document.getElementById("detailsPanel"); if (p) { p.classList.remove("open"); } }
 function toggleDetailsPanel() { var p = document.getElementById("detailsPanel"); if (p) { p.classList.toggle("open"); } }
 
+// Load a saved map into the editor (replacing the in-memory map). Starts a fresh
+// undo history and clears the modified flag — the caller confirms first if there
+// were unsaved edits to discard.
+function loadMapById(id) {
+    for (var j = 0; j < maps.length; j++) {
+        if (maps[j].id == id) {
+            vMap = JSON.parse(JSON.stringify(maps[j]));
+            syncStartEdgesFromMap();
+            $('#author').val(vMap.author);
+            $('#name').val(vMap.name);
+            setSelectedObject(null);
+            clearHistory();
+            mapModified = false;
+            showEditor();
+            return;
+        }
+    }
+}
+
 function clientConnect() {
     var server = io();
 
@@ -197,15 +224,14 @@ function clientConnect() {
                 var searchAttr = ((data.name || "") + ' ' + (data.author || "")).replace(/"/g, '&quot;');
                 $("#loadWindow").append('<div class="map-image" data-search="' + searchAttr + '"><button id="' + data.id + '" data-gp-nav><img src="' + data.thumbnail + '"><div class="desc">' + data.name + ' | ' + data.author + '</div></button></div>');
                 $("#" + data.id).on("click", function () {
-                    for (var j = 0; j < maps.length; j++) {
-                        if (maps[j].id == this.id) {
-                            vMap = JSON.parse(JSON.stringify(maps[j]));
-                            syncStartEdgesFromMap();
-                            $('#author').val(vMap.author);
-                            $('#name').val(vMap.name);
-                            showEditor();
-                            return;
-                        }
+                    var id = this.id;
+                    // Loading a different map replaces the in-memory map, so warn first
+                    // if there are unsaved edits (controller-friendly modal).
+                    if (mapModified) {
+                        openWipeConfirm("Loading this map will discard the edits you haven't saved. Continue?",
+                            function () { loadMapById(id); }, "Discard & load");
+                    } else {
+                        loadMapById(id);
                     }
                 })
             });
@@ -226,14 +252,20 @@ function tryStart() {
 function loadPatterns() {
 
     //Tiles — grade the terrain textures through the shared palette (utils.js)
-    // so the editing surface matches the in-game look.
-    patterns[config.tileMap.lava.id] = makeSeamlessPattern(gradeTexture(lava, "lava"));
-    patterns[config.tileMap.ice.id] = makeSeamlessPattern(gradeTexture(ice, "ice"));
-    patterns[config.tileMap.fast.id] = makeSeamlessPattern(gradeTexture(grass, "grass"));
-    patterns[config.tileMap.normal.id] = makeSeamlessPattern(gradeTexture(dirt, "dirt"));
-    patterns[config.tileMap.slow.id] = makeSeamlessPattern(gradeTexture(sand, "sand"));
+    // so the editing surface matches the in-game look. Cache the graded canvases
+    // in gradedTex so the palette swatches can show the real texture too.
+    gradedTex.lava = gradeTexture(lava, "lava");
+    gradedTex.ice = gradeTexture(ice, "ice");
+    gradedTex.grass = gradeTexture(grass, "grass");
+    gradedTex.dirt = gradeTexture(dirt, "dirt");
+    gradedTex.sand = gradeTexture(sand, "sand");
+    patterns[config.tileMap.lava.id] = makeSeamlessPattern(gradedTex.lava);
+    patterns[config.tileMap.ice.id] = makeSeamlessPattern(gradedTex.ice);
+    patterns[config.tileMap.fast.id] = makeSeamlessPattern(gradedTex.grass);
+    patterns[config.tileMap.normal.id] = makeSeamlessPattern(gradedTex.dirt);
+    patterns[config.tileMap.slow.id] = makeSeamlessPattern(gradedTex.sand);
     patterns[config.tileMap.random.id] = makePattern(random, config.tileMap.random.color);
-    patterns[config.tileMap.ability.id] = makePattern(bombIcon, makeSeamlessPattern(gradeTexture(dirt, "dirt")));
+    patterns[config.tileMap.ability.id] = makePattern(bombIcon, makeSeamlessPattern(gradedTex.dirt));
 
     brushColor = patterns[config.tileMap.normal.id];
 }
@@ -268,6 +300,92 @@ function makeSeamlessPattern(image) {
     canvasPattern.height = iconHeight;
     ctxPattern.drawImage(image, 0, 0, iconWidth, iconHeight);
     return createContext.createPattern(canvasPattern, 'repeat');
+}
+
+// --- textured palette swatches ------------------------------------------------
+// Render each tile/hazard button to show what it actually paints (the graded
+// terrain texture, or the hazard's in-game look) rather than a flat colour —
+// mirroring the lobby skin picker. The button's title carries the name (hover).
+function buildSwatchDataURL(opts) {
+    var size = 96;
+    var c = document.createElement("canvas");
+    c.width = size;
+    c.height = size;
+    var ctx = c.getContext("2d");
+    if (opts.texture) {
+        ctx.drawImage(opts.texture, 0, 0, size, size);
+    } else if (opts.color) {
+        ctx.fillStyle = opts.color;
+        ctx.fillRect(0, 0, size, size);
+    }
+    if (opts.icon) {
+        var iw = opts.icon.width || 1, ih = opts.icon.height || 1;
+        var s = (size * 0.62) / Math.max(iw, ih);
+        var w = iw * s, h = ih * s;
+        ctx.drawImage(opts.icon, (size - w) / 2, (size - h) / 2, w, h);
+    }
+    return c.toDataURL();
+}
+// A hazard swatch draws the in-game look (orange disc + red attack ring; the
+// moving bumper adds its black rail) over a dirt ground — like a bumper sitting on
+// terrain — so it contrasts in both themes and reads as "what you'll place".
+function buildHazardSwatchDataURL(kind) {
+    var size = 96;
+    var c = document.createElement("canvas");
+    c.width = size;
+    c.height = size;
+    var ctx = c.getContext("2d");
+    if (gradedTex.dirt) {
+        ctx.drawImage(gradedTex.dirt, 0, 0, size, size);
+    } else {
+        ctx.fillStyle = "#7a5b3a";
+        ctx.fillRect(0, 0, size, size);
+    }
+    var cx = size / 2, cy = size / 2;
+    if (kind === "movingBumper") {
+        ctx.strokeStyle = "#111";
+        ctx.lineWidth = 10;
+        ctx.beginPath();
+        ctx.moveTo(16, cy);
+        ctx.lineTo(size - 16, cy);
+        ctx.stroke();
+    }
+    ctx.strokeStyle = "red";
+    ctx.lineWidth = 5;
+    ctx.beginPath();
+    ctx.arc(cx, cy, 28, 0, 2 * Math.PI);
+    ctx.stroke();
+    ctx.fillStyle = "orange";
+    ctx.beginPath();
+    ctx.arc(cx, cy, 19, 0, 2 * Math.PI);
+    ctx.fill();
+    return c.toDataURL();
+}
+function applyTileSwatches() {
+    if (config == null) { return; }
+    var tiles = [
+        ["slowTileButton", { texture: gradedTex.sand }],
+        ["normalTileButton", { texture: gradedTex.dirt }],
+        ["fastTileButton", { texture: gradedTex.grass }],
+        ["lavaTileButton", { texture: gradedTex.lava }],
+        ["iceTileButton", { texture: gradedTex.ice }],
+        ["abilityTileButton", { texture: gradedTex.dirt, icon: bombIcon }],
+        ["randomTileButton", { color: config.tileMap.random.color, icon: random }],
+        ["goalTileButton", { color: config.tileMap.goal.color }]
+    ];
+    for (var i = 0; i < tiles.length; i++) {
+        var el = document.getElementById(tiles[i][0]);
+        if (el == null) { continue; }
+        el.classList.add("swatch");
+        el.style.backgroundImage = "url(" + buildSwatchDataURL(tiles[i][1]) + ")";
+    }
+    var hazards = [["bumperButton", "bumper"], ["movingBumperButton", "movingBumper"]];
+    for (var h = 0; h < hazards.length; h++) {
+        var hb = document.getElementById(hazards[h][0]);
+        if (hb == null) { continue; }
+        hb.classList.add("swatch");
+        hb.style.backgroundImage = "url(" + buildHazardSwatchDataURL(hazards[h][1]) + ")";
+    }
 }
 
 
@@ -477,6 +595,7 @@ function rebuild() {
     setSelectedObject(null);
     vMap = generateVMap();
     clearHistory(); // a fresh map starts with an empty undo history
+    mapModified = false;
     $('#author').val("");
     $('#name').val("");
     $("#createNewImage").attr("src", createCanvas.toDataURL("image/jpeg", 0.1));
@@ -488,6 +607,7 @@ function init() {
     initEditorGamepad();
     installEditorShortcuts();
     installMapSearch();
+    applyTileSwatches();
     recomputeStartLayout();
     updateStartEdgeButtons();
     setTool({ kind: "select" }); // sensible default; pick a tile/hazard to start painting
@@ -622,6 +742,7 @@ function applyStartEdges(edges) {
         setSelectedObject(null);
         vMap = generateVMap();
         clearHistory(); // the reshape replaced every cell — old undo steps are stale
+        mapModified = true; // a reshape is itself an unsaved edit
     }
     if (vMap != null) { vMap.startEdges = startEdges.slice(); }
     updateStartEdgeButtons();

--- a/client/scripts/editorTools.js
+++ b/client/scripts/editorTools.js
@@ -65,6 +65,9 @@ function afterHistoryChange() {
     if (typeof dirty !== "undefined") {
         dirty = true;
     }
+    // An empty undo stack means we're back at the map's loaded/created baseline (a
+    // fresh load/new clears history too), so no unsaved edits remain to warn about.
+    if (typeof mapModified !== "undefined") { mapModified = edUndoStack.length > 0; }
     updateUndoRedoButtons();
 }
 
@@ -95,6 +98,12 @@ function handleEditorShortcut(e) {
     // Don't hijack keys while the on-screen keyboard is up or a field has focus.
     if (typeof oskIsOpen === "function" && oskIsOpen()) { return; }
     if (editorTypingTarget(document.activeElement)) { return; }
+    // While the confirm modal is open, the gamepad is trapped to its buttons; the
+    // keyboard must defer too, or a stray key would mutate the map behind the dialog
+    // the user is being asked to confirm (Escape is handled by create.js's own
+    // keydown that closes the modal).
+    var modal = document.getElementById("wipeConfirmModal");
+    if (modal != null && !modal.classList.contains("hidden")) { return; }
     // Shortcuts only make sense on the editing surface, not the map list.
     if (!document.body.classList.contains("editor-open")) { return; }
     if (typeof config === "undefined" || config == null) { return; }
@@ -123,7 +132,7 @@ function handleEditorShortcut(e) {
             editorSelectHazard("movingBumper"); e.preventDefault(); return;
         case "r": case "R":
             editorRotateSelected(e.shiftKey ? -15 : 15); e.preventDefault(); return;
-        case "Delete": case "Backspace":
+        case "Delete":
             editorDeleteSelected(); e.preventDefault(); return;
         case "Escape":
             editorDeselect(); return; // modal Escape is handled separately in create.js

--- a/client/scripts/editorTools.js
+++ b/client/scripts/editorTools.js
@@ -1,0 +1,170 @@
+// Editor tooling shared by create.js: a generic undo/redo command stack, the
+// keyboard-shortcut bindings, and the map-list search filter. Kept out of
+// create.js (already large) per the ~300-line/file convention. These run in the
+// same global scope as create.js (the bundle concatenates files, no modules), so
+// they call create.js helpers directly (setTool/editorSelectTile/…); create.js's
+// init() drives the install* entry points below.
+
+// --- generic undo/redo command stack -----------------------------------------
+// A command is { undo: fn, redo: fn }. create.js builds the domain-specific
+// closures (paint-stroke diffs, hazard add/remove/rotate) and hands them here;
+// this module only owns the two stacks and the button state. Destructive
+// regenerates (wipe / start-edge reshape) call clearHistory() — those aren't
+// undoable by design (matching the "full snapshots are expensive" backlog note).
+var edUndoStack = [];
+var edRedoStack = [];
+var ED_UNDO_LIMIT = 200;
+
+function pushCommand(cmd) {
+    if (cmd == null || typeof cmd.undo !== "function" || typeof cmd.redo !== "function") {
+        return;
+    }
+    edUndoStack.push(cmd);
+    if (edUndoStack.length > ED_UNDO_LIMIT) {
+        edUndoStack.shift();
+    }
+    edRedoStack = []; // a fresh action invalidates the redo branch
+    updateUndoRedoButtons();
+}
+
+function editorUndo() {
+    if (edUndoStack.length === 0) {
+        return;
+    }
+    var cmd = edUndoStack.pop();
+    cmd.undo();
+    edRedoStack.push(cmd);
+    afterHistoryChange();
+}
+
+function editorRedo() {
+    if (edRedoStack.length === 0) {
+        return;
+    }
+    var cmd = edRedoStack.pop();
+    cmd.redo();
+    edUndoStack.push(cmd);
+    afterHistoryChange();
+}
+
+function clearHistory() {
+    edUndoStack = [];
+    edRedoStack = [];
+    updateUndoRedoButtons();
+}
+
+// After undo/redo a hazard may have vanished (or moved); drop any stale selection
+// and force a redraw. create.js owns setSelectedObject/dirty.
+function afterHistoryChange() {
+    if (typeof setSelectedObject === "function") {
+        setSelectedObject(null);
+    }
+    if (typeof dirty !== "undefined") {
+        dirty = true;
+    }
+    updateUndoRedoButtons();
+}
+
+function updateUndoRedoButtons() {
+    var u = document.getElementById("undoButton");
+    var r = document.getElementById("redoButton");
+    if (u != null) { u.disabled = edUndoStack.length === 0; }
+    if (r != null) { r.disabled = edRedoStack.length === 0; }
+}
+
+// --- keyboard shortcuts -------------------------------------------------------
+// Bound once from create.js init(). Only fire while the editor surface is open
+// (not the map-list) and never while typing in a text field or driving the
+// on-screen keyboard, so the editor stays usable with mouse + keyboard the way an
+// experienced user expects without stealing input from the Details fields.
+
+function installEditorShortcuts() {
+    document.addEventListener("keydown", handleEditorShortcut, false);
+}
+
+function editorTypingTarget(el) {
+    if (el == null) { return false; }
+    var tag = (el.tagName || "").toLowerCase();
+    return tag === "input" || tag === "textarea" || el.isContentEditable === true;
+}
+
+function handleEditorShortcut(e) {
+    // Don't hijack keys while the on-screen keyboard is up or a field has focus.
+    if (typeof oskIsOpen === "function" && oskIsOpen()) { return; }
+    if (editorTypingTarget(document.activeElement)) { return; }
+    // Shortcuts only make sense on the editing surface, not the map list.
+    if (!document.body.classList.contains("editor-open")) { return; }
+    if (typeof config === "undefined" || config == null) { return; }
+
+    var ctrl = e.ctrlKey || e.metaKey;
+    if (ctrl && (e.key === "z" || e.key === "Z")) {
+        if (e.shiftKey) { editorRedo(); } else { editorUndo(); }
+        e.preventDefault();
+        return;
+    }
+    if (ctrl && (e.key === "y" || e.key === "Y")) {
+        editorRedo();
+        e.preventDefault();
+        return;
+    }
+    if (ctrl) { return; } // leave other ctrl/cmd combos to the browser
+
+    switch (e.key) {
+        case "v": case "V": case "s": case "S":
+            editorSelectTool("select"); e.preventDefault(); return;
+        case "e": case "E":
+            editorSelectTool("eraser"); e.preventDefault(); return;
+        case "b": case "B":
+            editorSelectHazard("bumper"); e.preventDefault(); return;
+        case "m": case "M":
+            editorSelectHazard("movingBumper"); e.preventDefault(); return;
+        case "r": case "R":
+            editorRotateSelected(e.shiftKey ? -15 : 15); e.preventDefault(); return;
+        case "Delete": case "Backspace":
+            editorDeleteSelected(); e.preventDefault(); return;
+        case "Escape":
+            editorDeselect(); return; // modal Escape is handled separately in create.js
+    }
+
+    // Number row 1..8 → tile brushes, in the palette's visual order.
+    var tileOrder = ["slow", "normal", "fast", "lava", "ice", "ability", "random", "goal"];
+    var n = parseInt(e.key, 10);
+    if (!isNaN(n) && n >= 1 && n <= tileOrder.length) {
+        editorSelectTile(tileOrder[n - 1]);
+        e.preventDefault();
+    }
+}
+
+// --- map-list search ----------------------------------------------------------
+// Filters the saved-map tiles in #loadWindow by name/author substring. The pinned
+// "Create a new map / Continue editing" tile (#createNew's wrapper) is tagged
+// data-keep so it always stays visible — the filter only ever hides library maps.
+function installMapSearch() {
+    var input = document.getElementById("mapSearch");
+    if (input == null) { return; }
+    input.addEventListener("input", applyMapSearch, false);
+    var clear = document.getElementById("mapSearchClear");
+    if (clear != null) {
+        clear.addEventListener("click", function () {
+            input.value = "";
+            applyMapSearch();
+            input.focus();
+            return false;
+        }, false);
+    }
+}
+
+function applyMapSearch() {
+    var input = document.getElementById("mapSearch");
+    if (input == null) { return; }
+    var q = (input.value || "").trim().toLowerCase();
+    var tiles = document.querySelectorAll("#loadWindow .map-image");
+    for (var i = 0; i < tiles.length; i++) {
+        var tile = tiles[i];
+        if (tile.getAttribute("data-keep") === "1") {
+            continue; // never hide the New / Continue tile
+        }
+        var hay = (tile.getAttribute("data-search") || "").toLowerCase();
+        tile.style.display = (q === "" || hay.indexOf(q) !== -1) ? "" : "none";
+    }
+}

--- a/client/scripts/editorTools.js
+++ b/client/scripts/editorTools.js
@@ -24,6 +24,9 @@ function pushCommand(cmd) {
         edUndoStack.shift();
     }
     edRedoStack = []; // a fresh action invalidates the redo branch
+    // Any undoable action is an unsaved edit — used to warn before loading another
+    // map (create.js owns the flag; shared global scope).
+    if (typeof mapModified !== "undefined") { mapModified = true; }
     updateUndoRedoButtons();
 }
 


### PR DESCRIPTION
Rebuilds the in-browser map editor (`client/create.html` + `client/scripts/create.js`) into a controller/touch/keyboard-friendly, MS-Paint-style tool — and fixes a batch of long-standing editor UX backlog items along the way.

## Layout
- Responsive CSS-grid: **top action bar + left tool rail + canvas** on desktop; reflows to a **top tool dock + canvas + bottom action dock** on phones/tablets.
- **Touch is now usable** — the old layout `display:none`'d the whole control panel under 768px and had zero touch handlers. Touch now drives the same paint/place/select paths as the mouse (single-finger tracked by identifier).
- Styling pass via the site theme tokens (verified light + dark).

## New mechanics
- **Unified tool model** (`activeTool` via `setTool()`); legacy render flags derived from it so draw/paint code is untouched. Adds a Select tool + Eraser + active-tool highlight.
- New **`editorTools.js`** module: generic **undo/redo** command stack (Ctrl+Z / Ctrl+Shift+Z), **keyboard shortcuts** (S/E/1–8/B/M/R/Del/Esc), map-list **search**.
- **On-canvas hazard handles** — grab to rotate (any angle) or delete; plus Rotate−/Rotate+ buttons (15° each way).
- **Right-click** deletes a hazard / right-drag erases to dirt.
- **Textured palette swatches** — tile/hazard buttons show the real graded texture they paint (mirrors the lobby skin picker); name on hover via `title`.
- **Discard-edits confirm** — loading a different map while you have unsaved edits prompts first (controller-friendly modal); non-destructive "Continue editing" flow preserved.
- **Required-field validation** (author + name) before Copy/Upload, with inline field flags + auto-opening Details; status toasts auto-reset.

## Backlog items resolved
All 7 editor UX items (missing-input feedback, status reset, rotate ±, undo, keyboard shortcuts, right-click, map-list search) plus the stacked-duplicate-hazard selection bug (selection is now index-based).

## Review
Browser-verified on desktop + phone-width, light + dark. A full xhigh `/code-review` pass surfaced 13 findings (keyboard-vs-modal parity, touch/chording/multi-touch robustness, on-canvas handle clamping, non-sticky `mapModified`, HTML escaping, polish) — **all 13 patched** in the last commit. `npm run build` + headless smoke (51 maps) green throughout.

Client-only (`create.html`/`create.js`/`editorTools.js`); CHANGELOG entry added though the editor is exempt from the release-notes gate.

**Note:** real-device touch + multi-controller hardware validation is the remaining manual pass (headless/desktop can't cover it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)