### PR TITLE
ui(loading): stylize the asset-loading screen

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -499,19 +499,76 @@ canvas {
         line-height: 1.4;
     }
 }
-#progressContainer{
-    width: 50%;
-    border-style: solid;
+#progressContainer {
+    position: fixed;
+    inset: calc(var(--navbar-height) + var(--safe-top)) 0 0 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: var(--bg);
+    color: var(--text);
+    text-align: center;
+    z-index: 10;
+}
+.loading-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    width: min(420px, 88vw);
+}
+.loading-brand {
+    font-family: "San Francisco";
+    font-size: clamp(2rem, 9vw, 3.4em);
+    line-height: 1;
+    letter-spacing: -0.01em;
+}
+.loading-caption {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    letter-spacing: 0.02em;
+}
+.loading-dots span {
+    display: inline-block;
+    animation: loadingDot 1.2s infinite ease-in-out;
+}
+.loading-dots span:nth-child(2) { animation-delay: 0.15s; }
+.loading-dots span:nth-child(3) { animation-delay: 0.30s; }
+@keyframes loadingDot {
+    0%, 80%, 100% { opacity: 0.25; transform: translateY(0); }
+    40%           { opacity: 1;    transform: translateY(-2px); }
 }
 #progressWindow {
     width: 100%;
-    background-color: grey;
+    height: 12px;
+    background-color: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    overflow: hidden;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.08);
 }
-
 #progressBar {
     width: 1%;
-    height: 30px;
-    background-color: green;
+    height: 100%;
+    background-image:
+        linear-gradient(135deg,
+            rgba(255,255,255,0.22) 25%, transparent 25%,
+            transparent 50%, rgba(255,255,255,0.22) 50%,
+            rgba(255,255,255,0.22) 75%, transparent 75%),
+        linear-gradient(90deg, #57c46a, #2ea043);
+    background-size: 24px 24px, 100% 100%;
+    border-radius: 999px;
+    transition: width 0.25s ease-out;
+    animation: loadingStripe 1s linear infinite;
+}
+@keyframes loadingStripe {
+    from { background-position: 0 0, 0 0; }
+    to   { background-position: 24px 0, 0 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .loading-dots span,
+    #progressBar { animation: none; }
 }
 #controlPanel {
     border-radius: 20px;

--- a/client/play.html
+++ b/client/play.html
@@ -55,7 +55,13 @@
                     <div class="rotate-text">Rotate your device to landscape to play</div>
                 </div>
             </div>
-            <div id="progressContainer" class="row justify-content-center align-self-center mx-auto">Loading Assets..<div id="progressWindow"><div id="progressBar"></div></div></div>
+            <div id="progressContainer">
+                <div class="loading-stack">
+                    <span class="loading-brand">Chao Chao</span>
+                    <span class="loading-caption">Loading assets<span class="loading-dots" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span></span>
+                    <div id="progressWindow" role="progressbar" aria-label="Loading assets"><div id="progressBar"></div></div>
+                </div>
+            </div>
             <div id="gameWindow" >
             <!-- Live crowd drawn in the letterbox bars, behind the play canvas. -->
             <canvas id="audienceCanvas"></canvas>


### PR DESCRIPTION
## Summary
- Replaces the bare grey/green `Loading Assets..` bar (default solid border, hard-coded `grey`/`green`, no theme awareness) with a centered themed card: **Chao Chao** wordmark, `Loading assets…` caption with a bouncing-dot animation, and a rounded pill progress bar (themed `--surface-2` track, green gradient with a diagonal shimmer stripe).
- Honors the existing `--bg` / `--text` / `--text-muted` / `--surface-2` / `--border` tokens so it looks right in both light and dark themes.
- Respects `prefers-reduced-motion` (drops the dot bounce and stripe animation).

## Scope
- Two files touched: `client/play.html` (markup restructure inside `#progressContainer`) and `client/css/styles.css` (replaces the old `#progressContainer`/`#progressWindow`/`#progressBar` block).
- Client-only, no JS change — `progressBar.style.width = …%` in `game.js` still drives the bar exactly as before; `progressContainer.hide()` on lobby entry still works; the 20s timeout fallback (`progressContainer.html(…)`) still renders cleanly inside the themed wrapper.
- CHANGELOG-exempt (UI/CSS, no `server/config.json`/`server/game.js`/`server/engine.js` change).

## Test plan
- [x] Browser-verified on `localhost:3081` in **light** theme — bar at 45%
- [x] Browser-verified in **dark** theme — bar at 65%
- [x] Headless smoke (`node .github/scripts/smoke-test.js`) green: 52 maps booted/ticked clean post-rebase
- [ ] Operator visual pass on real device (light + dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)