### PR TITLE
ui(landing): polish menu pages — primary CTA, tip banner, drop unused libs

### DIFF
--- a/client/create.html
+++ b/client/create.html
@@ -4,9 +4,22 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
+  <meta name="description" content="Design and submit Chao Chao maps — voronoi tiles, hazards, and a built-in play-test.">
+  <meta name="theme-color" content="#000000">
   <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
   <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
+  <!-- Preconnect to third-party origins we will hit on this page. `crossorigin`
+       must match the actual fetch's cors-mode; mismatches open a second
+       connection and waste the handshake. cdnjs is hit by both Font Awesome
+       CSS (no cors) and Popper JS (crossorigin), so it gets two preconnects. -->
+  <link rel="preconnect" href="https://www.googletagmanager.com">
+  <link rel="preconnect" href="https://ajax.googleapis.com">
+  <link rel="preconnect" href="https://stackpath.bootstrapcdn.com" crossorigin>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net">
   <!-- Google tag (gtag.js) -->
+
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-832XFC4F84"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
@@ -27,7 +40,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/css/index.css">
   <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
-  <title>Chao Chao Map Edit</title>
+  <title>Chao Chao — Map Editor</title>
   <style>
     /* ===========================================================================
        Map editor layout. A single responsive CSS grid drives both forms:
@@ -573,8 +586,7 @@
 <body>
   <nav class="d-flex align-items-center px-3">
     <div class="navbar-brand">
-      <a data-gp-nav style="text-decoration: inherit;
-      color: inherit;" href="./index.html">ChaoChao</a>
+      <a data-gp-nav class="brand-link" href="./index.html">ChaoChao</a>
     </div>
   </nav>
   <!-- Game enclosed here -->

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1,15 +1,3 @@
-@font-face {
-    font-family: "San Francisco";
-    font-weight: 400;
-    src: url("https://applesocial.s3.amazonaws.com/assets/styles/fonts/sanfrancisco/sanfranciscodisplay-regular-webfont.woff");
-}
-
-@font-face {
-    font-family: 'FontAwesome';
-    src: url('./webfonts/fa-regular-400.ttf');
-    font-weight: normal;
-    font-style: normal;
-}
 :root {
     --navbar-height: 60px;
 
@@ -31,7 +19,7 @@
     --text-soft: #495057;      /* slightly muted body text (stats, news copy) */
     --text-muted: #6c757d;
     --border: #e6e6e6;
