### PR TITLE
Late-join an in-progress match as a spectator (race next round)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- You can now join a match that's already in progress from the **Join** menu (or with a Game ID / shared link): in-progress games show a **Spectate** button instead of a greyed-out "In progress". You watch the current round, then race in when the next round starts — an on-screen banner shows the kart colour you'll race as. Only genuinely full games stay unjoinable.
+- Plug in a second controller mid-race for **local couch co-op** and your friend now gets the same Spectate-then-race-next-round treatment, with the banner fading down so it doesn't get in your way while you're still racing.
 
 ## v0.19.0 — 2026-05-28
 

--- a/backlog.md
+++ b/backlog.md
@@ -41,6 +41,10 @@ Tracked work that is known and intentionally deferred. The currently-in-progress
 
 ## Lobby (`server/game.js`, `server/hostess.js`, `client/scripts/...`)
 
+### Bugs
+
+- **`Room.leave` doesn't clean up the leaving player's aimers / projectiles / held ability.** `room.leave(clientID)` (`game.js:56`) deletes the entry from `clientList` and `playerList` but leaves any `aimerList`/`projectileList`/`abilityList` entries owned by that id still in those maps, with `ownerId` now pointing at a player that no longer exists. The per-tick update loops keep iterating those orphans, the compressor keeps emitting them, and any owner-deref (e.g. `playerList[ownerId]` in `SwapAimer` construction / ability handling) sees `undefined`. Pre-existing, but **late-join-spectate now makes it hit far more often** (a stranger can briefly hold an ability picked up via the brutal ability round, then leave). Also: `tempSpectatorList` is only re-emptied at `resetPlayers` — between leave and the next round reset, a departed spectator's `Player` ref lingers there too. Fix: on leave, drop the player's id from `aimerList`/`projectileList`/`abilityList`/`tempSpectatorList`.
+
 ### Features
 
 - **AI hub — toggle bots and surface their count.** Bots auto-spawn via `fillGridWithBots` (`game.js:441`, called from `startGated`) at a random 6–10 count (`config.ai.minGrid`/`maxGrid`) with no player control, and `hostess.getRooms` (`hostess.js:18`) doesn't expose a bot count. Add a lobby hub to enable/disable AI, and include "+N AI" as a join detail in the room listing (join page + lobby).

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -181,6 +181,16 @@ function registerConnectionHandlers(server) {
 		if (playerList[myID] != null) {
 			myPlayer = playerList[myID];
 		}
+		// Joined a match already racing/collapsing? The server spawned this player as
+		// a temp spectator (parked off-arena, not alive) who races from the next
+		// round — flag the slot so drawSpectatorBanner explains the wait. The server
+		// spectator-izes exactly the racing/collapsing states, so the state alone is
+		// the signal; the banner's own !alive check gates the display. Cleared for
+		// every slot at the next startGated.
+		if (localPlayers[primarySlot]) {
+			localPlayers[primarySlot].lateJoinSpectating =
+				(currentState == config.stateMap.racing || currentState == config.stateMap.collapsing);
+		}
 		//Late joiners: pick up the race already in progress on the right track/mood.
 		if (gameState.music != null) {
 			setBackgroundMusic(gameState.music.mood, gameState.music.track);
@@ -206,7 +216,13 @@ function registerConnectionHandlers(server) {
 	server.on("playerJoin", function (appendPlayerList) {
 		clientList[appendPlayerList.id] = appendPlayerList.id;
 		appendNewPlayer(appendPlayerList.player);
-		playSound(playerJoinSound);
+		// Pre-late-join this only fired pre-race (lobby/waiting). With public
+		// late-join enabled, the same broadcast now reaches racers mid-round for a
+		// spectator who isn't even on the track — don't ring the chime over an
+		// active race. Lobby/waiting/gameOver keep the welcome cue.
+		if (currentState != config.stateMap.racing && currentState != config.stateMap.collapsing) {
+			playSound(playerJoinSound);
+		}
 	});
 	server.on("playerLeft", function (id) {
 		// Always drop the rendered player. AI racers live in playerList but may be
@@ -402,6 +418,11 @@ function registerStateHandlers(server) {
 		// Match starting — force-close any open hub panel + drop the zones/prompts.
 		if (typeof lobbyHubReset === "function") {
 			lobbyHubReset();
+		}
+		// The next round gates everyone in, including any late-join spectators from
+		// the previous round — they're racing now, so drop the banner for every slot.
+		for (var ljs = 0; ljs < localPlayers.length; ljs++) {
+			if (localPlayers[ljs]) { localPlayers[ljs].lateJoinSpectating = false; }
 		}
 		currentState = config.stateMap.gated;
 	});
@@ -973,6 +994,19 @@ function registerSecondaryHandlers(sock, slot) {
 			lp.myID = gs.myID;
 			lp.joined = true;
 			lp.everJoined = true;
+			// A pad seat that joins (or reconnects) mid-race lands as a temp spectator
+			// who races from the next round — flag the slot so it gets the spectating
+			// banner too (the primary keeps racing). Read the state from THIS gs
+			// payload (compressor.gameState JSON-stringifies an array with state at
+			// [0]) rather than the global currentState the primary maintains on its
+			// own socket — separate sockets can deliver events in different orders,
+			// so the global may have already advanced past the snapshot's state.
+			var gsRoomState = null;
+			if (config != null && gs != null && gs.game != null) {
+				try { gsRoomState = JSON.parse(gs.game)[0]; } catch (e) { gsRoomState = null; }
+			}
+			lp.lateJoinSpectating = config != null && gsRoomState != null &&
+				(gsRoomState == config.stateMap.racing || gsRoomState == config.stateMap.collapsing);
 			if (lp.reconnectTimer) {
 				clearTimeout(lp.reconnectTimer);
 				lp.reconnectTimer = null;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -608,6 +608,7 @@ function drawObjects(dt) {
         currentState == config.stateMap.collapsing) {
         drawMapTitle();
     }
+    drawSpectatorBanner();
     drawHUD();
     drawMouseDriveIndicator();
     drawOffscreenGoalIndicator();
@@ -3305,6 +3306,91 @@ function drawHUD() {
     drawVirtualButtons();
     drawTouchControls();
     drawTitle();
+}
+
+// Local players (slots) that joined this match mid-race and are still waiting:
+// the server parked them as temp spectators who race from the next round. Covers
+// the primary AND any co-op pad seat that joined after the gate. The per-slot
+// lateJoinSpectating flag distinguishes a late joiner from a racer who just died
+// this round (both are !alive during racing).
+function spectatingLocalPlayers() {
+    var out = [];
+    if (typeof localPlayers === "undefined" || typeof playerList === "undefined" || !playerList) {
+        return out;
+    }
+    for (var s = 0; s < localPlayers.length; s++) {
+        var lp = localPlayers[s];
+        if (!lp || lp.myID == null || !lp.lateJoinSpectating) {
+            continue;
+        }
+        var p = playerList[lp.myID];
+        if (p != null && !p.alive) {
+            out.push(p);
+        }
+    }
+    return out;
+}
+
+// A centered hint for local players who joined a match mid-round: each races from
+// the next round. Drawn in HUD (screen) space below the GameID/Players/Round row,
+// ending with a mini kart per waiting player in the colour the server assigned it
+// (same sprite + colour-blind remap as their real kart), so they know what
+// they'll race as. State-gated to the live race so it never bleeds into the
+// game-over / lobby screens. When a local player is actively RACING on this
+// shared couch screen, the whole banner is faded so it doesn't obscure their run;
+// at full strength only when everyone local is waiting.
+function drawSpectatorBanner() {
+    if (currentState != config.stateMap.racing && currentState != config.stateMap.collapsing) {
+        return;
+    }
+    var specs = spectatingLocalPlayers();
+    if (specs.length === 0) {
+        return;
+    }
+    var racingPresent = livingLocalPlayers().length > 0;
+
+    var swatchR = 10;          // kart disc radius drawn in the banner
+    var discGap = 6;           // spacing between multiple kart discs
+    var sprites = [];
+    for (var i = 0; i < specs.length; i++) {
+        if (specs[i].color != null) {
+            sprites.push(getPlayerSprite(specs[i].color, swatchR, "black"));
+        }
+    }
+    var hasSwatch = sprites.length > 0;
+    var text = hasSwatch ? "Spectating — you'll race next round as"
+        : "Spectating — you'll race next round";
+    var gap = hasSwatch ? 10 : 0;  // text -> first swatch spacing
+    var swatchW = hasSwatch ? (sprites.length * swatchR * 2 + (sprites.length - 1) * discGap) : 0;
+
+    gameContext.save();
+    // Considerate fade when a local kart is still racing; full strength otherwise.
+    gameContext.globalAlpha = racingPresent ? 0.6 : 1.0;
+    gameContext.font = "bold 18px Arial";
+    gameContext.textAlign = "left";
+    gameContext.textBaseline = "alphabetic";
+    var textW = gameContext.measureText(text).width;
+    var padX = 14;
+    var w = textW + gap + swatchW + padX * 2;
+    var cx = LOGICAL_WIDTH / 2;
+    var y = 52;
+    var boxX = cx - w / 2;
+
+    gameContext.fillStyle = "rgba(0, 0, 0, 0.55)";
+    roundRectPath(gameContext, boxX, y - 19, w, 28, 8); // in the play bundle (audience.js)
+    gameContext.fill();
+
+    var textX = boxX + padX;
+    gameContext.fillStyle = "white";
+    gameContext.fillText(text, textX, y);
+
+    var discCx = textX + textW + gap + swatchR;
+    var discCy = y - 5; // vertical centre of the pill (top y-19, height 28)
+    for (var j = 0; j < sprites.length; j++) {
+        gameContext.drawImage(sprites[j], discCx - sprites[j].halfSize, discCy - sprites[j].halfSize);
+        discCx += swatchR * 2 + discGap;
+    }
+    gameContext.restore();
 }
 
 function drawGameInfo() {

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -135,6 +135,11 @@ function makeLocalPlayer(slot, socket, isPrimary) {
         isPrimary: !!isPrimary,
         joined: false,
         everJoined: false,        // has this slot ever confirmed a room? (drives auto-rejoin)
+        // True when THIS slot joined a match already racing: the server parked it as
+        // a temp spectator that races from the next round. Per-slot so a co-op seat
+        // that joins mid-race gets the spectating banner while P1 keeps racing.
+        // Drives drawSpectatorBanner; cleared for every slot at the next startGated.
+        lateJoinSpectating: false,
         reconnectTimer: null,     // grace timer started on a transient disconnect
         leaveConfirm: false,      // showing the inline "leave?" confirm in this player's block
         leaveConfirmTimer: null,  // auto-cancel timer for the inline leave confirm

--- a/client/scripts/join.js
+++ b/client/scripts/join.js
@@ -148,23 +148,33 @@ function buildCard(room, maxPlayers) {
         info.appendChild(buildStat('AI', aiLabel));
     }
 
-    // A full or already-started room is surfaced (so it doesn't silently
-    // vanish) but can't be joined: grey the card and disable its button.
+    // A room with space is joinable even mid-match. The label reflects what the
+    // join actually does: only a LIVE race (racing/collapsing) makes you a
+    // spectator for the round, so that reads "Spectate"; every other joinable
+    // state (lobby, the gated countdown, the between-rounds overview, the
+    // game-over screen) drops you straight in, so it reads "Join". (Keying off the
+    // coarse `locked` flag would mislabel gated/overview/gameOver as "Spectate".)
+    // Only a FULL room can't be joined — surfaced greyed so it doesn't vanish.
     var joinable = room.joinable !== false;
     var joinBtn = document.createElement('a');
     if (joinable) {
         joinBtn.href = './play.html?gameid=' + encodeURIComponent(room.gameID);
         joinBtn.className = 'btn btn-outline-info join-btn';
-        joinBtn.setAttribute('data-gp-nav', ''); // joinable rooms only; locked/full cards stay unfocusable
-        joinBtn.textContent = 'Join';
+        joinBtn.setAttribute('data-gp-nav', ''); // joinable rooms only; full cards stay unfocusable
+        if (isLiveRace(room)) {
+            joinBtn.textContent = 'Spectate';
+            joinBtn.title = 'Race in progress — watch this round, race the next.';
+        } else {
+            joinBtn.textContent = 'Join';
+        }
     } else {
-        // Not joinable: a started match reads "In progress"; a room that's merely
-        // full (still in the lobby, not locked) reads "Full" — a slot may open up.
+        // Not joinable means full: a slot may open up, so it's shown greyed rather
+        // than hidden.
         card.classList.add('gameCard-locked');
         joinBtn.className = 'btn btn-outline-secondary join-btn disabled';
         joinBtn.setAttribute('aria-disabled', 'true');
         joinBtn.setAttribute('tabindex', '-1');
-        joinBtn.textContent = room.locked ? 'In progress' : 'Full';
+        joinBtn.textContent = 'Full';
     }
 
     card.appendChild(info);
@@ -203,6 +213,18 @@ function buildStat(label, value) {
     span.appendChild(labelEl);
     span.appendChild(valueEl);
     return span;
+}
+
+// True when joining the room right now would drop you into a LIVE race as a
+// spectator-until-next-round (server determineGameState's racing/collapsing
+// branch). Other locked states (gated/overview/gameOver) put you straight into
+// play, so they aren't "spectating". Falls back to false until config arrives.
+function isLiveRace(room) {
+    if (config == null || config.stateMap == null) {
+        return false;
+    }
+    return room.state === config.stateMap.racing ||
+        room.state === config.stateMap.collapsing;
 }
 
 function stateLabel(state) {

--- a/server/game.js
+++ b/server/game.js
@@ -263,6 +263,12 @@ class Game {
 		client.emit("tileChanges", JSON.stringify(this.gameBoard.gatherTileChanges()));
 		//Send current abilities
 		client.emit("allAbilityHoldings", JSON.stringify(this.gameBoard.gatherAbilities()));
+		// Late-join spectator: send the LIVE hazard list (the puck, mid-round volcano
+		// debris, lightning hazards, etc.). newMap only carries the map's round-start
+		// hazards, and updateHazardList on the client only updates EXISTING entries
+		// — without this, a mid-race joiner is blind to anything spawned after
+		// the round began. Mirrors the lobby branch above.
+		client.emit("applyHazards", compressor.newHazards(this.gameBoard.hazardList));
 	}
 	checkLobbyStart() {
 		debug.log("checkLobbyStart: playerCount=", this.playerCount, " min=", c.minPlayersToStart, " state=", this.currentState);
@@ -346,6 +352,14 @@ class Game {
 		var playersConcluded = 0;
 
 		for (var player in this.playerList) {
+			// A temp spectator (late joiner waiting for the next round) is alive=false
+			// but isn't IN this round — they must not be infected, exploded, or
+			// credited as a kill, all of which the !alive branch below would do. They
+			// just count as already-concluded so the round can end normally.
+			if (this.playerList[player].isSpectator) {
+				playersConcluded++;
+				continue;
+			}
 			if (!this.playerList[player].alive && !this.playerList[player].reachedGoal) {
 				playersConcluded++;
 
@@ -367,10 +381,6 @@ class Game {
 						this.playerList[player].exploded = true;
 					}
 				}
-				continue;
-			}
-			if (this.playerList[player].isSpectator) {
-				playersConcluded++
 				continue;
 			}
 			if (this.playerList[player].awake == false) {
@@ -561,6 +571,15 @@ class Game {
 	// Called whenever a human joins; a no-op in normal flow (no bots while joinable),
 	// and a human is never refused a slot a bot is holding.
 	trimBotsToCapacity() {
+		// Late-join changed who calls this: a public join can now land in a locked
+		// room mid-race, and despawning a bot then would blink a kart out of the
+		// active race for every viewer. fillGridWithBots already promises bots are
+		// "held across rounds within a match" — keep the same promise on the join
+		// side. Cap may transiently exceed by a few seats inside one match; the
+		// next match's resetGame -> removeBots re-rolls the grid cleanly.
+		if (this.locked) {
+			return;
+		}
 		var cap = c.maxPlayersInRoom || 25;
 		var humanCount = 0, botIds = [];
 		for (var id in this.playerList) {
@@ -2196,6 +2215,11 @@ class GameBoard {
 		for (var specID in this.tempSpectatorList) {
 			this.tempSpectatorList[specID].isSpectator = false;
 		}
+		// The round reset turns every temp spectator into an active racer, so the
+		// cohort is spent — drop the references. Otherwise a late joiner who left
+		// before the reset would linger here for the room's lifetime and get
+		// re-touched (a stale-object write) every round.
+		this.tempSpectatorList = {};
 	}
 	clean() {
 		this.lobbyStartButton = null;

--- a/server/hostess.js
+++ b/server/hostess.js
@@ -18,11 +18,12 @@ exports.getRooms = function () {
 		if (room.isPreview) {
 			continue;
 		}
-		// A full room, or one whose match has started (locked), can't be joined
-		// — but it should still appear so the join page can show it greyed out
-		// ("In progress") instead of having it silently vanish. Flag joinability
-		// explicitly (mirrors findARoom's matchmaking test).
-		var joinable = room.hasSpace() && !room.isLocked();
+		// Late-join: a started (locked) match is now joinable as long as it has
+		// space — the joiner spectates the current round and races from the next
+		// (determineGameState's racing branch). Only a FULL room is unjoinable, and
+		// it's still listed (greyed "Full") rather than silently vanishing. `locked`
+		// is sent alongside so the join page can label an in-progress room as such.
+		var joinable = room.hasSpace();
 		// AI hub: surface the room's bots so the join page shows them. aiCount is the
 		// LIVE bot count (non-zero during a race). aiPlanned is how many bots will
 		// actually spawn NEXT race for the current human count — computed for every
@@ -88,7 +89,7 @@ exports.kickFromRoom = function (clientID) {
 		}
 	}
 }
-exports.joinARoom = function (sig, clientID, coop) {
+exports.joinARoom = function (sig, clientID) {
 	var room = roomList[sig];
 	if (room == null) {
 		return false;
@@ -101,20 +102,14 @@ exports.joinARoom = function (sig, clientID, coop) {
 	if (room.isPreview && !room.hasSpace()) {
 		return false;
 	}
-	// getRooms now advertises full and locked (mid-match) rooms so the join page
-	// can show them greyed out — but the disabled UI button is not the enforcement.
-	// Reject a hand-typed/shared ?gameid= (or "Join by ID") into a full or started
-	// room so it can't overflow capacity or drop a player into a live race. Mirrors
-	// findARoom's matchmaking test; preview rooms are handled above.
-	//
-	// A local co-op seat (coop) is exempt from the locked check: it joins the
-	// primary's exact room mid-game and lands as a spectator (determineGameState),
-	// racing from the next round — so a controller plugged in after the gate can
-	// still join instead of being booted. Capacity is still enforced for everyone.
+	// Late-join: a started (locked) match can now be joined as long as it has
+	// space. The joiner lands as a temp spectator (determineGameState's racing /
+	// collapsing branch) and races from the next round. Matchmaking (id == -1)
+	// never resolves to a locked room — findARoom filters them — so a locked room
+	// only reaches here via a deliberate join (the join page, "Join by ID", a
+	// shared ?gameid= link, or a local co-op seat), which is exactly the intent.
+	// Capacity is still enforced for everyone; preview-full is handled above.
 	if (!room.isPreview && !room.hasSpace()) {
-		return false;
-	}
-	if (!room.isPreview && !coop && room.isLocked()) {
 		return false;
 	}
 	room.join(clientID);

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -229,11 +229,13 @@ function checkForMail(client) {
 		} else {
 			roomSig = id;
 		}
-		// coop = a local co-op seat joining the primary's exact room. Such a join is
-		// allowed into an already-started (locked) room, landing as a spectator who
-		// races from the next round (determineGameState's racing branch). A bare
-		// enterGame (matchmaking / hand-typed id) is still blocked from locked rooms.
-		var room = hostess.joinARoom(roomSig, client.id, coop === true);
+		// Any deliberate join (join page, "Join by ID", shared id, or a local co-op
+		// seat) may now land in an already-started (locked) room, spawning as a
+		// spectator who races from the next round (determineGameState's racing
+		// branch). joinARoom enforces capacity; matchmaking (id == -1) still avoids
+		// locked rooms in findARoom. The legacy `coop` event arg is no longer needed
+		// server-side but clients may still send it — accepted and ignored.
+		var room = hostess.joinARoom(roomSig, client.id);
 		if (room == false) {
 			debug.log("enterGame: joinARoom FAILED for client=", client.id, " roomSig=", roomSig);
 			client.emit("roomNotFound");


### PR DESCRIPTION
## What

Lets players join a match that's already in progress from the **Join** menu (and via Join-by-ID / shared `?gameid=` links / a controller plugged in mid-race for couch co-op). In-progress games show a **"Spectate"** button instead of a greyed-out "In progress"; the joiner watches the current round and races in at the start of the next. Only genuinely full games stay unjoinable.

The engine already had the late-join-as-spectator path built (`determineGameState` racing/collapsing → `setTempSpectator`; next round's `resetPlayers` reactivates) — it was fenced to local co-op seats by a `coop` flag on `joinARoom`/`enterGame`. This PR opens that gate to public deliberate joins (the join page, Join-by-ID, shared links), and extends the on-screen spectator banner to cover co-op pad seats too, with a considerate fade when a local kart is still racing on the shared screen.

## Why

The Join page already advertised in-progress games but bounced any click with a disabled "In progress" button. A real match runs many rounds — being locked out the whole match is a lot of friction, especially when a friend sends you a link or someone wanders past on a controller.

## Behaviour

- **Join page card label** keys off the *actual* room state (`racing`/`collapsing` → "Spectate"; `lobby`/`gated`/`overview`/`gameOver` → "Join"), so the label reflects what the join will actually do — not the coarse "locked for the whole match" flag.
- **Spectator banner** ("Spectating — you'll race next round as ⬤") shows the kart colour the server assigned, using the same sprite renderer + colour-blind remap as the real kart. The banner is **per-slot** so each waiting local player (primary or co-op pad seat) gets their own swatch, and the whole banner fades to `globalAlpha 0.6` when any local kart is still racing on the shared screen.
- **State-gated to live race** so the banner can never bleed into the game-over / lobby screens, even if the spectated round is the match's last (collapsing → gameOver, which skips `startGated`).

## Notable correctness fixes the review pass surfaced

These were all exposed by lifting the lock — none affect the existing co-op-only path differently from before, but the public path makes them much more reachable:

- **`trimBotsToCapacity` no longer despawns a racing bot mid-match.** `fillGridWithBots` already explicitly promises bots are "held across rounds within a match" — the join-side trim was the contradicting odd-one-out. Trim now early-returns when the room is locked; the next match's `resetGame → removeBots` re-rolls the grid cleanly.
- **`checkForWinners` no longer infects / explodes temp spectators.** A spectator (`alive=false`, parked at `-100,-100`) used to hit the `!alive && !reachedGoal` branch BEFORE the `isSpectator` check; on an infection brutal round they'd be resurrected as a zombie out of bounds. The `isSpectator` early-return now runs first.
- **Late-joiner sees live hazards.** `checkSendGameStateUpdates` now emits `applyHazards` for racing/collapsing too (mirroring the lobby branch), so a mid-race joiner isn't blind to the puck / mid-round volcano debris / lightning hazards.
- **Secondary `gs` reads state from its own snapshot.** A pad seat joining mid-race now derives its `lateJoinSpectating` flag from the `gs.game` payload it just received, not from the primary's global `currentState` (which could have advanced on the primary's separate socket).
- **`playerJoin` chime suppressed during racing** so a stranger arriving as a spectator can't ring a bell over an active race.
- **`tempSpectatorList` is emptied at the round reset** rather than just having its entries flipped — prevents stale `Player` refs accumulating in a long-lived room (see also the backlog entry below).

## New backlog entry

Added a Lobby bug entry: **`Room.leave` doesn't clean up the leaving player's aimers / projectiles / held ability.** Pre-existing leak (the per-tick loops still iterate orphan entries with a dangling `ownerId`), but the late-join path hits it more often — fix is independent of this PR.

## Tests

- `npm run build` — 3 bundles
- `.github/scripts/smoke-test.js` — Session A (full-stack messenger + engine + compressor) and Session B (52 maps) clean
- **New focused headless test** (`late-join-test.js`) — 18 assertions on the real engine via the real messenger handlers:
  - locked room is now joinable; deliberate join is accepted
  - joiner is a temp spectator (`isSpectator=true`, `!alive`)
  - engine ticks cleanly for 60 frames with a spectator present
  - **mid-race late join does NOT despawn a racing bot** (regression guard for the trim fix)
  - **spectator is NOT infected by `checkForWinners` during an infection brutal round** (regression guard for the spectator-branch fix)
  - **mid-race joiner receives `applyHazards`** (regression guard for the live-hazard fix)
  - next round reactivates the spectator (flag cleared, `alive=true`, racing in)
  - matchmaking (`id == -1`) still avoids locked rooms

## Out of scope / parked

- `Room.leave` aimer/projectile/ability cleanup → new backlog entry.
- Analytics noise (`round_complete` emitted without a matching `round_start` for a late-joiner) — pre-existing on the co-op path; minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
