### PR TITLE
fix(map-ci): start competing-lines overlay at the gate, not mid-map

### DIFF
--- a/.github/scripts/validate-submitted-map.js
+++ b/.github/scripts/validate-submitted-map.js
@@ -113,17 +113,37 @@ function effectiveStartEdges(map) {
 
 function isFiniteNum(n) { return typeof n === 'number' && isFinite(n); }
 
+// The playable surface, clamped to the world. The voronoi cells only cover the
+// map's bbox, which CAN be inset from the world edge (e.g. a "bottom"-start map
+// whose surface stops short of y=worldHeight). Sampling gate origins along the
+// raw world edge then lands them in that empty margin, where nearestCellIndex
+// snaps each to a far interior/corner cell — so the rendered lines appear to
+// start from random points mid-map instead of the gate. deriveBbox recovers the
+// surface bounds from the cell polygons (reconstruct() drops the bbox field).
+function playableBounds(map) {
+    const W = config.worldWidth, H = config.worldHeight;
+    let b = null;
+    try { b = mapFormat.deriveBbox(map); } catch (e) { b = null; }
+    if (!b || !isFiniteNum(b.xl) || !isFiniteNum(b.yt) || !isFiniteNum(b.xr) || !isFiniteNum(b.yb) || b.xr <= b.xl || b.yb <= b.yt) {
+        return { xl: 0, yt: 0, xr: W, yb: H };
+    }
+    return { xl: Math.max(0, b.xl), yt: Math.max(0, b.yt), xr: Math.min(W, b.xr), yb: Math.min(H, b.yb) };
+}
+
 // Sample a handful of start positions along an edge's gate (inset from the edge
-// and its ends), mirroring where racers actually gate. ~half of GATE_DEPTH in.
-function gateOrigins(edge) {
-    const W = config.worldWidth, H = config.worldHeight, IN = 40, N = 6;
-    const lin = (a, b) => { const out = []; for (let i = 0; i < N; i++) { out.push(a + (b - a) * (i / (N - 1))); } return out; };
+// and its ends), mirroring where racers actually gate. Sampled along the PLAYABLE
+// surface edge (not the world edge) and inset ~half of GATE_DEPTH, so every origin
+// sits inside a real cell near the gate rather than in the empty world margin.
+function gateOrigins(edge, map) {
+    const IN = 40, N = 6;
+    const b = playableBounds(map);
+    const lin = (a, c2) => { const out = []; for (let i = 0; i < N; i++) { out.push(a + (c2 - a) * (i / (N - 1))); } return out; };
     switch (edge) {
-        case 'right':  return lin(IN, H - IN).map(y => ({ x: W - IN, y }));
-        case 'top':    return lin(IN, W - IN).map(x => ({ x, y: IN }));
-        case 'bottom': return lin(IN, W - IN).map(x => ({ x, y: H - IN }));
+        case 'right':  return lin(b.yt + IN, b.yb - IN).map(y => ({ x: b.xr - IN, y }));
+        case 'top':    return lin(b.xl + IN, b.xr - IN).map(x => ({ x, y: b.yt + IN }));
+        case 'bottom': return lin(b.xl + IN, b.xr - IN).map(x => ({ x, y: b.yb - IN }));
         case 'left':
-        default:       return lin(IN, H - IN).map(y => ({ x: IN, y }));
+        default:       return lin(b.yt + IN, b.yb - IN).map(y => ({ x: b.xl + IN, y }));
     }
 }
 
@@ -158,7 +178,7 @@ function competingPaths(map) {
     for (const c of map.cells) { if (c && c.site) { siteById[c.site.voronoiId] = { x: c.site.x, y: c.site.y }; } }
 
     const origins = [];
-    for (const edge of effectiveStartEdges(map)) { origins.push(...gateOrigins(edge)); }
+    for (const edge of effectiveStartEdges(map)) { origins.push(...gateOrigins(edge, map)); }
 
     const cands = [];
     for (let i = 0; i < origins.length; i++) {
@@ -174,7 +194,7 @@ function competingPaths(map) {
         if (route && Array.isArray(route.path) && route.path.length >= 2) {
             let secs = 0;
             try { secs = cellGraph.estimatePathTime(map, route.path) || 0; } catch (e) { secs = 0; }
-            if (secs > 0) { cands.push({ path: route.path, seconds: secs }); }
+            if (secs > 0) { cands.push({ path: route.path, seconds: secs, origin: origins[i] }); }
         }
     }
 
@@ -191,16 +211,29 @@ function competingPaths(map) {
             const uni = setC.size + ch.set.size - inter;
             if (uni > 0 && inter / uni > ROUTE_DEDUPE_OVERLAP) { dup = true; break; }
         }
-        if (!dup) { chosen.push({ path: c.path, seconds: c.seconds, set: setC }); }
+        if (!dup) { chosen.push({ path: c.path, seconds: c.seconds, set: setC, origin: c.origin }); }
         if (chosen.length >= MAX_ROUTES) { break; }
     }
 
-    return chosen.map((c, i) => ({
-        label: i === 0 ? 'Fastest line' : 'Alt ' + String.fromCharCode(64 + i), // Alt A, Alt B…
-        seconds: +c.seconds.toFixed(1),
-        color: ROUTE_COLORS[i % ROUTE_COLORS.length].name,
-        points: c.path.map(id => siteById[id]).filter(Boolean)
-    }));
+    return chosen.map((c, i) => {
+        const sitePts = c.path.map(id => siteById[id]).filter(Boolean);
+        // Anchor the rendered line at its gate origin so it visibly starts ON the
+        // gate (inside the playfield, spread across the start edge) rather than at
+        // the first cell SITE, which is the cell's centroid set in from the edge —
+        // and, when the gate sits over a no-cell margin, can be a far interior cell.
+        // The origin lies in path[0]'s own cell, so this segment stays inside the
+        // surface. Skip it if origin ≈ first site (no visible gap to bridge).
+        const first = sitePts[0];
+        const points = (first && c.origin && Math.hypot(first.x - c.origin.x, first.y - c.origin.y) > 1)
+            ? [{ x: c.origin.x, y: c.origin.y }, ...sitePts]
+            : sitePts;
+        return {
+            label: i === 0 ? 'Fastest line' : 'Alt ' + String.fromCharCode(64 + i), // Alt A, Alt B…
+            seconds: +c.seconds.toFixed(1),
+            color: ROUTE_COLORS[i % ROUTE_COLORS.length].name,
+            points
+        };
+    });
 }
 
 function deepValidate(map) {

--- a/.github/scripts/validate-submitted-map.js
+++ b/.github/scripts/validate-submitted-map.js
@@ -211,22 +211,16 @@ function competingPaths(map) {
             const uni = setC.size + ch.set.size - inter;
             if (uni > 0 && inter / uni > ROUTE_DEDUPE_OVERLAP) { dup = true; break; }
         }
-        if (!dup) { chosen.push({ path: c.path, seconds: c.seconds, set: setC, origin: c.origin }); }
+        if (!dup) { chosen.push({ ...c, set: setC }); }
         if (chosen.length >= MAX_ROUTES) { break; }
     }
 
     return chosen.map((c, i) => {
         const sitePts = c.path.map(id => siteById[id]).filter(Boolean);
         // Anchor the rendered line at its gate origin so it visibly starts ON the
-        // gate (inside the playfield, spread across the start edge) rather than at
-        // the first cell SITE, which is the cell's centroid set in from the edge —
-        // and, when the gate sits over a no-cell margin, can be a far interior cell.
-        // The origin lies in path[0]'s own cell, so this segment stays inside the
-        // surface. Skip it if origin ≈ first site (no visible gap to bridge).
-        const first = sitePts[0];
-        const points = (first && c.origin && Math.hypot(first.x - c.origin.x, first.y - c.origin.y) > 1)
-            ? [{ x: c.origin.x, y: c.origin.y }, ...sitePts]
-            : sitePts;
+        // gate; path[0]'s site is the cell centroid (inset from the edge) and, when
+        // the gate sits over a no-cell margin, can resolve to a far interior cell.
+        const points = c.origin ? [{ x: c.origin.x, y: c.origin.y }, ...sitePts] : sitePts;
         return {
             label: i === 0 ? 'Fastest line' : 'Alt ' + String.fromCharCode(64 + i), // Alt A, Alt B…
             seconds: +c.seconds.toFixed(1),


### PR DESCRIPTION
## Summary
The map-submission CI's competing-lines overlay drew routes starting from random
interior points on PR #187's `bottom`-start map ("What Goes Up"). Root cause:
gate origins were sampled along the raw WORLD edge, but a map's voronoi cells
only cover its `bbox`, which can be inset from the world (this map's `bbox.yb`
is 693, world is 768). Origins landed in the empty margin, and `nearestCellIndex`
snapped each to a far interior/corner cell — that snapped cell became the
visible line start.

## Changes (`.github/scripts/validate-submitted-map.js`)
- New `playableBounds(map)` helper — recovers the playable surface from
  `mapFormat.deriveBbox(map)` (since `reconstruct()` strips the bbox field) and
  clamps to the world.
- `gateOrigins(edge, map)` now samples along the playable bbox edge instead of
  the world edge.
- Each route's gate origin is prepended to its rendered points, so every line
  visibly starts ON the gate — inside the playfield, spread across the start
  edge — and runs to the goal.

Maps with a full-world bbox (every legacy map and most submissions) see no
behavior change — `deriveBbox == world` so origins land in the same place.

## Test plan
- [x] Reproduced on PR #187's map: lines now start at `y=653` (the bottom
      playable edge), spread across `x` (812, 1069, 1326), each ending at the
      goal (717, 526).
- [x] Re-rendered a normal full-world-bbox map (LobbyTutorial, default left
      start): lines still start at the left edge, no regression.
- [x] Smoke test green — 52 committed maps tick the live engine clean.
- [ ] Note: this CI script only runs on PRs touching `client/maps/**`, so the
      fix won't be exercised by this PR's checks. It'll first run on the next
      actual map submission.

## Deferred follow-ups (from \`/code-review high\`)
Out-of-scope for this overlay fix; flagging for separate work:

1. **\`server/cellGraph.js:387\` — \`edgeSampleOrigins\` has the same bug.** Both
   \`reachableFromEdge\` (the submission validity gate) and \`computeMapParTime\`
   still sample raw world edges. On an inset-bbox map, validation can pass
   because of an accidental snap, and the embedded \`parTime\` is wrong.
2. **Sim vs overlay startpoint mismatch.** The playability sim spawns racers
   via the engine (world-edge gate); the overlay now starts at the playable
   bbox edge. On inset-bbox maps the comment juxtaposes incomparable times.
3. **\`validateMap\` should reject inset-bbox + declared start-edge.** A map
   declaring \`startEdges:["bottom"]\` whose \`bbox.yb < worldHeight\` lets racers
   spawn off the playable surface. Closing this would obviate findings #1–#2.
4. **\`server/mapFormat.js\` \`reconstruct()\` could preserve \`bbox\`.** It already
   validates it and feeds it to voronoi.compute — preserving it would let
   \`playableBounds\` collapse to a one-line clamp.
5. **\`GATE_DEPTH\` constant duplicated** between \`server/game.js:32\` and the CI
   script. If GATE_DEPTH changes, both the overlay and \`edgeSampleOrigins\`
   drift off the real gate.

CHANGELOG-exempt (CI/build change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)