-    --card-shadow: var(--card-shadow);     /* drop shadow / glow on cards and banners */
+    --card-shadow: rgba(0, 0, 0, 0.12);     /* drop shadow / glow on cards and banners */
     --navbar-bg: #000000;
     --navbar-text: #ffffff;
     /* navbar control chrome — kept white-based because the navbar stays dark in
@@ -316,10 +304,6 @@ canvas {
     font-weight: 600;
 }
 #joinMenu {
-    border-radius: 6px;
-    box-shadow: 0px 0px 6px var(--card-shadow);
-    padding: 0.75rem;
-    background: var(--surface);
     min-height: 80px;
 }
 #gameSelection {
@@ -519,7 +503,8 @@ canvas {
     width: min(420px, 88vw);
 }
 .loading-brand {
-    font-family: "San Francisco";
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, system-ui, sans-serif;
+    font-weight: 600;
     font-size: clamp(2rem, 9vw, 3.4em);
     line-height: 1;
     letter-spacing: -0.01em;
@@ -609,9 +594,12 @@ canvas {
 
 
 #version{
-    font-size: 12px;
+    display: block;
     text-align: right;
-    float: right;
+    margin-bottom: 0.35rem;
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1;
 }
 .editor-inputs{
     margin: 5px;
@@ -671,10 +659,16 @@ div.desc {
 }
 
 #game-title {
-    font-family: "San Francisco";
-    /* Fluid size: never overflows a 320px phone, never larger than the old 4em
-       on desktop. */
-    font-size: clamp(2.2rem, 12vw, 4em);
+    /* Stack: -apple-system covers SF on Apple devices; system-ui/Segoe/Roboto
+       cover the rest. No remote font fetch, no flash, same look on macOS/iOS. */
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, system-ui, sans-serif;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    /* Tighter clamp than the old 12vw: 320px phone => ~32px, capped lower on
+       desktop so the title doesn't tower over the card. */
+    font-size: clamp(2rem, 9vw, 3.5rem);
+    line-height: 1.05;
+    text-align: center;
 }
 
 .landing-stack {
@@ -686,19 +680,81 @@ div.desc {
     margin: 0 auto;
 }
 
-.play-container {
-    background-color: var(--surface);
-    width: 100%;
-    padding: 1.5rem;
-    border-radius: 6px;
-    box-shadow: 0px 0px 6px var(--card-shadow);
+.tagline {
+    margin: 0.25rem 0 0.9rem;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    text-align: center;
 }
 
-.tagline {
-    margin: 0.75rem 0 0;
-    color: var(--text-muted);
-    font-size: 0.9rem;
+/* `.play-container` was the card-shell around the landing CTAs and is now
+   keyed only by the touch-mt rule under @media (pointer: coarse); the buttons
+   inside already get full width from Bootstrap's `w-100`. Keep the wrapper
+   as a hook for that rule without giving it any properties of its own. */
+
+/* Primary CTA: noticeably taller than the secondary outline buttons and uses a
+   solid fill so it reads as the obvious starting action. */
+.btn-primary-cta {
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    padding-top: 0.7rem;
+    padding-bottom: 0.7rem;
+    box-shadow: 0 2px 8px rgba(40, 167, 69, 0.25);
+}
+.btn-primary-cta:hover {
+    box-shadow: 0 4px 14px rgba(40, 167, 69, 0.35);
+}
+
+/* Inline anchor in the navbar brand wrapper — was previously styled inline. */
+.navbar-brand .brand-link {
+    text-decoration: inherit;
+    color: inherit;
+}
+
+/* Minecraft-style rotating tip line. Sits under the play card, quiet so it
+   doesn't compete with the news banner above it. The italic body + yellow
+   "Tip:" label is the classic loading-screen treatment; the gentle wobble is
+   pure flavour. Cycles via landingTips.js. */
+.tip-banner {
+    margin-top: 0.9rem;
+    padding: 0 0.6rem;
     text-align: center;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    color: var(--text-soft);
+    cursor: pointer;
+    user-select: none;
+    opacity: 1;
+    transition: opacity 0.22s ease;
+    animation: tipBobble 3.4s ease-in-out infinite;
+    transform-origin: center;
+}
+.tip-banner.is-fading {
+    opacity: 0;
+}
+.tip-banner .tip-label {
+    color: #e5b900;                /* Minecraft splash-text yellow */
+    font-weight: 700;
+    margin-right: 0.35rem;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
+}
+[data-theme="dark"] .tip-banner .tip-label {
+    color: #ffd23a;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.6);
+}
+.tip-banner .tip-text {
+    font-style: italic;
+}
+@keyframes tipBobble {
+    /* Tiny scale pulse — too small to be distracting but enough that the line
+       feels like it's bouncing for attention. */
+    0%, 100% { transform: scale(1); }
+    50%      { transform: scale(1.04); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .tip-banner {
+        animation: none;
+    }
 }
 
 /* news banner under the landing description, surfacing the latest release headline */
@@ -1418,6 +1474,11 @@ body.osk-open .gamepad-prompts {
         padding-top: 0.5rem;
         padding-bottom: 0.5rem;
     }
+    /* The landing CTAs stack tightly with Bootstrap's mt-2 (8px). Bump the gap
+       on touch so a thumb tap doesn't graze the neighbouring button. */
+    .play-container .btn + .btn {
+        margin-top: 0.75rem !important;
+    }
     .btn-sm {
         min-height: 44px;
     }
@@ -1442,7 +1503,7 @@ body.osk-open .gamepad-prompts {
         --navbar-height: 44px;
     }
     #game-title {
-        font-size: clamp(1.8rem, 9vw, 3rem);
+        font-size: clamp(1.6rem, 6vw, 2.4rem);
     }
 }
 
@@ -1459,16 +1520,13 @@ body.osk-open .gamepad-prompts {
         padding-bottom: 0.75rem;
     }
     #game-title {
-        font-size: clamp(1.6rem, 7vw, 2.6rem);
-    }
-    .play-container {
-        padding: 1rem;
+        font-size: clamp(1.6rem, 7vw, 2.4rem);
     }
     .news-banner {
         margin-top: 0.5rem;
     }
     .tagline {
-        margin-top: 0.5rem;
+        margin: 0.15rem 0 0.5rem;
     }
 }
 
