### PR TITLE
fix: trench-prune perf regression (client-perf) + map JSON no-cache

### DIFF
--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -312,10 +312,22 @@ function paintTrenchSegment(ctx, s) {
 function paintTrenchSegments(ctx) {
     if (currentMap != null && currentMap.cells != null && trenchSegments.length > 0) {
         var sandId = config.tileMap.slow.id;
+        var cells = currentMap.cells;
+        // Build voronoiId -> current tile id ONCE (O(cells)), then drop any segment whose
+        // stamped cell is no longer sand via an O(1) lookup. The previous per-segment
+        // nearest-site scan was O(segments x cells) and, on tile-change-heavy rounds (a
+        // brutal round rebuilds the cache most ticks, with up to TRENCH_SEGMENT_MAX
+        // segments), measurably spiked per-frame scripting time.
+        var idByVid = {};
+        for (var c2 = 0; c2 < cells.length; c2++) {
+            idByVid[cells[c2].site.voronoiId] = cells[c2].id;
+        }
         var kept = [];
         for (var k = 0; k < trenchSegments.length; k++) {
             var s = trenchSegments[k];
-            if (tileIdAt((s.bx + s.ex) / 2, (s.by + s.ey) / 2) === sandId) {
+            // s.vid is the sand cell the segment was stamped on; keep a legacy segment
+            // without one rather than risk dropping a valid groove.
+            if (s.vid == null || idByVid[s.vid] === sandId) {
                 kept.push(s);
             }
         }
@@ -326,9 +338,10 @@ function paintTrenchSegments(ctx) {
     }
 }
 // Record a trench segment and stamp it straight into the live map cache so it shows
-// immediately (without waiting for the next cache rebuild).
-function stampSandTrench(bx, by, ex, ey, dir, radius) {
-    trenchSegments.push({ bx: bx, by: by, ex: ex, ey: ey, dir: dir, r: radius });
+// immediately (without waiting for the next cache rebuild). `vid` is the voronoiId of
+// the sand cell the segment sits on, used for O(1) pruning when the tile changes.
+function stampSandTrench(bx, by, ex, ey, dir, radius, vid) {
+    trenchSegments.push({ bx: bx, by: by, ex: ex, ey: ey, dir: dir, r: radius, vid: vid });
     if (trenchSegments.length > TRENCH_SEGMENT_MAX) {
         trenchSegments.shift();
     }

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -1324,22 +1324,27 @@ function terrainParticleColor(tile) {
 	return dustColor();
 }
 
-// Which tile id a point sits on. The map is a Voronoi diagram, so the cell a
-// point belongs to is simply the one whose site is nearest — cheap and exact,
-// and it tracks tile changes (bombs, tileSwap) since cell.id is mutated in place.
-function tileIdAt(x, y) {
+// The cell a point sits in. The map is a Voronoi diagram, so it's simply the cell
+// whose site is nearest — cheap and exact, and it tracks tile changes (bombs,
+// tileSwap) since cell.id is mutated in place.
+function nearestCell(x, y) {
 	if (currentMap == null || currentMap.cells == null) {
 		return null;
 	}
 	var cells = currentMap.cells;
-	var bestId = null, bestD = Infinity;
+	var bestCell = null, bestD = Infinity;
 	for (var i = 0; i < cells.length; i++) {
 		var s = cells[i].site;
 		var dx = s.x - x, dy = s.y - y;
 		var d = dx * dx + dy * dy;
-		if (d < bestD) { bestD = d; bestId = cells[i].id; }
+		if (d < bestD) { bestD = d; bestCell = cells[i]; }
 	}
-	return bestId;
+	return bestCell;
+}
+// Tile id at a point (the nearest cell's id), or null if the map isn't ready.
+function tileIdAt(x, y) {
+	var cell = nearestCell(x, y);
+	return cell != null ? cell.id : null;
 }
 
 // `count` flecks kicked up behind a moving player, coloured by the terrain and
@@ -1441,7 +1446,7 @@ function addSandTrench(bx, by, ex, ey, dir, radius) {
 // round wipes it (resetRound clears the decal). LOW never reaches here (the extraFx
 // gate at the call site skips the trench on phone-class devices); the addSandTrench
 // fading effect is the fallback if the decal ever isn't available.
-function spawnSandTrail(p) {
+function spawnSandTrail(p, vid) {
 	if (p.trenchX == null) { p.trenchX = p.x; p.trenchY = p.y; return; }
 	var dx = p.x - p.trenchX, dy = p.y - p.trenchY;
 	var d2 = dx * dx + dy * dy;
@@ -1454,7 +1459,9 @@ function spawnSandTrail(p) {
 			currentState == config.stateMap.collapsing ||
 			currentState == config.stateMap.lobby);
 		if (inGame && typeof stampSandTrench === "function") {
-			stampSandTrench(p.trenchX, p.trenchY, p.x, p.y, dir, p.radius);
+			// Pass the sand cell's voronoiId so the trench can later be pruned in O(1)
+			// when that tile stops being sand, instead of a per-segment nearest-site scan.
+			stampSandTrench(p.trenchX, p.trenchY, p.x, p.y, dir, p.radius, vid);
 		} else {
 			addSandTrench(p.trenchX, p.trenchY, p.x, p.y, dir, p.radius);
 		}
@@ -1525,7 +1532,8 @@ function updateMovementParticles(dt) {
 		// walkThresh so the ambient ice/dirt flecks still stay quiet at idle.
 		var sandThresh = maxSpeed * 0.03;
 		if (speed > sandThresh && p.dustCD <= 0) {
-			var tile = tileIdAt(p.x, p.y);
+			var dustCell = nearestCell(p.x, p.y);
+			var tile = dustCell != null ? dustCell.id : null;
 			// Drop the trench anchor the moment the kart leaves sand, so a trench is
 			// only ever stamped along CONTINUOUS sand travel. Otherwise two sand cells
 			// separated by a short non-sand gap (< p.radius * 4) would reuse the old
@@ -1561,7 +1569,7 @@ function updateMovementParticles(dt) {
 				// light puff of displaced sand on top so the trench art stays readable
 				// rather than being buried under a cloud of flecks.
 				if (extraFx) {
-					spawnSandTrail(p);
+					spawnSandTrail(p, dustCell.site.voronoiId);
 				}
 				spawnTerrainParticle(p, sandColor(), 1.8, 1);
 				p.dustCD = cd(speed > fastThresh ? 90 : 130);

--- a/index.js
+++ b/index.js
@@ -180,12 +180,13 @@ app.use(function (req, res, next) {
 // Set real cache lifetimes by kind so a browser/CDN can serve from the edge:
 //   - /assets/** (images + sounds): content-stable media, cache hard (30 days).
 //     A CDN edge-caches these near the player; purge the CDN on the rare change.
-//   - /maps/**: map JSON is mostly add-only (new file = new name = cache miss),
-//     so a day's cache is safe and a new/edited map still surfaces quickly.
-//   - everything else (JS bundles, CSS — unhashed, change on deploy): no-cache
-//     so a deploy is picked up at once; the ETag keeps the unchanged case a 304.
+//   - everything else, INCLUDING /maps/**: JS bundles, CSS, and map JSON are all
+//     unhashed and can change in place on deploy (e.g. the curated lobby map is
+//     edited, not renamed), so use no-cache — a deploy/map edit is picked up at
+//     once and the ETag keeps the unchanged case a cheap 304. (Map JSON is small;
+//     the revalidation cost the asset cache avoids was about the tens-of-MB media,
+//     not KB maps. A previous 1-day map cache made lobby/map edits lag a full day.)
 var ASSET_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
-var MAP_MAX_AGE_MS = 24 * 60 * 60 * 1000;        // 1 day
 app.use(express.static(htmlPath, {
     etag: true,
     lastModified: true,
@@ -193,8 +194,6 @@ app.use(express.static(htmlPath, {
         var rel = path.relative(htmlPath, filePath);
         if (rel.indexOf('assets' + path.sep) === 0) {
             res.set('Cache-Control', 'public, max-age=' + Math.floor(ASSET_MAX_AGE_MS / 1000));
-        } else if (rel.indexOf('maps' + path.sep) === 0) {
-            res.set('Cache-Control', 'public, max-age=' + Math.floor(MAP_MAX_AGE_MS / 1000));
         } else {
             res.set('Cache-Control', 'no-cache');
         }


### PR DESCRIPTION
Two small prod-affecting fixes from the empty-tile work (#220), which merged into **v0.25.0** with a `client-perf` regression and a stale-map-cache issue.

## 1. Perf: trench prune `O(cells + segments)` (fixes the `client-perf` gate)
PR #220's sand-trench prune ran a **per-segment nearest-site scan over every cell** on each map-cache rebuild. On tile-change-heavy rounds (a brutal round rebuilds the cache most ticks, with up to 800 trench segments) that's `O(segments × cells)` — it regressed client **scripting ~+45%** (4.56 → 6.62 ms/frame on the 25-kart brutal scenario) and shipped in v0.25.0.

Fix: stamp each segment with the `voronoiId` of the sand cell it sits on (reusing the nearest-cell scan the dust/trail logic **already** does each frame — no new scan), then prune via a single `voronoiId → current-id` map per rebuild: `O(cells)` to build + `O(1)` per segment. Behaviour identical (a segment whose cell stops being sand is still dropped). `tileIdAt` now delegates to a shared `nearestCell` helper.

## 2. Cache: serve map JSON `no-cache` (fixes stale lobby/edge tiles in prod)
Maps were cached `public, max-age=86400` on the assumption they're add-only (new file = new name = cache miss). But the **curated lobby map is edited in place**, so returning players' browsers served the day-old map for up to 24h after a deploy — the new lobby holes/edge tiles didn't appear until the cache expired.

Fix: serve `/maps/**` with `no-cache` (ETag revalidation), like the JS bundles/CSS that also change in place on deploy. Map JSON is KB-sized, so the revalidation the asset cache avoids — which targeted the tens-of-MB audio/images — doesn't apply here; those keep their 30-day cache.

## Testing
- `validate-content.js` (52 maps) + `smoke-test.js` pass.
- Prune logic verified in isolation (keeps sand-cell + legacy segments, drops a changed-to-dirt segment).
- Cache headers verified against a running server: `/maps/*.json` → `no-cache`, `/assets/img/*.png` → `max-age=2592000`, `/scripts/*.js` → `no-cache`.
- The `client-perf` gate itself only runs in CI (Playwright) — relying on it to confirm the regression is gone.

## Note / possible follow-up
`no-cache` adds one small revalidation round-trip per map fetch for distant players. If that's a concern, an alternative is version-busting the map URL (`?v=<APP_VERSION>`) so maps can keep a long immutable cache and still refresh on deploy — happy to do that instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)