### PR TITLE
feat(ai): telegraph reasoning — bots predict ability effect and time the release

### DIFF
--- a/.github/scripts/ai-telegraph-engine-test.js
+++ b/.github/scripts/ai-telegraph-engine-test.js
@@ -1,0 +1,281 @@
+'use strict';
+
+// Real-engine headless test for "AI telegraph reasoning". Unlike ai-telegraph-test.js
+// (which calls decideAbility in isolation), this boots the REAL server modules, pins
+// a map, forces the racing state, hands a bot a held ability, and drives the LIVE
+// tick loop (room.update(dt)) — exactly like punch-rework-test.js / smoke-test.js.
+// Date.now is mocked into a clock we advance per tick (a tight synchronous loop
+// otherwise freezes wall-clock, so the held-ability "armed" floor never elapses), and
+// the fake socket.io `io` RECORDS every emit so we can assert the ability actually
+// fired end-to-end (bombUsed/spawnBomb, iceCannon/spawnSnowFlake, swapUsed,
+// blindfoldUsed) and that the spawned projectile was aimed where we expect.
+
+const fs = require('fs');
+const path = require('path');
+const repoRoot = path.join(__dirname, '..', '..');
+const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
+const config = require(path.join(repoRoot, 'server', 'config.json'));
+const mapFormat = require(path.join(repoRoot, 'server', 'mapFormat.js'));
+const abilities = require(path.join(repoRoot, 'server', 'entities', 'abilities.js'));
+
+const LAVA = config.tileMap.lava.id;
+const NORMAL = config.tileMap.normal.id;
+const DT = config.serverTickSpeed / 1000;
+
+let failures = 0;
+function check(cond, msg) {
+    if (cond) { console.log('  ok  - ' + msg); }
+    else { failures++; console.log('::error::FAIL - ' + msg); }
+}
+
+// Recording fake io: every messageRoomBySig -> io.to(sig).emit(header,payload) lands here.
+let recorded = [];
+const fakeIo = { to() { return { emit(header, payload) { recorded.push({ header, payload }); } }; }, sockets: { emit() { } } };
+messenger.build(fakeIo);
+
+function snap45(deg) { var d = Math.round(deg / 45) * 45; return ((d % 360) + 360) % 360; }
+function bearing(fx, fy, tx, ty) { return snap45(Math.atan2(ty - fy, tx - fx) * 180 / Math.PI); }
+function mag(x, y) { return Math.sqrt(x * x + y * y); }
+
+// Nearest-site tile id at (x,y) — same resolution isLavaAt() uses in the engine.
+function tileIdAt(map, x, y) {
+    let best = Infinity, id = -1;
+    for (let i = 0; i < map.cells.length; i++) {
+        const cl = map.cells[i];
+        if (!cl || !cl.site) { continue; }
+        const dx = cl.site.x - x, dy = cl.site.y - y, d = dx * dx + dy * dy;
+        if (d < best) { best = d; id = cl.id; }
+    }
+    return id;
+}
+function lavaWithin(map, x, y, r) {
+    if (tileIdAt(map, x, y) === LAVA) { return true; }
+    for (let a = 0; a < 360; a += 45) {
+        const rad = a * Math.PI / 180;
+        if (tileIdAt(map, x + Math.cos(rad) * r, y + Math.sin(rad) * r) === LAVA) { return true; }
+    }
+    return false;
+}
+
+const realNow = Date.now;
+let clock = 1000000;
+
+// Boot a fresh room with `nBots` bots (+ optional human), pinned to `map`, in racing.
+function bootRoom(sig, map, nBots, withHuman) {
+    const game = require(path.join(repoRoot, 'server', 'game.js'));
+    const room = game.getRoom(sig, 8);
+    room.game.gameBoard.isPreview = true;
+    room.game.gameBoard.previewMap = map;
+    for (let i = 0; i < nBots; i++) {
+        const bid = sig + '-bot' + i;
+        const bot = room.world.createNewBot(bid, { id: 'tester' + i, name: 'T' + i, title: '', aggression: 0.6, skill: 0.8, tempo: 1, risk: 0.4, focus: 'combat' });
+        room.playerList[bid] = bot;
+        room.game.determineGameState(bot);
+    }
+    if (withHuman) {
+        const hid = sig + '-human';
+        const h = room.world.createNewPlayer(hid);
+        h.roomSig = sig;
+        room.playerList[hid] = h;
+        room.game.determineGameState(h);
+    }
+    room.game.startLobby(); room.game.startGated(); room.game.startRace();
+    return room;
+}
+
+// Find safe (open, non-lava) anchor cells on the map, plus a lava-adjacent one.
+function findAnchors(map) {
+    const open = [];     // normal cells with no lava within 200px (truly open)
+    const lavaEdge = []; // normal cells WITH lava within 70px (a hazard pinch)
+    for (let i = 0; i < map.cells.length; i++) {
+        const cl = map.cells[i];
+        if (!cl || !cl.site || cl.id !== NORMAL) { continue; }
+        const p = { x: cl.site.x, y: cl.site.y };
+        if (lavaWithin(map, p.x, p.y, 70)) { lavaEdge.push(p); }
+        else if (!lavaWithin(map, p.x, p.y, 200)) { open.push(p); }
+    }
+    return { open, lavaEdge };
+}
+
+// Give a player a held ability instance + register it the way a tile pickup does.
+function holdAbility(room, player, Ctor) {
+    player.ability = new Ctor(player.id, player.roomSig);
+    player.acquiredAbility = { mapID: null }; // registers into gameBoard.abilityList next updatePlayers
+}
+
+// Pin a player in place (zero drift) so the engine can't carry it off our test setup.
+function pin(p, x, y) {
+    p.x = x; p.y = y; p.newX = x; p.newY = y; p.velX = 0; p.velY = 0;
+    p.alive = true; p.reachedGoal = false;
+}
+
+// Drive the live tick loop until `eventHeader` is recorded (or `maxTicks`), re-pinning
+// `pins` (array of {p,x,y}) every tick and advancing the mocked clock one tick. Returns
+// the recorded entry for eventHeader, or null.
+function tickUntil(room, pins, eventHeader, maxTicks) {
+    for (let f = 0; f < maxTicks; f++) {
+        pins.forEach(q => pin(q.p, q.x, q.y));
+        room.update(DT);
+        clock += config.serverTickSpeed;
+        const hit = recorded.find(r => r.header === eventHeader);
+        if (hit) { return hit; }
+    }
+    return null;
+}
+
+try {
+    Date.now = () => clock;
+
+    const mapsDir = path.join(repoRoot, 'client', 'maps');
+    const file = fs.readdirSync(mapsDir).filter(f => f.endsWith('.json'))[0];
+    const map = mapFormat.hydrate(JSON.parse(fs.readFileSync(path.join(mapsDir, file), 'utf8')));
+    const anchors = findAnchors(map);
+    console.log('Map: ' + file + ' — open anchors: ' + anchors.open.length + ', lava-edge anchors: ' + anchors.lavaEdge.length);
+
+    // ----------------------------------------------------------------------
+    console.log('\n[A] held bomb fires AT a rival (live tick + recorded emit)');
+    {
+        const room = bootRoom('tg-bomb', map, 2, false);
+        const bots = Object.values(room.playerList);
+        const bot = bots[0], rival = bots[1];
+        const A = anchors.open[0];
+        // Rival placed off to the side, in throw range (< 340), away from lava.
+        let R = { x: A.x, y: A.y + 250 };
+        if (lavaWithin(map, R.x, R.y, 30)) { R = { x: A.x + 250, y: A.y }; }
+        holdAbility(room, bot, abilities.Bomb);
+        recorded = [];
+        const used = tickUntil(room, [{ p: bot, x: A.x, y: A.y }, { p: rival, x: R.x, y: R.y }], 'spawnBomb', 150);
+        check(used != null, 'a held bomb actually fired (spawnBomb emitted)');
+        check(recorded.some(r => r.header === 'bombUsed'), 'bombUsed emitted through the real ability.use()');
+        const proj = room.game.gameBoard.projectileList[bot.id];
+        const expectAtRival = bearing(A.x, A.y, R.x, R.y);
+        const travelSnap = snap45(Math.atan2(bot.targetDirY, bot.targetDirX) * 180 / Math.PI);
+        check(proj != null && proj.type === 'bomb', 'a bomb projectile was spawned');
+        check(proj != null && proj.angle === expectAtRival, 'bomb is aimed AT the rival (angle ' + (proj && proj.angle) + ' = ' + expectAtRival + ')');
+        if (expectAtRival !== travelSnap) {
+            check(proj != null && proj.angle !== travelSnap, 'bomb is NOT lobbed down our own travel lane (travel ' + travelSnap + ')');
+        } else {
+            console.log('  ..  - (rival happened to lie on the travel lane; down-track contrast skipped)');
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    console.log('\n[B] iceCannon still aims along TRAVEL, not at a rival');
+    {
+        const room = bootRoom('tg-ice', map, 2, false);
+        const bots = Object.values(room.playerList);
+        const bot = bots[0], rival = bots[1];
+        const A = anchors.open[1] || anchors.open[0];
+        holdAbility(room, bot, abilities.IceCannon);
+        // First learn our goal heading, then place the rival AHEAD (closer to goal) but
+        // laterally off the travel line so "aims along travel" is distinguishable.
+        pin(bot, A.x, A.y); pin(rival, A.x + 200, A.y + 200);
+        room.update(DT); clock += config.serverTickSpeed;
+        const goal = bot.ai.goal || { x: A.x + 1000, y: A.y };
+        let gx = goal.x - A.x, gy = goal.y - A.y; const gm = mag(gx, gy) || 1; gx /= gm; gy /= gm;
+        const perpx = -gy, perpy = gx;
+        // a bit toward the goal (so rival ranks ahead) + a big lateral offset.
+        let R = { x: A.x + gx * 90 + perpx * 250, y: A.y + gy * 90 + perpy * 250 };
+        if (lavaWithin(map, R.x, R.y, 30)) { R = { x: A.x + gx * 90 - perpx * 250, y: A.y + gy * 90 - perpy * 250 }; }
+        recorded = [];
+        const used = tickUntil(room, [{ p: bot, x: A.x, y: A.y }, { p: rival, x: R.x, y: R.y }], 'spawnSnowFlake', 150);
+        check(used != null, 'ice cannon fired while chasing on open runway (spawnSnowFlake emitted)');
+        check(recorded.some(r => r.header === 'iceCannon'), 'iceCannon emitted through the real ability.use()');
+        const proj = room.game.gameBoard.projectileList[bot.id];
+        const travelSnap = snap45(Math.atan2(bot.targetDirY, bot.targetDirX) * 180 / Math.PI);
+        const atRival = bearing(A.x, A.y, R.x, R.y);
+        check(proj != null && proj.type === 'snowFlake', 'a snowflake projectile was spawned');
+        check(proj != null && proj.angle === travelSnap, 'snowflake aims ALONG travel (angle ' + (proj && proj.angle) + ' = ' + travelSnap + ')');
+        if (atRival !== travelSnap) {
+            check(proj != null && proj.angle !== atRival, 'snowflake does NOT aim at the rival (rival bearing ' + atRival + ')');
+        } else {
+            console.log('  ..  - (travel lane happened to point at the rival; contrast skipped)');
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    console.log('\n[C] swap: fires on the leader when behind; never force-fires while leading');
+    {
+        // C1 — behind, leader in range on safe ground -> swapUsed.
+        const room = bootRoom('tg-swap1', map, 2, false);
+        const bots = Object.values(room.playerList);
+        const bot = bots[0], leader = bots[1];
+        const A = anchors.open[0];
+        pin(bot, A.x, A.y); pin(leader, A.x + 150, A.y); room.update(DT); clock += config.serverTickSpeed;
+        const goal = bot.ai.goal || { x: A.x + 1000, y: A.y };
+        let gx = goal.x - A.x, gy = goal.y - A.y; const gm = mag(gx, gy) || 1; gx /= gm; gy /= gm;
+        // Leader ahead (toward goal), within SWAP_RANGE (280), on open ground.
+        let L = { x: A.x + gx * 180, y: A.y + gy * 180 };
+        if (lavaWithin(map, L.x, L.y, 70)) { L = { x: A.x + gx * 140, y: A.y + gy * 140 }; }
+        holdAbility(room, bot, abilities.Swap);
+        recorded = [];
+        const used = tickUntil(room, [{ p: bot, x: A.x, y: A.y }, { p: leader, x: L.x, y: L.y }], 'swapUsed', 150);
+        check(used != null, 'swap fires when behind with the leader in range on safe ground');
+
+        // C2 — bot is LEADING and the round is collapsing (forced): must NEVER swap.
+        const room2 = bootRoom('tg-swap2', map, 2, false);
+        const b2 = Object.values(room2.playerList);
+        const lead = b2[0], trail = b2[1];
+        const A2 = anchors.open[0];
+        pin(lead, A2.x, A2.y); pin(trail, A2.x + 100, A2.y); room2.update(DT); clock += config.serverTickSpeed;
+        const goal2 = lead.ai.goal || { x: A2.x + 1000, y: A2.y };
+        let g2x = goal2.x - A2.x, g2y = goal2.y - A2.y; const g2m = mag(g2x, g2y) || 1; g2x /= g2m; g2y /= g2m;
+        // Put the LEADER (our bot) closest to the goal; the trailer behind it.
+        const leadPos = { x: A2.x + g2x * 120, y: A2.y + g2y * 120 };
+        const trailPos = { x: A2.x - g2x * 120, y: A2.y - g2y * 120 };
+        const safeLead = !lavaWithin(map, leadPos.x, leadPos.y, 40) && !lavaWithin(map, trailPos.x, trailPos.y, 40);
+        holdAbility(room2, lead, abilities.Swap);
+        room2.game.startCollapse(goal2.x, goal2.y); // force the "use it or lose it" path
+        recorded = [];
+        tickUntil(room2, [{ p: lead, x: leadPos.x, y: leadPos.y }, { p: trail, x: trailPos.x, y: trailPos.y }], '__never__', 25);
+        if (safeLead) {
+            check(!recorded.some(r => r.header === 'swapUsed'), 'a leading bot NEVER force-swaps (no swapUsed even at collapse)');
+        } else {
+            console.log('  ..  - (could not place a safe leading pair clear of the collapse; skipped)');
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    console.log('\n[D] blindfold fires when a human is in a lava pinch and the bot is on open ground');
+    {
+        if (anchors.lavaEdge.length === 0 || anchors.open.length === 0) {
+            console.log('  ..  - (map has no lava-edge cell to stage the pinch; skipped)');
+        } else {
+            const room = bootRoom('tg-blind', map, 1, true);
+            const all = Object.values(room.playerList);
+            const bot = all.find(p => p.isAI);
+            const human = all.find(p => !p.isAI);
+            const A = anchors.open[0];
+            pin(bot, A.x, A.y); pin(human, anchors.lavaEdge[0].x, anchors.lavaEdge[0].y);
+            room.update(DT); clock += config.serverTickSpeed;
+            // Ensure the human ranks AHEAD of the bot (so rank>=1): pick the bot anchor
+            // farthest from the bot's goal among open cells, vs the human's lava-edge cell.
+            const goal = bot.ai.goal;
+            let H = anchors.lavaEdge[0];
+            let Ba = A;
+            if (goal != null) {
+                const hGoal = mag(goal.x - H.x, goal.y - H.y);
+                // choose an open anchor that is farther from goal than the human (bot behind)
+                let chosen = null;
+                for (const o of anchors.open) {
+                    if (!lavaWithin(map, o.x, o.y, 200) && mag(goal.x - o.x, goal.y - o.y) > hGoal + 50) { chosen = o; break; }
+                }
+                if (chosen) { Ba = chosen; }
+            }
+            holdAbility(room, bot, abilities.Blindfold);
+            recorded = [];
+            const used = tickUntil(room, [{ p: bot, x: Ba.x, y: Ba.y }, { p: human, x: H.x, y: H.y }], 'blindfoldUsed', 150);
+            check(used != null, 'blindfold fires when a human is hugging lava and the bot is safe & behind');
+        }
+    }
+} finally {
+    Date.now = realNow;
+}
+
+console.log('');
+if (failures > 0) {
+    console.log('AI-telegraph engine test FAILED with ' + failures + ' error(s).');
+    process.exit(1);
+}
+console.log('AI-telegraph engine test passed.');
+process.exit(0);

--- a/.github/scripts/ai-telegraph-test.js
+++ b/.github/scripts/ai-telegraph-test.js
@@ -171,6 +171,14 @@ try {
         ctx = ctxWith([bot, trailer], { collapsing: true }); // forced
         decide(bot, ctx, AB.swap.id, ARMED);
         check(bot.attack === false, 'never force-swaps while in the lead (even when forced)');
+
+        // 6d: "behind" only because the sole rival already FINISHED -> no live target,
+        // so a forced swap must NOT fire (it would just arm an aimer that fizzles).
+        bot = makeBot(500, 500);                 // goalRank counts a finished rival as ahead
+        const finisher = player('done', 1900, 500, { reachedGoal: true });
+        ctx = ctxWith([bot, finisher], { collapsing: true }); // forced + rank>=1, but raceLeader -> null
+        decide(bot, ctx, AB.swap.id, ARMED);
+        check(bot.attack === false, 'forced swap does NOT fire with no live target (finished rival != stealable)');
     }
 
     // -----------------------------------------------------------------------

--- a/.github/scripts/ai-telegraph-test.js
+++ b/.github/scripts/ai-telegraph-test.js
@@ -1,0 +1,248 @@
+'use strict';
+
+// Headless behaviour test for "AI telegraph reasoning": bots PREDICT an ability's
+// effect and TIME its release for maximum impact instead of firing on the first
+// plain range/armed gate. Exercises the REAL decision logic in
+// server/aiController.js `decideAbility` (+ its targeting helpers) directly — no
+// network, no browser — like punch-rework-test.js. The `armed`/`forced` gates are
+// driven purely off nav.held + ctx.collapsing, so no mocked clock is needed here;
+// the all-maps engine sweep is covered by smoke-test.js (run separately in CI).
+
+const path = require('path');
+const repoRoot = path.join(__dirname, '..', '..');
+const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
+const config = require(path.join(repoRoot, 'server', 'config.json'));
+
+// decideAbility emits room messages on fire (bombUsed/swapUsed/…) via messenger —
+// give it a recording fake io so those calls don't throw and we can sanity-check.
+const emitted = [];
+const fakeIo = { to() { return { emit(ev) { emitted.push(ev); } }; }, sockets: { emit() { } } };
+messenger.build(fakeIo);
+
+const ai = require(path.join(repoRoot, 'server', 'aiController.js'));
+const T = ai._test;
+const AB = config.tileMap.abilities;
+const LAVA = config.tileMap.lava.id;
+const NORMAL = config.tileMap.normal.id;
+
+let failures = 0;
+function check(cond, msg) {
+    if (cond) { console.log('  ok  - ' + msg); }
+    else { failures++; console.log('::error::FAIL - ' + msg); }
+}
+
+// snap45 mirror so expected facings are computed the same way the engine snaps them.
+function snap45(deg) { var d = Math.round(deg / 45) * 45; return ((d % 360) + 360) % 360; }
+function bearing(fx, fy, tx, ty) { return snap45(Math.atan2(ty - fy, tx - fx) * 180 / Math.PI); }
+
+// A coarse 50px grid of cells: a vertical LAVA band at x in [1400,1650], normal
+// elsewhere, so isLavaAt()/lavaNear() resolve against real nearest-site geometry.
+function buildMap() {
+    const cells = [];
+    let vid = 0;
+    for (let x = 0; x <= 2100; x += 50) {
+        for (let y = 0; y <= 1050; y += 50) {
+            const id = (x >= 1400 && x <= 1650) ? LAVA : NORMAL;
+            cells.push({ id, site: { x, y, voronoiId: vid++ } });
+        }
+    }
+    return { cells };
+}
+const MAP = buildMap();
+const GOAL = { x: 2000, y: 500 }; // farther right = closer to goal = "ahead" in the race
+
+function player(id, x, y, opts) {
+    opts = opts || {};
+    return Object.assign({
+        id, x, y, velX: 0, velY: 0, alive: true, reachedGoal: false,
+        isSpectator: false, isAI: true
+    }, opts);
+}
+// players: array of player objects -> dict keyed by id, plus the bot.
+function ctxWith(players, over) {
+    const dict = {};
+    players.forEach(p => { dict[p.id] = p; });
+    return Object.assign({
+        players: dict, map: MAP, lavaId: LAVA, goalTiles: [{ x: 1900, y: 500 }],
+        collapsing: false, projectileList: {}
+    }, over);
+}
+function makeBot(x, y, over) {
+    const b = player('bot', x, y, { isAI: true });
+    b.ai = Object.assign({ abilityTempo: 1, goal: GOAL, focus: 'combat', bombFiredAt: 0 }, (over && over.ai) || {});
+    b.targetDirX = (over && over.targetDirX != null) ? over.targetDirX : 1; // default heading +x (down-track)
+    b.targetDirY = (over && over.targetDirY != null) ? over.targetDirY : 0;
+    b.angle = -999; b.attack = false;
+    return b;
+}
+// armed: held >= minHold (=2 at tempo 1); not forced (held < maxHold=30, not collapsing).
+const ARMED = { held: 5, lavaAhead: false, sharpTurn: false, braking: false };
+const HELD = { held: 1, lavaAhead: false, sharpTurn: false, braking: false }; // below minHold -> not armed
+function decide(bot, ctx, abilityId, nav) {
+    bot.angle = -999; bot.attack = false;
+    T.decideAbility(bot, ctx, { id: abilityId }, Object.assign({}, nav));
+}
+
+try {
+    // -----------------------------------------------------------------------
+    console.log('\n[1] bomb fires AT a rival, not down-track');
+    {
+        const bot = makeBot(200, 500); // heading down-track (+x); down-track snap = 0
+        const rival = player('r', 400, 300); // off-axis, in range (dist 283 < 340)
+        const ctx = ctxWith([bot, rival]);
+        decide(bot, ctx, AB.bomb.id, ARMED);
+        check(bot.attack === true, 'armed bomb fires');
+        check(bot.angle === bearing(200, 500, 400, 300), 'aims at the rival (' + bot.angle + ' = ' + bearing(200, 500, 400, 300) + ')');
+        check(bot.angle !== snap45(0), 'NOT pointed down-track (down-track = ' + snap45(0) + ')');
+    }
+
+    // -----------------------------------------------------------------------
+    console.log('\n[2] bomb targets the race LEADER (no cluster), not merely the nearest');
+    {
+        const bot = makeBot(200, 500);
+        const leader = player('lead', 450, 500); // ahead (x larger -> closer to goal), dist 250
+        const back = player('back', 100, 500);    // nearer (dist 100) but BEHIND
+        const ctx = ctxWith([bot, leader, back]);
+        decide(bot, ctx, AB.bomb.id, ARMED);
+        check(bot.attack === true, 'fires');
+        check(bot.angle === bearing(200, 500, 450, 500), 'aims at the LEADER (bearing 0), not the nearer rival behind (bearing 180)');
+        check(bot.angle !== bearing(200, 500, 100, 500), 'did not just pick the closest body');
+    }
+
+    // -----------------------------------------------------------------------
+    console.log('\n[3] bomb prefers a CLUSTER (catches 2+) over a lone leader');
+    {
+        const bot = makeBot(200, 500);
+        const a = player('ca', 300, 750); // cluster pair (within blast 100 of each other)
+        const b = player('cb', 330, 770);
+        const lone = player('lead', 700, 500); // closer to goal but alone
+        const ctx = ctxWith([bot, a, b, lone]);
+        decide(bot, ctx, AB.bomb.id, ARMED);
+        check(bot.attack === true, 'fires');
+        const clusterAim = bearing(200, 500, 300, 750);
+        check(bot.angle === clusterAim, 'aims at the cluster (' + bot.angle + ' = ' + clusterAim + ')');
+        check(bot.angle !== bearing(200, 500, 700, 500), 'did NOT chase the lone leader (bearing 0) over the 2-body cluster');
+    }
+
+    // -----------------------------------------------------------------------
+    console.log('\n[4] held bomb telegraphs (aims at preferred target) without firing');
+    {
+        const bot = makeBot(200, 500);
+        const rival = player('r', 400, 300);
+        const ctx = ctxWith([bot, rival]);
+        decide(bot, ctx, AB.bomb.id, HELD); // below minHold -> not armed, not forced
+        check(bot.attack === false, 'does NOT fire while still holding');
+        check(bot.angle === bearing(200, 500, 400, 300), 'held bomb points at the rival (telegraph/intimidation)');
+    }
+
+    // -----------------------------------------------------------------------
+    console.log('\n[5] iceCannon still aims along travel (own-lane), not at a rival');
+    {
+        const bot = makeBot(200, 500, { targetDirX: 1, targetDirY: 0 }); // travelling +x
+        const rival = player('r', 500, 200); // ahead + off-axis (so bot is "behind")
+        const ctx = ctxWith([bot, rival]);
+        decide(bot, ctx, AB.iceCannon.id, ARMED);
+        check(bot.attack === true, 'ice cannon fires while chasing on open runway');
+        check(bot.angle === snap45(0), 'aims ALONG travel (' + bot.angle + '), not at the rival (' + bearing(200, 500, 500, 200) + ')');
+    }
+
+    // -----------------------------------------------------------------------
+    console.log('\n[6] swap: targets the leader on safe ground; never force-fires while leading');
+    {
+        // 6a: behind, leader in range on safe (non-lava) ground -> steal.
+        let bot = makeBot(200, 500);
+        let leader = player('lead', 400, 500);   // ahead, dist 200 < SWAP_RANGE, normal ground
+        let behind = player('back', 100, 500);
+        let ctx = ctxWith([bot, leader, behind]);
+        decide(bot, ctx, AB.swap.id, ARMED);
+        check(bot.attack === true, 'swaps the in-range leader on safe ground');
+
+        // 6b: leader is lava-adjacent -> hold (would land somewhere we'd die / be re-passed).
+        bot = makeBot(1300, 500);
+        leader = player('lead', 1380, 500);      // ahead, dist 80, but lava band starts at 1400
+        ctx = ctxWith([bot, leader]);
+        check(T.lavaNear(ctx, 1380, 500, 70) === true, 'leader ground reads as lava-adjacent');
+        decide(bot, ctx, AB.swap.id, ARMED);
+        check(bot.attack === false, 'does NOT steal onto lava-adjacent ground (not forced)');
+
+        // 6c: bot is LEADING -> never force a random-target swap, even at collapse.
+        bot = makeBot(1900, 500);                // closest to goal = rank 0
+        const trailer = player('t', 1000, 500);
+        ctx = ctxWith([bot, trailer], { collapsing: true }); // forced
+        decide(bot, ctx, AB.swap.id, ARMED);
+        check(bot.attack === false, 'never force-swaps while in the lead (even when forced)');
+    }
+
+    // -----------------------------------------------------------------------
+    console.log('\n[7] blindfold: fire on a rival hazard-pinch; hold when the bot itself is pinched');
+    {
+        // 7a: human rival lava-adjacent + bot on open ground -> fire.
+        let bot = makeBot(200, 500);
+        let human = player('h', 1380, 500, { isAI: false }); // ahead + lava-adjacent
+        let ctx = ctxWith([bot, human]);
+        decide(bot, ctx, AB.blindfold.id, ARMED);
+        check(bot.attack === true, 'blinds the room when a human is hugging lava and the bot is safe');
+
+        // 7b: same rival pinch, but the BOT is in a pinch too -> hold (would blind itself badly).
+        bot = makeBot(200, 500);
+        ctx = ctxWith([bot, human]);
+        decide(bot, ctx, AB.blindfold.id, { held: 5, lavaAhead: true, sharpTurn: false, braking: false });
+        check(bot.attack === false, 'does NOT fire when the bot itself is in the hazard');
+
+        // 7c: nobody in a pinch (all open ground, away from the goal) -> bank it.
+        bot = makeBot(200, 500);
+        const humanSafe = player('h', 500, 500, { isAI: false }); // open ground, far from goal tile
+        ctx = ctxWith([bot, humanSafe]);
+        decide(bot, ctx, AB.blindfold.id, ARMED);
+        check(bot.attack === false, 'holds when no rival is in a hazard pinch');
+    }
+
+    // -----------------------------------------------------------------------
+    console.log('\n[8] cut behaviour unchanged (regression guard)');
+    {
+        // 8a: out of CUT_RANGE -> hold, but the beam still points AT the nearest rival.
+        let bot = makeBot(200, 500);
+        let rival = player('r', 300, 350); // dist ~180 > CUT_RANGE (78)
+        let ctx = ctxWith([bot, rival]);
+        decide(bot, ctx, AB.cut.id, ARMED);
+        check(bot.attack === false, 'held cut does not fire out of range');
+        check(bot.angle === bearing(200, 500, 300, 350), 'held cut beam still aims at the nearest rival (telegraph)');
+
+        // 8b: in range + armed -> fire, aiming along travel (shove perpendicular).
+        bot = makeBot(200, 500, { targetDirX: 1, targetDirY: 0 });
+        rival = player('r', 260, 500); // dist 60 < CUT_RANGE
+        ctx = ctxWith([bot, rival]);
+        decide(bot, ctx, AB.cut.id, ARMED);
+        check(bot.attack === true, 'cut fires when a rival is in range');
+        check(bot.angle === snap45(0), 'cut aims along travel when firing');
+    }
+
+    // -----------------------------------------------------------------------
+    console.log('\n[9] speedDebuff times on an AHEAD-and-near rival, not just any near body');
+    {
+        // 9a: a rival ahead and within range -> fire (catch-up value).
+        let bot = makeBot(500, 500);
+        let ahead = player('a', 700, 500); // ahead (closer to goal), dist 200 < 340
+        let ctx = ctxWith([bot, ahead]);
+        decide(bot, ctx, AB.speedDebuff.id, ARMED);
+        check(bot.attack === true, 'slows the field when an ahead rival is near');
+
+        // 9b: the only NEAR rival is behind us; the ahead rival is far -> hold.
+        bot = makeBot(500, 500);
+        const nearBehind = player('b', 300, 500); // near (dist 200) but BEHIND
+        const farAhead = player('f', 1900, 500);  // ahead but far (dist 1400 > 340)
+        ctx = ctxWith([bot, nearBehind, farAhead]);
+        decide(bot, ctx, AB.speedDebuff.id, ARMED);
+        check(bot.attack === false, 'does NOT waste it on a rival who is already behind');
+    }
+} finally {
+    // nothing to restore (no clock mock).
+}
+
+console.log('');
+if (failures > 0) {
+    console.log('AI-telegraph test FAILED with ' + failures + ' error(s).');
+    process.exit(1);
+}
+console.log('AI-telegraph test passed.');
+process.exit(0);

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -142,6 +142,9 @@ jobs:
       - name: Headless AI telegraph-reasoning test (ability targeting + timing)
         run: node .github/scripts/ai-telegraph-test.js
 
+      - name: Headless AI telegraph-reasoning ENGINE test (live tick + recorded emits)
+        run: node .github/scripts/ai-telegraph-engine-test.js
+
   perf-tick-budget:
     # Server-side worst-case load: a full 25-kart grid in a stacked brutal round.
     # Proves one room still ticks well within the 30 Hz interval. Zero new deps —

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Headless punch-rework test (momentum, stamina, clash reflect)
         run: node .github/scripts/punch-rework-test.js
 
+      - name: Headless AI telegraph-reasoning test (ability targeting + timing)
+        run: node .github/scripts/ai-telegraph-test.js
+
   perf-tick-budget:
     # Server-side worst-case load: a full 25-kart grid in a stacked brutal round.
     # Proves one room still ticks well within the 30 Hz interval. Zero new deps —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Ability changes
+
+- Bots now play their banked abilities like a thinking opponent instead of firing the moment something wanders into range. A held bomb is aimed at the racer ahead of you (or whoever it can catch the most of at once) and lobbed where you're headed, not where you were; a held swap waits for the actual leader and won't steal you onto a patch of lava it'd just die on; a debuff is saved for when the racers ahead are the ones who'll feel it; and a room-wide blindfold is held back until rivals are in a spot where going blind really hurts — at a lava edge or fighting over the finish — and the bot itself is on safe ground.
+- Bots now visibly line a held bomb (and, as before, a held cut) up on a target, so you can read the threat coming and react before they pull the trigger.
 
 ## v0.25.1 — 2026-05-28
 

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -780,7 +780,10 @@ function decideAbility(bot, ctx, ability, nav) {
         if (rank >= 1) {
             var leadS = raceLeader(bot, ctx, goal);
             var landingSafe = leadS != null && !lavaNear(ctx, leadS.player.x, leadS.player.y, SWAP_LAND_PROBE);
-            if (forced || (leadS != null && leadS.dist < SWAP_RANGE && armed && landingSafe)) { bot.attack = true; }
+            // Require a live swap target even when forced: if we're only "behind"
+            // because a rival already finished (raceLeader -> null), forcing a swap
+            // just arms a warning aimer that fizzles with no one to steal from.
+            if (leadS != null && (forced || (leadS.dist < SWAP_RANGE && armed && landingSafe))) { bot.attack = true; }
         }
         return;
     }

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -366,6 +366,10 @@ var BOMB_THROW_RANGE = 340; // px: throw a bomb at a rival within this
 var SWAP_RANGE = 280;       // px: only swap with a rival this near (and only when behind)
 var CUT_RANGE = 78;         // px: cut when a rival is this close
 var BOMB_MAX_HOLD = 2.6;    // s: detonate before the bomb's 3s auto-expire
+var BOMB_LEAD_TIME = 0.35;  // s: lead a moving target by this much when aiming a thrown bomb
+var SWAP_LAND_PROBE = 70;   // px: a swap leaves us on the target's ground — don't steal onto lava this close
+var BLIND_HAZARD_PROBE = 60;// px: a rival is "in a pinch" for a blindfold if lava is this close to them
+var GOAL_CONTEST_RANGE = 160;// px: a rival this near a goal tile is contesting the finish (good blindfold timing)
 var PUNCH_MOMENTUM_MIN = 0.4; // min momentum-toward-target (as a fraction of a full-power
                               // charge) before a bot throws a routine offensive punch — so
                               // it commits to a closing hit instead of a weak standing tap
@@ -460,6 +464,122 @@ function lavaBeyond(ctx, bot, target, dist) {
     var dx = target.x - bot.x, dy = target.y - bot.y;
     var m = mag(dx, dy) || 1;
     return isLavaAt(ctx, target.x + (dx / m) * dist, target.y + (dy / m) * dist);
+}
+
+// --- Telegraph-reasoning helpers: PREDICT an ability's effect and TIME its release
+// for maximum impact, instead of firing on the first plain range gate. ---
+
+// Straight-line distance from a player to the goal point a bot is pathing toward.
+function goalDistOf(p, goal) { return goal == null ? Infinity : mag(goal.x - p.x, goal.y - p.y); }
+
+// Rivals that are AHEAD of the bot in the race (closer to the goal), each tagged with
+// its distance to the bot. Nearest-first. Empty when no goal is known (degrade safely).
+function rivalsAhead(bot, ctx, goal) {
+    var out = [];
+    if (goal == null) { return out; }
+    var mine = goalDistOf(bot, goal);
+    for (var id in ctx.players) {
+        var p = ctx.players[id];
+        if (!isRacer(p, bot)) { continue; }
+        if (goalDistOf(p, goal) >= mine) { continue; } // not ahead of us
+        out.push({ player: p, dist: mag(p.x - bot.x, p.y - bot.y), goalDist: goalDistOf(p, goal) });
+    }
+    out.sort(function (a, b) { return a.dist - b.dist; });
+    return out;
+}
+// The race LEADER among the bot's rivals (the rival closest to the goal) with its
+// distance to the bot. null when there are no rivals. Falls back to the bot-nearest
+// rival when no goal is known so callers still get a sensible target.
+function raceLeader(bot, ctx, goal) {
+    var best = null;
+    for (var id in ctx.players) {
+        var p = ctx.players[id];
+        if (!isRacer(p, bot)) { continue; }
+        var gd = goalDistOf(p, goal);
+        var d = mag(p.x - bot.x, p.y - bot.y);
+        if (best == null || gd < best.goalDist || (gd === best.goalDist && d < best.dist)) {
+            best = { player: p, dist: d, goalDist: gd };
+        }
+    }
+    return best;
+}
+// Where a moving target will be after `t` seconds at its current velocity. A thrown
+// bomb persists (~3s) and its trigger watches for a rival entering the blast, so
+// aiming at where the rival is HEADED keeps the bomb's line crossing their path.
+function leadPoint(p, t) { return { x: p.x + (p.velX || 0) * t, y: p.y + (p.velY || 0) * t }; }
+
+// True if (x,y) is on, or lava-adjacent within `probe` of, a lava cell (samples the
+// containing cell plus 8 points one probe out). Used to keep abilities from putting
+// the bot (swap landing) or judging a rival (blindfold) on safe vs. dangerous ground.
+function lavaNear(ctx, x, y, probe) {
+    if (isLavaAt(ctx, x, y)) { return true; }
+    for (var a = 0; a < 360; a += 45) {
+        var r = a * Math.PI / 180;
+        if (isLavaAt(ctx, x + Math.cos(r) * probe, y + Math.sin(r) * probe)) { return true; }
+    }
+    return false;
+}
+// The point a held bomb should be thrown at to MAXIMIZE impact, lead-predicted by
+// rival velocity. Preference order: a Nemesis bot's human; a CLUSTER centroid where
+// the blast catches 2+ rivals at once; else the race LEADER; else the nearest rival.
+// Only considers rivals inside BOMB_THROW_RANGE — returns null if none are in range
+// (so the bomb stays held/telegraphed rather than wasted down an empty track).
+function bombTarget(bot, ctx, goal) {
+    var cands = [];
+    for (var id in ctx.players) {
+        var p = ctx.players[id];
+        if (!isRacer(p, bot)) { continue; }
+        if (mag(p.x - bot.x, p.y - bot.y) >= BOMB_THROW_RANGE) { continue; }
+        cands.push(p);
+    }
+    if (cands.length === 0) { return null; }
+    var blast = AB.bomb.explosionRadius;
+    // Nemesis (focus 'human'): hunt the human first if one is in range.
+    if (bot.ai && bot.ai.focus === 'human') {
+        for (var hi = 0; hi < cands.length; hi++) {
+            if (!cands[hi].isAI) { return leadPoint(cands[hi], BOMB_LEAD_TIME); }
+        }
+    }
+    var leads = cands.map(function (p) { return leadPoint(p, BOMB_LEAD_TIME); });
+    // Cluster: pick the lead-position whose blast catches the most rivals at once.
+    var bestI = 0, bestCount = 0;
+    for (var i = 0; i < leads.length; i++) {
+        var n = 0;
+        for (var j = 0; j < leads.length; j++) {
+            if (mag(leads[i].x - leads[j].x, leads[i].y - leads[j].y) < blast) { n++; }
+        }
+        if (n > bestCount) { bestCount = n; bestI = i; }
+    }
+    if (bestCount >= 2) { return leads[bestI]; }
+    // No cluster: aim at the LEADER (closest to goal) among candidates, else nearest.
+    var li = 0, best = Infinity;
+    for (var k = 0; k < cands.length; k++) {
+        var score = goal != null ? goalDistOf(cands[k], goal) : mag(cands[k].x - bot.x, cands[k].y - bot.y);
+        if (score < best) { best = score; li = k; }
+    }
+    return leads[li];
+}
+// Blindfold blinds the WHOLE room (the bot too, in effect), so it only pays off when
+// the disruption lands harder on rivals than on us: the bot is on easy, open ground
+// while at least one rival is in terrain where losing vision really hurts — hugging
+// lava, or right on a contested goal. Otherwise bank it for the endgame.
+function blindfoldWorthIt(bot, ctx, nav, goal) {
+    if (nav.lavaAhead || nav.sharpTurn || nav.braking) { return false; } // bot itself in a pinch
+    for (var id in ctx.players) {
+        var p = ctx.players[id];
+        if (!isRacer(p, bot)) { continue; }
+        if (lavaNear(ctx, p.x, p.y, BLIND_HAZARD_PROBE)) { return true; }
+        if (goalContested(ctx, p)) { return true; }
+    }
+    return false;
+}
+function goalContested(ctx, p) {
+    var gt = ctx.goalTiles;
+    if (!gt || gt.length === 0) { return false; }
+    for (var i = 0; i < gt.length; i++) {
+        if (mag(gt[i].x - p.x, gt[i].y - p.y) < GOAL_CONTEST_RANGE) { return true; }
+    }
+    return false;
 }
 
 // --- Phase 5 helpers ---
@@ -621,7 +741,8 @@ function decideAbility(bot, ctx, ability, nav) {
     var armed = held >= minHold;
     var endgame = ctx.collapsing === true; // round ending -> deploy now or waste it
     var forced = endgame || held > maxHold;
-    var rank = goalRank(bot, ctx.players, bot.ai.goal);
+    var goal = bot.ai.goal;
+    var rank = goalRank(bot, ctx.players, goal);
     var racers = countRacers(ctx.players);
     var behind = racers > 1 && rank >= 1;  // at least one rival is ahead of us
     var aimAhead = function () { bot.angle = snap45(Math.atan2(bot.targetDirY, bot.targetDirX) * 180 / Math.PI); };
@@ -630,22 +751,36 @@ function decideAbility(bot, ctx, ability, nav) {
     var openRunway = !nav.lavaAhead && !nav.sharpTurn && !nav.braking;
 
     if (id === AB.bomb.id) {
-        var nr = preferredTarget(bot, ctx); // Nemesis aims at the human
-        if (nr != null && nr.dist < BOMB_THROW_RANGE && armed) {
-            bot.angle = snap45(angleDeg(bot.x, bot.y, nr.player.x, nr.player.y));
+        // TIME the throw for impact rather than firing at the first rival in range:
+        // aim where the blast catches the most rivals (a cluster) or the race leader,
+        // lead-predicted for a moving target (see bombTarget).
+        var btgt = bombTarget(bot, ctx, goal);
+        if (btgt != null && armed) {
+            bot.angle = snap45(angleDeg(bot.x, bot.y, btgt.x, btgt.y));
             bot.attack = true; bot.ai.bombFiredAt = Date.now();
         } else if (forced) {
             // No target in range — lob it down the track to lay slow tiles ahead.
             aimAhead(); bot.attack = true; bot.ai.bombFiredAt = Date.now();
+        } else {
+            // Still holding: telegraph the threat by pointing the bomb at our
+            // preferred target (Nemesis -> human) so a held bomb reads as a deliberate
+            // aimed threat and pressures the rival, instead of spinning with our
+            // steering. Facing only — movement uses targetDirX/Y.
+            var preB = preferredTarget(bot, ctx);
+            if (preB != null) { bot.angle = snap45(angleDeg(bot.x, bot.y, preB.player.x, preB.player.y)); }
         }
         return;
     }
     if (id === AB.swap.id) {
-        // Swap with a leader when behind (a random-target swap while leading risks
-        // giving away the lead, so never force it while in front).
+        // STEAL the lead, deliberately: only swap when behind (a random-target swap
+        // while leading risks giving away the lead, so never force it while in front).
+        // Time it for when the race LEADER is within the swap's catch radius AND their
+        // ground is safe to inherit — don't steal onto lava-adjacent ground we'd die
+        // on or be instantly re-passed from. Endgame still forces it so it isn't wasted.
         if (rank >= 1) {
-            var nrs = preferredTarget(bot, ctx);
-            if (nrs != null && ((nrs.dist < SWAP_RANGE && armed) || forced)) { bot.attack = true; }
+            var leadS = raceLeader(bot, ctx, goal);
+            var landingSafe = leadS != null && !lavaNear(ctx, leadS.player.x, leadS.player.y, SWAP_LAND_PROBE);
+            if (forced || (leadS != null && leadS.dist < SWAP_RANGE && armed && landingSafe)) { bot.attack = true; }
         }
         return;
     }
@@ -665,10 +800,14 @@ function decideAbility(bot, ctx, ability, nav) {
         return;
     }
     if (id === AB.speedDebuff.id) {
-        // Slows ALL rivals — hold it until a rival is near AND ahead of us (catch-up
-        // value); a runaway leader banks it for the collapse instead of wasting it.
-        var nrd = nearestRival(bot, ctx.players);
-        if ((armed && behind && nrd != null && nrd.dist < BOMB_THROW_RANGE) || forced) { bot.attack = true; }
+        // Slows ALL rivals — time it for max catch-up value: a rival (ideally a
+        // cluster of them) is AHEAD of us and near, so the slow bites the racers we
+        // actually need to reel in. A runaway leader with no one ahead banks it for
+        // the collapse instead of wasting it on rivals already behind.
+        var aheadD = rivalsAhead(bot, ctx, goal);
+        var aheadNear = 0;
+        for (var ai2 = 0; ai2 < aheadD.length; ai2++) { if (aheadD[ai2].dist < BOMB_THROW_RANGE) { aheadNear++; } }
+        if ((armed && behind && aheadNear >= 1) || forced) { bot.attack = true; }
         return;
     }
     if (id === AB.speedBuff.id) {
@@ -685,8 +824,10 @@ function decideAbility(bot, ctx, ability, nav) {
     }
     if (id === AB.blindfold.id) {
         // Room-wide blind: best when a human rival is in play and the bot isn't out
-        // front; otherwise bank it until the round's wrapping up so it isn't wasted.
-        if ((hasHumanRival(bot, ctx.players) && rank >= 1 && armed) || forced) { bot.attack = true; }
+        // front, AND the disruption lands harder on rivals than on the bot itself —
+        // the bot is on easy ground while a rival is in a hazard pinch (lava edge /
+        // contested goal). Otherwise bank it until the round's wrapping up.
+        if ((hasHumanRival(bot, ctx.players) && rank >= 1 && armed && blindfoldWorthIt(bot, ctx, nav, goal)) || forced) { bot.attack = true; }
         return;
     }
     if (id === AB.tileSwap.id) {
@@ -1523,5 +1664,10 @@ module.exports._test = {
     decideAbility: decideAbility,
     newBotState: newBotState,
     chargeHoldFor: chargeHoldFor,
-    emergencyBrakeNeeded: emergencyBrakeNeeded
+    emergencyBrakeNeeded: emergencyBrakeNeeded,
+    bombTarget: bombTarget,
+    raceLeader: raceLeader,
+    rivalsAhead: rivalsAhead,
+    lavaNear: lavaNear,
+    blindfoldWorthIt: blindfoldWorthIt
 };


### PR DESCRIPTION
## What

Bots already HOLD abilities the whole round; this makes them spend abilities **deliberately** — predicting the effect and timing the release for maximum impact — instead of firing on the first plain range/armed gate. Builds on the existing held-Cut "aim-while-holding" telegraph.

### Behavior changes (`server/aiController.js` `decideAbility`)
- **Bomb** — aims at the race **leader**, or a **cluster** where the blast catches the most rivals at once, **lead-predicted** by rival velocity. While still holding (not yet armed), the bomb **telegraphs** by pointing at the preferred target (Nemesis → human), so you can read the threat coming.
- **Swap** — targets the actual **leader**, only when behind, and only when the leader's ground is **safe to inherit** (not lava-adjacent). Never force-swaps while leading; never force-swaps with no live target.
- **speedDebuff** — fires only when a rival **ahead** of the bot is near (real catch-up value), not just any near body.
- **Blindfold** — room-wide blind only when the disruption lands harder on rivals than on the bot: a rival in a **hazard pinch** (lava edge / contested goal) while the bot itself is on safe, open ground.
- **IceCannon** aiming unchanged (own-lane → keeps aiming along travel). **Cut** unchanged.

Player-facing CHANGELOG bullet added under `## Unreleased`.

## Tests
Two new headless tests, both wired into `pr-validation.yml`:
- `.github/scripts/ai-telegraph-test.js` — drives the **real** `decideAbility` with crafted contexts; precise targeting/timing assertions (bomb leader/cluster/not-down-track, ice along travel, swap leader/never-while-leading/no-live-target, blindfold hazard-pinch vs bot-pinched, Cut regression, speedDebuff ahead-near).
- `.github/scripts/ai-telegraph-engine-test.js` — boots the **real** server, pins a map, forces `racing`, hands a bot a held ability, and drives the live `room.update(dt)` loop with a mocked clock + recording fake socket.io; asserts on emitted events (`bombUsed`/`spawnBomb`, `iceCannon`/`spawnSnowFlake`, `swapUsed`, `blindfoldUsed`) and the spawned projectile's aim.

A Codex review flagged one P2 (forced swap could fizzle when "behind" only because a rival finished) — fixed and regression-tested.

### Verification
- `npm run build` ✓
- `smoke-test.js` — PASS on all maps ✓
- both AI tests — PASS ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)