### PR TITLE
fix: bug-fix wave — preview thumbnail hazards/? tiles, infection lava, moving-bumper freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- Moving bumpers no longer freeze mid-track after running their first round-trip on maps where the rail isn't axis-aligned (e.g. *What Goes Up*) — they keep oscillating back and forth as intended.
+- After an infection round, the poison-green lava texture used to linger into the next round; lava now snaps back to red the moment the infection wears off.
+- The "next map" preview between rounds now shows bumpers and moving bumpers so you can see what's coming, and random ("?") tiles render with their ? icon instead of a flat purple cell.
 
 ## v0.20.1 — 2026-05-28
 

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -1496,6 +1496,33 @@ function renderMapThumbnail(map) {
         ctx.fillStyle = tileFill(cell.id);
         ctx.fill();
     }
+    // Hazards (same look as the editor canvas: orange disc + red attack ring,
+    // plus a black rail bar for moving bumpers). Without this, the load-list
+    // thumbnails dropped every bumper a map authored.
+    if (Array.isArray(map.hazards)) {
+        for (var hi = 0; hi < map.hazards.length; hi++) {
+            var hz = map.hazards[hi];
+            if (hz == null) { continue; }
+            if (hz.id === config.hazards.movingBumper.id) {
+                ctx.save();
+                ctx.translate(hz.x, hz.y);
+                ctx.rotate((hz.angle || 0) * Math.PI / 180);
+                ctx.fillStyle = "black";
+                ctx.fillRect(0, -config.hazards.movingBumper.height / 2,
+                    config.hazards.movingBumper.width, config.hazards.movingBumper.height);
+                ctx.restore();
+            }
+            ctx.beginPath();
+            ctx.arc(hz.x, hz.y, config.hazards.bumper.attackRadius, 0, 2 * Math.PI);
+            ctx.strokeStyle = "#E5392B";
+            ctx.lineWidth = 3;
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.arc(hz.x, hz.y, config.hazards.bumper.radius, 0, 2 * Math.PI);
+            ctx.fillStyle = config.hazards.bumper.color;
+            ctx.fill();
+        }
+    }
     var url = cv.toDataURL("image/jpeg", 0.7);
     if (map.id != null && patternsReady) { thumbnailCache[map.id] = url; }
     return url;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -150,6 +150,11 @@ blindfoldLargeIcon.scale = .5;
 
 var transferIcon = new Image(576, 512);
 transferIcon.src = "../assets/img/random.svg";
+// Question-mark icon for un-resolved random tiles in the next-map preview
+// thumbnail (the live map never has them — they're replaced before rendering —
+// but `maps[i]` keeps the original ids that the thumbnail draws from).
+var randomTileIcon = new Image(576, 512);
+randomTileIcon.src = "../assets/img/question-solid.svg";
 var copyIcon = new Image(576, 512);
 copyIcon.src = "../assets/img/copy-regular.svg";
 var bombIcon = new Image(576, 512);
@@ -343,7 +348,7 @@ var requiredImages = [
     snowFlakeIcon, windIcon, hourglassIcon, lightningIcon, cloudyIcon,
     infinityIcon, fiestaIcon, toolBoxIcon, moneyIcon, volcanoIcon,
     bombImage, snowFlakeImage, cloudImage, infectionIcon, puckIcon,
-    explosionIcon, moonIcon, scissorsIcon,
+    explosionIcon, moonIcon, scissorsIcon, randomTileIcon,
     lava, poison, grass, dirt, ice, sand,
     redFire, orangeFire, yellowFire, greenFire, blueFire, purpleFire
 ];