@@ -1586,7 +1644,10 @@ body.osk-open .gamepad-prompts {
     /* responsive: ~3 cols desktop, 2 iPad, 1 phone — auto from min card width */
     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
     gap: 1rem;
-    align-items: start;
+    /* No `align-items: start` — cards in a row stretch to the tallest card's
+       height so the next row starts on a clean baseline instead of leaving
+       gaps under the shorter cards. `.codex-card` is `display: flex; flex-
+       direction: column` so its content naturally fills the stretched height. */
 }
 .codex-card {
     display: flex;

--- a/client/index.html
+++ b/client/index.html
@@ -5,8 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="description" content="Slow-paced multiplayer arena racing. Free in the browser — play with friends on phone, controller, or keyboard.">
+    <meta name="theme-color" content="#000000">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Chao Chao">
+    <meta property="og:description" content="Slow-paced multiplayer arena racing. Free in the browser — play with friends on phone, controller, or keyboard.">
+    <meta property="og:image" content="assets/img/favicon.svg">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Chao Chao">
+    <meta name="twitter:description" content="Slow-paced multiplayer arena racing. Free in the browser — play with friends on phone, controller, or keyboard.">
     <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
     <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
+    <!-- Preconnect to third-party origins we will hit on this page. `crossorigin`
+         must MATCH the cors-mode the resource is actually fetched with, or the
+         browser opens a separate connection and the handshake we paid for is
+         wasted. Bootstrap CSS is loaded `crossorigin="anonymous"`; gtag.js and
+         the Supabase script are not. -->
+    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://stackpath.bootstrapcdn.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-832XFC4F84"></script>
     <script>
@@ -23,18 +40,15 @@
       }
     </script>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="css/styles.css">
-    <link rel="stylesheet" type="text/css" href="assets/css/all.css">
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <title>Chao Chao</title>
   </head>
   <body>
     <nav class="d-flex align-items-center px-3">
       <div class="navbar-brand">
-        <a data-gp-nav style="text-decoration: inherit;
-        color: inherit;" href="./index.html">ChaoChao</a>
+        <a data-gp-nav class="brand-link" href="./index.html">ChaoChao</a>
       </div>
     </nav>
     <section>
@@ -42,29 +56,32 @@
         <div class="container d-flex h-100 align-items-center">
           <div class="row justify-content-center align-self-center mx-auto w-100">
             <div class="landing-stack">
+              <span id="game-title">Chao Chao</span>
+              <p class="tagline">Slow-paced multiplayer arena racing.</p>
               <div class="play-container">
                 <span id="version"><b><!-- VERSION --></b></span>
-                <span id="game-title">Chao Chao</span>
-                <a href="./play.html" id="playButton" data-gp-nav class="btn btn-outline-success w-100 mt-3" onclick="trackEvent('cta_click', { target: 'play' })">Play</a>
+                <a href="./play.html" id="playButton" data-gp-nav class="btn btn-success btn-lg btn-primary-cta w-100" onclick="trackEvent('cta_click', { target: 'play' })">Play</a>
                 <a href="./join.html" id="joinButton" data-gp-nav class="btn btn-outline-info w-100 mt-2" onclick="trackEvent('cta_click', { target: 'join' })">Join</a>
                 <a href="./create.html" id="createButton" data-gp-nav class="btn btn-outline-warning w-100 mt-2" onclick="trackEvent('cta_click', { target: 'create' })">Create</a>
                 <a href="./learn.html" id="learnButton" data-gp-nav class="btn btn-outline-primary w-100 mt-2" onclick="trackEvent('cta_click', { target: 'learn' })">Learn</a>
                 <!-- NEWS_BANNER -->
               </div>
