### PR TITLE
fix(camera): stop auto-camera jerk at spawn gate near goal

### DIFF
--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -800,7 +800,9 @@ function computeFocusedView() {
     var wholeMap = { cx: LOGICAL_WIDTH / 2, cy: LOGICAL_HEIGHT / 2, scale: 1 };
     var pts = focusWorldPoints();
     if (pts.length === 0) {
-        // Nobody local alive to follow -> whole map (watch the action).
+        // Nobody local alive to follow -> whole map (watch the action). Drop the
+        // goal latch so it can't carry stale engagement into the next round/map.
+        worldGoalEngaged = false;
         return wholeMap;
     }
     var halfX = LOGICAL_WIDTH / (2 * WORLD_ZOOM_MAX);
@@ -823,7 +825,18 @@ function computeFocusedView() {
             if (d < nd) { nd = d; ng = goals[g]; }
         }
     }
-    if (ng && nd <= WORLD_ZOOM_ENGAGE) {
+    // Hysteresis: engage the goal framing once within ENGAGE, but don't let go
+    // until clearly past RELEASE. Otherwise a player drifting at the ENGAGE edge
+    // (e.g. circling the spawn gate beside the goal) flips the framing every few
+    // frames, which the gate-countdown ramp follows directly (a=1) and jerks.
+    if (!ng) {
+        worldGoalEngaged = false;
+    } else if (worldGoalEngaged) {
+        if (nd > WORLD_ZOOM_RELEASE) { worldGoalEngaged = false; }
+    } else if (nd <= WORLD_ZOOM_ENGAGE) {
+        worldGoalEngaged = true;
+    }
+    if (ng && worldGoalEngaged) {
         minX = Math.min(minX, ng.x - WORLD_ZOOM_PAD);
         maxX = Math.max(maxX, ng.x + WORLD_ZOOM_PAD);
         minY = Math.min(minY, ng.y - WORLD_ZOOM_PAD);
@@ -845,6 +858,7 @@ function computeWorldViewTarget(dt) {
     var wholeMap = { cx: LOGICAL_WIDTH / 2, cy: LOGICAL_HEIGHT / 2, scale: 1 };
     if (!cameraZoomEnabled || myPlayer == null || typeof world === "undefined" || world == null) {
         worldViewFocusedElapsed = 0;
+        worldGoalEngaged = false;
         return wholeMap;
     }
     // Focus once the round is live (gate countdown + race); plus the LOBBY on
@@ -860,6 +874,7 @@ function computeWorldViewTarget(dt) {
         inLobbyTouch);
     if (!focused) {
         worldViewFocusedElapsed = 0;
+        worldGoalEngaged = false;
         return wholeMap;
     }
     // Advance the focus-phase clock by the (already-clamped) frame dt rather than

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -42,8 +42,13 @@ var server = null,
     // palette. Persisted in localStorage (see the #colorblindControl wiring).
     colorblindEnabled = false,
     worldViewFocusedElapsed = 0,  // ms accumulated in the focus phase (frame-dt based, not wall-clock)
+    // Latched goal-engage state, so the framing can't flap when a player skims the
+    // edge of WORLD_ZOOM_ENGAGE (e.g. drifting around the spawn gate next to the
+    // goal). Engage at ENGAGE, only release past RELEASE — hysteresis kills the jerk.
+    worldGoalEngaged = false,
     WORLD_ZOOM_MAX = 1.8,      // tightest focus on the player while racing (shows some surroundings)
     WORLD_ZOOM_ENGAGE = 460,   // world-units: nearest goal pulls into frame within this
+    WORLD_ZOOM_RELEASE = 620,  // world-units: once engaged, only let go of the goal past this (hysteresis band)
     WORLD_ZOOM_PAD = 120,      // world-units padding around framed points
     WORLD_ZOOM_TAU = 620,      // smoothing time-constant (ms); higher = slower, gentler glide
     WORLD_ZOOM_HOLD_MS = 1100, // hold the whole-map view this long when a round starts, before easing in


### PR DESCRIPTION
## What

The auto-camera "pull the goal into frame" logic used a hard 460-unit threshold (`WORLD_ZOOM_ENGAGE`), recomputed every frame in `computeFocusedView()`. Drifting around the spawn gate right at that edge flips the goal in/out of range frame-to-frame, so the camera framing flaps. During the gate countdown the camera follows its target directly (`a = 1`, no smoothing), so the flapping shows up as a visible jerk.

## Fix

Add hysteresis via a latched `worldGoalEngaged` flag:
- **Engage** the goal framing once within `WORLD_ZOOM_ENGAGE` (460 units).
- **Release** only once clearly past the new `WORLD_ZOOM_RELEASE` (620 units).

Between the two thresholds the state is held, so skimming the edge no longer toggles the framing.

The latch is reset on every whole-map / camera-off / no-focus early-return path (`computeWorldViewTarget` disabled/no-player/no-world, not-focused, and `computeFocusedView` no-live-players) so it can't carry stale engagement into the next round or map.

## Testing

- `npm run build` + `.github/scripts/smoke-test.js` pass (engine ticked all 52 maps clean).
- Manually playtested locally: drifting around the spawn gate beside a goal no longer jerks the camera.

Client-only camera/rendering change — `server/{config.json,game.js,engine.js}` untouched, so no CHANGELOG entry required (UI-exempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)