### PR TITLE
feat(fx): lava-death sinking corpse + fading kart trails + ambient terrain polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- Driving into lava now shows your kart **sinking and burning** — it shrinks, darkens, and bobs under for a few seconds while still on fire, with embers and bubble pops rising around it. Works on the lobby's lava-and-respawn teaching pool too.
+- Player trails behind each kart now **fade out after about 5 seconds** instead of building up the whole round, and the trail itself is a little thinner — keeps your line readable without filling the map.
+- Ice now leaves skate marks at any speed (was only at a full glide), and bare dirt picks up a subtle puff at a walk. On phone-class devices these subtler effects are skipped to keep frames smooth.
 
 ## v0.21.1 — 2026-05-28
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -325,9 +325,29 @@ function registerScoreHandlers(server) {
 			// Use the authoritative server position (tx/ty), not the eased render
 			// position (x/y), so the death skull/ping lands where the kart actually
 			// died (x/y lags by ~tau, noticeable for a fast death into lava).
-			playerList[id].deathX = (playerList[id].tx != null) ? playerList[id].tx : playerList[id].x;
-			playerList[id].deathY = (playerList[id].ty != null) ? playerList[id].ty : playerList[id].y;
+			// Prefer the authoritative position from the server (packet.x/y); fall
+			// back to the eased/server-tx position only if the server didn't send
+			// it (a kart that crossed onto lava between server ticks has its post-
+			// lava tx/ty sent in the NEXT gameUpdates, after this event).
+			var srvX = (packet != null && packet.x != null) ? packet.x : null;
+			var srvY = (packet != null && packet.y != null) ? packet.y : null;
+			playerList[id].deathX = (srvX != null) ? srvX :
+				((playerList[id].tx != null) ? playerList[id].tx : playerList[id].x);
+			playerList[id].deathY = (srvY != null) ? srvY :
+				((playerList[id].ty != null) ? playerList[id].ty : playerList[id].y);
 			playerList[id].deathAt = Date.now();
+			// Lava deaths get the sinking corpse. The server now tags the cause
+			// directly (packet.cause === "lava"); we still keep a tile-lookup
+			// fallback for the edge case where the server doesn't send a cause
+			// (legacy/test paths) but the authoritative position lands on lava.
+			var byLava = (packet != null && packet.cause === "lava");
+			if (!byLava && typeof tileIdAt === "function" && config != null &&
+				config.tileMap != null && config.tileMap.lava != null) {
+				byLava = (tileIdAt(playerList[id].deathX, playerList[id].deathY) == config.tileMap.lava.id);
+			}
+			if (byLava && typeof spawnSinkingCorpse === "function") {
+				spawnSinkingCorpse(playerList[id]);
+			}
 		}
 		recapMarkHighlight('death', [id]); // flag an elimination moment for the recap
 		createDownRankSymbol(id);
@@ -704,6 +724,23 @@ function registerCombatHandlers(server) {
 						playerList[id].deathMessage = null;
 					}
 				}, 800, packet.id);
+				// Sink the kart into the lobby lava too. The server snapshots the
+				// PRE-teleport position into packet.x/y, which is the authoritative
+				// lava-cell position (the gameUpdates packet carrying the spawn
+				// pad coords lands AFTER this event). Fall back to tx/ty only if
+				// the server didn't send it. The synthetic player-like object keeps
+				// the live playerList entry unmutated.
+				if (typeof spawnSinkingCorpse === "function") {
+					var dx = (packet.x != null) ? packet.x : ((p.tx != null) ? p.tx : p.x);
+					var dy = (packet.y != null) ? packet.y : ((p.ty != null) ? p.ty : p.y);
+					spawnSinkingCorpse({
+						deathX: dx,
+						deathY: dy,
+						color: p.color,
+						angle: p.angle,
+						radius: p.radius
+					});
+				}
 			}
 		}
 		playSound(packet.death ? playerDiedSound : playerFinished);

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -2428,52 +2428,96 @@ function drawArmedRing(x, y, color, radius) {
     gameContext.restore();
 }
 
