### PR TITLE
revert(editor): drop "Load from JSON file" load-window tile

### DIFF
--- a/.github/scripts/lint-button-input.js
+++ b/.github/scripts/lint-button-input.js
@@ -37,8 +37,6 @@ const ALLOWLIST = [
       why: 'icon emoji-cancel link (has aria-label); reachable via gamepad.js "#emojiMenu a"' },
     { page: 'create.html', match: (e) => e.id === 'createNew', skip: ['class'],
       why: 'id-styled "Create a new map" tile; reachable via editorGamepad "#loadWindow button"' },
-    { page: 'create.html', match: (e) => e.id === 'loadFromFileButton', skip: ['class'],
-      why: 'id-styled "Load from JSON file" load-window tile (sibling of createNew); reachable via data-gp-nav' },
 ];
 
 function attr(s, n) {

--- a/client/create.html
+++ b/client/create.html
@@ -688,14 +688,6 @@
           <div class="desc">Create a new map</div>
         </button>
       </div>
-      <div class="map-image" data-keep="1">
-        <button id="loadFromFileButton" data-gp-nav title="Load a map from a .json file you saved">
-          <div class="load-file-thumb"><i class="fa fa-upload fa-4x" aria-hidden="true"></i></div>
-          <div class="desc">Load from JSON file</div>
-        </button>
-        <input type="file" id="loadFromFileInput" accept=".json,application/json" style="display:none;">
-        <div id="loadFileStatus" class="load-file-status" style="display:none;"></div>
-      </div>
     </div>
 
     <!-- Controller-friendly confirm dialog (replaces native confirm(), which a

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -664,23 +664,6 @@ div.map-image img {
     height: auto;
 }
 
-/* The "Load from JSON file" tile has no thumbnail image, so give it a box that
-   matches the square-ish footprint of a rendered map thumbnail beside it. */
-.load-file-thumb {
-    width: 100%;
-    height: 192px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: rgba(127, 127, 127, 0.18);
-    border-radius: 4px;
-}
-.load-file-status {
-    font-size: 12px;
-    text-align: center;
-    padding: 4px;
-}
-
 div.desc {
     font-size: 12px;
     padding: 7px;

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -198,46 +198,6 @@ function loadMapById(id) {
     }
 }
 
-// Transient feedback for the "Load from JSON file" tile (the load window has no
-// #exportStatus, which lives in the editor panel). Mirrors showExportStatus.
-var loadFileStatusTimer = null;
-function showLoadFileStatus(message, color) {
-    var el = $("#loadFileStatus");
-    el.text(message).css("color", color).show();
-    if (loadFileStatusTimer) { clearTimeout(loadFileStatusTimer); }
-    loadFileStatusTimer = setTimeout(function () { el.hide(); }, 4000);
-}
-
-// Load a map from raw .json text the player saved off. Accepts either a bare
-// map object or the { map: {...} } wrapper the preview path uses, and only
-// requires a cells array — same permissiveness as loadMapById, which doesn't
-// re-validate library maps either (submit/preview is the real trust boundary).
-function loadMapFromFile(text) {
-    var parsed = null;
-    try {
-        parsed = JSON.parse(text);
-    } catch (e) {
-        showLoadFileStatus("That file isn't valid JSON.", "red");
-        return;
-    }
-    if (parsed != null && parsed.map != null && Array.isArray(parsed.map.cells)) {
-        parsed = parsed.map;
-    }
-    if (parsed == null || !Array.isArray(parsed.cells) || parsed.cells.length === 0) {
-        showLoadFileStatus("That file isn't a chaochao map.", "red");
-        return;
-    }
-    vMap = parsed;
-    syncStartEdgesFromMap();
-    $('#author').val(vMap.author || "");
-    $('#name').val(vMap.name || "");
-    setSelectedObject(null);
-    clearHistory();
-    mapModified = false;
-    mapReady = true;
-    showEditor();
-}
-
 function clientConnect() {
     var server = io();
 
@@ -559,25 +519,6 @@ function setupPage() {
         showLoadWindow();
         removeListeners();
         return false;
-    });
-
-    // Load a map from a .json file the player saved off (e.g. the "Copy to
-    // clipboard" export, pasted into a file). The button just opens the native
-    // file picker; the actual load happens in the input's change handler.
-    $("#loadFromFileButton").on("click", function () {
-        $("#loadFileStatus").hide();
-        $("#loadFromFileInput").trigger("click");
-        return false;
-    });
-    $("#loadFromFileInput").on("change", function (e) {
-        var file = e.target && e.target.files ? e.target.files[0] : null;
-        if (file == null) { return; }
-        var reader = new FileReader();
-        reader.onload = function (ev) { loadMapFromFile(ev.target.result); };
-        reader.onerror = function () { showLoadFileStatus("Couldn't read that file.", "red"); };
-        reader.readAsText(file);
-        // Clear the value so picking the same file again still fires "change".
-        this.value = "";
     });
     window.addEventListener('contextmenu', suppressContextMenu, false);
     window.addEventListener('resize', resize, false);


### PR DESCRIPTION
## Summary
- Removes the **Load from JSON file** tile from the map-editor load window (added in 1cfe23f).
- Drops its CSS (`.load-file-thumb`, `.load-file-status`) and the matching `loadFromFileButton` allowlist entry in `lint-button-input.js`.
- The library load list and the **Create a new map** tile are untouched.

## Test plan
- [x] `npm run build` produces the three bundles
- [x] `node .github/scripts/smoke-test.js` — engine runs on all 52 maps
- [x] `node .github/scripts/lint-button-input.js` — button lint passes
- [ ] Manual: load `create.html`, confirm the upload tile no longer appears and library/`Create a new map` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)