### PR TITLE
Playthrough bug + skin polish wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,17 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- Cart skins now show everywhere your kart appears — on the round-overview scoreboard and in the end-of-match recap — and they read more cleanly with no colour circle poking out behind them. When you catch fire, the skin itself chars and burns instead of the flames hiding behind it. Your trail always uses your own colour now, even with a skin equipped.
+- Brutal-round icons now appear next to the round-start announcement and stay as a small badge in the top-right for the whole round, so you can always tell which modes are active.
+- A racer one notch from winning has a bold, shimmering trail again, so the about-to-win player is easy to spot.
+- The slowdown ability now shows a clear "drag" effect closing in on whoever's slowed.
+
+### Bug fixes
+
+- You now slide along the edge of a hole when you push into it at an angle, instead of stopping dead.
+- Fixed the game-over screen not showing when a match ended during a blackout (or blindfold) round.
 
 ## v0.25.2 — 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 - You now slide along the edge of a hole when you push into it at an angle, instead of stopping dead.
 - Fixed the game-over screen not showing when a match ended during a blackout (or blindfold) round.
+- Fixed the between-rounds map preview showing the poison-green "zombie" lava colour left over from a just-finished infection round.
 
 ## v0.25.2 — 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### General
 
-- Cart skins now show everywhere your kart appears — on the round-overview scoreboard and in the end-of-match recap — and they read more cleanly with no colour circle poking out behind them. When you catch fire, the skin itself chars and burns instead of the flames hiding behind it. Your trail always uses your own colour now, even with a skin equipped.
+- Cart skins now show everywhere your kart appears — on the round-overview scoreboard and in the end-of-match recap — and they read more cleanly with no colour circle poking out behind them. When you catch fire, the skin itself glows red-hot and burns instead of the flames hiding behind it. Your trail always uses your own colour now, even with a skin equipped.
 - Brutal-round icons now appear next to the round-start announcement and stay as a small badge in the top-right for the whole round, so you can always tell which modes are active.
 - A racer one notch from winning has a bold, shimmering trail again, so the about-to-win player is easy to spot.
 - The slowdown ability now shows a clear "drag" effect closing in on whoever's slowed.

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -545,6 +545,12 @@ function registerStateHandlers(server) {
 		// as the leader closes in on the win.
 		updateAudienceIntensity();
 		calculateNotchMoveAmt();
+		// resetRound() above cleared the `infection` flag, but the baked lava pattern is
+		// still the poison-green texture from the just-ended infection round (loadPatterns
+		// only re-bakes it on a map load, which hasn't happened yet). Rebuild patterns now
+		// so the next-map preview thumbnail — which reads patterns[lava] — doesn't inherit
+		// the zombie lava colour.
+		loadPatterns();
 		loadMapPreview(packet.nextMapID);
 		// Clear last round's leaderboards so stale rows don't flash on the new
 		// overview before the server's async queries return.

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -669,6 +669,11 @@ function registerCombatHandlers(server) {
 		var punch = spawnPunch(packet);
 		spawnPunchEffect(punch);
 		var owner = playerList[punch.ownerId];
+		// Seed the cart-skin punch animation (forward lunge + impact pop) on a kart's
+		// own melee swing — not on bumper hits, which aren't a kart throwing a punch.
+		if (owner != null && punch.type == "player") {
+			owner.punchAnimAt = Date.now();
+		}
 		if (owner != null && owner.infected) {
 			playSoundVaried(zombieSwing, 0.1);
 			return;

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -1109,8 +1109,14 @@ function registerEffectHandlers(server) {
 
 	server.on("speedDebuff", function (owner) {
 		playSound(speedDebuff);
-		if (playerList[owner] != null) {
-			playerList[owner].speedDebuffUntil = Date.now() + config.tileMap.abilities.speedDebuff.duration;
+		// speedDebuff slows everyone EXCEPT the owner (see gameBoard.applySpeedDebuff),
+		// so the "slowed" aura belongs on the other karts — not on the caster. Mirror the
+		// server's target set (skip the owner, the dead, and zombies).
+		var until = Date.now() + config.tileMap.abilities.speedDebuff.duration;
+		for (var id in playerList) {
+			if (id == owner) { continue; }
+			if (playerList[id].alive === false || playerList[id].infected) { continue; }
+			playerList[id].speedDebuffUntil = until;
 		}
 		playerAbilityUsed(owner);
 	});

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -603,6 +603,13 @@ function registerStateHandlers(server) {
 		// Match over — clear the final round's sand trench so it doesn't linger into
 		// the game-over screen or the return to the lobby.
 		if (typeof discardTrenchDecal === "function") { discardTrenchDecal(); }
+		// Clear any full-screen brutal overlay still up when the match ended — the
+		// blackout darkness or a blindfold tint — so it can't sit on top of (and hide)
+		// the game-over screen. These are set by their own events, never re-set per
+		// tick, so clearing them here holds for the whole game-over screen.
+		blackout = false;
+		blackoutStart = null;
+		blindfold = {};
 		playerWon = packet.winner;
 		achievements = packet.achievements;
 		recapHarvestRound();      // fold the final round's clips into the archive first

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -576,6 +576,16 @@ function drawDinoSkin(ctx, anim, paint) {
     // boundary) — nothing extends past where the regular cart would.
     ctx.save();
     ctx.scale(1.12, 1.12);
+    // Contrasting dark outline traced around every part (not just the body/head, and
+    // not the old low-contrast darkened-hue line) so the dino's silhouette reads
+    // clearly against any terrain or kart colour — same idea as the regular cart's
+    // black rim. Round joins/caps keep the outline clean at the leg/tail/spine points.
+    var outline = "#141414";
+    var outlineW = 0.11;
+    ctx.lineJoin = "round";
+    ctx.lineCap = "round";
+    ctx.strokeStyle = outline;
+    ctx.lineWidth = outlineW;
 
     // Legs (under body).
     ctx.fillStyle = cartSkinShade(paint, -0.35);
@@ -589,6 +599,7 @@ function drawDinoSkin(ctx, anim, paint) {
         ctx.beginPath();
         ctx.ellipse(legs[i][0] + legs[i][2], legs[i][1], 0.16, 0.1, 0, 0, Math.PI * 2);
         ctx.fill();
+        ctx.stroke();
     }
 
     // Tail.
@@ -599,11 +610,10 @@ function drawDinoSkin(ctx, anim, paint) {
     ctx.lineTo(-0.55, 0.18);
     ctx.closePath();
     ctx.fill();
+    ctx.stroke();
 
     // Body.
     ctx.fillStyle = paint;
-    ctx.strokeStyle = cartSkinShade(paint, -0.45);
-    ctx.lineWidth = 0.06;
     ctx.beginPath();
     ctx.ellipse(-0.05, 0, 0.6, 0.45, 0, 0, Math.PI * 2);
     ctx.fill();
@@ -619,11 +629,11 @@ function drawDinoSkin(ctx, anim, paint) {
         ctx.lineTo(px + 0.1, 0);
         ctx.closePath();
         ctx.fill();
+        ctx.stroke();
     }
 
     // Head.
     ctx.fillStyle = paint;
-    ctx.strokeStyle = cartSkinShade(paint, -0.45);
     ctx.beginPath();
     ctx.ellipse(0.58, 0, 0.3, 0.26, 0, 0, Math.PI * 2); // head pulled in: front 0.88 * 1.12 ≈ 0.99
     ctx.fill();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -483,7 +483,7 @@ function drawCartSkin(player, centerX, centerY, radius, painter) {
             Math.round(hc.g + (90 - hc.g) * hf) + "," +
             Math.round(hc.b + (10 - hc.b) * hf) + ")";
     }
-    painter(ctx, anim, paint);
+    painter(ctx, anim, paint, !!(player && player.onFire > 0));
     ctx.restore();
 }
 
@@ -503,7 +503,7 @@ function cartRoundRectPath(ctx, x, y, w, h, r) {
     ctx.closePath();
 }
 
-function drawFiretruckSkin(ctx, anim, paint) {
+function drawFiretruckSkin(ctx, anim, paint, hot) {
     // Normalized space (radius == 1), forward == +X. Five-Alarm monster truck,
     // painted in the player's chosen cart colour (tinted body + darker outline),
     // white "5" badge, ladder, big wheels with spinning spokes.
@@ -539,9 +539,10 @@ function drawFiretruckSkin(ctx, anim, paint) {
         ctx.restore();
     }
 
-    // Body (player colour) with a darker outline of the same hue.
+    // Body (player colour) with a darker outline of the same hue — or a bright glowing
+    // outline while burning, so the hot-orange truck reads as molten-hot.
     ctx.fillStyle = cartSkinShade(paint, -0.05);
-    ctx.strokeStyle = cartSkinShade(paint, -0.45);
+    ctx.strokeStyle = hot ? "#ffe27a" : cartSkinShade(paint, -0.45);
     ctx.lineWidth = 0.07;
     cartRoundRectPath(ctx, -0.78, -0.52, 1.56, 1.04, 0.18);
     ctx.fill();
@@ -584,7 +585,7 @@ function drawFiretruckSkin(ctx, anim, paint) {
     ctx.restore();
 }
 
-function drawDinoSkin(ctx, anim, paint) {
+function drawDinoSkin(ctx, anim, paint, hot) {
     // Top-down dino painted in the player's chosen cart colour (tinted body/limbs,
     // darker legs + spine of the same hue). Head toward +X, tail toward -X.
     paint = paint || "#43b047";
@@ -599,15 +600,19 @@ function drawDinoSkin(ctx, anim, paint) {
     // not the old low-contrast darkened-hue line) so the dino's silhouette reads
     // clearly against any terrain or kart colour — same idea as the regular cart's
     // black rim. Round joins/caps keep the outline clean at the leg/tail/spine points.
-    var outline = "#141414";
+    // When burning, glow the outline bright and barely darken the limbs/spine, so the
+    // hot-orange dino reads as molten-hot instead of a dark silhouette in the flames.
+    var outline = hot ? "#ffe27a" : "#141414";
     var outlineW = 0.11;
+    var shadeDeep = hot ? -0.1 : -0.35;
+    var shadeTail = hot ? -0.04 : -0.12;
     ctx.lineJoin = "round";
     ctx.lineCap = "round";
     ctx.strokeStyle = outline;
     ctx.lineWidth = outlineW;
 
     // Legs (under body).
-    ctx.fillStyle = cartSkinShade(paint, -0.35);
+    ctx.fillStyle = cartSkinShade(paint, shadeDeep);
     var legs = [
         [0.28, 0.55, legSwing],
         [-0.3, 0.55, -legSwing],
@@ -622,7 +627,7 @@ function drawDinoSkin(ctx, anim, paint) {
     }
 
     // Tail.
-    ctx.fillStyle = cartSkinShade(paint, -0.12);
+    ctx.fillStyle = cartSkinShade(paint, shadeTail);
     ctx.beginPath();
     ctx.moveTo(-0.55, -0.18);
     ctx.lineTo(-0.88, 0); // tail tip pulled in: -0.88 * 1.12 ≈ -0.99, inside the boundary
@@ -639,7 +644,7 @@ function drawDinoSkin(ctx, anim, paint) {
     ctx.stroke();
 
     // Spine plates.
-    ctx.fillStyle = cartSkinShade(paint, -0.35);
+    ctx.fillStyle = cartSkinShade(paint, shadeDeep);
     for (var p = 0; p < 3; p++) {
         var px = -0.3 + p * 0.28;
         ctx.beginPath();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -2362,6 +2362,18 @@ function drawPlayer(player, dt) {
         } else if (player.cartSkin === "dino") {
             drawCartSkin(player, player.x + camera.getCameraX(), player.y + camera.getCameraY(), player.radius, drawDinoSkin);
         }
+        // The base sprite (skipped for skinned karts) is where the "you're being
+        // targeted" red rim lives, so re-draw that tell around the skin when this kart
+        // is in an aimer's target list (swap/explosive).
+        if (hasCartSkin && playerStrokeColor === "red") {
+            gameContext.save();
+            gameContext.beginPath();
+            gameContext.lineWidth = 3;
+            gameContext.strokeStyle = "red";
+            gameContext.arc(player.x + camera.getCameraX(), player.y + camera.getCameraY(), player.radius + 1, 0, 2 * Math.PI);
+            gameContext.stroke();
+            gameContext.restore();
+        }
     } finally {
         if (dimKart) {
             gameContext.restore();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -474,10 +474,14 @@ function drawCartSkin(player, centerX, centerY, radius, painter) {
         ctx.scale(1 + punchK * 0.14, 1 + punchK * 0.14);    // impact pop
     }
     var paint = (player && player.color) ? player.color : null;
-    // While burning, char the skin toward black so the flames drawn on top read as
-    // the kart itself catching fire (rather than a flame floating over a clean skin).
+    // While burning, tint the skin toward glowing hot-orange (NOT black) so it reads as
+    // the skin itself on fire while staying recognizable — charring toward black just
+    // turned the small kart into an unreadable dark blob ("looks like a regular cart").
     if (paint && player.onFire > 0) {
-        paint = cartSkinShade(paint, -0.4);
+        var hc = cartSkinRGB(paint), hf = 0.6;
+        paint = "rgb(" + Math.round(hc.r + (255 - hc.r) * hf) + "," +
+            Math.round(hc.g + (90 - hc.g) * hf) + "," +
+            Math.round(hc.b + (10 - hc.b) * hf) + ")";
     }
     painter(ctx, anim, paint);
     ctx.restore();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -458,7 +458,13 @@ function drawCartSkin(player, centerX, centerY, radius, painter) {
     ctx.translate(centerX, centerY);
     ctx.rotate(heading);
     ctx.scale(radius, radius);
-    painter(ctx, anim, (player && player.color) ? player.color : null);
+    var paint = (player && player.color) ? player.color : null;
+    // While burning, char the skin toward black so the flames drawn on top read as
+    // the kart itself catching fire (rather than a flame floating over a clean skin).
+    if (paint && player.onFire > 0) {
+        paint = cartSkinShade(paint, -0.4);
+    }
+    painter(ctx, anim, paint);
     ctx.restore();
 }
 
@@ -2252,9 +2258,6 @@ function drawPlayer(player, dt) {
     if (DEBUG_FORCE_FIRE && player.id == myID) {
         player.onFire = 500;
     }
-    if (player.onFire > 0) {
-        drawFire(player);
-    }
     drawSpeedFx(player);
     // Draw a halo behind your own kart(s) — the primary plus every couch co-op
     // slot — so you can always find yourself in a crowded pack.
@@ -2332,23 +2335,28 @@ function drawPlayer(player, dt) {
         gameContext.save();
         gameContext.globalAlpha = NONLOCAL_KART_ALPHA;
     }
+    // A cart skin fully replaces the kart body, so skip the base colour disc (and the
+    // avatar overlay that rides it) — otherwise the round sprite pokes out around the
+    // irregular skin silhouette and reads as an unwanted "background". The skin is
+    // tinted with the player's colour, so their identity still carries.
+    var hasCartSkin = (player.cartSkin === "firetruck" || player.cartSkin === "dino");
     // try/finally so a thrown drawImage (e.g. an undecoded sprite -> InvalidStateError)
     // can't skip the restore() and leak the dimmed/flash alpha onto the rest of the frame.
     try {
-        gameContext.drawImage(
-            sprite,
-            player.x + camera.getCameraX() - sprite.halfSize,
-            player.y + camera.getCameraY() - sprite.halfSize
-        );
-        // Opt-in avatar skin: the player's picture, shrunk inside a distinct border,
-        // overlaid on the kart so it reads as an external (not earned) skin. Drawn
-        // INSIDE the dim/immune alpha scope so it fades/flashes with the kart body
-        // (non-local karts dim during a race; immune karts pulse) instead of popping.
-        drawAvatarSkin(player, sprite);
-        // Cosmetic cart skin (procedural overlay), drawn on top of the base sprite
-        // (and avatar) so it reads as an equipped skin. Uses the SAME screen anchor
-        // as the sprite blit above (player.x/y + camera offset), so the camera
-        // offset is applied exactly once.
+        if (!hasCartSkin) {
+            gameContext.drawImage(
+                sprite,
+                player.x + camera.getCameraX() - sprite.halfSize,
+                player.y + camera.getCameraY() - sprite.halfSize
+            );
+            // Opt-in avatar skin: the player's picture, shrunk inside a distinct border,
+            // overlaid on the kart so it reads as an external (not earned) skin. Drawn
+            // INSIDE the dim/immune alpha scope so it fades/flashes with the kart body
+            // (non-local karts dim during a race; immune karts pulse) instead of popping.
+            drawAvatarSkin(player, sprite);
+        }
+        // Cosmetic cart skin (procedural overlay). Uses the SAME screen anchor as the
+        // sprite blit (player.x/y + camera offset), so the camera offset is applied once.
         if (player.cartSkin === "firetruck") {
             drawCartSkin(player, player.x + camera.getCameraX(), player.y + camera.getCameraY(), player.radius, drawFiretruckSkin);
         } else if (player.cartSkin === "dino") {
@@ -2361,6 +2369,12 @@ function drawPlayer(player, dt) {
         if (immune) {
             gameContext.restore();
         }
+    }
+    // Burn flames render AFTER the kart body/skin (so they sit on top of an equipped
+    // skin instead of being hidden behind it) and OUTSIDE the dim/immune alpha scope,
+    // so the threat reads at full intensity on every kart.
+    if (player.onFire > 0) {
+        drawFire(player);
     }
 
     if (player.ability != null) {
@@ -3049,16 +3063,9 @@ function drawTrail(player) {
     gameContext.lineWidth = dashed ? 4 : 3;
     gameContext.lineCap = "round";
     gameContext.lineJoin = "round";
-    // Skin-aware trail: an equipped cart skin overrides the kart colour with a themed
-    // hue (fiery for the fire truck, earthy green for the dino). Alpha/fade-bucket and
-    // dashed-near-victory styling below are untouched — only the stroke colour changes.
-    var trailColor = player.color;
-    if (player.cartSkin === "firetruck") {
-        trailColor = "#ff5a1f";
-    } else if (player.cartSkin === "dino") {
-        trailColor = "#4caf3a";
-    }
-    gameContext.strokeStyle = trailColor;
+    // Trail always uses the player's own colour, even with a cart skin equipped — the
+    // colour is the player's identity, so a blue dino trails blue (not skin-themed).
+    gameContext.strokeStyle = player.color;
     if (typeof perfGlow === "function" && perfGlow()) {
         gameContext.shadowBlur = 3;
         gameContext.shadowColor = "black";
@@ -5019,15 +5026,6 @@ function drawPlayerIcon(player, notchDistanceApart) {
     drawScoreBoardTrail(notchX, player);
     drawFireOverview(notchX, player);
     //drawAbiltiesOverview(notchX, player);
-    gameContext.arc(notchX, 0, config.playerBaseRadius * 2, 0, 2 * Math.PI);
-
-    gameContext.save();
-    gameContext.beginPath();
-    gameContext.lineWidth = 5;
-    gameContext.strokeStyle = "black";
-    gameContext.arc(notchX, 0, config.playerBaseRadius * 2, 0, 2 * Math.PI);
-    gameContext.stroke();
-    gameContext.restore();
 
     if (playerAnimating === player.id) {
         if (player.distanceToMove - moveAmt < 0 && player.distanceToMove + moveAmt > 0) {
@@ -5040,8 +5038,26 @@ function drawPlayerIcon(player, notchDistanceApart) {
 
     player.x = notchX;
     player.y = 0;
-    gameContext.fillStyle = player.color;
-    gameContext.fill();
+    var iconRadius = config.playerBaseRadius * 2;
+    // Match the in-game look: a skinned kart shows its procedural skin (tinted by the
+    // player's colour) instead of the plain colour disc + ring. Heading falls back to
+    // the kart's angle since overview icons are static.
+    if (player.cartSkin === "firetruck" || player.cartSkin === "dino") {
+        var iconPainter = (player.cartSkin === "firetruck") ? drawFiretruckSkin : drawDinoSkin;
+        drawCartSkin(player, notchX, 0, iconRadius, iconPainter);
+    } else {
+        gameContext.beginPath();
+        gameContext.arc(notchX, 0, iconRadius, 0, 2 * Math.PI);
+        gameContext.fillStyle = player.color;
+        gameContext.fill();
+        gameContext.save();
+        gameContext.beginPath();
+        gameContext.lineWidth = 5;
+        gameContext.strokeStyle = "black";
+        gameContext.arc(notchX, 0, iconRadius, 0, 2 * Math.PI);
+        gameContext.stroke();
+        gameContext.restore();
+    }
 }
 
 function drawFireOverview(x, player) {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -2291,6 +2291,13 @@ function drawPlayer(player, dt) {
     if (DEBUG_FORCE_FIRE && player.id == myID) {
         player.onFire = 500;
     }
+    // Burn flame is drawn BEHIND the kart body/skin: the flame sprite (55px) is far
+    // bigger than the kart (~15px), so on top it fully engulfs the kart and every cart
+    // looks the same. Behind, the scorched skin stays visible/recognizable on top of
+    // the flames — reading as "this skin is on fire" rather than a generic blaze.
+    if (player.onFire > 0) {
+        drawFire(player);
+    }
     drawSpeedFx(player);
     // Draw a halo behind your own kart(s) — the primary plus every couch co-op
     // slot — so you can always find yourself in a crowded pack.
@@ -2414,12 +2421,6 @@ function drawPlayer(player, dt) {
         if (immune) {
             gameContext.restore();
         }
-    }
-    // Burn flames render AFTER the kart body/skin (so they sit on top of an equipped
-    // skin instead of being hidden behind it) and OUTSIDE the dim/immune alpha scope,
-    // so the threat reads at full intensity on every kart.
-    if (player.onFire > 0) {
-        drawFire(player);
     }
 
     if (player.ability != null) {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -570,6 +570,12 @@ function drawDinoSkin(ctx, anim, paint) {
     // darker legs + spine of the same hue). Head toward +X, tail toward -X.
     paint = paint || "#43b047";
     var legSwing = Math.sin(anim * 4) * 0.22;
+    // Scale the whole dino up so its body fills more of the cart's circle (it read
+    // small next to the plain disc). The tail tip and head front are pulled in below
+    // so that even after this scale the silhouette stays inside radius 1.0 (the cart
+    // boundary) — nothing extends past where the regular cart would.
+    ctx.save();
+    ctx.scale(1.12, 1.12);
 
     // Legs (under body).
     ctx.fillStyle = cartSkinShade(paint, -0.35);
@@ -589,7 +595,7 @@ function drawDinoSkin(ctx, anim, paint) {
     ctx.fillStyle = cartSkinShade(paint, -0.12);
     ctx.beginPath();
     ctx.moveTo(-0.55, -0.18);
-    ctx.lineTo(-1.0, 0);
+    ctx.lineTo(-0.88, 0); // tail tip pulled in: -0.88 * 1.12 ≈ -0.99, inside the boundary
     ctx.lineTo(-0.55, 0.18);
     ctx.closePath();
     ctx.fill();
@@ -619,19 +625,20 @@ function drawDinoSkin(ctx, anim, paint) {
     ctx.fillStyle = paint;
     ctx.strokeStyle = cartSkinShade(paint, -0.45);
     ctx.beginPath();
-    ctx.ellipse(0.62, 0, 0.3, 0.26, 0, 0, Math.PI * 2);
+    ctx.ellipse(0.58, 0, 0.3, 0.26, 0, 0, Math.PI * 2); // head pulled in: front 0.88 * 1.12 ≈ 0.99
     ctx.fill();
     ctx.stroke();
 
     // Eye.
     ctx.fillStyle = "#ffffff";
     ctx.beginPath();
-    ctx.arc(0.72, -0.12, 0.07, 0, Math.PI * 2);
+    ctx.arc(0.68, -0.12, 0.07, 0, Math.PI * 2);
     ctx.fill();
     ctx.fillStyle = "#111";
     ctx.beginPath();
-    ctx.arc(0.74, -0.12, 0.035, 0, Math.PI * 2);
+    ctx.arc(0.70, -0.12, 0.035, 0, Math.PI * 2);
     ctx.fill();
+    ctx.restore();
 }
 function getPlayerSprite(color, radius, strokeColor) {
     var key = color + '|' + radius + '|' + strokeColor;
@@ -1247,17 +1254,18 @@ function computeWorldViewTarget(dt) {
         worldGoalEngaged = false;
         return wholeMap;
     }
-    // Focus once the round is live (gate countdown + race); plus the LOBBY on
-    // touch, where the whole-map view leaves the player a tiny dot on a phone —
-    // a follow camera keeps them readable while they walk to a station. (Desktop
-    // lobby stays whole-map; touch lobby taps are inverse-mapped through the zoom
-    // in onTouchStart so station hit-testing still lines up.)
-    var inLobbyTouch = (currentState === config.stateMap.lobby &&
-        typeof isTouchScreen !== "undefined" && isTouchScreen);
+    // Focus once the round is live (gate countdown + race); plus the LOBBY whenever
+    // the dynamic camera is on (cameraZoomEnabled, checked above) — a follow camera
+    // keeps the player readable while they walk to a station instead of a tiny dot on
+    // the whole-map view. Applies on desktop too now (camera toggle on), matching the
+    // race behaviour and touch: the lobby hub panel is drawn in HUD/screen space (so it
+    // doesn't zoom and its hit-testing is unaffected) and mouse-walk is inverse-mapped
+    // through the zoom in calcMousePos, so walking to stations still lines up.
+    var inLobby = (currentState === config.stateMap.lobby);
     var focused = (currentState === config.stateMap.gated ||
         currentState === config.stateMap.racing ||
         currentState === config.stateMap.collapsing ||
-        inLobbyTouch);
+        inLobby);
     if (!focused) {
         worldViewFocusedElapsed = 0;
         worldGoalEngaged = false;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -2618,13 +2618,36 @@ function drawSpeedFx(player) {
         }
     }
     if (player.speedDebuffUntil != null && now < player.speedDebuffUntil) {
-        var rp = (now / 700) % 1;
+        // "Drag" read: four chevrons converging INWARD on the kart (the opposite of the
+        // speed-buff streaks that fly outward) plus a heavy saturated ring hugging the
+        // body — so a slowed kart is obvious even when it's barely moving.
+        var cp = (now / 600) % 1;                     // 0..1 convergence cycle
+        var dist = player.radius + 16 - cp * 13;      // chevrons march inward over the cycle
+        var chevAlpha = Math.sin(cp * Math.PI) * 0.85; // fade in as they appear, out as they close
+        var arms = player.radius * 0.45;
         gameContext.save();
-        gameContext.globalAlpha = (1 - rp) * 0.4;
-        gameContext.strokeStyle = "rgba(80,80,160,1)";
-        gameContext.lineWidth = 2;
+        gameContext.translate(player.x, player.y);
+        gameContext.strokeStyle = "rgba(120,80,200," + chevAlpha.toFixed(3) + ")";
+        gameContext.lineWidth = 2.5;
+        gameContext.lineCap = "round";
+        gameContext.lineJoin = "round";
+        for (var ci = 0; ci < 4; ci++) {
+            gameContext.save();
+            gameContext.rotate(ci * Math.PI / 2 + Math.PI / 4); // 4 diagonals
+            // ">" with its point aimed back at the kart (-X), arms flaring outward.
+            gameContext.beginPath();
+            gameContext.moveTo(dist + arms, -arms);
+            gameContext.lineTo(dist, 0);
+            gameContext.lineTo(dist + arms, arms);
+            gameContext.stroke();
+            gameContext.restore();
+        }
+        // Heavy saturated ring hugging the kart.
+        gameContext.globalAlpha = 0.5;
+        gameContext.strokeStyle = "rgba(95,70,150,1)";
+        gameContext.lineWidth = 3;
         gameContext.beginPath();
-        gameContext.arc(player.x, player.y, player.radius + 2 + rp * 12, 0, 2 * Math.PI);
+        gameContext.arc(0, 0, player.radius + 3, 0, 2 * Math.PI);
         gameContext.stroke();
         gameContext.restore();
     }
@@ -3060,7 +3083,7 @@ function drawTrail(player) {
     var baseAlpha = dim ? NONLOCAL_TRAIL_ALPHA : 1;
     var dashed = !!trail.wasNearVictory;
     gameContext.save();
-    gameContext.lineWidth = dashed ? 4 : 3;
+    gameContext.lineWidth = dashed ? 6 : 3;
     gameContext.lineCap = "round";
     gameContext.lineJoin = "round";
     // Trail always uses the player's own colour, even with a cart skin equipped — the
@@ -3071,7 +3094,8 @@ function drawTrail(player) {
         gameContext.shadowColor = "black";
     }
     if (dashed) {
-        gameContext.setLineDash([20, 3, 3, 3, 3, 3, 3, 3]);
+        // Clean chunky dash (the old dotty tail read as noise once semi-transparent).
+        gameContext.setLineDash([18, 10]);
     }
     // Cumulative segment lengths up to vertex i (cumLen[0] = 0). Needed only for
     // the dashed style — the offset is what makes the dash pattern continuous
@@ -3097,6 +3121,11 @@ function drawTrail(player) {
     }
     for (var b = 0; b < TRAIL_DRAW_BUCKETS; b++) {
         var bucketAlpha = baseAlpha * (1 - (b + 0.5) / TRAIL_DRAW_BUCKETS);
+        if (dashed) {
+            // Keep the near-victory trail bold along its whole length — don't let the
+            // age-fade dim it into near-invisibility; it's the "about to win" cue.
+            bucketAlpha = Math.max(bucketAlpha, baseAlpha * 0.55);
+        }
         if (bucketAlpha <= 0.01) {
             continue;
         }
@@ -3119,6 +3148,24 @@ function drawTrail(player) {
                 runStart = -1;
             }
         }
+    }
+    if (dashed) {
+        // Animated shimmer: a single bright gold segment that sweeps along the whole
+        // victory trail (~1/s), so the "about to win" dash visibly pulses with motion
+        // instead of sitting static. One extra stroke — near-victory is rare.
+        var totalLen = cumLen[verts.length - 1];
+        var sweep = (now / 1000) % 1;
+        gameContext.globalAlpha = baseAlpha * 0.9;
+        gameContext.strokeStyle = "rgba(255,240,170,1)";
+        gameContext.lineWidth = 3;
+        gameContext.setLineDash([16, totalLen + 40]); // one lit segment, rest is gap
+        gameContext.lineDashOffset = -sweep * (totalLen + 56);
+        gameContext.beginPath();
+        gameContext.moveTo(verts[0].x, verts[0].y);
+        for (var sv = 1; sv < verts.length; sv++) {
+            gameContext.lineTo(verts[sv].x, verts[sv].y);
+        }
+        gameContext.stroke();
     }
     gameContext.restore();
 }
@@ -4250,11 +4297,51 @@ function compareSite(siteA, siteB) {
 function drawHUD() {
     drawGameInfo();
     drawRaceTimer();
+    drawBrutalBadges();
     drawSpectatorLeaderboard();
     drawWorldRecordBanner();
     drawVirtualButtons();
     drawTouchControls();
     drawTitle();
+}
+
+// Persistent top-right badge (just under the race timer) showing one icon per active
+// brutal-round mode for the whole round — so a player who looked away, or who joined
+// after the announcement card faded, can always tell which modes are live. Reuses the
+// recap badge style (light tile + dark silhouette) so the icons read over any terrain.
+function drawBrutalBadges() {
+    if (brutalRound != true || brutalRoundConfig == null || brutalRoundConfig.brutalTypes == null) { return; }
+    if (currentState != config.stateMap.racing && currentState != config.stateMap.collapsing) { return; }
+    if (typeof brutalRoundImages === "undefined" || brutalRoundImages == null) { return; }
+    var icons = [];
+    for (var i = 0; i < brutalRoundConfig.brutalTypes.length; i++) {
+        var img = brutalRoundImages[brutalRoundConfig.brutalTypes[i]];
+        if (img != null) { icons.push(img); }
+    }
+    if (icons.length === 0) { return; }
+    var bw = 30, bh = 28, gap = 5, topY = 56;
+    var totalW = icons.length * bw + (icons.length - 1) * gap;
+    var startX = LOGICAL_WIDTH - 20 - totalW; // right-aligned under the timer
+    gameContext.save();
+    for (var k = 0; k < icons.length; k++) {
+        var bx = startX + k * (bw + gap);
+        gameContext.fillStyle = "rgba(255,255,255,0.82)";
+        gameContext.fillRect(bx, topY, bw, bh);
+        gameContext.strokeStyle = "rgba(0,0,0,0.55)";
+        gameContext.lineWidth = 1.5;
+        gameContext.strokeRect(bx, topY, bw, bh);
+        var ic = icons[k];
+        if (ic.complete !== false && (ic.naturalWidth == null || ic.naturalWidth > 0)) {
+            try {
+                var ratio = (ic.width && ic.height) ? (ic.height / ic.width) : 0.88;
+                var iw = bw - 8;
+                var ih = iw * ratio;
+                if (ih > bh - 6) { ih = bh - 6; iw = ih / ratio; }
+                gameContext.drawImage(ic, bx + (bw - iw) / 2, topY + (bh - ih) / 2, iw, ih);
+            } catch (e) { /* icon not decoded — badge tile still flags it */ }
+        }
+    }
+    gameContext.restore();
 }
 
 // Screen-space banner that drops in when ANY player (you, an opponent, an
@@ -4842,18 +4929,38 @@ function drawTitle() {
             gameContext.font = "50px Arial";
             gameContext.strokeText('Brutal Round', 0, 0);
             gameContext.fillText('Brutal Round', 0, 0);
-            var titles = [];
+            var titleRows = [];
             for (var i = 0; i < brutalRoundConfig.brutalTypes.length; i++) {
                 for (var prop in config.brutalRounds) {
                     if (config.brutalRounds[prop].id == brutalRoundConfig.brutalTypes[i]) {
-                        titles.push(config.brutalRounds[prop].title);
+                        titleRows.push({ title: config.brutalRounds[prop].title, id: brutalRoundConfig.brutalTypes[i] });
                     }
                 }
             }
             gameContext.font = "30px Arial";
-            for (var j = 0; j < titles.length; j++) {
-                gameContext.strokeText(titles[j], 0, 40 + (35 * j));
-                gameContext.fillText(titles[j], 0, 40 + (35 * j));
+            for (var j = 0; j < titleRows.length; j++) {
+                var ty = 40 + (35 * j);
+                gameContext.strokeText(titleRows[j].title, 0, ty);
+                gameContext.fillText(titleRows[j].title, 0, ty);
+                // Mode icon hugging the left edge of the title text — same iconography as
+                // the recap badges + the persistent corner badge — fading with the card.
+                var tImg = brutalRoundImages[titleRows[j].id];
+                if (tImg != null && tImg.complete !== false && (tImg.naturalWidth == null || tImg.naturalWidth > 0)) {
+                    var tw = gameContext.measureText(titleRows[j].title).width;
+                    var iratio = (tImg.width && tImg.height) ? (tImg.height / tImg.width) : 0.88;
+                    var iw2 = 30, ih2 = 30 * iratio;
+                    var ix2 = -tw / 2 - 12 - iw2;
+                    var iy2 = ty - 14 - ih2 / 2;
+                    gameContext.save();
+                    gameContext.globalAlpha = alpha;
+                    gameContext.fillStyle = "rgba(255,255,255,0.85)";
+                    gameContext.fillRect(ix2 - 3, iy2 - 3, iw2 + 6, ih2 + 6);
+                    gameContext.strokeStyle = "rgba(0,0,0,0.55)";
+                    gameContext.lineWidth = 1.5;
+                    gameContext.strokeRect(ix2 - 3, iy2 - 3, iw2 + 6, ih2 + 6);
+                    try { gameContext.drawImage(tImg, ix2, iy2, iw2, ih2); } catch (e) { /* icon not decoded — tile still flags it */ }
+                    gameContext.restore();
+                }
             }
             gameContext.restore();
         }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -448,10 +448,14 @@ function getCartSpeed(player) {
     return Math.sqrt(vx * vx + vy * vy);
 }
 
-function drawCartSkin(player, centerX, centerY, radius, painter) {
+function drawCartSkin(player, centerX, centerY, radius, painter, headingOverride) {
     var ctx = gameContext;
-    var heading = getCartHeading(player);
-    var speed = getCartSpeed(player);
+    // headingOverride pins the skin to a fixed angle (used by the overview scoreboard, a
+    // static display — otherwise it'd freeze at whatever heading the kart had when the
+    // race ended). A pinned heading also implies an idle pose (no movement-driven anim).
+    var pinned = (typeof headingOverride === "number");
+    var heading = pinned ? headingOverride : getCartHeading(player);
+    var speed = pinned ? 0 : getCartSpeed(player);
     // Animation runs faster while moving, but always ticks a little when idle.
     var anim = cartSkinAnimTime * (0.6 + Math.min(speed, 6) * 0.5);
     // Punch animation: a quick forward lunge + scale "pop" when this kart throws a
@@ -5206,7 +5210,9 @@ function drawPlayerIcon(player, notchDistanceApart) {
     // the kart's angle since overview icons are static.
     if (player.cartSkin === "firetruck" || player.cartSkin === "dino") {
         var iconPainter = (player.cartSkin === "firetruck") ? drawFiretruckSkin : drawDinoSkin;
-        drawCartSkin(player, notchX, 0, iconRadius, iconPainter);
+        // Fixed heading (face right, toward the finish) so the scoreboard icon doesn't
+        // freeze at the kart's last racing angle.
+        drawCartSkin(player, notchX, 0, iconRadius, iconPainter, 0);
     } else {
         gameContext.beginPath();
         gameContext.arc(notchX, 0, iconRadius, 0, 2 * Math.PI);

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -454,10 +454,25 @@ function drawCartSkin(player, centerX, centerY, radius, painter) {
     var speed = getCartSpeed(player);
     // Animation runs faster while moving, but always ticks a little when idle.
     var anim = cartSkinAnimTime * (0.6 + Math.min(speed, 6) * 0.5);
+    // Punch animation: a quick forward lunge + scale "pop" when this kart throws a
+    // melee punch (seeded by the server "punch" event -> player.punchAnimAt). Sharp
+    // attack (peak at 30% of the window) and gentler settle, so it reads as an impact
+    // rather than a pulse; applies to every skin since it lives here in drawCartSkin.
+    var punchK = 0;
+    if (player && player.punchAnimAt != null) {
+        var pe = (Date.now() - player.punchAnimAt) / 220;
+        if (pe >= 0 && pe < 1) {
+            punchK = (pe < 0.3) ? (pe / 0.3) : (1 - (pe - 0.3) / 0.7);
+        }
+    }
     ctx.save();
     ctx.translate(centerX, centerY);
     ctx.rotate(heading);
     ctx.scale(radius, radius);
+    if (punchK > 0) {
+        ctx.translate(punchK * 0.12, 0);                    // lunge forward (heading is local +X)
+        ctx.scale(1 + punchK * 0.14, 1 + punchK * 0.14);    // impact pop
+    }
     var paint = (player && player.color) ? player.color : null;
     // While burning, char the skin toward black so the flames drawn on top read as
     // the kart itself catching fire (rather than a flame floating over a clean skin).

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -982,7 +982,9 @@ function drawCartSkinPreview(id, cx, cy, r, paint) {
         gameContext.ellipse(cx + r * 0.7, cy - r * 0.1, r * 0.4, r * 0.35, 0, 0, Math.PI * 2);
         gameContext.fill();
     } else {
-        gameContext.fillStyle = "rgba(255,255,255,0.4)";
+        // The plain "regular" cart: preview it in the player's chosen colour so it
+        // re-tints live as they change colour, matching the skin previews above.
+        gameContext.fillStyle = paint || "rgba(255,255,255,0.4)";
         gameContext.beginPath();
         gameContext.arc(cx, cy, r * 0.7, 0, Math.PI * 2);
         gameContext.fill();

--- a/client/scripts/recap.js
+++ b/client/scripts/recap.js
@@ -1186,6 +1186,12 @@ function recapDrawCar(pr, exits, frameT) {
 		gameContext.restore();
 	}
 
+	// Burn flame BEHIND the body/skin (matches live play) — the big flame sprite would
+	// otherwise engulf the small kart and hide the skin entirely.
+	if (p.onFire > 0 && typeof drawFire === "function") {
+		drawFire(p);
+	}
+
 	// Kart body: a procedural cart skin replaces the coloured disc (matches live play,
 	// where the skin is tinted by the player's colour and the base disc is suppressed).
 	var recapPainter = (p.cartSkin === "firetruck") ? (typeof drawFiretruckSkin === "function" ? drawFiretruckSkin : null)
@@ -1201,11 +1207,6 @@ function recapDrawCar(pr, exits, frameT) {
 		try {
 			gameContext.drawImage(sprite, p.x - sprite.halfSize, p.y - sprite.halfSize);
 		} catch (e) { /* an undecoded sprite — skip this kart, keep the montage alive */ }
-	}
-
-	// Burn flames on top of the body/skin (matches live play).
-	if (p.onFire > 0 && typeof drawFire === "function") {
-		drawFire(p);
 	}
 
 	if (p.ability != null && typeof drawAbilityIndicator === "function") {

--- a/client/scripts/recap.js
+++ b/client/scripts/recap.js
@@ -167,7 +167,10 @@ function recapCaptureFrame() {
 		recapMeta[p.id] = {
 			color: p.color,
 			radius: (p.radius != null) ? p.radius : 12,
-			name: p.name || null
+			name: p.name || null,
+			// Cart skin is fixed for the match, so the static look carries it (no need
+			// to spend a per-frame tuple slot). Lets the replay render the equipped skin.
+			cartSkin: (p.cartSkin != null) ? p.cartSkin : null
 		};
 	}
 	if (players.length === 0) {
@@ -1144,6 +1147,7 @@ function recapDrawCar(pr, exits, frameT) {
 		velX: pr[RF_VX], velY: pr[RF_VY], color: meta.color,
 		radius: meta.radius, onFire: pr[RF_FIRE], ability: pr[RF_ABILITY],
 		name: meta.name,
+		cartSkin: meta.cartSkin,
 		// rebuild the buff/debuff window flags drawSpeedFx checks (future expiry = active)
 		speedBuffUntil: pr[RF_SPEEDFX] === 1 ? Date.now() + 99999 : null,
 		speedDebuffUntil: pr[RF_SPEEDFX] === 2 ? Date.now() + 99999 : null
@@ -1182,16 +1186,26 @@ function recapDrawCar(pr, exits, frameT) {
 		gameContext.restore();
 	}
 
-	if (p.onFire > 0 && typeof drawFire === "function") {
-		drawFire(p);
-	}
-
-	// The cached kart sprite (a coloured disc), blitted at world coords.
-	if (typeof getPlayerSprite === "function") {
+	// Kart body: a procedural cart skin replaces the coloured disc (matches live play,
+	// where the skin is tinted by the player's colour and the base disc is suppressed).
+	var recapPainter = (p.cartSkin === "firetruck") ? (typeof drawFiretruckSkin === "function" ? drawFiretruckSkin : null)
+		: (p.cartSkin === "dino") ? (typeof drawDinoSkin === "function" ? drawDinoSkin : null)
+		: null;
+	if (recapPainter != null && typeof drawCartSkin === "function") {
+		try {
+			drawCartSkin(p, p.x, p.y, p.radius, recapPainter);
+		} catch (e) { /* skin painter threw — skip, keep the montage alive */ }
+	} else if (typeof getPlayerSprite === "function") {
+		// The cached kart sprite (a coloured disc), blitted at world coords.
 		var sprite = getPlayerSprite(p.color, p.radius, "black");
 		try {
 			gameContext.drawImage(sprite, p.x - sprite.halfSize, p.y - sprite.halfSize);
 		} catch (e) { /* an undecoded sprite — skip this kart, keep the montage alive */ }
+	}
+
+	// Burn flames on top of the body/skin (matches live play).
+	if (p.onFire > 0 && typeof drawFire === "function") {
+		drawFire(p);
 	}
 
 	if (p.ability != null && typeof drawAbilityIndicator === "function") {

--- a/client/scripts/recap.js
+++ b/client/scripts/recap.js
@@ -39,9 +39,14 @@ var RECAP_EXIT_FX_MS = 750;    // how long a death/goal poof lingers before the 
 var RECAP_EXPLOSION_MS = 430;  // explosion effect lifetime (matches spawnExplosion's maxAge)
 var RECAP_MUZZLE_MS = 160;     // muzzle-flash lifetime (matches spawnMuzzleFlash's maxAge)
 var RECAP_SHOCKWAVE_MS = 1100; // one collapse-shockwave ring pass (600px/s out to ~650px)
-var RECAP_MAP_SNAP_MS = 450;   // min gap between dynamic-map snapshots (collapse/explosion/swap)
+var RECAP_MAP_SNAP_MS = 450;   // min gap between dynamic-map snapshots (explosion/swap, slow racing changes)
+var RECAP_MAP_SNAP_COLLAPSE_MS = 110; // finer gap while collapsing — lava grows every tick, and a 450ms
+                               // gap left the killing lava up to ~half a second behind the death frame
+                               // in the replay (so a kart "died to nothing" until the next snapshot)
 var RECAP_MAP_SCALE = 0.6;     // downscale map snapshots (clips are small) to bound memory
-var RECAP_MAP_MAX = 28;        // cap rolling map snapshots per round (downscaled, so cheap)
+var RECAP_MAP_MAX = 48;        // cap rolling map snapshots per round (downscaled, so cheap); higher to
+                               // hold a finely-sampled collapse window without evicting the pre-collapse
+                               // baseline that earlier (racing) clips render from
 
 // per-player frame tuple: [id, x, y, angle, velX, velY, state, onFire, ability, infected, emote, speedFx]
 // emote = active emoji string or null; speedFx = 0 none / 1 buff / 2 debuff
@@ -220,7 +225,13 @@ function recapCaptureMap() {
 	}
 	var now = Date.now();
 	var first = recapMaps.length === 0;
-	if (!first && !(recapMapDirty && now - recapLastMapSnap >= RECAP_MAP_SNAP_MS)) {
+	// Sample finely while the map is collapsing (lava grows every tick) so the replay's
+	// lava reaches each victim in step with their death; coarse otherwise (racing map
+	// barely changes, so frequent snapshots would just burn memory).
+	var collapsing = (typeof currentState !== "undefined" && typeof config !== "undefined" &&
+		config != null && config.stateMap != null && currentState === config.stateMap.collapsing);
+	var snapGap = collapsing ? RECAP_MAP_SNAP_COLLAPSE_MS : RECAP_MAP_SNAP_MS;
+	if (!first && !(recapMapDirty && now - recapLastMapSnap >= snapGap)) {
 		return;
 	}
 	var scale = RECAP_MAP_SCALE;

--- a/server/engine.js
+++ b/server/engine.js
@@ -754,6 +754,7 @@ function nearestSolidCell(x, y, map) {
 //      bleeds energy, leaving the player stranded in the void. Redirect this tick's
 //      step straight at the nearest solid ground and point their velocity that way,
 //      so they consistently climb back out.
+var EMPTY_BOUNCE_DAMP = 0.25;
 function bounceOffEmptyCells(player, map) {
 	if (!mapHasEmptyCells(map)) {
 		return; // no holes on this map — skip the per-tick lookup entirely
@@ -794,28 +795,33 @@ function bounceOffEmptyCells(player, map) {
 	var nx = player.x - hole.site.x;
 	var ny = player.y - hole.site.y;
 	var nm = Math.sqrt(nx * nx + ny * ny);
+	var slid = false;
 	if (nm > 1e-6) {
 		nx /= nm; ny /= nm;
 		// Remove the inward component from this tick's step...
 		var sx = player.newX - player.x, sy = player.newY - player.y;
 		var sDot = sx * nx + sy * ny;            // < 0 => step points into the hole
 		if (sDot < 0) { sx -= sDot * nx; sy -= sDot * ny; }
-		// ...and from the velocity, so the glide carries into the next tick.
-		var vDot = player.velX * nx + player.velY * ny;
-		if (vDot < 0) { player.velX -= vDot * nx; player.velY -= vDot * ny; }
 		var slidX = player.x + sx, slidY = player.y + sy;
 		if (emptyCellAt(slidX, slidY, map) == null) {
+			// Clean slide: commit the tangential move and strip the inward part of the
+			// velocity so the glide carries into the next tick.
+			var vDot = player.velX * nx + player.velY * ny;
+			if (vDot < 0) { player.velX -= vDot * nx; player.velY -= vDot * ny; }
 			player.newX = slidX;
 			player.newY = slidY;
-		} else {
-			// Tangential slide still lands in a hole (curved rim / corner) — hold position
-			// rather than risk placing the player inside the void.
-			player.newX = player.x;
-			player.newY = player.y;
+			slid = true;
 		}
-	} else {
+	}
+	if (!slid) {
+		// The site-vector normal is only approximate, so a glancing slide near a corner
+		// or long/curved rim can still land in the hole (or the player sits on the site).
+		// Fall back to the old rim bounce — reverse + damp — so the kart can't pin against
+		// the rim retaining inward speed and re-attack the hole every tick.
 		player.newX = player.x;
 		player.newY = player.y;
+		player.velX = -player.velX * EMPTY_BOUNCE_DAMP;
+		player.velY = -player.velY * EMPTY_BOUNCE_DAMP;
 	}
 	player.bounced = true;
 }

--- a/server/engine.js
+++ b/server/engine.js
@@ -746,15 +746,14 @@ function nearestSolidCell(x, y, map) {
 	return bestCell;
 }
 // Keep players out of empty holes the way the world edge stops them. Two cases:
-//   1. On solid ground, projected move would enter a hole -> slide along the rim:
-//      keep the tangential part of the move, drop the part heading into the hole, so
-//      a glancing push glides along the edge and only a head-on push stalls.
+//   1. On solid ground, projected move would enter a hole -> slide along the hole's
+//      border edge: project the move/velocity onto the nearest edge's tangent, so the
+//      kart deflects AROUND the cell (even pushing straight in) instead of dead-stopping.
 //   2. Already inside a hole (a hard punch/knockback flung the center past the rim,
 //      or a spawn landed there) -> DON'T just reverse velocity; that oscillates and
 //      bleeds energy, leaving the player stranded in the void. Redirect this tick's
 //      step straight at the nearest solid ground and point their velocity that way,
 //      so they consistently climb back out.
-var EMPTY_BOUNCE_DAMP = 0.25;
 function bounceOffEmptyCells(player, map) {
 	if (!mapHasEmptyCells(map)) {
 		return; // no holes on this map — skip the per-tick lookup entirely
@@ -785,36 +784,55 @@ function bounceOffEmptyCells(player, map) {
 	if (emptyCellAt(player.newX, player.newY, map) == null) {
 		return; // on solid ground and the projected move stays on solid ground
 	}
-	// Case 1: outside -> inside. Slide along the rim by resolving each axis independently
-	// (the robust top-down wall-slide): keep whichever of the X-only / Y-only sub-moves
-	// stays on solid ground, so a glancing approach glides along the edge while a head-on
-	// push (both sub-moves blocked) stops cleanly. Never lands the player inside a hole.
-	var clearX = (emptyCellAt(player.newX, player.y, map) == null);
-	var clearY = (emptyCellAt(player.x, player.newY, map) == null);
-	if (clearX && clearY) {
-		// Both single-axis moves are individually clear but the diagonal lands in a hole
-		// (a concave corner). Keep the larger component so the kart keeps sliding along
-		// one edge instead of stopping at the corner.
-		if (Math.abs(player.newX - player.x) >= Math.abs(player.newY - player.y)) {
-			player.newY = player.y; player.velY = 0;
-		} else {
-			player.newX = player.x; player.velX = 0;
+	// Case 1: outside -> inside. Slide ALONG the hole's actual border edge so the kart
+	// deflects around the cell even when pushing straight in (not a dead-stop). Find the
+	// hole-polygon edge nearest the kart, then project both the intended step and the
+	// velocity onto that edge's tangent — the component parallel to the rim survives, the
+	// component into the rim is dropped.
+	var hole = emptyCellAt(player.newX, player.newY, map);
+	var hes = hole.halfedges;
+	var bestD2 = Infinity, tanX = 0, tanY = 0, foundEdge = false;
+	for (var hi = 0; hi < hes.length; hi++) {
+		var a = getStartpoint(hes[hi]);
+		var b = getEndpoint(hes[hi]);
+		var ex = b.x - a.x, ey = b.y - a.y;
+		var elen2 = ex * ex + ey * ey;
+		if (elen2 < 1e-9) { continue; }
+		// Closest point on segment a-b to the kart, then its distance.
+		var tt = ((player.x - a.x) * ex + (player.y - a.y) * ey) / elen2;
+		if (tt < 0) { tt = 0; } else if (tt > 1) { tt = 1; }
+		var ddx = player.x - (a.x + tt * ex), ddy = player.y - (a.y + tt * ey);
+		var d2 = ddx * ddx + ddy * ddy;
+		if (d2 < bestD2) {
+			bestD2 = d2;
+			var el = Math.sqrt(elen2);
+			tanX = ex / el; tanY = ey / el;
+			foundEdge = true;
 		}
-	} else if (clearX) {
-		// Blocked vertically — slide horizontally along the rim.
-		player.newY = player.y;
-		player.velY = 0;
-	} else if (clearY) {
-		// Blocked horizontally — slide vertically along the rim.
-		player.newX = player.x;
-		player.velX = 0;
+	}
+	if (foundEdge) {
+		var sx = player.newX - player.x, sy = player.newY - player.y;
+		var sProj = sx * tanX + sy * tanY;            // intended motion along the rim
+		var vProj = player.velX * tanX + player.velY * tanY;
+		var slidX = player.x + sProj * tanX;
+		var slidY = player.y + sProj * tanY;
+		// Keep the tangential velocity either way so the glide carries into the next tick;
+		// only commit the slid position if it stays out of the hole (sharp-corner guard).
+		player.velX = vProj * tanX;
+		player.velY = vProj * tanY;
+		if (emptyCellAt(slidX, slidY, map) == null) {
+			player.newX = slidX;
+			player.newY = slidY;
+		} else {
+			player.newX = player.x;
+			player.newY = player.y;
+		}
 	} else {
-		// Both sub-moves hit the hole (head-on into the rim, or a concave pocket) — stop
-		// at the edge and bleed the speed so the kart settles instead of jittering.
+		// Degenerate hole with no usable edge — just hold position.
 		player.newX = player.x;
 		player.newY = player.y;
-		player.velX = -player.velX * EMPTY_BOUNCE_DAMP;
-		player.velY = -player.velY * EMPTY_BOUNCE_DAMP;
+		player.velX = 0;
+		player.velY = 0;
 	}
 	player.bounced = true;
 }

--- a/server/engine.js
+++ b/server/engine.js
@@ -785,39 +785,32 @@ function bounceOffEmptyCells(player, map) {
 	if (emptyCellAt(player.newX, player.newY, map) == null) {
 		return; // on solid ground and the projected move stays on solid ground
 	}
-	// Case 1: outside -> inside. Slide along the rim instead of dead-stopping: strip the
-	// part of the move (and velocity) heading INTO the hole and keep the tangential part,
-	// so a player pushing at an angle glides along the edge. A head-on push still stalls,
-	// since its whole motion is the inward component.
-	var hole = emptyCellAt(player.newX, player.newY, map);
-	// Outward normal: from the hole's site toward the player. Approximate but stable —
-	// the safety re-check below guarantees we never actually place the player in a hole.
-	var nx = player.x - hole.site.x;
-	var ny = player.y - hole.site.y;
-	var nm = Math.sqrt(nx * nx + ny * ny);
-	var slid = false;
-	if (nm > 1e-6) {
-		nx /= nm; ny /= nm;
-		// Remove the inward component from this tick's step...
-		var sx = player.newX - player.x, sy = player.newY - player.y;
-		var sDot = sx * nx + sy * ny;            // < 0 => step points into the hole
-		if (sDot < 0) { sx -= sDot * nx; sy -= sDot * ny; }
-		var slidX = player.x + sx, slidY = player.y + sy;
-		if (emptyCellAt(slidX, slidY, map) == null) {
-			// Clean slide: commit the tangential move and strip the inward part of the
-			// velocity so the glide carries into the next tick.
-			var vDot = player.velX * nx + player.velY * ny;
-			if (vDot < 0) { player.velX -= vDot * nx; player.velY -= vDot * ny; }
-			player.newX = slidX;
-			player.newY = slidY;
-			slid = true;
+	// Case 1: outside -> inside. Slide along the rim by resolving each axis independently
+	// (the robust top-down wall-slide): keep whichever of the X-only / Y-only sub-moves
+	// stays on solid ground, so a glancing approach glides along the edge while a head-on
+	// push (both sub-moves blocked) stops cleanly. Never lands the player inside a hole.
+	var clearX = (emptyCellAt(player.newX, player.y, map) == null);
+	var clearY = (emptyCellAt(player.x, player.newY, map) == null);
+	if (clearX && clearY) {
+		// Both single-axis moves are individually clear but the diagonal lands in a hole
+		// (a concave corner). Keep the larger component so the kart keeps sliding along
+		// one edge instead of stopping at the corner.
+		if (Math.abs(player.newX - player.x) >= Math.abs(player.newY - player.y)) {
+			player.newY = player.y; player.velY = 0;
+		} else {
+			player.newX = player.x; player.velX = 0;
 		}
-	}
-	if (!slid) {
-		// The site-vector normal is only approximate, so a glancing slide near a corner
-		// or long/curved rim can still land in the hole (or the player sits on the site).
-		// Fall back to the old rim bounce — reverse + damp — so the kart can't pin against
-		// the rim retaining inward speed and re-attack the hole every tick.
+	} else if (clearX) {
+		// Blocked vertically — slide horizontally along the rim.
+		player.newY = player.y;
+		player.velY = 0;
+	} else if (clearY) {
+		// Blocked horizontally — slide vertically along the rim.
+		player.newX = player.x;
+		player.velX = 0;
+	} else {
+		// Both sub-moves hit the hole (head-on into the rim, or a concave pocket) — stop
+		// at the edge and bleed the speed so the kart settles instead of jittering.
 		player.newX = player.x;
 		player.newY = player.y;
 		player.velX = -player.velX * EMPTY_BOUNCE_DAMP;

--- a/server/engine.js
+++ b/server/engine.js
@@ -746,14 +746,14 @@ function nearestSolidCell(x, y, map) {
 	return bestCell;
 }
 // Keep players out of empty holes the way the world edge stops them. Two cases:
-//   1. On solid ground, projected move would enter a hole -> stop at the rim and
-//      bounce back (reverse + damp), matching preventEscape's player-edge feel.
+//   1. On solid ground, projected move would enter a hole -> slide along the rim:
+//      keep the tangential part of the move, drop the part heading into the hole, so
+//      a glancing push glides along the edge and only a head-on push stalls.
 //   2. Already inside a hole (a hard punch/knockback flung the center past the rim,
 //      or a spawn landed there) -> DON'T just reverse velocity; that oscillates and
 //      bleeds energy, leaving the player stranded in the void. Redirect this tick's
 //      step straight at the nearest solid ground and point their velocity that way,
 //      so they consistently climb back out.
-var EMPTY_BOUNCE_DAMP = 0.25;
 function bounceOffEmptyCells(player, map) {
 	if (!mapHasEmptyCells(map)) {
 		return; // no holes on this map — skip the per-tick lookup entirely
@@ -784,11 +784,39 @@ function bounceOffEmptyCells(player, map) {
 	if (emptyCellAt(player.newX, player.newY, map) == null) {
 		return; // on solid ground and the projected move stays on solid ground
 	}
-	// Case 1: outside -> inside. Stop at the rim and bounce back.
-	player.newX = player.x;
-	player.newY = player.y;
-	player.velX = -player.velX * EMPTY_BOUNCE_DAMP;
-	player.velY = -player.velY * EMPTY_BOUNCE_DAMP;
+	// Case 1: outside -> inside. Slide along the rim instead of dead-stopping: strip the
+	// part of the move (and velocity) heading INTO the hole and keep the tangential part,
+	// so a player pushing at an angle glides along the edge. A head-on push still stalls,
+	// since its whole motion is the inward component.
+	var hole = emptyCellAt(player.newX, player.newY, map);
+	// Outward normal: from the hole's site toward the player. Approximate but stable —
+	// the safety re-check below guarantees we never actually place the player in a hole.
+	var nx = player.x - hole.site.x;
+	var ny = player.y - hole.site.y;
+	var nm = Math.sqrt(nx * nx + ny * ny);
+	if (nm > 1e-6) {
+		nx /= nm; ny /= nm;
+		// Remove the inward component from this tick's step...
+		var sx = player.newX - player.x, sy = player.newY - player.y;
+		var sDot = sx * nx + sy * ny;            // < 0 => step points into the hole
+		if (sDot < 0) { sx -= sDot * nx; sy -= sDot * ny; }
+		// ...and from the velocity, so the glide carries into the next tick.
+		var vDot = player.velX * nx + player.velY * ny;
+		if (vDot < 0) { player.velX -= vDot * nx; player.velY -= vDot * ny; }
+		var slidX = player.x + sx, slidY = player.y + sy;
+		if (emptyCellAt(slidX, slidY, map) == null) {
+			player.newX = slidX;
+			player.newY = slidY;
+		} else {
+			// Tangential slide still lands in a hole (curved rim / corner) — hold position
+			// rather than risk placing the player inside the void.
+			player.newX = player.x;
+			player.newY = player.y;
+		}
+	} else {
+		player.newX = player.x;
+		player.newY = player.y;
+	}
 	player.bounced = true;
 }
 function pointIntersection(x, y, cell) {


### PR DESCRIPTION
A wave of playtest-reported bugs and cart-skin polish, all caught in a recent playthrough.

## Skins (firetruck + dino)
- Equipped cart skins now render everywhere a kart is drawn — **round-overview scoreboard** (fixed facing, idle pose) and the **end-of-match recap** — not just live racing, and with **no base colour disc poking out** behind the skin.
- **Trail uses the player's own colour** even with a skin equipped (dropped the hardcoded skin-themed hues).
- **Burning** reads as the skin on fire: flame drawn *behind* the (recognizable) skin, which glows **hot-orange with a bright molten outline** while on fire.
- **Punch animation**: a forward lunge + impact pop on a melee swing (both skins).
- Dino: scaled up ~12% (still inside the cart boundary) with a **contrasting dark outline** around the whole silhouette.
- Lobby skin-hub: the plain "regular" cart preview now **re-tints live** with the chosen colour; targeted (swap/bomb) skinned karts get the red "you're targeted" rim back.

## FX
- **Brutal-round icons** render on the round-start announcement card **and** as a persistent top-right badge for the whole round.
- **Near-victory trail** restored to bold + a sweeping gold shimmer.
- **Slowdown ability** shows a clear inward-chevron "drag" aura — now on the **slowed racers**, not the caster.

## Gameplay / state
- **Wall-slide**: pushing into an empty/collapsed-cell border now slides *along* the cell edge (projected onto the true border tangent) instead of dead-stopping. *(engine.js — game mechanic; CHANGELOG updated.)*
- **Blackout/blindfold game-over**: the game-over screen no longer stays hidden behind the full-screen overlay when a match ends mid-round.
- **Zombie-lava preview**: the between-rounds next-map preview no longer shows the poison-green infection lava left baked from the prior round.
- **Recap collapse-death sync**: the map is sampled finely (110ms vs 450ms) while collapsing, so a lava-collapse death in the recap shows the lava reaching the kart *as* it dies instead of ~2s later.

## Verification
- `npm run build` + `.github/scripts/smoke-test.js` green (engine ticks all 52 maps through every state).
- Reviewed: `/code-review` (high) — 2 findings fixed (slide rim-pin fallback, lost target rim on skins); Codex review — clean.
- Operator-confirmed in playtest: wall-slide, desktop lobby follow-camera, regular-cart preview, skin punch, recap skin, overview angle, brutal icons. Burning-skin look browser-verified.
- Remaining operator playtest confirmation (condition-gated): slowdown aura w/ a 2nd racer, blackout game-over, victory trail, targeting rim on skins, zombie-lava preview, recap collapse-death sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)