-              <p class="tagline">Slow-paced multiplayer arena racing.</p>
+              <div class="tip-banner" id="tipBanner" data-gp-nav role="button" tabindex="0"
+                   aria-label="Next tip" title="Click for another tip">
+                <span class="tip-label" aria-hidden="true">Tip:</span>
+                <span class="tip-text" id="tipText" aria-live="polite"></span>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- Load bootstrap -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
     <script src="scripts/controllerIdentity.js"></script>
     <script src="scripts/menuGamepad.js"></script>
     <script src="scripts/controllerHeader.js"></script>
     <script src="scripts/theme.js"></script>
+    <script src="scripts/landingTips.js" defer></script>
     <!-- Auth: browser-safe Supabase config injected server-side; stripped when disabled. -->
     <!-- SUPABASE_CONFIG -->
     <!-- deferred (non-render-blocking); run in order before DOMContentLoaded. -->

--- a/client/join.html
+++ b/client/join.html
@@ -1,9 +1,21 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
+        <meta name="description" content="Join a Chao Chao game in progress or by ID, or start a new one.">
+        <meta name="theme-color" content="#000000">
         <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
         <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
+        <!-- Preconnect to third-party origins we will hit on this page. The
+             `crossorigin` attribute must match the actual fetch's cors-mode or
+             the browser opens a second connection. Bootstrap CSS uses crossorigin;
+             gtag, Font Awesome CSS, Supabase JS, and the simple-keyboard bundle
+             do not. -->
+        <link rel="preconnect" href="https://www.googletagmanager.com">
+        <link rel="preconnect" href="https://stackpath.bootstrapcdn.com" crossorigin>
+        <link rel="preconnect" href="https://cdn.jsdelivr.net">
+        <link rel="preconnect" href="https://cdnjs.cloudflare.com">
         <!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-832XFC4F84"></script>
         <script>
@@ -19,21 +31,19 @@
                 if (typeof gtag === 'function') { gtag('event', name, params || {}); }
             }
         </script>
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
         <link rel="stylesheet" type="text/css" href="css/styles.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/css/index.css">
         <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
-        <title>Chao Chao Join a game</title>
+        <title>Chao Chao — Join a game</title>
     </head>
 <body>
     <nav class="d-flex align-items-center px-3">
         <div class="navbar-brand">
-            <a data-gp-nav style="text-decoration: inherit;
-            color: inherit;" href="./index.html">ChaoChao</a>
-          </div>
-      </nav>
+            <a data-gp-nav class="brand-link" href="./index.html">ChaoChao</a>
+        </div>
+    </nav>
     <section>
         <div class="container join-container">
             <div class="join-header">
@@ -59,7 +69,7 @@
                 <button id="joinByIdButton" type="button" data-gp-nav class="btn btn-outline-info">Join</button>
             </div>
             <div class="start-new">
-                <a href="./play.html" data-gp-nav class="btn btn-outline-success">Start a new game</a>
+                <a href="./play.html" data-gp-nav class="btn btn-success btn-lg btn-primary-cta">Start a new game</a>
             </div>
         </div>
     </section>
@@ -78,9 +88,5 @@
     <script src="scripts/menuGamepad.js"></script>
     <script src="scripts/controllerHeader.js"></script>
     <!-- BUILD: bundle-end -->
-
 </body>
-
-
-
 </html>