@@ -407,6 +412,11 @@ function loadPatterns() {
     patterns[config.tileMap.fast.id] = makeSeamlessPattern(gGrass);
     patterns[config.tileMap.normal.id] = makeSeamlessPattern(gDirt);
     patterns[config.tileMap.slow.id] = makeSeamlessPattern(gSand);
+    // Random tiles are replaced (applyRandomTiles) before any cell in the LIVE
+    // map renders, so this pattern is only used by the next-map preview
+    // thumbnail (buildMapThumbnailCanvas), which draws straight from maps[i]'s
+    // un-replaced cell ids. Without it the thumbnail fell back to flat purple.
+    patterns[config.tileMap.random.id] = makePattern(randomTileIcon, config.tileMap.random.color);
 
 
 

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -533,6 +533,39 @@ function buildMapThumbnailCanvas(map) {
 		ctx.fillStyle = thumbnailTileFill(cell.id);
 		ctx.fill();
 	}
+	// Hazards: matches drawBumper/drawMovingBumper in draw.js (orange disc +
+	// red attack ring; moving bumper also draws its rail). The thumbnail can't
+	// know the moving bumper's current position along the rail, so it draws
+	// the bumper at the rail anchor — where every round starts it anyway.
+	if (Array.isArray(map.hazards)) {
+		var bumperColor = config.hazards.bumper.color;
+		var bumperRingColor = "#E5392B";
+		var attackR = config.hazards.bumper.attackRadius;
+		var bodyR = config.hazards.bumper.radius;
+		var mbWidth = config.hazards.movingBumper.width;
+		var mbHeight = config.hazards.movingBumper.height;
+		for (var hi = 0; hi < map.hazards.length; hi++) {
+			var hz = map.hazards[hi];
+			if (hz == null) { continue; }
+			if (hz.id === config.hazards.movingBumper.id) {
+				ctx.save();
+				ctx.translate(hz.x, hz.y);
+				ctx.rotate((hz.angle || 0) * Math.PI / 180);
+				ctx.fillStyle = "black";
+				ctx.fillRect(0, -mbHeight / 2, mbWidth, mbHeight);
+				ctx.restore();
+			}
+			ctx.beginPath();
+			ctx.arc(hz.x, hz.y, attackR, 0, 2 * Math.PI);
+			ctx.strokeStyle = bumperRingColor;
+			ctx.lineWidth = 3;
+			ctx.stroke();
+			ctx.beginPath();
+			ctx.arc(hz.x, hz.y, bodyR, 0, 2 * Math.PI);
+			ctx.fillStyle = bumperColor;
+			ctx.fill();
+		}
+	}
 	return cv;
 }
 function applyAbilites(abilities) {
@@ -590,6 +623,12 @@ function clearInfection() {
 }
 
 function applyBrutalMap(brconfig) {
+	// Always recompute `infection` from this round's config: the early-return
+	// branch used to leave it untouched, so a non-brutal round after an
+	// infection round inherited the poison-lava texture (loadPatterns()
+	// reads this flag) and the visuals never cleared.
+	infection = brconfig.brutal != false &&
+		brconfig.brutalTypes.indexOf(config.brutalRounds.infection.id) != -1;
 	if (brconfig.brutal == false) {
 		brutalRound = false;
 		brutalRoundConfig = null;
@@ -598,11 +637,6 @@ function applyBrutalMap(brconfig) {
 	brutalRound = true;
 	brutalRoundConfig = brconfig;
 	playSound(brutalRoundSound);
-	if (brutalRoundConfig.brutalTypes.indexOf(config.brutalRounds.infection.id) != -1) {
-		infection = true;
-	} else {
-		infection = false;
-	}
 }
 
 function spawnLobbyStartButton(payload) {

--- a/server/engine.js
+++ b/server/engine.js
@@ -177,10 +177,15 @@ class Engine {
 				// near end only while heading back. Guarding both ends keeps a
 				// single overshoot (e.g. from a long tick) from flipping the
 				// angle every frame and trapping the bumper jittering in place.
+				// Assign exact values (rail.angle or rail.angle - 180) instead of
+				// ±= 180: a non-axis-aligned rail.angle (e.g. -3.85°) doesn't
+				// round-trip in float, so after one full cycle hazard.angle drifts
+				// ~10 ULPs from rail.angle and the strict-eq `movingOutward` check
+				// stays false at the second far-end clamp — bumper freezes there.
 				if (movingOutward && currentDist > hazard.rail.lengthSq) {
-					hazard.angle -= 180;
+					hazard.angle = hazard.rail.angle - 180;
 				} else if (!movingOutward && currentDist < hazard.lengthSq) {
-					hazard.angle += 180;
+					hazard.angle = hazard.rail.angle;
 				}
 
 				newVelX = Math.cos((hazard.angle) * (Math.PI / 180)) * hazard.speed * this.dt;
@@ -203,7 +208,7 @@ class Engine {
 					// would re-clamp to the same spot every tick and freeze there. Turn it
 					// around now if it was heading outward, so it heads back next tick.
 					if (hazard.angle == hazard.rail.angle) {
-						hazard.angle -= 180;
+						hazard.angle = hazard.rail.angle - 180;
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Four bugs surfaced during play, all fixed in this PR.

- **Map preview doesn't render hazards** (next-map thumbnail, `buildMapThumbnailCanvas` in `gameboard.js` + `renderMapThumbnail` in `create.js`). Thumbnail builders now draw static and moving bumpers, matching the live render (orange disc + red attack ring + black rail bar).
- **`?` tiles in the preview were plain purple** (`draw.js`). Added `randomTileIcon` (question-solid.svg) and registered `patterns[config.tileMap.random.id]` in `loadPatterns()`. The live map never sees this pattern (random tiles get replaced before render), but the next-map preview thumbnail draws from `maps[i]`'s un-replaced cell ids, which now show the `?` icon over purple.
- **Zombie-lava brutal visual persisted after an infection round** (`applyBrutalMap` in `gameboard.js`). The early-return for non-brutal rounds skipped the `infection = false` reset, so the poison-green lava texture stuck around. Now `infection` is recomputed from the round's own config every call, before any return.
- **Moving bumpers froze on *What Goes Up*** (`server/engine.js updateHazards`). Root cause: `hazard.angle -= 180` / `+= 180` doesn't perfectly round-trip in float on non-axis-aligned rails. After one full oscillation, `hazard.angle` drifted ~10 ULPs from `rail.angle`, so the strict-eq `movingOutward` check stayed false at the second far-end clamp and the bumper stuck. Now assigns exact values (`rail.angle` or `rail.angle - 180`), so the angle never accumulates drift.

## Test plan

- [x] `node .github/scripts/smoke-test.js` — all 52 maps tick through waiting → racing → collapsing.
- [x] `npm run build` — all three bundles compile.
- [x] Headless reproduction of the moving-bumper freeze on *What Goes Up*: 872/1000 stuck ticks pre-fix → 0/2000 post-fix.
- [x] Headless test of `applyBrutalMap` for the three regression cases (infection→non-brutal, infection→hockey-brutal, non-brutal→infection→non-brutal) — all green.
- [x] Browser: editor preview path on a synthetic map with hazards + `?` tiles — next-map thumbnail shows bumpers, moving-bumper rails, and `?`-pattern random cells (verified by pixel sampling: hazard centers RGB (240,123,54) = #F07B36).
- [x] Browser: live preview of *What Goes Up* — moving bumper sampled 174× over 8s shows 13 direction reversals and 0 stuck samples.
- [ ] Operator manual check on a real multi-round game (infection-brutal → non-brutal lava reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)