### PR TITLE
fix(maps): always validate a walkable path to the goal from the start

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -625,15 +625,20 @@ exports.validateMap = function (vMap, config) {
         if (!startEdgeCheck.valid) {
             return startEdgeCheck;
         }
-        // Every start edge must have a goal reachable from it, or that side's
-        // racers can never finish (most likely on an opposite-edge combo with an
-        // off-center / walled-off goal). Server-only — the cell graph isn't in the
-        // editor bundle, so the editor surfaces this via the preview/submit
-        // rejection rather than inline.
-        for (var se = 0; se < vMap.startEdges.length; se++) {
-            if (!cellGraph.reachableFromEdge(vMap, vMap.startEdges[se])) {
-                return { valid: false, reason: "No goal is reachable from the " + vMap.startEdges[se] + " start." };
-            }
+    }
+    // Every (effective) start edge must have a goal reachable from it, or that
+    // side's racers can never finish (most likely on an opposite-edge combo with
+    // an off-center / walled-off goal). When startEdges is absent the map still
+    // starts somewhere at runtime — gameBoard.resolveStartEdges defaults to the
+    // left gate — so the default must be checked too, mirroring the same
+    // resolution computeMapParTime uses; otherwise a goal walled off from the
+    // left start slips through validation and leaves the map uncompletable.
+    // Server-only — the cell graph isn't in the editor bundle, so the editor
+    // surfaces this via the preview/submit rejection rather than inline.
+    var effectiveStartEdges = (Array.isArray(vMap.startEdges) && vMap.startEdges.length > 0) ? vMap.startEdges : ["left"];
+    for (var se = 0; se < effectiveStartEdges.length; se++) {
+        if (!cellGraph.reachableFromEdge(vMap, effectiveStartEdges[se])) {
+            return { valid: false, reason: "No goal is reachable from the " + effectiveStartEdges[se] + " start." };
         }
     }
     return { valid: true };


### PR DESCRIPTION
## Problem

`validateMap` only ran the goal-reachability check (`cellGraph.reachableFromEdge`) when a map **explicitly set `startEdges`**. Maps without `startEdges` — the legacy default *and* the map editor's default — skipped it entirely, yet still launch from the **left gate** at runtime (`gameBoard.resolveStartEdges` defaults to `["left"]`).

The result: a map whose goal is walled off by lava from the left start could pass validation and ship **uncompletable**.

## Fix

Resolve the *effective* start edges (defaulting to `["left"]` when absent — the same resolution `computeMapParTime` already uses) and run `reachableFromEdge` over those. Because `validateMap` is the single source of truth, this closes the gap in three places at once:

- **Before submission** — the editor's `submitNewMap` handler calls `validateMap` *before* any PR is created, so an uncompletable map is rejected in the editor with `"No goal is reachable from the left start."`
- **CI** — `validate-content.js` runs `validateMap` over every committed map on each PR.
- The deep `validate-submitted-map.js` check already did this for the default edge, so all layers are now consistent.

## Verification

- **Blast radius:** all **52** committed maps still pass `validate-content.js` (zero regressions).
- **Adversarial:** an all-lava-except-one-goal map is now rejected with `"No goal is reachable from the left start."` — previously it passed because `startEdges` was absent.
- `npm run build`, `smoke-test.js`, and `validate-content.js` all green.
- Codex review: no issues found.

No CHANGELOG entry: the change is in `server/utils.js` (validation/editor hardening), exempt from the release-notes-check rule (only `config.json`/`game.js`/`engine.js` trigger it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)