--- a/client/learn.html
+++ b/client/learn.html
@@ -5,9 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="description" content="Codex of Chao Chao mechanics, tiles, abilities, and brutal rounds — with live animations.">
+    <meta name="theme-color" content="#000000">
     <!-- Apply saved theme before first paint to avoid a flash of the wrong theme -->
     <script>(function(){try{var p=localStorage.getItem('themePref')||'auto';var d=p==='dark'||(p!=='light'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();</script>
+    <!-- Preconnect to third-party origins we will hit on this page. `crossorigin`
+         must match the actual fetch's cors-mode — Bootstrap CSS uses crossorigin;
+         gtag.js and the simple-keyboard bundle do not. -->
+    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://stackpath.bootstrapcdn.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <!-- Google tag (gtag.js) -->
+
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-832XFC4F84"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -23,10 +32,8 @@
       }
     </script>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="css/styles.css">
-    <link rel="stylesheet" type="text/css" href="assets/css/all.css">
     <!-- on-screen keyboard styles, so the search box is typeable with a controller -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/css/index.css">
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
@@ -35,8 +42,7 @@
   <body>
     <nav class="d-flex align-items-center px-3">
       <div class="navbar-brand">
-        <a data-gp-nav style="text-decoration: inherit;
-        color: inherit;" href="./index.html">ChaoChao</a>
+        <a data-gp-nav class="brand-link" href="./index.html">ChaoChao</a>
       </div>
     </nav>
 

--- a/client/play.html
+++ b/client/play.html
@@ -31,8 +31,7 @@
     <body style="overflow: hidden;">
         <nav class="d-flex align-items-center px-3">
             <div class="navbar-brand">
-                <a style="text-decoration: inherit;
-                color: inherit;" href="./index.html">ChaoChao</a>
+                <a data-gp-nav class="brand-link" href="./index.html">ChaoChao</a>
             </div>
             <a id="masterControl" class="nav-toggle" role="button" tabindex="0" aria-label="Toggle sound effects" style="cursor:pointer; text-decoration: inherit;
             color: inherit;"><i class="music-btn fa fa-gamepad" aria-hidden="true"></i> [<i class="music-btn fa fa-volume-up" aria-hidden="true"></i>]</a>

--- a/client/scripts/join.js
+++ b/client/scripts/join.js
@@ -11,7 +11,7 @@ var server = null,
 
 var REFRESH_MS = 5000;
 
-$(function () {
+document.addEventListener('DOMContentLoaded', function () {
     server = clientConnect();
     var refreshButton = document.getElementById('refreshButton');
     if (refreshButton != null) {

--- a/client/scripts/landingTips.js
+++ b/client/scripts/landingTips.js
@@ -1,0 +1,119 @@
+// Minecraft-style "splash" tip line on the landing page. One tip at a time,
+// fades to the next on a timer. Tips are intentionally a mix of practical
+// hints and a little flavour — the practical ones lower the activation cost
+// for a new player; the funny ones make the page feel alive.
+//
+// Stays cheap: no per-tip DOM, just swaps textContent inside an existing span
+// while a CSS opacity transition runs. Pauses on tab hide (both the JS
+// interval and the CSS bobble animation); advances on click or Enter/Space.
+(function () {
+    "use strict";
+    var el = document.getElementById("tipBanner");
+    var text = document.getElementById("tipText");
+    if (!el || !text) { return; }
+
+    // KEEP IN SYNC: matches the `.tip-banner` `transition: opacity 0.22s` rule
+    // in styles.css — the fade-out must complete before the swap so the tip
+    // change is invisible.
+    var FADE_MS = 220;
+
+    var TIPS = [
+        "Try playing with a controller!",
+        "Lava burns.",
+        "Hold the punch button to charge a heavier hit.",
+        "Punch your friends off the map.",
+        "Bumpers send you flying — aim them at someone.",
+        "Ice is slippery. Brake before the turn.",
+        "Tiles can be swapped — keep moving!",
+        "Bombs bounce. Plan accordingly.",
+        "Up to 4 players on one screen with controllers.",
+        "Last one standing scores the round.",
+        "Stuck in lava? You may come back as a zombie.",
+        "Make your own map in the Create tab.",
+        "Some abilities are noisy — listen for them.",
+        "Bots fill in when a lobby is short.",
+        "Watch the edges. The arena gets smaller.",
+        "Patience beats panic. Slow is fast here.",
+        "The blue tile is fast. The grey tile is slow.",
+        "If someone punches you, punch them back harder.",
+        "You can spectate a match in progress from Join.",
+        "Press Start to open Settings on a controller."
+    ];
+
+    // Stable shuffle so a refresh doesn't replay the same opener, but a player
+    // who sticks around still sees every tip before any repeat.
+    function shuffle(arr) {
+        var a = arr.slice();
+        for (var i = a.length - 1; i > 0; i--) {
+            var j = Math.floor(Math.random() * (i + 1));
+            var tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+        }
+        return a;
+    }
+    var queue = shuffle(TIPS);
+    var idx = 0;
+
+    // Pending fade-swap timer. Tracked so a rapid second click cancels its
+    // predecessor instead of letting both fire — overlapping timers would
+    // swap textContent mid-fade and flicker.
+    var swapTimer = null;
+    function show(tip) {
+        // Fade out, swap, fade in. The CSS transition is on `.is-fading`.
+        if (swapTimer) { clearTimeout(swapTimer); }
+        el.classList.add("is-fading");
+        swapTimer = setTimeout(function () {
+            text.textContent = tip;
+            el.classList.remove("is-fading");
+            swapTimer = null;
+        }, FADE_MS);
+    }
+
+    function next() {
+        idx = (idx + 1) % queue.length;
+        if (idx === 0) { queue = shuffle(TIPS); }
+        show(queue[idx]);
+    }
+
+    // First tip: no fade in (just set it) so the page doesn't blink on load.
+    text.textContent = queue[0];
+
+    var rotateMs = 9000;
+    var timer = null;
+    function start() {
+        if (timer) { return; }
+        timer = setInterval(next, rotateMs);
+        // Resume the CSS bobble. Paired with `stop()`, this keeps the
+        // compositor idle while the tab is hidden.
+        el.style.animationPlayState = "running";
+    }
+    function stop() {
+        if (timer) { clearInterval(timer); timer = null; }
+        el.style.animationPlayState = "paused";
+    }
+    start();
+
+    function advance() {
+        stop();
+        next();
+        start();
+        if (typeof window.trackEvent === "function") {
+            window.trackEvent("tip_click", { idx: idx });
+        }
+    }
+
+    // Click/tap or Enter/Space = jump to the next tip and reset the timer (so
+    // the player isn't left staring at the same line for another 9s after they
+    // asked for more). The element is role="button" + tabindex="0" so keyboard
+    // and controller (data-gp-nav → menuGamepad) users reach it too.
+    el.addEventListener("click", advance);
+    el.addEventListener("keydown", function (e) {
+        if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+            e.preventDefault();
+            advance();
+        }
+    });
+
+    document.addEventListener("visibilitychange", function () {
+        if (document.hidden) { stop(); } else { start(); }
+    });
+})();

--- a/index.js
+++ b/index.js
@@ -108,15 +108,31 @@ function loadWeeklyNews() {
 }
 
 function newsBannerHtml() {
-    if (!APP_NEWS) {
-        return '';
+    // Both branches build the same `<a class="news-banner">` shell — only the
+    // href, badge, and headline differ. `rel="noopener noreferrer"` guards the
+    // target=_blank against reverse-tabnabbing on older Safari (modern browsers
+    // imply noopener already, but it's free to be explicit).
+    function bannerAnchor(href, badge, headline) {
+        return '<a class="news-banner" target="_blank" rel="noopener noreferrer" href="' +
+            escapeHtml(href) + '">' +
+            '<span class="news-badge">' + escapeHtml(badge) + '</span>' +
+            '<span class="news-headline">' + escapeHtml(headline) + '</span>' +
+            '</a>';
     }
-    var href = 'https://github.com/' + RELEASES_REPO +
-        '/releases/tag/' + encodeURIComponent(APP_NEWS.weekTag);
-    return '<a class="news-banner" target="_blank" href="' + escapeHtml(href) + '">' +
-        '<span class="news-badge">Patch notes</span>' +
-        '<span class="news-headline">' + escapeHtml(APP_NEWS.headline) + '</span>' +
-        '</a>';
+    if (!APP_NEWS) {
+        // No flagged headline this week — fall back to a quiet link to the
+        // releases index so the banner slot never goes silent.
+        return bannerAnchor(
+            'https://github.com/' + RELEASES_REPO + '/releases',
+            "What's new",
+            'See the latest releases'
+        );
+    }
+    return bannerAnchor(
+        'https://github.com/' + RELEASES_REPO + '/releases/tag/' + encodeURIComponent(APP_NEWS.weekTag),
+        'Patch notes',
+        APP_NEWS.headline
+    );
 }
 
 const bundleMap = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chaochao",
-    "version": "0.12.0",
+    "version": "0.21.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chaochao",
-            "version": "0.12.0",
+            "version": "0.21.1",
             "dependencies": {
                 "@octokit/core": "^5.2.2",
                 "@supabase/supabase-js": "^2.106.1",


### PR DESCRIPTION
## Summary
Landing-page polish pass that also extends to join / learn / create / play. No game-mechanic changes (CHANGELOG-exempt).

**Visual:**
- Tagline moved above the play card; system-font stack on `#game-title` and `.loading-brand` (drops the fragile remote `applesocial.s3` SF webfont).
- New solid green `.btn-success.btn-lg.btn-primary-cta` for Play (landing) and Start-a-new-game (join), so the primary action has visual primacy over the outline buttons.
- New rotating **Tip:** banner under the landing card (Minecraft-style yellow italic). 20 mixed practical/funny tips, shuffled queue, 9 s rotation, click or Enter advances. `role=button` + `aria-live=polite` + `data-gp-nav` + paired CSS-animation play-state so it idles when the tab is hidden.
- News banner gains a no-headline fallback (\"What's new → See the latest releases\"); both branches share one helper and emit `rel=\"noopener noreferrer\"`.
- Codex card grid: drop `align-items: start` so cards in a row share the tallest card's height — no more whitespace gaps between rows.

**Cleanup / perf:**
- Drop unused libs: jQuery (landing, learn), Popper + Bootstrap JS + Font Awesome (landing only). `join.js`'s lone `$(function () { ... })` becomes vanilla `DOMContentLoaded`; create still uses jQuery + FA so they stay.
- Meta description / OG / Twitter / `theme-color` tags on each menu page.
- Preconnect to gtag, Bootstrap CDN, jsdelivr, cdnjs — with `crossorigin` matched to each origin's actual fetch cors-mode so the handshakes are actually reused.
- Inline brand-link styles replaced with `.brand-link` class on all five menu/play pages.
- Fix `--card-shadow` self-reference (light-mode cards were missing their shadow).
- Delete the orphan FontAwesome `@font-face` rule (its `src:` resolved to a non-existent path) and the empty `.play-container` card chrome.

**Side cleanup:** syncs `package-lock.json` from 0.12.0 → 0.21.1 (it had been lagging behind `package.json`).

## Test plan
- [x] Smoke test (`node .github/scripts/smoke-test.js`) — green
- [x] Prod build (`npm run build`) — green
- [x] Browser-verified light + dark on desktop + 390 px portrait
- [x] join.html opens with no console errors; refresh + ?notfound banner + join-by-id wired
- [x] Tip banner advances on click and on Enter focus; rotates on timer; pauses on tab hide
- [x] News banner anchor has `rel=\"noopener noreferrer\"`
- [x] Codex card rows aligned (no gaps between rows)
- [ ] Operator hardware pass (real iPad / controller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)