### PR TITLE
ci: add security/supply-chain checks (Dependabot, npm audit, CodeQL)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot keeps dependencies current and opens PRs the moment a known CVE
+# lands in something we ship. Two ecosystems:
+#   npm            — runtime + dev deps (express, socket.io, @octokit, etc.).
+#   github-actions — the `uses:` actions in .github/workflows/ (so the floating
+#                    @v4 tags get bumped/repinned as new majors ship).
+# Security updates are opened regardless of the schedule below; the weekly
+# cadence just batches routine version bumps so the PR list stays manageable.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    # Group the routine (non-security) bumps into a single PR per run so they
+    # don't drown out feature PRs. Security updates still come through on their own.
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+# Static security analysis (SAST) for the JavaScript on both sides of the wire.
+# The motivating surface: the unauthenticated `submitNewMap` socket event flows
+# user input into a GITHUB_AUTH-backed PR-creation path (utils.submitPullRequest),
+# so CodeQL's injection / taint-tracking queries are directly relevant here.
+# Runs on PRs into main, pushes to main, and a weekly schedule so newly-shipped
+# queries re-scan the existing tree.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Mondays 09:30 UTC — staggered after the dependency audit.
+    - cron: "30 9 * * 1"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze JavaScript
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for CodeQL to upload results to the Security tab.
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # security-and-quality adds maintainability queries on top of the
+          # default security set; drop to `security-extended` if it gets noisy.
+          queries: security-and-quality
+
+      # No build step: this is an interpreted JS codebase, so CodeQL extracts
+      # straight from source. (The esbuild bundles in client/scripts/dist/ are
+      # generated output and .gitignored, so there's nothing to compile here.)
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           # security-and-quality adds maintainability queries on top of the
@@ -42,6 +42,6 @@ jobs:
       # straight from source. (The esbuild bundles in client/scripts/dist/ are
       # generated output and .gitignored, so there's nothing to compile here.)
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,48 @@
+name: Dependency audit
+
+# Fails when a dependency we ship has a known high/critical vulnerability.
+# `npm audit` is currently clean — this gate keeps it that way as the deps
+# (express, socket.io, @octokit, jsonwebtoken, …) accrue CVEs over time.
+# Dependabot opens the fix PRs; this check is what makes a vulnerable tree red.
+#
+# Why a dedicated workflow (not a job in pr-validation.yml): pr-validation skips
+# map-only PRs via paths-ignore, but a vulnerability gate must run on every PR
+# and every push to main, plus a weekly sweep that catches CVEs disclosed against
+# deps we already have pinned (no code change needed to go red).
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Mondays 09:00 UTC — surfaces newly-disclosed CVEs against the current lock.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # Audit the lockfile directly — no install needed, so this stays fast and
+      # can't be perturbed by install-time scripts. --audit-level=high means
+      # moderate/low findings are reported but don't fail the build; high and
+      # critical do. Runtime deps are what ship to players, so audit those first…
+      - name: Audit production dependencies (fail on high/critical)
+        run: npm audit --omit=dev --audit-level=high
+
+      # …then surface dev-dep findings too, but advisory-only (build tooling and
+      # Playwright don't ship to players, so a dev-only CVE shouldn't block a PR).
+      - name: Audit dev dependencies (advisory)
+        if: always()
+        continue-on-error: true
+        run: npm audit --audit-level=high


### PR DESCRIPTION
Adds the security/supply-chain CI lane the repo was missing. Functional/gameplay/a11y/perf coverage was already strong; this fills the dependency + SAST gap (the unauthenticated \`submitNewMap\` → \`GITHUB_AUTH\` PR-creation surface is the motivating risk).

## What's added
- **`.github/dependabot.yml`** — weekly update PRs for `npm` + `github-actions`. Routine minor/patch bumps grouped into one PR per run; security updates open on disclosure regardless of cadence. Also keeps the floating `actions/*@v4` tags current.
- **`.github/workflows/dependency-audit.yml`** — `npm audit` gate on PR / push-to-main / weekly Monday cron (catches CVEs disclosed against already-pinned deps with no code change). Fails on **high/critical in production deps**; dev-dep findings (esbuild, Playwright) are advisory-only since they don't ship to players. Audits the lockfile directly — no install, stays fast.
- **`.github/workflows/codeql.yml`** — JS/TS SAST on PR / push / weekly, `security-and-quality` query suite, `codeql-action@v4`. No build step (interpreted JS; the esbuild bundles are generated + gitignored).

## Verification
- All three parse as valid YAML; `actionlint` clean (per Codex review).
- `npm audit --omit=dev --audit-level=high` → **0 vulnerabilities** on the current lockfile (gate is green from day one).
- Codex review: no actionable issues.

## Manual follow-ups (repo settings, not files)
- Enable **Secret scanning + push protection** (Settings → Code security).
- After merge, CodeQL's first run populates the **Security tab** automatically — advanced setup needs no separate toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)