### PR TITLE
chore: ignore *.local.md (local-only notes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ perf-trace.zip
 map-review-out/
 review-comment.md
 changed_maps.txt
+
+# Local-only notes / strategy docs (not committed)
+*.local.md


### PR DESCRIPTION
Adds a \`*.local.md\` glob to \`.gitignore\` so local-only notes files (e.g. \`STRATEGY.local.md\`) stay untracked across clones / worktrees.

No functional change; no CHANGELOG entry required (does not touch \`server/config.json\` / \`server/game.js\` / \`server/engine.js\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)