### PR TITLE
fix(rooms): clean up a leaving player's owned entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- When a player leaves mid-round, any ability indicator, swap/explosion targeting circle, or bomb/ice projectile they were holding now vanishes with them instead of lingering as a ghost stuck to a player who's no longer there.
 
 ## v0.23.0 — 2026-05-28
 

--- a/server/entities/gameBoard.js
+++ b/server/entities/gameBoard.js
@@ -328,6 +328,14 @@ class GameBoard {
 				delete this.abilityList[id];
 				continue;
 			}
+			// Defensive: if the owning player has left the room mid-round, the ability
+			// is orphaned. Room.leave clears it via removeOwnedEntities, but never let
+			// the owner-derefs below (e.g. the SwapAimer construction) read a missing
+			// player — drop the orphan and move on.
+			if (this.playerList[this.abilityList[id].ownerId] == null) {
+				delete this.abilityList[id];
+				continue;
+			}
 			if (this.abilityList[id].swap) {
 				this.abilityList[id].swap = false;
 				var aimer = new SwapAimer(this.playerList[this.abilityList[id].ownerId].x, this.playerList[this.abilityList[id].ownerId].y, c.tileMap.abilities.swap.startSize, "red", this.abilityList[id].ownerId, this.roomSig);
@@ -1359,6 +1367,42 @@ class GameBoard {
 		player.x = -100;
 		player.y = -100;
 		this.tempSpectatorList[player.id] = player;
+	}
+	// Drop every entity owned by a player who is leaving the room, so the per-tick
+	// update loops and the compressor stop touching ghosts whose owner is no longer
+	// in playerList (an owner-deref like the SwapAimer construction in checkAbilities
+	// would otherwise read `undefined`). aimerList / abilityList / tempSpectatorList
+	// are keyed by owner id; projectileList is mixed-keyed (bombs/snowflakes by owner
+	// id, but brutal-round clouds by hash and the hockey puck by roomSig), so
+	// projectiles are matched on ownerId rather than key — which leaves the
+	// clouds/puck (owned by a hash/roomSig, never a client id) correctly untouched.
+	//
+	// Clients build their own projectileList/aimerList from spawn events and only
+	// prune them on terminateProj/terminateAimer (gameUpdates never removes missing
+	// entries), so emit the matching terminate BEFORE the server-side delete or the
+	// ghost stays rendered until the next reset. Both lists are keyed client-side by
+	// ownerId, which for a player-owned entity equals the leaving id. (The player's
+	// ability indicator hangs off playerList[id].ability and is already cleared by
+	// the playerLeft handler.)
+	removeOwnedEntities(clientID) {
+		var aimer = this.aimerList[clientID];
+		if (aimer != null) {
+			// SwapAimer arms a setInterval (this.index); clear it so the orphaned
+			// aimer doesn't keep a live closure (and itself) alive after we drop it.
+			if (aimer.index != null) {
+				clearInterval(aimer.index);
+			}
+			messenger.messageRoomBySig(this.roomSig, "terminateAimer", clientID);
+			delete this.aimerList[clientID];
+		}
+		delete this.abilityList[clientID];
+		delete this.tempSpectatorList[clientID];
+		for (var projID in this.projectileList) {
+			if (this.projectileList[projID].ownerId == clientID) {
+				messenger.messageRoomBySig(this.roomSig, "terminateProj", projID);
+				delete this.projectileList[projID];
+			}
+		}
 	}
 	resetProjectiles() {
 		messenger.messageRoomBySig(this.roomSig, "resetProjectiles", null);

--- a/server/game.js
+++ b/server/game.js
@@ -64,6 +64,10 @@ class Room {
 		client.leave(String(this.sig));
 		delete this.clientList[clientID];
 		delete this.playerList[clientID];
+		// Remove anything this player owned (aimer/ability/projectile/temp-spectator
+		// entry) so the per-tick loops and compressor don't keep iterating and
+		// emitting orphans whose ownerId now points at a player that's gone.
+		this.game.gameBoard.removeOwnedEntities(clientID);
 		this.clientCount--;
 	}
 	update(dt) {


### PR DESCRIPTION
## Problem

`Room.leave(clientID)` deleted the player from `clientList`/`playerList` but left behind every entry that player *owned* in `aimerList` / `abilityList` / `projectileList` / `tempSpectatorList`, with `ownerId` now pointing at a player that no longer exists. The per-tick update loops kept iterating those orphans, the compressor kept emitting them, and the `SwapAimer`-construction owner-deref in `checkAbilities` could read `undefined`. `tempSpectatorList` was also only emptied at `resetPlayers`, so a departed spectator's `Player` ref lingered between a leave and the next round reset.

Pre-existing, but **late-join-spectate makes it hit much more often**: a stranger can briefly hold an ability picked up via the brutal ability round, then leave — orphaning it mid-round.

## Fix

- New `GameBoard.removeOwnedEntities(clientID)`, called from `Room.leave`:
  - Drops the owner-keyed `aimerList` / `abilityList` / `tempSpectatorList` entries.
  - Removes any `projectileList` entry whose `ownerId` matches. `projectileList` is **mixed-keyed** (bombs/snowflakes by owner id, brutal-round clouds by a hash, the hockey puck by `roomSig`), so matching on `ownerId` rather than key correctly leaves the foreign-owned clouds/puck untouched.
  - Emits `terminateAimer` / `terminateProj` **before** each server-side delete — clients build their own `aimerList`/`projectileList` from spawn events and only prune on those terminate events (`gameUpdates` never removes missing entries), so a server-only delete would leave the ghost rendered until the next reset. (The ability indicator hangs off `playerList[id].ability` and is already cleared by the existing `playerLeft` handler.)
  - Clears the `SwapAimer`'s `setInterval` so the orphan doesn't leak a live closure.
- Defensive guard in `checkAbilities`: an ability whose owner is no longer in `playerList` is dropped instead of dereferencing a missing player.

## Verification

- Headless test against the **real engine**: forced a race, gave one player an ability + swap aimer + bomb projectile + temp-spectator entry (plus a foreign cloud and puck), called `room.leave`, and asserted: all owned entries removed; foreign cloud/puck survived; `terminateAimer`/`terminateProj` emitted **only** for the leaving owner; 60 follow-up ticks don't throw; compressor never emits the departed owner. Separately injected an owner-less ability and confirmed the defensive guard drops it without crashing.
- **Negative control:** with the cleanup call disabled, the same test fails exactly the orphan checks — proving it's not vacuous.
- Existing `.github/scripts/smoke-test.js` passes (Session A full-stack + Session B all 52 maps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)