+// Render the kart's trail with each segment's alpha scaled by the segment's
+// AGE — newest segments are full opacity, the head of the buffer (vertices
+// approaching TRAIL_FADE_MS) fades to 0 and is dropped on the next update.
+// Segments are bucketed by age so each kart costs ~TRAIL_DRAW_BUCKETS stroke
+// calls per frame regardless of vertex count. Within each bucket, CONTIGUOUS
+// runs of segments are emitted as one moveTo + many lineTo so the canvas dash
+// pattern doesn't restart per segment — and lineDashOffset is set to the
+// cumulative path length at each run start so dashes line up across runs too
+// (matters for the near-victory dashed style; the codex review caught that the
+// per-segment subpaths were killing the dash cue at our 30Hz sample cadence).
+var TRAIL_DRAW_BUCKETS = 6;
 function drawTrail(player) {
     var trail = player.trail;
-    if (trail == null) {
+    if (trail == null || trail.vertices == null || trail.vertices.length < 2) {
         return;
     }
-    // Direct trail mode (low-end profile): stroke the capped recent tail straight
-    // onto the main canvas. The vertices are world coords (same space as the
-    // canvas blit's origin), so this aligns identically under the world pass —
-    // but with no per-kart world-sized texture to re-upload to the GPU each frame.
-    if ((typeof perfTrailDirect === "function") && perfTrailDirect()) {
-        var verts = trail.vertices;
-        if (verts == null || verts.length < 2) {
-            return;
-        }
-        var maxN = (typeof perfTrailDirectMax === "function") ? perfTrailDirectMax() : 240;
-        var start = Math.max(0, verts.length - maxN);
-        var dim = !isLocalId(player.id);
-        gameContext.save();
-        if (dim) {
-            gameContext.globalAlpha = NONLOCAL_TRAIL_ALPHA;
-        }
-        gameContext.strokeStyle = player.color;
-        gameContext.lineWidth = 5;
-        gameContext.lineCap = "round";
-        gameContext.lineJoin = "round";
-        gameContext.beginPath();
-        gameContext.moveTo(verts[start].x, verts[start].y);
-        for (var i = start + 1; i < verts.length; i++) {
-            gameContext.lineTo(verts[i].x, verts[i].y);
-        }
-        gameContext.stroke();
-        gameContext.restore();
+    var fadeMs = (typeof TRAIL_FADE_MS !== "undefined") ? TRAIL_FADE_MS : 5000;
+    var now = Date.now();
+    // Defensive expiry: trim head verts past their fade window even if update
+    // hasn't run this frame (e.g. dead karts whose trail still draws briefly).
+    var verts = trail.vertices;
+    while (verts.length > 0 && now - verts[0].t > fadeMs) {
+        verts.shift();
+    }
+    if (verts.length < 2) {
         return;
     }
-    if (trail.canvas != null) {
-        // Fade other players' trails so your own line stays legible in the pack.
-        var dimC = !isLocalId(player.id);
-        if (dimC) {
-            gameContext.save();
-            gameContext.globalAlpha = NONLOCAL_TRAIL_ALPHA;
-        }
-        gameContext.drawImage(trail.canvas, trail.canvasOriginX, trail.canvasOriginY);
-        if (dimC) {
-            gameContext.restore();
+    var dim = !isLocalId(player.id);
+    var baseAlpha = dim ? NONLOCAL_TRAIL_ALPHA : 1;
+    var dashed = !!trail.wasNearVictory;
+    gameContext.save();
+    gameContext.lineWidth = dashed ? 4 : 3;
+    gameContext.lineCap = "round";
+    gameContext.lineJoin = "round";
+    gameContext.strokeStyle = player.color;
+    if (typeof perfGlow === "function" && perfGlow()) {
+        gameContext.shadowBlur = 3;
+        gameContext.shadowColor = "black";
+    }
+    if (dashed) {
+        gameContext.setLineDash([20, 3, 3, 3, 3, 3, 3, 3]);
+    }
+    // Cumulative segment lengths up to vertex i (cumLen[0] = 0). Needed only for
+    // the dashed style — the offset is what makes the dash pattern continuous
+    // across the run boundaries when a stroke starts mid-trail.
+    var cumLen = null;
+    if (dashed) {
+        cumLen = new Array(verts.length);
+        cumLen[0] = 0;
+        for (var k = 1; k < verts.length; k++) {
+            var dx = verts[k].x - verts[k - 1].x;
+            var dy = verts[k].y - verts[k - 1].y;
+            cumLen[k] = cumLen[k - 1] + Math.sqrt(dx * dx + dy * dy);
         }
     }
+    var bucketMs = fadeMs / TRAIL_DRAW_BUCKETS;
+    // Bucket-index for the segment ENDING at vertex i (the segment verts[i-1] →
+    // verts[i] is in this bucket). >= TRAIL_DRAW_BUCKETS marks "expired".
+    var segBucket = new Array(verts.length);
+    segBucket[0] = -1;
+    for (var ii = 1; ii < verts.length; ii++) {
+        var age = now - verts[ii].t;
+        segBucket[ii] = (age >= fadeMs) ? TRAIL_DRAW_BUCKETS : Math.floor(age / bucketMs);
+    }
+    for (var b = 0; b < TRAIL_DRAW_BUCKETS; b++) {
+        var bucketAlpha = baseAlpha * (1 - (b + 0.5) / TRAIL_DRAW_BUCKETS);
+        if (bucketAlpha <= 0.01) {
+            continue;
+        }
+        gameContext.globalAlpha = bucketAlpha;
+        var runStart = -1;
+        for (var i = 1; i <= verts.length; i++) {
+            var inBucket = (i < verts.length) && (segBucket[i] === b);
+            if (inBucket) {
+                if (runStart === -1) {
+                    runStart = i - 1;
+                    if (dashed) {
+                        gameContext.lineDashOffset = cumLen[runStart];
+                    }
+                    gameContext.beginPath();
+                    gameContext.moveTo(verts[runStart].x, verts[runStart].y);
+                }
+                gameContext.lineTo(verts[i].x, verts[i].y);
+            } else if (runStart !== -1) {
+                gameContext.stroke();
+                runStart = -1;
+            }
+        }
+    }
+    gameContext.restore();
 }
 
 // --- Death ping ---

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -1120,6 +1120,144 @@ function spawnDustParticle(x, y, vx, vy, size, color) {
 	});
 }
 
+// A flame sprite on top of a sinking corpse. Mirrors drawFire's translate+rotate,
+// but takes explicit (x, y, angle, size) so it can be driven from an effect that
+// no longer has a live player entry (the dead kart isn't in playerList anymore).
+function drawCorpseFire(x, y, angleDeg, size) {
+	if (typeof redFire === "undefined" || redFire == null || redFire.spriteSheet == null) {
+		return;
+	}
+	gameContext.save();
+	var ar = angleDeg * (Math.PI / 180);
+	gameContext.translate(x - 5 * Math.cos(ar), y - 5 * Math.sin(ar));
+	gameContext.rotate((angleDeg - 90) * (Math.PI / 180));
+	redFire.spriteSheet.update(dt);
+	redFire.spriteSheet.draw(size, size);
+	gameContext.restore();
+}
+
+// A "crashed and sinking" corpse: when a player dies on lava, leave a shrinking,
+// darkening disc bobbing slightly as it sinks, with a flame sprite on top for the
+// first ~70% of the dive plus a fading surface ring and a slow drip of embers and
+// lava bubble pops. Lives ~2.8s in the effects list, which is cleaned up by the
+// usual `updateEffects` path. Entirely cosmetic: doesn't touch playerList or any
+// recap/networking state. Skipped on LOW (perfExtraFx) — most of the new visual
+// budget for this feature lives here.
+function spawnSinkingCorpse(player) {
+	if (player == null) {
+		return;
+	}
+	if (typeof perfExtraFx === "function" && !perfExtraFx()) {
+		return;
+	}
+	var cx = (player.deathX != null) ? player.deathX : player.x;
+	var cy = (player.deathY != null) ? player.deathY : player.y;
+	if (cx == null || cy == null || isNaN(cx) || isNaN(cy)) {
+		return;
+	}
+	var color = player.color || "#cc3333";
+	var angle0 = (player.angle != null) ? player.angle : 0;
+	var radius0 = (player.radius != null && player.radius > 0) ? player.radius : 11;
+	// Longer sink + flame phase reads as a slow burnout, not a flash. The flame
+	// stays visible through ~80% of the sink and shrinks gently with the body
+	// (not aggressively) so it's still legible when the disc is small.
+	var maxAge = 3600;
+	var flameCutoff = 0.8;
+	// Closure state for the per-frame update (embers + bubble pops on a cadence).
+	var lastEmberAt = -1000; // negative so the first ember fires immediately
+	var lastBubbleAt = -1000;
+	addEffect({
+		x: cx,
+		y: cy,
+		maxAge: maxAge,
+		update: function (deltaT) {
+			var age = this.age;
+			var t = age / maxAge;
+			// Embers ride on the same per-tier embers knob that the running flame uses,
+			// so a Balanced profile that already dims live-fire embers also dims these.
+			if (t < 0.9 && age - lastEmberAt >= 110) {
+				lastEmberAt = age;
+				if (typeof perfEmbers !== "function" || perfEmbers()) {
+					spawnEmber(cx + (Math.random() * 2 - 1) * radius0 * 0.6,
+						cy + (Math.random() * 2 - 1) * radius0 * 0.4);
+				}
+			}
+			// Lava bubble pops: orange droplets that rise + fade. perfCount thins them
+			// on Balanced (0.6) and would on Low too — but Low never reaches this code.
+			if (t < 0.95 && age - lastBubbleAt >= 220) {
+				lastBubbleAt = age;
+				var n = (typeof perfCount === "function") ? perfCount(2) : 2;
+				for (var i = 0; i < n; i++) {
+					var ang = Math.random() * Math.PI * 2;
+					var r = Math.random() * radius0 * 0.85;
+					var bx = cx + Math.cos(ang) * r;
+					var by = cy + Math.sin(ang) * r;
+					var vx = (Math.random() * 2 - 1) * 0.012;
+					var vy = -(0.022 + Math.random() * 0.022);
+					var hue = 18 + Math.random() * 22;
+					var size = 1.6 + Math.random() * 2.2;
+					spawnDustParticle(bx, by, vx, vy, size, "hsl(" + hue + ", 92%, 55%)");
+				}
+			}
+		},
+		draw: function (ctx, t) {
+			var sink = t;
+			var bodyR = radius0 * (1 - 0.85 * sink);
+			if (bodyR <= 0.5) {
+				return;
+			}
+			// Surface lava ring: a quick widening ring at the moment of impact,
+			// fully gone by ~70% sink.
+			if (sink < 0.7) {
+				var ringAlpha = 0.85 * (1 - sink / 0.7);
+				ctx.save();
+				ctx.globalAlpha = ringAlpha;
+				ctx.beginPath();
+				ctx.arc(cx, cy, radius0 * (1 + 0.45 * sink), 0, 2 * Math.PI);
+				ctx.strokeStyle = "rgba(255, 130, 50, 1)";
+				ctx.lineWidth = 2.4;
+				ctx.stroke();
+				ctx.restore();
+			}
+			// Sinking disc: roll slowly, bob slightly, dim toward black as it goes under.
+			var rollDeg = angle0 + 35 * sink;
+			var bob = 3 * Math.sin(sink * Math.PI);
+			ctx.save();
+			ctx.translate(cx, cy + bob);
+			ctx.rotate(rollDeg * Math.PI / 180);
+			ctx.globalAlpha = clamp01(1 - sink * 0.85);
+			ctx.beginPath();
+			ctx.arc(0, 0, bodyR, 0, 2 * Math.PI);
+			ctx.fillStyle = color;
+			ctx.fill();
+			// Scorch overlay strengthens with the sink so the disc reads "burnt" not
+			// just "small" — pure black at low alpha multiplies the tint toward dark.
+			ctx.globalAlpha = clamp01(sink * 0.75);
+			ctx.beginPath();
+			ctx.arc(0, 0, bodyR, 0, 2 * Math.PI);
+			ctx.fillStyle = "rgba(20, 10, 4, 1)";
+			ctx.fill();
+			// Thin outline so the corpse stays legible over the lava texture.
+			ctx.globalAlpha = clamp01(1 - sink);
+			ctx.lineWidth = 1.4;
+			ctx.strokeStyle = "rgba(0, 0, 0, 0.8)";
+			ctx.stroke();
+			ctx.restore();
+			// Flame on top through the first ~80% of the sink, shrinking gently so
+			// it stays legible while the disc gets small.
+			if (sink < flameCutoff) {
+				var flameT = sink / flameCutoff;
+				var flameAlpha = 1 - flameT;
+				var flameSize = 55 * (1 - 0.4 * sink);
+				ctx.save();
+				ctx.globalAlpha = flameAlpha;
+				drawCorpseFire(cx, cy + bob, rollDeg, flameSize);
+				ctx.restore();
+			}
+		}
+	});
+}
+
 // A rising, cooling ember for a burning player (complements the flame sprite).
 function spawnEmber(x, y) {
 	var vx = (Math.random() * 2 - 1) * 0.015;
@@ -1290,17 +1428,26 @@ function updateMovementParticles(dt) {
 			}
 		}
 
-		// Moving -> terrain-aware trail. Ice leaves skate marks even at a walk;
-		// grass/sand sprinkle flecks; bare dirt only kicks up dust at speed.
+		// Moving -> terrain-aware trail. Ice glides leave skate marks; at a walk
+		// it sheds a faint shaving fleck. Grass/sand sprinkle at any pace. Bare
+		// dirt kicks up a subtle puff at a walk and a stronger one at speed.
+		// The walking-speed flecks (ice shavings + dirt puff) are AMBIENT and
+		// gated by perfExtraFx() so LOW skips them.
+		var extraFx = (typeof perfExtraFx === "function") ? perfExtraFx() : true;
 		if (speed > walkThresh && p.dustCD <= 0) {
 			var tile = tileIdAt(p.x, p.y);
 			if (tile == config.tileMap.ice.id) {
-				// Skate trails only when actually gliding fast across the ice.
+				// Same line-mark look at every pace (matches the Codex scene):
+				// two cyan blade tracks under the cart, just at a slower cadence
+				// when walking so the marks don't run continuously together.
 				if (speed > fastThresh) {
 					spawnIceTrail(p);
 					p.dustCD = cd(40);
 				} else {
-					p.dustCD = cd(60);
+					if (extraFx) {
+						spawnIceTrail(p);
+					}
+					p.dustCD = cd(120);
 				}
 			} else if (tile == config.tileMap.fast.id) {
 				// Grass dialed back ~20% (smaller flecks) — it read a touch strong.
@@ -1313,9 +1460,13 @@ function updateMovementParticles(dt) {
 				spawnTerrainParticle(p, dustColor(), 2.5, 2);
 				p.dustCD = cd(50);
 			} else {
-				// Bare dirt at a walk: nothing to emit; recheck shortly (keeps the
-				// per-frame nearest-cell lookup throttled).
-				p.dustCD = cd(60);
+				// Bare dirt at a walk: a single subtle puff at a slower cadence
+				// than the fast-speed burst. Skipped on LOW; the throttle still
+				// ticks so we don't recheck the tile every frame.
+				if (extraFx) {
+					spawnTerrainParticle(p, dustColor(), 1.5, 1);
+				}
+				p.dustCD = cd(extraFx ? 110 : 60);
 			}
 		}
 
@@ -1368,142 +1519,49 @@ function positionEmojiSlots() {
 }
 
 
+// Trail vertices stay visible for TRAIL_FADE_MS milliseconds, then they're
+// dropped off the head of the list. drawTrail (draw.js) re-strokes the
+// remaining vertices each frame with alpha scaled by age, so older bits of the
+// path naturally fade out. At the 30 Hz trail sample cadence this caps each
+// kart's vertex buffer at ~150 entries — small enough to re-stroke cheaply on
+// the main canvas, so the previous per-kart offscreen-canvas + direct-mode
+// split is gone (perfTrailDirect now no-ops; both render paths converge here).
+var TRAIL_FADE_MS = 5000;
 class Trail {
 	constructor(initialPosition) {
-		this.vertices = [];
-		this.maxLength = 100000;
-		this.canvas = null;
-		this.ctx = null;
-		this.canvasOriginX = 0;
-		this.canvasOriginY = 0;
-		this.wasNearVictory = false;
-		this.accumulatedLength = 0;
+		this.vertices = []; // each entry: { x, y, t }
 		this.lastColor = null;
-	}
-	_ensureCanvas() {
-		if (this.canvas != null || world == null) {
-			return;
-		}
-		var pad = 8;
-		this.canvas = document.createElement("canvas");
-		this.canvas.width = world.width + pad * 2;
-		this.canvas.height = world.height + pad * 2;
-		this.ctx = this.canvas.getContext("2d");
-		this.canvasOriginX = world.x - pad;
-		this.canvasOriginY = world.y - pad;
-	}
-	_applyStrokeStyle(color, dashed) {
-		this.ctx.lineWidth = dashed ? 6 : 5;
-		// shadowBlur on every trail segment is a per-frame fill cost; drop it on
-		// profiles that disable glow (the trail still reads as a solid stroke).
-		this.ctx.shadowBlur = (typeof perfGlow === "function" && !perfGlow()) ? 0 : 3;
-		this.ctx.shadowColor = "black";
-		this.ctx.strokeStyle = color;
-		this.ctx.setLineDash(dashed ? [20, 3, 3, 3, 3, 3, 3, 3] : []);
-	}
-	_redrawAll(color, dashed) {
-		this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-		var total = 0;
-		for (var i = 1; i < this.vertices.length; i++) {
-			var dx = this.vertices[i].x - this.vertices[i - 1].x;
-			var dy = this.vertices[i].y - this.vertices[i - 1].y;
-			total += Math.sqrt(dx * dx + dy * dy);
-		}
-		this.accumulatedLength = total;
-		if (this.vertices.length < 2) {
-			return;
-		}
-		this._applyStrokeStyle(color, dashed);
-		this.ctx.lineDashOffset = 0;
-		this.ctx.beginPath();
-		var v0 = this.vertices[0];
-		this.ctx.moveTo(v0.x - this.canvasOriginX, v0.y - this.canvasOriginY);
-		for (var j = 1; j < this.vertices.length; j++) {
-			var v = this.vertices[j];
-			this.ctx.lineTo(v.x - this.canvasOriginX, v.y - this.canvasOriginY);
-		}
-		this.ctx.stroke();
+		this.wasNearVictory = false;
 	}
 	update(currentPosition, player) {
-		var last = this.vertices.length > 0 ? this.vertices[this.vertices.length - 1] : null;
-		if (last != null && currentPosition.x == last.x && currentPosition.y == last.y) {
-			// Parked, so no new segment — but still repaint if the colour changed
-			// (e.g. toggling colour-blind assist while stationary), otherwise the
-			// cached strip stays two-toned until the kart next moves.
-			if (this.canvas != null && player != null && this.lastColor != null && this.lastColor !== player.color) {
-				var nvStill = player.notches == gameLength;
-				if (DEBUG_FORCE_NEAR_VICTORY && player.id == myID) {
-					nvStill = true;
-				}
-				this._redrawAll(player.color, nvStill);
-				this.wasNearVictory = nvStill;
-				this.lastColor = player.color;
-			}
-			return;
+		var now = Date.now();
+		// Expire vertices off the head before considering new ones, so the
+		// buffer stays bounded even when sat at the spawn pad.
+		while (this.vertices.length > 0 && now - this.vertices[0].t > TRAIL_FADE_MS) {
+			this.vertices.shift();
 		}
-		// Direct trail mode (low-end profile): keep only a capped recent tail and
-		// let drawTrail stroke it onto the main canvas each frame. Avoids the
-		// per-kart world-sized offscreen canvas whose every-frame mutation forces a
-		// full-texture GPU re-upload — the source of the paint stutter on weak
-		// devices. No _ensureCanvas, no incremental stroke, no growing _redrawAll.
-		if ((typeof perfTrailDirect === "function") && perfTrailDirect()) {
-			var dcap = (typeof perfTrailDirectMax === "function") ? perfTrailDirectMax() : 240;
-			while (this.vertices.length >= dcap) {
-				this.vertices.shift();
-			}
-			this.vertices.push(currentPosition);
+		var last = this.vertices.length > 0 ? this.vertices[this.vertices.length - 1] : null;
+		// Parked? Don't add a duplicate vertex — but keep tracking colour so a
+		// mid-round colour-blind toggle propagates to the next live segment.
+		if (last != null && currentPosition.x === last.x && currentPosition.y === last.y) {
 			if (player != null) {
 				this.lastColor = player.color;
 			}
 			return;
 		}
-		if (this.vertices.length > this.maxLength) {
-			this.vertices.shift();
+		this.vertices.push({ x: currentPosition.x, y: currentPosition.y, t: now });
+		if (player != null) {
+			this.lastColor = player.color;
+			var isNV = player.notches == gameLength;
+			if (DEBUG_FORCE_NEAR_VICTORY && player.id == myID) {
+				isNV = true;
+			}
+			this.wasNearVictory = isNV;
 		}
-		this.vertices.push(currentPosition);
-
-		this._ensureCanvas();
-		if (this.canvas == null || player == null) {
-			return;
-		}
-
-		var isNearVictory = player.notches == gameLength;
-		if (DEBUG_FORCE_NEAR_VICTORY && player.id == myID) {
-			isNearVictory = true;
-		}
-		// Repaint the whole strip in one colour when the near-victory style flips OR
-		// the player's colour changes mid-round (e.g. toggling colour-blind assist),
-		// so the cached canvas never ends up two-toned.
-		var colorChanged = (this.lastColor != null && this.lastColor !== player.color);
-		this.lastColor = player.color;
-		if (isNearVictory != this.wasNearVictory || colorChanged) {
-			this._redrawAll(player.color, isNearVictory);
-			this.wasNearVictory = isNearVictory;
-			return;
-		}
-		if (last == null) {
-			return;
-		}
-		var sdx = currentPosition.x - last.x;
-		var sdy = currentPosition.y - last.y;
-		var segLen = Math.sqrt(sdx * sdx + sdy * sdy);
-
-		this._applyStrokeStyle(player.color, isNearVictory);
-		this.ctx.lineDashOffset = isNearVictory ? this.accumulatedLength : 0;
-		this.ctx.beginPath();
-		this.ctx.moveTo(last.x - this.canvasOriginX, last.y - this.canvasOriginY);
-		this.ctx.lineTo(currentPosition.x - this.canvasOriginX, currentPosition.y - this.canvasOriginY);
-		this.ctx.stroke();
-
-		this.accumulatedLength += segLen;
 	}
 	reset(player) {
 		this.vertices = [];
 		this.wasNearVictory = false;
-		this.accumulatedLength = 0;
 		this.lastColor = null;
-		if (this.ctx != null) {
-			this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-		}
 	}
 }

--- a/client/scripts/perf.js
+++ b/client/scripts/perf.js
@@ -31,7 +31,8 @@ var PERF_PROFILES = {
         audience: true,          // letterbox crowd
         trailDirect: false,      // false = full per-kart offscreen trail canvas; true = stroke a capped tail straight to the main canvas (avoids re-uploading a world-sized texture/kart/frame on weak GPUs)
         mapScale: 1,             // resolution of the cached map texture (1 = full); <1 shrinks it so each re-upload on a tile change moves fewer bytes (the GPU-paint stutter on weak GPUs)
-        dprCap: 2                // device-pixel-ratio ceiling for the backing store
+        dprCap: 2,               // device-pixel-ratio ceiling for the backing store
+        extraFx: true            // walking-speed terrain flecks (ice/dirt) + lava-death sinking corpse — non-essential ambient feedback
     },
     // Tablets / small desktop windows: trim particle volume, keep the glow and
     // crowd (they read well on a mid device).
@@ -45,7 +46,8 @@ var PERF_PROFILES = {
         audience: true,
         trailDirect: false,
         mapScale: 1,
-        dprCap: 2
+        dprCap: 2,
+        extraFx: true
     },
     // Phones / low-end: shed the fill-rate-heavy work — glow passes, the crowd,
     // embers — cap effects hard, and drop the DPR a notch so the backing store
@@ -60,7 +62,8 @@ var PERF_PROFILES = {
         audience: false,
         trailDirect: true,
         mapScale: 0.6,
-        dprCap: 1.5
+        dprCap: 1.5,
+        extraFx: false           // skip walking-speed flecks and the multi-particle lava sinking animation on phone-class devices
     }
 };
 
@@ -236,6 +239,11 @@ function perfCooldown(ms) {
 // alone — they're not in the per-frame racing budget the LOW tier targets.
 function perfGlow() { return !!PERF.glow; }
 function perfEmbers() { return !!PERF.embers; }
+// Gates ambient "extra" FX whose absence isn't visible at a glance: walking-speed
+// terrain flecks (sand/ice/dirt) and the multi-particle lava-death sinking corpse.
+// Off on LOW; the always-on terrain feedback (fast-speed flecks, skate trails) is
+// not gated here so the racing read still has terrain cues even on a phone.
+function perfExtraFx() { return !!PERF.extraFx; }
 function perfTrailDirect() { return !!PERF.trailDirect; }
 function perfTrailDirectMax() { return PERF_TRAIL_DIRECT_MAX; }
 function perfMapScale() { return PERF.mapScale || 1; }

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -833,7 +833,7 @@ class Player extends Circle {
 			if (this.punchedBy == null && this.burnedBy != null) {
 				this.punchedBy = this.burnedBy;
 			}
-			this.killSelf();
+			this.killSelf("lava");
 			return;
 		}
 		if (object.id == c.tileMap.ice.id) {
@@ -904,7 +904,7 @@ class Player extends Circle {
 			this.notches -= 1;
 		}
 	}
-	killPlayer(packet) {
+	killPlayer(packet, cause) {
 		if (packet.currentState != c.stateMap.racing &&
 			packet.currentState != c.stateMap.collapsing) {
 			return;
@@ -946,10 +946,22 @@ class Player extends Circle {
 		// "killed" marks a player-caused death (punched/cut/blown into oblivion or
 		// the lava) versus an environmental/self death, so the crowd only cheers
 		// kills — not someone driving themselves into the lava.
-		messenger.messageRoomBySig(packet.roomSig, "playerDied", { id: packet.id, killed: packet.murderedBy != null });
+		// `cause` + `x`/`y` are AUTHORITATIVE: the client needs them to decide
+		// whether to spawn the sinking-corpse FX without racing the next
+		// gameUpdates packet (which is what carries the late tx/ty for a kart
+		// that crossed onto lava between server ticks). `cause` is null for
+		// non-lava deaths (gate-wall, infection-timer, AFK, bomb) so the client
+		// can also distinguish without inspecting the tile.
+		messenger.messageRoomBySig(packet.roomSig, "playerDied", {
+			id: packet.id,
+			killed: packet.murderedBy != null,
+			cause: cause || null,
+			x: packet.x,
+			y: packet.y
+		});
 	}
-	killSelf() {
-		this.killPlayer(this);
+	killSelf(cause) {
+		this.killPlayer(this, cause);
 	}
 	reset(currentState) {
 		this.alive = true;

--- a/server/game.js
+++ b/server/game.js
@@ -1882,6 +1882,12 @@ class GameBoard {
 	// and goal touches leaves notches and achievement stats byte-for-byte unchanged.
 	// type is "death" or "goal" purely to pick which feedback cue the client plays.
 	respawnInLobby(player, type) {
+		// Snapshot the pre-teleport position so the client knows WHERE the player
+		// died/scored in world coords (the teleport below overwrites player.x/y,
+		// and the next gameUpdates packet — which would otherwise be the source —
+		// carries the post-teleport spawn-pad coords).
+		var preX = player.x;
+		var preY = player.y;
 		var loc = this.getLobbySpawnLoc();
 		player.x = loc.x;
 		player.y = loc.y;
@@ -1901,7 +1907,13 @@ class GameBoard {
 		player.invulnUntil = Date.now() + c.lobbyRespawnInvulnMs;
 		player.invulnHeldInCircle = false; // re-latches once they reach the start circle
 		player.onSanctuary = true; // landed on the background spawn pad
-		messenger.messageRoomBySig(this.roomSig, "lobbyRespawn", { id: player.id, death: (type == "death"), invulnMs: c.lobbyRespawnInvulnMs });
+		messenger.messageRoomBySig(this.roomSig, "lobbyRespawn", {
+			id: player.id,
+			death: (type == "death"),
+			invulnMs: c.lobbyRespawnInvulnMs,
+			x: preX,
+			y: preY
+		});
 	}
 	// A jittered point inside the spawn pad (a background region, inherently safe).
 	// Jitter keeps several simultaneous respawns from stacking on one spot.


### PR DESCRIPTION
## Summary

- **Sinking-corpse animation on lava deaths** — when a kart dies on lava the kart shrinks/darkens/bobs under for a few seconds while still on fire, with a fading orange surface ring, ember drip, and lava bubble pops. Works for both real lava-cell deaths (race + collapse) and the lobby's lava-and-respawn teaching path.
- **Kart trails fade after 5 s** — each trail sample is timestamped and gets dropped off the head after `TRAIL_FADE_MS` (5000 ms). Drawn with a 6-bucket age-fade so older sections fade gracefully, and trail width trimmed from 5 → 3 (4 dashed). Bucketed-runs preserve the near-victory dashed pattern (continuous `lineDashOffset` across runs of the same bucket).
- **Ambient terrain polish** — ice now lays skate marks at any pace (matched the Codex scene), bare dirt picks up a subtle puff at a walk. Gated by a new `perfExtraFx()` knob: on for HIGH + BALANCED, off for LOW so phone-class devices stay smooth.

### Protocol extension (server side)

`server/entities/player.js` + `server/game.js` now include `cause` + `x`/`y` on `playerDied` and pre-teleport `x`/`y` on `lobbyRespawn`. This is what fixes the codex review's `[P2] Use authoritative death data for lava classification` finding — the client no longer races the next `gameUpdates` packet for the death tile.

### Codex review fixes applied in this branch

- [P2] Authoritative position/cause on death events — handled via the server-side extension above.
- [P2] Near-victory dashed trail continuity — `drawTrail` now batches contiguous-in-bucket segments into one `moveTo + lineTo*` run per bucket and sets `lineDashOffset` to the cumulative path length at each run start, so the dash pattern doesn't restart per 30Hz sample.

## Test plan

- [ ] Drive into lava during a race → kart visibly sinks while burning, ring + bubbles + embers; works on collapse-induced lava too.
- [ ] Drive into the lobby's lava pool → same sinking animation, then normal respawn-pad teleport with invuln flash.
- [ ] Non-lava deaths (infection-timer expiry, AFK kick, gate-wall during collapse) do NOT spawn the sinking corpse.
- [ ] Player trail fades to nothing ~5 s behind the cart; no permanent line buildup over a long round.
- [ ] Near-victory dashed style is visibly dashed (not solid) — set notches to win-1 and confirm the dash pattern reads.
- [ ] Performance toggle (High / Balanced / Low):
  - HIGH: full FX (ice walking marks, dirt walk-puff, sinking corpse).
  - BALANCED: same, with ember/bubble counts thinned via existing `perfCount`/`perfEmbers`.
  - LOW: walking-pace ice/dirt flecks skipped, sinking corpse skipped (only the existing baseline fast-speed flecks + skate trail still emit).
- [ ] Headless smoke (`node .github/scripts/smoke-test.js`) — passes locally on all 52 maps.
- [ ] `npm run build` produces all three bundles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)