### PR TITLE
Cart skins (first pass): Five-Alarm fire truck + dinosaur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- New cart skins! Equip a Five-Alarm fire truck or a dinosaur in the skin shop — each has its own animated wheels/legs and a custom fiery or earthy trail, layered on top of your usual color.
 
 ## v0.25.0 — 2026-05-28
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -126,6 +126,19 @@ function registerLobbyHubHandlers(server) {
 			preloadAvatarImage(p.avatarUrl);
 		}
 	});
+	// A player equipped/cleared a cosmetic cart skin (room broadcast — like color,
+	// cartSkin isn't in the per-tick updates, only the spawn packet). Independent of
+	// color/avatar, so we touch nothing else here.
+	server.on("playerCartSkinChanged", function (payload) {
+		if (payload == null) {
+			return;
+		}
+		var p = playerList[payload.id];
+		if (p == null) {
+			return;
+		}
+		p.cartSkin = payload.cartSkin || null;
+	});
 	// The primary's skin request was rejected (color taken). Flash the picker.
 	server.on("skinRejected", function (payload) {
 		if (typeof flagSkinRejected === "function") {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -420,8 +420,11 @@ function getCartHeading(player) {
     if (vx * vx + vy * vy > 0.01) {
         return Math.atan2(vy, vx);
     }
-    if (typeof player.angle === "number" && player.angle !== 0) {
-        return player.angle;
+    if (typeof player.angle === "number") {
+        // player.angle is in DEGREES on the client (cf. drawFire / aimers), but the
+        // velocity branch above returns radians — convert so an idle skinned kart
+        // faces its heading. 0° (due east) is a valid heading, not "missing".
+        return player.angle * Math.PI / 180;
     }
     return -Math.PI / 2; // default: face up
 }
@@ -2178,7 +2181,7 @@ function drawMapTitle() {
 // dino leg cycle). Advanced once per frame in drawPlayers, NOT per player.
 var cartSkinAnimTime = 0;
 function drawPlayers(dt) {
-    cartSkinAnimTime += dt || 0;
+    cartSkinAnimTime += (dt || 0) / 1000; // dt is milliseconds; this accumulator is seconds
     // Draw remote players first, then ALL local players (the primary plus any
     // couch co-op slots) on top — so your own karts always read clearly over
     // other players' floating emojis and name labels.

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -383,6 +383,37 @@ function getBlackoutHoleSprite() {
 // the player's heading and scaled so the cart radius == 1.0; "forward" (travel
 // direction) is +X. Each painter draws in that normalized space. Callers pass the
 // already-camera-adjusted screen center, so the camera offset is never double-applied.
+// Resolve any CSS colour (palette name/hex/colour-blind remap) to {r,g,b} by
+// painting one pixel and reading it back — works for ANY colour without parsing.
+// Cached; the palette is ~22 colours so this stays tiny.
+var _cartSkinRGB = {};
+function cartSkinRGB(color) {
+    if (_cartSkinRGB[color] != null) {
+        return _cartSkinRGB[color];
+    }
+    var c = document.createElement("canvas");
+    c.width = c.height = 1;
+    var cx = c.getContext("2d");
+    cx.fillStyle = "#000";   // fallback if `color` is invalid
+    cx.fillStyle = color;
+    cx.fillRect(0, 0, 1, 1);
+    var d = cx.getImageData(0, 0, 1, 1).data;
+    var rgb = { r: d[0], g: d[1], b: d[2] };
+    _cartSkinRGB[color] = rgb;
+    return rgb;
+}
+// Lighten (amt>0, toward white) / darken (amt<0, toward black) a colour by a 0..1
+// fraction, so one picked colour fans out into body/outline/leg shades.
+function cartSkinShade(color, amt) {
+    var c = cartSkinRGB(color);
+    var t = amt < 0 ? 0 : 255;
+    var f = amt < 0 ? -amt : amt;
+    return "rgb(" +
+        Math.round(c.r + (t - c.r) * f) + "," +
+        Math.round(c.g + (t - c.g) * f) + "," +
+        Math.round(c.b + (t - c.b) * f) + ")";
+}
+
 function getCartHeading(player) {
     var vx = player.velX || 0;
     var vy = player.velY || 0;
@@ -411,7 +442,7 @@ function drawCartSkin(player, centerX, centerY, radius, painter) {
     ctx.translate(centerX, centerY);
     ctx.rotate(heading);
     ctx.scale(radius, radius);
-    painter(ctx, anim, speed);
+    painter(ctx, anim, (player && player.color) ? player.color : null);
     ctx.restore();
 }
 
@@ -431,9 +462,11 @@ function cartRoundRectPath(ctx, x, y, w, h, r) {
     ctx.closePath();
 }
 
-function drawFiretruckSkin(ctx, anim) {
-    // Normalized space (radius == 1), forward == +X. Five-Alarm monster truck:
-    // red body, white "5" badge, ladder, big wheels with spinning spokes.
+function drawFiretruckSkin(ctx, anim, paint) {
+    // Normalized space (radius == 1), forward == +X. Five-Alarm monster truck,
+    // painted in the player's chosen cart colour (tinted body + darker outline),
+    // white "5" badge, ladder, big wheels with spinning spokes.
+    paint = paint || "#d11f1f";
     var wheelR = 0.42;
     var wheels = [
         [0.5, 0.72],
@@ -465,9 +498,9 @@ function drawFiretruckSkin(ctx, anim) {
         ctx.restore();
     }
 
-    // Body.
-    ctx.fillStyle = "#d11f1f";
-    ctx.strokeStyle = "#7a0d0d";
+    // Body (player colour) with a darker outline of the same hue.
+    ctx.fillStyle = cartSkinShade(paint, -0.05);
+    ctx.strokeStyle = cartSkinShade(paint, -0.45);
     ctx.lineWidth = 0.07;
     cartRoundRectPath(ctx, -0.78, -0.52, 1.56, 1.04, 0.18);
     ctx.fill();
@@ -500,7 +533,7 @@ function drawFiretruckSkin(ctx, anim) {
     ctx.beginPath();
     ctx.arc(-0.32, 0, 0.2, 0, Math.PI * 2);
     ctx.fill();
-    ctx.fillStyle = "#d11f1f";
+    ctx.fillStyle = cartSkinShade(paint, -0.05);
     ctx.save();
     ctx.font = "0.3px sans-serif";
     ctx.textAlign = "center";
@@ -510,12 +543,14 @@ function drawFiretruckSkin(ctx, anim) {
     ctx.restore();
 }
 
-function drawDinoSkin(ctx, anim) {
-    // Top-down dino: body, head toward +X, tail toward -X, four cycling legs.
+function drawDinoSkin(ctx, anim, paint) {
+    // Top-down dino painted in the player's chosen cart colour (tinted body/limbs,
+    // darker legs + spine of the same hue). Head toward +X, tail toward -X.
+    paint = paint || "#43b047";
     var legSwing = Math.sin(anim * 4) * 0.22;
 
     // Legs (under body).
-    ctx.fillStyle = "#2f7d32";
+    ctx.fillStyle = cartSkinShade(paint, -0.35);
     var legs = [
         [0.28, 0.55, legSwing],
         [-0.3, 0.55, -legSwing],
@@ -529,7 +564,7 @@ function drawDinoSkin(ctx, anim) {
     }
 
     // Tail.
-    ctx.fillStyle = "#3a9d3e";
+    ctx.fillStyle = cartSkinShade(paint, -0.12);
     ctx.beginPath();
     ctx.moveTo(-0.55, -0.18);
     ctx.lineTo(-1.0, 0);
@@ -538,8 +573,8 @@ function drawDinoSkin(ctx, anim) {
     ctx.fill();
 
     // Body.
-    ctx.fillStyle = "#43b047";
-    ctx.strokeStyle = "#236626";
+    ctx.fillStyle = paint;
+    ctx.strokeStyle = cartSkinShade(paint, -0.45);
     ctx.lineWidth = 0.06;
     ctx.beginPath();
     ctx.ellipse(-0.05, 0, 0.6, 0.45, 0, 0, Math.PI * 2);
@@ -547,7 +582,7 @@ function drawDinoSkin(ctx, anim) {
     ctx.stroke();
 
     // Spine plates.
-    ctx.fillStyle = "#2f7d32";
+    ctx.fillStyle = cartSkinShade(paint, -0.35);
     for (var p = 0; p < 3; p++) {
         var px = -0.3 + p * 0.28;
         ctx.beginPath();
@@ -559,8 +594,8 @@ function drawDinoSkin(ctx, anim) {
     }
 
     // Head.
-    ctx.fillStyle = "#43b047";
-    ctx.strokeStyle = "#236626";
+    ctx.fillStyle = paint;
+    ctx.strokeStyle = cartSkinShade(paint, -0.45);
     ctx.beginPath();
     ctx.ellipse(0.62, 0, 0.3, 0.26, 0, 0, Math.PI * 2);
     ctx.fill();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -377,6 +377,205 @@ function getBlackoutHoleSprite() {
     blackoutHoleSprite = canvas;
     return canvas;
 }
+
+// ---- Cart skins (procedural overlay, drawn on top of the colored cart) ----
+// drawCartSkin builds a local coordinate space centered on the cart, rotated to
+// the player's heading and scaled so the cart radius == 1.0; "forward" (travel
+// direction) is +X. Each painter draws in that normalized space. Callers pass the
+// already-camera-adjusted screen center, so the camera offset is never double-applied.
+function getCartHeading(player) {
+    var vx = player.velX || 0;
+    var vy = player.velY || 0;
+    if (vx * vx + vy * vy > 0.01) {
+        return Math.atan2(vy, vx);
+    }
+    if (typeof player.angle === "number" && player.angle !== 0) {
+        return player.angle;
+    }
+    return -Math.PI / 2; // default: face up
+}
+
+function getCartSpeed(player) {
+    var vx = player.velX || 0;
+    var vy = player.velY || 0;
+    return Math.sqrt(vx * vx + vy * vy);
+}
+
+function drawCartSkin(player, centerX, centerY, radius, painter) {
+    var ctx = gameContext;
+    var heading = getCartHeading(player);
+    var speed = getCartSpeed(player);
+    // Animation runs faster while moving, but always ticks a little when idle.
+    var anim = cartSkinAnimTime * (0.6 + Math.min(speed, 6) * 0.5);
+    ctx.save();
+    ctx.translate(centerX, centerY);
+    ctx.rotate(heading);
+    ctx.scale(radius, radius);
+    painter(ctx, anim, speed);
+    ctx.restore();
+}
+
+// Rounded-rect path helper (CanvasRenderingContext2D.roundRect isn't available on
+// every target we support).
+function cartRoundRectPath(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + w - r, y);
+    ctx.arcTo(x + w, y, x + w, y + r, r);
+    ctx.lineTo(x + w, y + h - r);
+    ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+    ctx.lineTo(x + r, y + h);
+    ctx.arcTo(x, y + h, x, y + h - r, r);
+    ctx.lineTo(x, y + r);
+    ctx.arcTo(x, y, x + r, y, r);
+    ctx.closePath();
+}
+
+function drawFiretruckSkin(ctx, anim) {
+    // Normalized space (radius == 1), forward == +X. Five-Alarm monster truck:
+    // red body, white "5" badge, ladder, big wheels with spinning spokes.
+    var wheelR = 0.42;
+    var wheels = [
+        [0.5, 0.72],
+        [0.5, -0.72],
+        [-0.5, 0.72],
+        [-0.5, -0.72],
+    ];
+    for (var i = 0; i < wheels.length; i++) {
+        ctx.save();
+        ctx.translate(wheels[i][0], wheels[i][1]);
+        ctx.beginPath();
+        ctx.arc(0, 0, wheelR, 0, Math.PI * 2);
+        ctx.fillStyle = "#1a1a1a";
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc(0, 0, wheelR * 0.45, 0, Math.PI * 2);
+        ctx.fillStyle = "#cfcfcf";
+        ctx.fill();
+        ctx.rotate(anim * 3); // spinning spokes
+        ctx.strokeStyle = "#555";
+        ctx.lineWidth = 0.06;
+        for (var s = 0; s < 4; s++) {
+            var a = (s * Math.PI) / 2;
+            ctx.beginPath();
+            ctx.moveTo(0, 0);
+            ctx.lineTo(Math.cos(a) * wheelR * 0.85, Math.sin(a) * wheelR * 0.85);
+            ctx.stroke();
+        }
+        ctx.restore();
+    }
+
+    // Body.
+    ctx.fillStyle = "#d11f1f";
+    ctx.strokeStyle = "#7a0d0d";
+    ctx.lineWidth = 0.07;
+    cartRoundRectPath(ctx, -0.78, -0.52, 1.56, 1.04, 0.18);
+    ctx.fill();
+    ctx.stroke();
+
+    // Cab window (front, toward +X).
+    ctx.fillStyle = "#bfe6ff";
+    cartRoundRectPath(ctx, 0.28, -0.34, 0.4, 0.68, 0.08);
+    ctx.fill();
+
+    // Ladder rails + rungs.
+    ctx.strokeStyle = "#e8e8e8";
+    ctx.lineWidth = 0.05;
+    ctx.beginPath();
+    ctx.moveTo(-0.55, -0.18);
+    ctx.lineTo(0.15, -0.18);
+    ctx.moveTo(-0.55, 0.18);
+    ctx.lineTo(0.15, 0.18);
+    ctx.stroke();
+    for (var r = 0; r < 4; r++) {
+        var lx = -0.5 + r * 0.18;
+        ctx.beginPath();
+        ctx.moveTo(lx, -0.18);
+        ctx.lineTo(lx, 0.18);
+        ctx.stroke();
+    }
+
+    // White "5" badge.
+    ctx.fillStyle = "#ffffff";
+    ctx.beginPath();
+    ctx.arc(-0.32, 0, 0.2, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = "#d11f1f";
+    ctx.save();
+    ctx.font = "0.3px sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.translate(-0.32, 0);
+    ctx.fillText("5", 0, 0.02);
+    ctx.restore();
+}
+
+function drawDinoSkin(ctx, anim) {
+    // Top-down dino: body, head toward +X, tail toward -X, four cycling legs.
+    var legSwing = Math.sin(anim * 4) * 0.22;
+
+    // Legs (under body).
+    ctx.fillStyle = "#2f7d32";
+    var legs = [
+        [0.28, 0.55, legSwing],
+        [-0.3, 0.55, -legSwing],
+        [0.28, -0.55, -legSwing],
+        [-0.3, -0.55, legSwing],
+    ];
+    for (var i = 0; i < legs.length; i++) {
+        ctx.beginPath();
+        ctx.ellipse(legs[i][0] + legs[i][2], legs[i][1], 0.16, 0.1, 0, 0, Math.PI * 2);
+        ctx.fill();
+    }
+
+    // Tail.
+    ctx.fillStyle = "#3a9d3e";
+    ctx.beginPath();
+    ctx.moveTo(-0.55, -0.18);
+    ctx.lineTo(-1.0, 0);
+    ctx.lineTo(-0.55, 0.18);
+    ctx.closePath();
+    ctx.fill();
+
+    // Body.
+    ctx.fillStyle = "#43b047";
+    ctx.strokeStyle = "#236626";
+    ctx.lineWidth = 0.06;
+    ctx.beginPath();
+    ctx.ellipse(-0.05, 0, 0.6, 0.45, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+
+    // Spine plates.
+    ctx.fillStyle = "#2f7d32";
+    for (var p = 0; p < 3; p++) {
+        var px = -0.3 + p * 0.28;
+        ctx.beginPath();
+        ctx.moveTo(px - 0.1, 0);
+        ctx.lineTo(px, -0.22);
+        ctx.lineTo(px + 0.1, 0);
+        ctx.closePath();
+        ctx.fill();
+    }
+
+    // Head.
+    ctx.fillStyle = "#43b047";
+    ctx.strokeStyle = "#236626";
+    ctx.beginPath();
+    ctx.ellipse(0.62, 0, 0.3, 0.26, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+
+    // Eye.
+    ctx.fillStyle = "#ffffff";
+    ctx.beginPath();
+    ctx.arc(0.72, -0.12, 0.07, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = "#111";
+    ctx.beginPath();
+    ctx.arc(0.74, -0.12, 0.035, 0, Math.PI * 2);
+    ctx.fill();
+}
 function getPlayerSprite(color, radius, strokeColor) {
     var key = color + '|' + radius + '|' + strokeColor;
     var cached = playerSpriteCache[key];
@@ -1940,7 +2139,11 @@ function drawMapTitle() {
     }
 }
 
+// Accumulated time (seconds) driving cart-skin animation (fire-truck wheel spin,
+// dino leg cycle). Advanced once per frame in drawPlayers, NOT per player.
+var cartSkinAnimTime = 0;
 function drawPlayers(dt) {
+    cartSkinAnimTime += dt || 0;
     // Draw remote players first, then ALL local players (the primary plus any
     // couch co-op slots) on top — so your own karts always read clearly over
     // other players' floating emojis and name labels.
@@ -2091,6 +2294,15 @@ function drawPlayer(player, dt) {
         // INSIDE the dim/immune alpha scope so it fades/flashes with the kart body
         // (non-local karts dim during a race; immune karts pulse) instead of popping.
         drawAvatarSkin(player, sprite);
+        // Cosmetic cart skin (procedural overlay), drawn on top of the base sprite
+        // (and avatar) so it reads as an equipped skin. Uses the SAME screen anchor
+        // as the sprite blit above (player.x/y + camera offset), so the camera
+        // offset is applied exactly once.
+        if (player.cartSkin === "firetruck") {
+            drawCartSkin(player, player.x + camera.getCameraX(), player.y + camera.getCameraY(), player.radius, drawFiretruckSkin);
+        } else if (player.cartSkin === "dino") {
+            drawCartSkin(player, player.x + camera.getCameraX(), player.y + camera.getCameraY(), player.radius, drawDinoSkin);
+        }
     } finally {
         if (dimKart) {
             gameContext.restore();
@@ -2786,7 +2998,16 @@ function drawTrail(player) {
     gameContext.lineWidth = dashed ? 4 : 3;
     gameContext.lineCap = "round";
     gameContext.lineJoin = "round";
-    gameContext.strokeStyle = player.color;
+    // Skin-aware trail: an equipped cart skin overrides the kart colour with a themed
+    // hue (fiery for the fire truck, earthy green for the dino). Alpha/fade-bucket and
+    // dashed-near-victory styling below are untouched — only the stroke colour changes.
+    var trailColor = player.color;
+    if (player.cartSkin === "firetruck") {
+        trailColor = "#ff5a1f";
+    } else if (player.cartSkin === "dino") {
+        trailColor = "#4caf3a";
+    }
+    gameContext.strokeStyle = trailColor;
     if (typeof perfGlow === "function" && perfGlow()) {
         gameContext.shadowBlur = 3;
         gameContext.shadowColor = "black";

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -248,6 +248,7 @@ function createPlayer(dataArray) {
 	playerList[index].name = dataArray[10] || null;   // AI racer identity (humans: null)
 	playerList[index].title = dataArray[11] || null;
 	playerList[index].avatarUrl = dataArray[12] || null;   // opt-in avatar skin (else null = colour skin)
+	playerList[index].cartSkin = dataArray[13] || null;    // cosmetic cart skin overlay (firetruck/dino), else null
 	playerList[index].deathMessage = null;
 	playerList[index].trail = new Trail({ x: dataArray[1], y: dataArray[2] });
 	playerList[index].fizzle = function () {

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -138,15 +138,79 @@ function stationPanelNav(lp, dx, dy) {
         return;
     }
     if (lp.stationPanel.kind === "skin") {
-        var count = skinOptionCount(lp);
-        if (!count) {
+        skinPanelNav(lp, dx, dy);
+    }
+}
+
+// Keyboard/gamepad nav over the skin panel's flat option space: the swatch+avatar
+// grid (SKIN_COLS wide) occupies [0, base-1], then the cart-skin row occupies
+// [base, base+cartN-1]. This keeps the cart cells reachable by pad/keyboard, not
+// just by pointer.
+function skinPanelNav(lp, dx, dy) {
+    var sp = lp.stationPanel;
+    var base = skinOptionCount(lp);
+    if (!base) { return; }
+    var cartN = CART_SKIN_OPTIONS.length;
+    var cols = SKIN_COLS;
+    var cur = sp.cursor || 0;
+    var maxRow = Math.floor((base - 1) / cols);
+
+    if (cur >= base) {
+        // Cursor is in the cart-skin row.
+        var cidx = cur - base;
+        if (dx !== 0) {
+            cidx += dx;
+            if (cidx < 0) { cidx = cartN - 1; }
+            if (cidx >= cartN) { cidx = 0; }
+        }
+        if (dy < 0) {
+            var up = maxRow * cols + cidx;        // back up into the grid's last row
+            sp.cursor = (up >= base) ? base - 1 : up;
             return;
         }
-        var i = lp.stationPanel.cursor || 0;
-        i += dx + dy * SKIN_COLS;
-        if (i < 0) { i = 0; }
-        if (i > count - 1) { i = count - 1; }
-        lp.stationPanel.cursor = i;
+        sp.cursor = base + cidx;                  // down keeps us in the (bottom) cart row
+        return;
+    }
+
+    // Cursor is in the swatch/avatar grid.
+    var row = Math.floor(cur / cols);
+    var col = cur % cols;
+    if (dx !== 0) {
+        col += dx;
+        if (col < 0) { col = cols - 1; }
+        if (col >= cols) { col = 0; }
+    }
+    if (dy > 0 && row === maxRow) {
+        sp.cursor = base + Math.min(col, cartN - 1); // drop into the cart row
+        return;
+    }
+    if (dy !== 0) {
+        row += dy;
+        if (row < 0) { row = 0; }
+        if (row > maxRow) { row = maxRow; }
+    }
+    var idx = row * cols + col;
+    if (idx >= base) { idx = base - 1; }         // last grid row may be partially filled
+    sp.cursor = idx;
+}
+
+// Commit the cell under the cursor: colour swatch, avatar, or cart skin.
+function skinPanelConfirm(lp) {
+    var sp = lp.stationPanel;
+    var base = skinOptionCount(lp);
+    var cur = sp.cursor || 0;
+    if (cur >= base) {
+        var opt = CART_SKIN_OPTIONS[cur - base];
+        if (opt) { stationPickCartSkin(lp, opt.id); } // id === null clears to the plain cart
+        return;
+    }
+    if (isAvatarIndex(lp, cur)) {
+        stationPickAvatar(lp);
+        return;
+    }
+    var pal = skinPalette();
+    if (cur >= 0 && cur < pal.length) {
+        stationPickSkin(lp, pal[cur]);
     }
 }
 
@@ -154,13 +218,7 @@ function stationPanelNav(lp, dx, dy) {
 // dismisses; for the skin picker it commits the colour under the cursor.
 function stationPanelConfirm(lp) {
     if (lp && lp.stationPanel && lp.stationPanel.kind === "skin") {
-        var cur = lp.stationPanel.cursor || 0;
-        if (isAvatarIndex(lp, cur)) {
-            stationPickAvatar(lp);
-        } else {
-            var pal = skinPalette();
-            stationPickSkin(lp, pal[cur]);
-        }
+        skinPanelConfirm(lp);
         return;
     }
     closeStationPanel(lp);
@@ -870,6 +928,11 @@ function drawCartSkinRow(lp, x, y, w, hit) {
     var cellW = (w - cgap * (n - 1)) / n;
     var current = currentCartSkin(lp);
     var currentColor = skinCurrentColor(lp);
+    // Which cart cell the keyboard/gamepad cursor is on (-1 = cursor is up in the
+    // swatch grid), so pad/keyboard users can see the highlighted cart option.
+    var sp = lp.stationPanel || {};
+    var cursorCart = (typeof sp.cursor === "number" && sp.cursor >= skinOptionCount(lp))
+        ? (sp.cursor - skinOptionCount(lp)) : -1;
     for (var i = 0; i < n; i++) {
         var opt = CART_SKIN_OPTIONS[i];
         var cx = x + i * (cellW + cgap);
@@ -881,6 +944,12 @@ function drawCartSkinRow(lp, x, y, w, hit) {
         gameContext.strokeStyle = sel ? "#ffd34d" : "rgba(255,255,255,0.2)";
         lhRoundRect(gameContext, cx, y, cellW, ch, 6);
         gameContext.stroke();
+        if (i === cursorCart) {
+            gameContext.strokeStyle = "#fff";
+            gameContext.lineWidth = 2.5;
+            lhRoundRect(gameContext, cx - 1, y - 1, cellW + 2, ch + 2, 7);
+            gameContext.stroke();
+        }
         drawCartSkinPreview(opt.id, cx + cellW / 2, y + ch * 0.34, ch * 0.22, currentColor);
         gameContext.fillStyle = "#fff";
         gameContext.font = "11px sans-serif";

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -869,6 +869,7 @@ function drawCartSkinRow(lp, x, y, w, hit) {
     var cgap = 8;
     var cellW = (w - cgap * (n - 1)) / n;
     var current = currentCartSkin(lp);
+    var currentColor = skinCurrentColor(lp);
     for (var i = 0; i < n; i++) {
         var opt = CART_SKIN_OPTIONS[i];
         var cx = x + i * (cellW + cgap);
@@ -880,7 +881,7 @@ function drawCartSkinRow(lp, x, y, w, hit) {
         gameContext.strokeStyle = sel ? "#ffd34d" : "rgba(255,255,255,0.2)";
         lhRoundRect(gameContext, cx, y, cellW, ch, 6);
         gameContext.stroke();
-        drawCartSkinPreview(opt.id, cx + cellW / 2, y + ch * 0.34, ch * 0.22);
+        drawCartSkinPreview(opt.id, cx + cellW / 2, y + ch * 0.34, ch * 0.22, currentColor);
         gameContext.fillStyle = "#fff";
         gameContext.font = "11px sans-serif";
         gameContext.textAlign = "center";
@@ -891,9 +892,12 @@ function drawCartSkinRow(lp, x, y, w, hit) {
 }
 
 // Tiny procedural preview swatch for a cart-skin cell.
-function drawCartSkinPreview(id, cx, cy, r) {
+function drawCartSkinPreview(id, cx, cy, r, paint) {
+    // Preview in the player's own cart colour so the thumbnail matches what they'll
+    // drive; fall back to representative colours when no colour is known.
+    var canShade = (typeof cartSkinShade === "function" && paint);
     if (id === "firetruck") {
-        gameContext.fillStyle = "#d11f1f";
+        gameContext.fillStyle = canShade ? cartSkinShade(paint, -0.05) : "#d11f1f";
         gameContext.fillRect(cx - r, cy - r * 0.6, r * 2, r * 1.2);
         gameContext.fillStyle = "#1a1a1a";
         gameContext.beginPath();
@@ -901,7 +905,7 @@ function drawCartSkinPreview(id, cx, cy, r) {
         gameContext.arc(cx + r * 0.6, cy + r * 0.6, r * 0.4, 0, Math.PI * 2);
         gameContext.fill();
     } else if (id === "dino") {
-        gameContext.fillStyle = "#43b047";
+        gameContext.fillStyle = paint || "#43b047";
         gameContext.beginPath();
         gameContext.ellipse(cx - r * 0.2, cy, r * 0.9, r * 0.6, 0, 0, Math.PI * 2);
         gameContext.fill();

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -176,6 +176,8 @@ function stationPanelAction(lp, action) {
         closeStationPanel(lp);
     } else if (action === "pickAvatar") {
         stationPickAvatar(lp);
+    } else if (action != null && action.indexOf("cartskin:") === 0) {
+        stationPickCartSkin(lp, action.slice("cartskin:".length) || null);
     } else if (action != null && action.indexOf("pick:") === 0) {
         stationPickSkin(lp, action.slice(5));
     }
@@ -270,6 +272,13 @@ function flushLobbyAIEmit() {
 // --- skin station model ------------------------------------------------------
 
 var SKIN_COLS = 6; // swatches per row in the picker grid
+var CART_SKIN_CELL_H = 46; // height of a cart-skin picker cell
+// Cosmetic cart skins (available to everyone). id null == plain colored cart.
+var CART_SKIN_OPTIONS = [
+    { id: null, label: "Default" },
+    { id: "firetruck", label: "Fire Truck" },
+    { id: "dino", label: "Dino" },
+];
 
 function skinPalette() {
     return (typeof config !== "undefined" && config && Array.isArray(config.colorPalette))
@@ -669,7 +678,8 @@ function drawStationPanel(lp, sp) {
     if (kind === "skin") {
         var rows = Math.max(1, Math.ceil(skinOptionCount(lp) / SKIN_COLS));
         w = 272;
-        h = 78 + rows * 34;
+        // base swatch grid height + an extra row for the cart-skin picker.
+        h = 78 + rows * 34 + CART_SKIN_CELL_H + 8;
     }
     var x = lhClamp(sp.x - w / 2, 8, LOGICAL_WIDTH - w - 8);
     var y = lhClamp(sp.y - h - 46, 8, LOGICAL_HEIGHT - h - 8);
@@ -843,6 +853,85 @@ function drawSkinPanelBody(lp, x, y, w, h, hit) {
         gameContext.textAlign = "center";
         gameContext.font = "bold 13px sans-serif";
         gameContext.fillText("Colour taken", x + w / 2, y + h - 12);
+    }
+    // Cart-skin picker row, one row below the swatch/avatar grid. Cart skins are
+    // independent of colour/avatar and open to everyone, so this always shows.
+    var gridRows = Math.ceil(skinOptionCount(lp) / SKIN_COLS);
+    var csY = top + gridRows * (cell + gap) + gap;
+    drawCartSkinRow(lp, x + pad, csY, w - pad * 2, hit);
+}
+
+// Default / Fire Truck / Dino cells with a tiny procedural preview + label. Each
+// cell pushes a "cartskin:<id>" hit action, handled by stationPanelAction.
+function drawCartSkinRow(lp, x, y, w, hit) {
+    var ch = CART_SKIN_CELL_H;
+    var n = CART_SKIN_OPTIONS.length;
+    var cgap = 8;
+    var cellW = (w - cgap * (n - 1)) / n;
+    var current = currentCartSkin(lp);
+    for (var i = 0; i < n; i++) {
+        var opt = CART_SKIN_OPTIONS[i];
+        var cx = x + i * (cellW + cgap);
+        var sel = current === opt.id;
+        gameContext.fillStyle = sel ? "rgba(255,255,255,0.16)" : "rgba(255,255,255,0.06)";
+        lhRoundRect(gameContext, cx, y, cellW, ch, 6);
+        gameContext.fill();
+        gameContext.lineWidth = sel ? 2 : 1;
+        gameContext.strokeStyle = sel ? "#ffd34d" : "rgba(255,255,255,0.2)";
+        lhRoundRect(gameContext, cx, y, cellW, ch, 6);
+        gameContext.stroke();
+        drawCartSkinPreview(opt.id, cx + cellW / 2, y + ch * 0.34, ch * 0.22);
+        gameContext.fillStyle = "#fff";
+        gameContext.font = "11px sans-serif";
+        gameContext.textAlign = "center";
+        gameContext.textBaseline = "middle";
+        gameContext.fillText(opt.label, cx + cellW / 2, y + ch * 0.76);
+        hit.options.push({ rect: { x: cx, y: y, w: cellW, h: ch }, action: "cartskin:" + (opt.id == null ? "" : opt.id) });
+    }
+}
+
+// Tiny procedural preview swatch for a cart-skin cell.
+function drawCartSkinPreview(id, cx, cy, r) {
+    if (id === "firetruck") {
+        gameContext.fillStyle = "#d11f1f";
+        gameContext.fillRect(cx - r, cy - r * 0.6, r * 2, r * 1.2);
+        gameContext.fillStyle = "#1a1a1a";
+        gameContext.beginPath();
+        gameContext.arc(cx - r * 0.6, cy + r * 0.6, r * 0.4, 0, Math.PI * 2);
+        gameContext.arc(cx + r * 0.6, cy + r * 0.6, r * 0.4, 0, Math.PI * 2);
+        gameContext.fill();
+    } else if (id === "dino") {
+        gameContext.fillStyle = "#43b047";
+        gameContext.beginPath();
+        gameContext.ellipse(cx - r * 0.2, cy, r * 0.9, r * 0.6, 0, 0, Math.PI * 2);
+        gameContext.fill();
+        gameContext.beginPath();
+        gameContext.ellipse(cx + r * 0.7, cy - r * 0.1, r * 0.4, r * 0.35, 0, 0, Math.PI * 2);
+        gameContext.fill();
+    } else {
+        gameContext.fillStyle = "rgba(255,255,255,0.4)";
+        gameContext.beginPath();
+        gameContext.arc(cx, cy, r * 0.7, 0, Math.PI * 2);
+        gameContext.fill();
+    }
+}
+
+// This local player's currently-equipped cart skin (server-authoritative), else null.
+function currentCartSkin(lp) {
+    var p = (lp && lp.myID != null && typeof playerList !== "undefined" && playerList) ? playerList[lp.myID] : null;
+    return (p && p.cartSkin) || null;
+}
+
+// Commit a cart-skin pick: emit on this slot's own socket. The change lands for
+// everyone via playerCartSkinChanged. "" clears back to the plain colored cart.
+function stationPickCartSkin(lp, skinId) {
+    if (!lp || !lp.socket) {
+        return;
+    }
+    lp.socket.emit("setCartSkin", { cartSkin: skinId || null });
+    var p = (lp.myID != null && typeof playerList !== "undefined" && playerList) ? playerList[lp.myID] : null;
+    if (p) {
+        p.cartSkin = skinId || null; // optimistic local update
     }
 }
 

--- a/server/compressor.js
+++ b/server/compressor.js
@@ -200,6 +200,7 @@ function newPlayerPacket(player) {
 	// Avatar-skin URL (null unless the player opted into the avatar skin). Static
 	// like name/title — spawn/append only, not per tick.
 	packet[12] = player.avatarUrl || null;
+	packet[13] = player.cartSkin || null;
 	return packet;
 }
 

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -202,6 +202,7 @@ class Player extends Circle {
 		// their Discord/Google picture (and `name`) shown on their kart for everyone.
 		// null = default colour skin, nameless. Set/cleared via messenger setAvatarSkin/setSkin.
 		this.avatarUrl = null;
+		this.cartSkin = null;
 		this.profile = null;
 		this.emoteReadyAt = 0;
 		//Steering outputs the engine's isAI branch reads each tick.

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -426,6 +426,29 @@ function checkForMail(client) {
 		messageRoomBySig(room.sig, "playerAvatarChanged", { id: client.id, avatarUrl: player.avatarUrl, name: player.name });
 	});
 
+	// Cosmetic cart skin (procedural overlay). Independent of color/avatar: equipping
+	// one does NOT clear them. Available to everyone (no ownership gating yet).
+	// Validated against an allowlist; "" / null clears back to the plain colored cart.
+	client.on('setCartSkin', function (payload) {
+		var room = hostess.getRoomBySig(roomMailList[client.id]);
+		if (room == undefined || room.game.currentState != c.stateMap.lobby) {
+			return;
+		}
+		var player = room.playerList[client.id];
+		if (player == null) {
+			return;
+		}
+		var cartSkin = payload && payload.cartSkin;
+		var allowed = ["firetruck", "dino"];
+		if (cartSkin === "" || cartSkin == null) {
+			cartSkin = null;
+		} else if (allowed.indexOf(cartSkin) === -1) {
+			return; // unknown skin id
+		}
+		player.cartSkin = cartSkin;
+		messageRoomBySig(room.sig, "playerCartSkinChanged", { id: client.id, cartSkin: player.cartSkin });
+	});
+
 	// Lobby AI station: set the room-wide bot override. { auto:true } => clear the
 	// override back to Auto (triangular-tier fill); enabled:false => no bots next
 	// race; enabled:true + count => exactly `count` bots. Lobby-only; last-writer-


### PR DESCRIPTION
## What

Adds two selectable cosmetic **cart skins** to the lobby skin shop, available to everyone (no ownership gating yet):

- **Fire Truck** — a Five-Alarm monster truck
- **Dino** — a dinosaur

Both are drawn **procedurally** on canvas (no image assets, transparent by nature), are an **independent** layer on top of your existing color/avatar choice (default = plain colored cart), and are **tinted to your chosen cart color**. Each has a small **animation loop** (firetruck wheels spin, dino legs cycle, faster while driving) and a **distinct trail** (fiery orange for firetruck, earthy green for dino).

## How it's wired

- `server/entities/player.js` — new `cartSkin` field (default `null`).
- `server/messenger.js` — `setCartSkin` handler: lobby-only, allowlist-validated (`firetruck`/`dino`, empty clears), broadcasts `playerCartSkinChanged`; does **not** clear color/avatar.
- `server/compressor.js` ↔ `client/scripts/gameboard.js` — cartSkin rides the spawn/append packet at index `[13]`, decoded in lockstep (covers initial snapshot + late joins; not in the per-tick fast packet, same as avatar).
- `client/scripts/client.js` — `playerCartSkinChanged` applies it live for everyone.
- `client/scripts/draw.js` — procedural `drawFiretruckSkin`/`drawDinoSkin`/`drawCartSkin`, tinted from `player.color` via `cartSkinRGB`/`cartSkinShade`; per-frame `cartSkinAnimTime` accumulator; skin-aware trail color.
- `client/scripts/lobbyHub.js` — Default / Fire Truck / Dino picker row with color-matched previews, reachable by pointer **and** keyboard/gamepad.

## Codex review fixes (already applied)

- Animation accumulated raw ms `dt` but the math expects seconds (ran ~1000x too fast) → divide by 1000.
- Idle `getCartHeading` returned `player.angle` (degrees) verbatim and skipped `0°` → convert to radians, treat `0°` as valid.
- Cart cells were pointer-only → extended the skin panel's keyboard/gamepad cursor space + focus ring.

## Verification

- `npm run build` ✅
- `node .github/scripts/smoke-test.js` ✅
- Rebased onto `origin/main`; CHANGELOG `## Unreleased` bullet added (player.js/messenger.js/compressor.js are mechanic-touching).

## Still needs in-browser playtest (visual-only)

Wheel/leg animation speed, idle orientation, trail colors, color tinting, picker highlight, and that a second player sees your equipped skin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)