### PR TITLE
Goal beacon + terrain visual pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- The whole board got a visual pass. Terrain now has richer, warmer colours and a subtle per-tile depth shading, so the ground reads as distinct tiles instead of one flat sheet.
+- The goal tile now glows like a beacon — a soft breathing light with an outward pulse ring — so it's easier to spot where you're racing to.
+- Lava churns and bubbles with rolling hot spots, and ice shows a soft reflection of the karts gliding over it.
+- Ability pickup icons now float and bob above their tile with a little shadow, so they read as a pickup to grab rather than a flat marking.
+- These animated touches scale with your graphics setting and turn off on the lowest setting, where the terrain still shows its new colours and depth.
 
 ## v0.25.3 — 2026-05-29
 

--- a/build.js
+++ b/build.js
@@ -12,6 +12,7 @@ const bundles = {
         'client/scripts/input.js',
         'client/scripts/gamepad.js',
         'client/scripts/draw.js',
+        'client/scripts/terrainfx.js',
         'client/scripts/gameboard.js',
         'client/scripts/lobbyHub.js',
         'client/scripts/audience.js',

--- a/client/play.html
+++ b/client/play.html
@@ -111,6 +111,7 @@
         <script src="scripts/input.js"></script>
         <script src="scripts/gamepad.js"></script>
         <script src="scripts/draw.js"></script>
+        <script src="scripts/terrainfx.js"></script>
         <script src="scripts/gameboard.js"></script>
         <script src="scripts/lobbyHub.js"></script>
         <script src="scripts/audience.js"></script>

--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -1480,11 +1480,13 @@ function cellIdFromPoint(xmouse, ymouse) {
         if (hit !== undefined) { return hit; }
     }
 }
+var tileIdByVid = null; // voronoiId -> tile id, for boundary-AO neighbour typing
 function renderCells() {
     var cells = vMap.cells,
         iCell = cells.length,
         cell;
 
+    tileIdByVid = buildIdByVoronoi(cells);
     while (iCell--) {
         renderCell(cells[iCell]);
     }
@@ -1525,6 +1527,7 @@ function renderMapThumbnail(map) {
     var ctx = cv.getContext('2d');
     ctx.fillStyle = tileFill(config.tileMap.normal.id);
     ctx.fillRect(0, 0, cv.width, cv.height);
+    var thumbIds = buildIdByVoronoi(map.cells);
     for (var i = 0; i < map.cells.length; i++) {
         var cell = map.cells[i];
         var hes = cell.halfedges;
@@ -1536,6 +1539,7 @@ function renderMapThumbnail(map) {
         ctx.closePath();
         ctx.fillStyle = tileFill(cell.id);
         ctx.fill();
+        paintCellEdgeAO(ctx, cell, thumbIds);
     }
     // Hazards (same look as the editor canvas: orange disc + red attack ring,
     // plus a black rail bar for moving bumpers). Without this, the load-list
@@ -1598,6 +1602,8 @@ function renderCell(cell) {
     createContext.strokeStyle = '#adadad';
     createContext.fill();
     createContext.stroke();
+    // Match the in-game board's depth: shadow only at terrain transitions.
+    if (tileIdByVid) { paintCellEdgeAO(createContext, cell, tileIdByVid); }
 }
 function getStartpoint(halfedge) {
     if (compareSite(halfedge.edge.lSite, halfedge.site)) {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -448,6 +448,30 @@ function getCartSpeed(player) {
     return Math.sqrt(vx * vx + vy * vy);
 }
 
+// Single source of truth for cart-skin dispatch. A skin name maps to its
+// procedural painter; null means "no skin" (plain colour disc). Add future
+// skins HERE and they automatically work everywhere this is consulted: the live
+// kart, the scoreboard notch icon, and the ice reflection.
+function cartSkinPainter(name) {
+    if (name === "firetruck") { return drawFiretruckSkin; }
+    if (name === "dino") { return drawDinoSkin; }
+    return null;
+}
+// Draw a kart's core appearance (skin or plain colour disc) centred at screen
+// (sx,sy). No highlights/avatar/FX — just the body — so callers like the ice
+// reflection get a faithful, skin-aware image for any current or future skin.
+function drawKartAppearance(player, sx, sy, headingOverride) {
+    var painter = cartSkinPainter(player.cartSkin);
+    if (painter != null) {
+        drawCartSkin(player, sx, sy, player.radius, painter, headingOverride);
+        return;
+    }
+    var sprite = getPlayerSprite(player.color, player.radius, null);
+    if (sprite != null) {
+        gameContext.drawImage(sprite, sx - sprite.halfSize, sy - sprite.halfSize);
+    }
+}
+
 function drawCartSkin(player, centerX, centerY, radius, painter, headingOverride) {
     var ctx = gameContext;
     // headingOverride pins the skin to a fixed angle (used by the overview scoreboard, a
@@ -1033,6 +1057,12 @@ function drawObjects(dt) {
         currentState == config.stateMap.racing) {
         // gated: pulsing red countdown line. racing: brief green release flash.
         drawGateLine();
+    }
+    // Animated terrain overlays (goal beacon, lava convection, ice reflections,
+    // swaying/kart-pushed grass blades). Drawn over the terrain and UNDER the
+    // karts; self-gates by state + perf profile.
+    if (typeof drawTerrainFX === "function") {
+        drawTerrainFX(dt);
     }
     drawPlayers(dt);
     drawProjectiles(dt);
@@ -2484,7 +2514,7 @@ function drawPlayer(player, dt) {
     // avatar overlay that rides it) — otherwise the round sprite pokes out around the
     // irregular skin silhouette and reads as an unwanted "background". The skin is
     // tinted with the player's colour, so their identity still carries.
-    var hasCartSkin = (player.cartSkin === "firetruck" || player.cartSkin === "dino");
+    var hasCartSkin = cartSkinPainter(player.cartSkin) != null;
     // try/finally so a thrown drawImage (e.g. an undecoded sprite -> InvalidStateError)
     // can't skip the restore() and leak the dimmed/flash alpha onto the rest of the frame.
     try {
@@ -2502,10 +2532,9 @@ function drawPlayer(player, dt) {
         }
         // Cosmetic cart skin (procedural overlay). Uses the SAME screen anchor as the
         // sprite blit (player.x/y + camera offset), so the camera offset is applied once.
-        if (player.cartSkin === "firetruck") {
-            drawCartSkin(player, player.x + camera.getCameraX(), player.y + camera.getCameraY(), player.radius, drawFiretruckSkin);
-        } else if (player.cartSkin === "dino") {
-            drawCartSkin(player, player.x + camera.getCameraX(), player.y + camera.getCameraY(), player.radius, drawDinoSkin);
+        var bodyPainter = cartSkinPainter(player.cartSkin);
+        if (bodyPainter != null) {
+            drawCartSkin(player, player.x + camera.getCameraX(), player.y + camera.getCameraY(), player.radius, bodyPainter);
         }
         // The base sprite (skipped for skinned karts) is where the "you're being
         // targeted" red rim lives, so re-draw that tell around the skin when this kart
@@ -3711,9 +3740,9 @@ function drawCollapseShockwaves() {
     }
     gameContext.restore();
 }
-// Lobby-only "practice room" floor treatment: a faint grid + a dashed inset frame
-// over the arena. Races never draw this, so a returning player instantly reads the
-// lobby as a distinct practice space (not a glitched race map) — without any text.
+// Lobby-only "practice room" floor treatment: a dashed inset frame over the
+// arena. Races never draw this, so a returning player instantly reads the lobby
+// as a distinct practice space (not a glitched race map) — without any text.
 // Drawn after drawWorld (the plain fill) and before the islands.
 function drawLobbyFloor() {
     if (world == null) {
@@ -3721,28 +3750,6 @@ function drawLobbyFloor() {
     }
     var ox = world.x + camera.getCameraX();
     var oy = world.y + camera.getCameraY();
-    // Faint grid, clipped to the arena so it never spills past the border.
-    gameContext.save();
-    gameContext.beginPath();
-    gameContext.rect(ox, oy, world.width, world.height);
-    gameContext.clip();
-    // Theme-aware faint lines: the theme's foreground "ink" (dark on the light theme,
-    // light on dark) at low alpha, so the practice grid reads on both themes.
-    gameContext.globalAlpha = 0.07;
-    gameContext.strokeStyle = themeColor('ink', 'black');
-    gameContext.lineWidth = 1;
-    var step = 64;
-    gameContext.beginPath();
-    for (var gx = step; gx < world.width; gx += step) {
-        gameContext.moveTo(ox + gx, oy);
-        gameContext.lineTo(ox + gx, oy + world.height);
-    }
-    for (var gy = step; gy < world.height; gy += step) {
-        gameContext.moveTo(ox, oy + gy);
-        gameContext.lineTo(ox + world.width, oy + gy);
-    }
-    gameContext.stroke();
-    gameContext.restore();
     // Dashed inset frame — a "this is a bounded practice area" cue (theme-aware).
     gameContext.save();
     gameContext.globalAlpha = 0.32;
@@ -4110,7 +4117,12 @@ function renderMapToCache() {
     }
     mapCtx.translate(-world.x + mapCanvasPad, -world.y + mapCanvasPad);
 
+    // Per-cell AO edge shading reads as depth, but it's an extra gradient fill
+    // per cell on every cache rebuild — skip it on the reduced-resolution
+    // (low-end) profile, where the flat graded texture already looks clean.
+    var aoOn = (typeof perfMapScale === "function" ? perfMapScale() : 1) === 1;
     var cells = currentMap.cells;
+    var aoIds = aoOn ? buildIdByVoronoi(cells) : null;
     var iCell = cells.length;
     while (iCell--) {
         mapCtx.beginPath();
@@ -4143,7 +4155,11 @@ function renderMapToCache() {
             mapCtx.setLineDash([2, 2]);
             mapCtx.lineWidth = 5;
             mapCtx.strokeStyle = '#FFFF00';
-            color = patterns[cell.id];
+            // Ability tiles: bake only the dirt underlay here; the ability icon is
+            // drawn hovering per-frame (drawTerrainFX) instead of flat in the cache.
+            // Fall back to the baked icon pattern if dirt isn't ready yet.
+            var dirtPat = patterns[config.tileMap.normal.id];
+            color = (dirtPat != null) ? dirtPat : patterns[cell.id];
         } else if (patterns[cell.id] != null) {
             color = patterns[cell.id];
             mapCtx.setLineDash([]);
@@ -4165,6 +4181,10 @@ function renderMapToCache() {
         mapCtx.fillStyle = color;
         mapCtx.fill();
         mapCtx.stroke();
+        // Terrain depth: soft inner shadow only where this cell meets a different
+        // terrain type, so same-type regions stay seamless. No-op for non-terrain
+        // tiles. Baked into the cache, so it's free per frame.
+        if (aoIds) { paintCellEdgeAO(mapCtx, cell, aoIds); }
     }
     drawTileBorders(mapCtx);
     drawLavaBorders(mapCtx);
@@ -5300,8 +5320,8 @@ function drawPlayerIcon(player, notchDistanceApart) {
     // Match the in-game look: a skinned kart shows its procedural skin (tinted by the
     // player's colour) instead of the plain colour disc + ring. Heading falls back to
     // the kart's angle since overview icons are static.
-    if (player.cartSkin === "firetruck" || player.cartSkin === "dino") {
-        var iconPainter = (player.cartSkin === "firetruck") ? drawFiretruckSkin : drawDinoSkin;
+    var iconPainter = cartSkinPainter(player.cartSkin);
+    if (iconPainter != null) {
         // Fixed heading (face right, toward the finish) so the scoreboard icon doesn't
         // freeze at the kart's last racing angle.
         drawCartSkin(player, notchX, 0, iconRadius, iconPainter, 0);

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -532,6 +532,7 @@ function buildMapThumbnailCanvas(map) {
 	var ctx = cv.getContext('2d');
 	ctx.fillStyle = thumbnailTileFill(config.tileMap.normal.id);
 	ctx.fillRect(0, 0, cv.width, cv.height);
+	var thumbIds = buildIdByVoronoi(map.cells);
 	for (var i = 0; i < map.cells.length; i++) {
 		var cell = map.cells[i];
 		var hes = cell.halfedges;
@@ -543,6 +544,7 @@ function buildMapThumbnailCanvas(map) {
 		ctx.closePath();
 		ctx.fillStyle = thumbnailTileFill(cell.id);
 		ctx.fill();
+		paintCellEdgeAO(ctx, cell, thumbIds);
 	}
 	// Hazards: matches drawBumper/drawMovingBumper in draw.js (orange disc +
 	// red attack ring; moving bumper also draws its rail). The thumbnail can't

--- a/client/scripts/terrainfx.js
+++ b/client/scripts/terrainfx.js
@@ -1,0 +1,313 @@
+// terrainfx.js — animated terrain overlays drawn each frame AFTER the map-cache
+// blit and UNDER the karts (called from drawObjects, right after drawMap()).
+//
+// Effects, all in world space (every coord adds camera.getCameraX/Y(), the same
+// convention drawPlayer uses, so they stay glued to the karts and the terrain):
+//   - Goal beacon     : breathing bright core + an expanding pulse ring, clipped
+//                       to each goal-cell cluster. Cheap + a gameplay signal, so
+//                       it runs on EVERY perf profile.
+//   - Lava convection : slow rolling hot patches (additive) clipped to lava.
+//   - Ice reflections : a flipped, squashed, low-alpha (blurred on glow profiles)
+//                       echo of each kart, clipped to ice — a glossy-floor look.
+//   - Ability icons   : float/bob the pickup icon above the tile (always on).
+// The two ambient ones (lava/ice) are gated to perfExtraFx() — on Low the flat
+// graded texture (+ baked AO) stands on its own. The per-map dataset
+// (cells-by-type, goal clusters, lava seeds) is rebuilt only when the terrain
+// changes (mapCacheRev), never per frame.
+
+var terrainFX = {
+    rev: -1,            // mapCacheRev the cell sets were built for
+    ice: [], lava: [], goal: [], ability: [],
+    goalClusters: [],
+    lavaSeeds: [],
+    abilityIcons: null   // lazily-built map: ability tile id -> icon Image
+};
+// Map each ability tile id to its icon image (the same Images loadPatterns uses).
+function tfxBuildAbilityIcons() {
+    var m = {};
+    var ab = config.tileMap.abilities;
+    if (ab == null) { return m; }
+    function set(name, ic) { if (ab[name] != null && typeof ic !== "undefined" && ic != null) { m[ab[name].id] = ic; } }
+    set("blindfold", typeof blindfoldIcon !== "undefined" ? blindfoldIcon : null);
+    set("swap", typeof transferIcon !== "undefined" ? transferIcon : null);
+    set("bomb", typeof bombIcon !== "undefined" ? bombIcon : null);
+    set("speedBuff", typeof windIcon !== "undefined" ? windIcon : null);
+    set("speedDebuff", typeof hourglassIcon !== "undefined" ? hourglassIcon : null);
+    set("tileSwap", typeof copyIcon !== "undefined" ? copyIcon : null);
+    set("iceCannon", typeof snowFlakeIcon !== "undefined" ? snowFlakeIcon : null);
+    set("cut", typeof scissorsIcon !== "undefined" ? scissorsIcon : null);
+    return m;
+}
+
+function terrainFXActive() {
+    if (typeof config === "undefined" || config == null) { return false; }
+    if (typeof currentMap === "undefined" || currentMap == null || currentMap.cells == null) { return false; }
+    if (typeof world === "undefined" || world == null) { return false; }
+    var s = (typeof currentState !== "undefined") ? currentState : null;
+    var sm = config.stateMap;
+    // Include the lobby: the tutorial lobby has real ability pickup tiles (ids
+    // 100-108) that need their hovering icon. The AI/skin hub zones are a separate
+    // `stations` payload (string ids "ai"/"skin"), NOT cells, so they don't go
+    // through here — no collision.
+    return s === sm.lobby || s === sm.gated || s === sm.racing || s === sm.collapsing;
+}
+
+function tfxCellVerts(cell) {
+    var he = cell.halfedges;
+    if (!he || he.length === 0) { return null; }
+    var verts = [];
+    var v = getStartpoint(he[0]);
+    verts.push({ x: v.x, y: v.y });
+    for (var i = 0; i < he.length; i++) {
+        v = getEndpoint(he[i]);
+        verts.push({ x: v.x, y: v.y });
+    }
+    return verts;
+}
+function tfxCentroid(verts) {
+    var cx = 0, cy = 0;
+    for (var i = 0; i < verts.length; i++) { cx += verts[i].x; cy += verts[i].y; }
+    return { x: cx / verts.length, y: cy / verts.length };
+}
+function tfxMaxRadius(verts, cx, cy) {
+    var r = 0;
+    for (var i = 0; i < verts.length; i++) {
+        var dx = verts[i].x - cx, dy = verts[i].y - cy;
+        var d = Math.sqrt(dx * dx + dy * dy);
+        if (d > r) { r = d; }
+    }
+    return r;
+}
+// Path a list of cells' polygons into the current ctx path (world coords + cam),
+// ready for clip() or fill(). Each cell is a verts array.
+function tfxPathCells(ctx, cells, camX, camY) {
+    ctx.beginPath();
+    for (var i = 0; i < cells.length; i++) {
+        var verts = cells[i].verts || cells[i];
+        ctx.moveTo(verts[0].x + camX, verts[0].y + camY);
+        for (var v = 1; v < verts.length; v++) {
+            ctx.lineTo(verts[v].x + camX, verts[v].y + camY);
+        }
+        ctx.closePath();
+    }
+}
+
+// ---- per-map dataset builders -----------------------------------------
+function tfxBuildCells() {
+    var tm = config.tileMap;
+    if (terrainFX.abilityIcons == null) { terrainFX.abilityIcons = tfxBuildAbilityIcons(); }
+    terrainFX.ice = []; terrainFX.lava = []; terrainFX.goal = []; terrainFX.ability = [];
+    var cells = currentMap.cells;
+    for (var i = 0; i < cells.length; i++) {
+        var cell = cells[i];
+        var verts = tfxCellVerts(cell);
+        if (!verts) { continue; }
+        var c = tfxCentroid(verts);
+        var rec = { verts: verts, cx: c.x, cy: c.y, vid: (cell.site ? cell.site.voronoiId : i) };
+        if (cell.id === tm.ice.id) { terrainFX.ice.push(rec); }
+        else if (cell.id === tm.lava.id) { terrainFX.lava.push(rec); }
+        else if (cell.id === tm.goal.id) { terrainFX.goal.push(rec); }
+        else if (terrainFX.abilityIcons[cell.id] != null) {
+            rec.id = cell.id;
+            rec.r = tfxMaxRadius(verts, c.x, c.y);
+            terrainFX.ability.push(rec);
+        }
+    }
+    tfxBuildGoalClusters();
+    tfxBuildLavaSeeds();
+}
+// Group touching goal cells into clusters (union-find over voronoi adjacency) so
+// a multi-cell goal reads as ONE beacon centred on the cluster, not a beacon per
+// tile. Each cluster stores its centroid, radius and member polygons (for clip).
+function tfxBuildGoalClusters() {
+    terrainFX.goalClusters = [];
+    var goals = terrainFX.goal;
+    var n = goals.length;
+    if (n === 0) { return; }
+    var vid2idx = {};
+    for (var i = 0; i < n; i++) { vid2idx[goals[i].vid] = i; }
+    var parent = [];
+    for (i = 0; i < n; i++) { parent[i] = i; }
+    function find(a) { while (parent[a] !== a) { parent[a] = parent[parent[a]]; a = parent[a]; } return a; }
+    function union(a, b) { parent[find(a)] = find(b); }
+    var cells = currentMap.cells, goalId = config.tileMap.goal.id;
+    for (i = 0; i < cells.length; i++) {
+        var cell = cells[i];
+        if (cell.id !== goalId || cell.site == null) { continue; }
+        var myIdx = vid2idx[cell.site.voronoiId];
+        if (myIdx == null) { continue; }
+        var he = cell.halfedges;
+        for (var h = 0; h < he.length; h++) {
+            var e = he[h].edge;
+            var nb = compareSite(e.lSite, he[h].site) ? e.rSite : e.lSite;
+            if (nb != null && vid2idx[nb.voronoiId] != null) { union(myIdx, vid2idx[nb.voronoiId]); }
+        }
+    }
+    var groups = {};
+    for (i = 0; i < n; i++) { var root = find(i); (groups[root] = groups[root] || []).push(i); }
+    for (var key in groups) {
+        var idxs = groups[key], cx = 0, cy = 0, verts = [];
+        for (var k = 0; k < idxs.length; k++) { var g = goals[idxs[k]]; cx += g.cx; cy += g.cy; verts.push(g.verts); }
+        cx /= idxs.length; cy /= idxs.length;
+        var r = 0;
+        for (k = 0; k < idxs.length; k++) {
+            var gv = goals[idxs[k]].verts;
+            var rr = tfxMaxRadius(gv, cx, cy);
+            if (rr > r) { r = rr; }
+        }
+        terrainFX.goalClusters.push({ cx: cx, cy: cy, r: r, cells: verts });
+    }
+}
+// One bubbling hotspot per lava cell (at its centroid), capped so a full-map
+// collapse doesn't spawn thousands. Subset by stride when over the cap.
+function tfxBuildLavaSeeds() {
+    terrainFX.lavaSeeds = [];
+    var lava = terrainFX.lava;
+    if (!lava.length) { return; }
+    var MAX = 70;
+    var stride = Math.max(1, Math.floor(lava.length / MAX));
+    for (var i = 0; i < lava.length; i += stride) {
+        var c = lava[i];
+        var r = tfxMaxRadius(c.verts, c.cx, c.cy);
+        terrainFX.lavaSeeds.push({
+            x: c.cx, y: c.cy,
+            r: Math.min(r * 0.9, 46) + 10,
+            ph: Math.random() * 6.28,
+            sp: 0.7 + Math.random() * 0.7
+        });
+    }
+}
+// ---- per-frame draw ----------------------------------------------------
+function drawTerrainFX(dtIgnored) {
+    if (!terrainFXActive()) { return; }
+    if (terrainFX.rev !== mapCacheRev) { tfxBuildCells(); terrainFX.rev = mapCacheRev; }
+
+    var t = Date.now() / 1000;
+    var camX = camera.getCameraX(), camY = camera.getCameraY();
+    var extra = (typeof perfExtraFx === "function") ? perfExtraFx() : true;
+
+    if (extra) {
+        tfxDrawLavaConvection(t, camX, camY);
+        tfxDrawIceReflections(camX, camY);
+    }
+    tfxDrawGoalBeacon(t, camX, camY);    // always — cheap + gameplay-critical
+    tfxDrawAbilityIcons(t, camX, camY);  // always — gameplay-critical pickup markers
+}
+
+// Ability pickups: float the icon above the tile (gentle bob + soft ground
+// shadow), like the lobby hub glyphs, instead of sitting flat in the texture.
+function tfxDrawAbilityIcons(t, camX, camY) {
+    var list = terrainFX.ability;
+    if (!list.length || terrainFX.abilityIcons == null) { return; }
+    var ctx = gameContext;
+    for (var i = 0; i < list.length; i++) {
+        var a = list[i];
+        var icon = terrainFX.abilityIcons[a.id];
+        if (icon == null || !icon.complete || icon.naturalWidth === 0) { continue; }
+        var cx = a.cx + camX, cy = a.cy + camY;
+        var d = Math.max(16, Math.min(a.r * 0.7, 30));
+        var bob = Math.sin(t * 2.4 + a.cx * 0.05) * 4;
+        var lift = 6;
+        // soft ground shadow (fainter/smaller as the icon rises)
+        var rise = (bob + 4) / 8; // 0..1
+        ctx.save();
+        ctx.globalAlpha = 0.30 - 0.10 * rise;
+        ctx.fillStyle = "#000000";
+        ctx.beginPath();
+        ctx.ellipse(cx, cy + d * 0.34, d * 0.42 * (1 - 0.12 * rise), d * 0.16 * (1 - 0.12 * rise), 0, 0, 2 * Math.PI);
+        ctx.fill();
+        ctx.restore();
+        // floating icon
+        ctx.drawImage(icon, cx - d / 2, cy - d / 2 - lift - bob, d, d);
+    }
+}
+
+function tfxDrawGoalBeacon(t, camX, camY) {
+    var cl = terrainFX.goalClusters;
+    if (!cl.length) { return; }
+    var ctx = gameContext;
+    var breath = 0.5 + 0.5 * Math.sin(t * 1.6);
+    var ring = (t * 0.5) % 1;
+    for (var i = 0; i < cl.length; i++) {
+        var g = cl[i], cx = g.cx + camX, cy = g.cy + camY, s = g.r;
+        ctx.save();
+        tfxPathCells(ctx, g.cells, camX, camY);
+        ctx.clip();
+        var cr = s * (0.5 + 0.22 * breath);
+        var core = ctx.createRadialGradient(cx, cy, 2, cx, cy, cr);
+        core.addColorStop(0, "rgba(255,255,255," + (0.30 + 0.40 * breath) + ")");
+        core.addColorStop(1, "rgba(255,232,154,0)");
+        ctx.fillStyle = core;
+        ctx.fillRect(cx - cr, cy - cr, cr * 2, cr * 2);
+        var rr = s * 0.25 + ring * s * 0.8;
+        ctx.globalAlpha = (1 - ring) * 0.7;
+        ctx.lineWidth = 3 + (1 - ring) * 3;
+        ctx.strokeStyle = "#FFE89A";
+        ctx.beginPath();
+        ctx.arc(cx, cy, rr, 0, 2 * Math.PI);
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+        ctx.restore();
+    }
+}
+
+function tfxDrawLavaConvection(t, camX, camY) {
+    var lava = terrainFX.lava, seeds = terrainFX.lavaSeeds;
+    if (!lava.length || !seeds.length) { return; }
+    var ctx = gameContext;
+    ctx.save();
+    tfxPathCells(ctx, lava, camX, camY);
+    ctx.clip();
+    ctx.globalCompositeOperation = "lighter";
+    for (var i = 0; i < seeds.length; i++) {
+        var s = seeds[i];
+        var ph = Math.sin(t * s.sp + s.ph);
+        var a = 0.18 * (0.6 + 0.4 * ph);
+        var r = s.r * (0.7 + 0.4 * (0.5 + 0.5 * ph));
+        var x = s.x + camX + Math.cos(t * s.sp * 0.7 + s.ph) * s.r * 0.15;
+        var y = s.y + camY + Math.sin(t * s.sp * 0.7 + s.ph) * s.r * 0.15;
+        var g = ctx.createRadialGradient(x, y, 1, x, y, r);
+        g.addColorStop(0, "rgba(255,210,90," + a + ")");
+        g.addColorStop(0.55, "rgba(255,120,25," + (a * 0.6) + ")");
+        g.addColorStop(1, "rgba(255,90,10,0)");
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(x, y, r, 0, 2 * Math.PI);
+        ctx.fill();
+    }
+    ctx.restore();
+}
+
+function tfxDrawIceReflections(camX, camY) {
+    var ice = terrainFX.ice;
+    if (!ice.length || typeof playerList === "undefined" || playerList == null) { return; }
+    var ctx = gameContext;
+    ctx.save();
+    tfxPathCells(ctx, ice, camX, camY);
+    ctx.clip();
+    var useBlur = (typeof perfGlow === "function") ? perfGlow() : true;
+    for (var id in playerList) {
+        var p = playerList[id];
+        if (p == null || p.alive === false) { continue; }
+        var rad = p.radius || 16;
+        var x = p.x + camX, y = p.y + camY;
+        // Cast the reflection fully BELOW the kart so its top sits at the kart's
+        // base (not hidden behind the body). Flip + squash about that pivot, and
+        // render the kart's ACTUAL appearance (skin-aware via drawKartAppearance)
+        // at low alpha + blur, so it stays faint and works for any current or
+        // future skin.
+        var pivot = y + rad * 1.95;
+        ctx.save();
+        ctx.globalAlpha = 0.38;
+        if (useBlur && "filter" in ctx) { ctx.filter = "blur(2.5px)"; }
+        ctx.translate(x, pivot);
+        ctx.scale(1.0, -0.85);
+        ctx.translate(-x, -pivot);
+        if (typeof drawKartAppearance === "function") {
+            drawKartAppearance(p, x, pivot);
+        }
+        ctx.restore();
+    }
+    ctx.restore();
+}
+

--- a/client/scripts/utils.js
+++ b/client/scripts/utils.js
@@ -165,12 +165,12 @@ function easeOutBack(t) {
 // with a tint blend — averaging toward one colour smooths noise out.
 var TILE_GRADE_ENABLED = true;
 var TILE_GRADE = {
-    grass:  { sat: 0.60, light: 0.90, contrast: 0.92 }, // kill the neon lime
-    dirt:   { sat: 0.90, light: 0.98, contrast: 0.96 }, // anchor tone, barely touched
-    sand:   { sat: 0.92, light: 0.86, contrast: 0.95 }, // drop the bright glow
-    ice:    { sat: 0.82, light: 0.97, contrast: 1.00, tint: [120, 200, 236], tintAmt: 0.20 }, // deepen blue via tint, mute sparkle noise
-    lava:   { sat: 0.92, light: 0.96, contrast: 1.00 }, // still hot, a touch less fluorescent
-    poison: { sat: 0.92, light: 0.96, contrast: 1.00 }  // lava's infection-round swap
+    grass:  { sat: 0.85, light: 0.92, contrast: 1.05, tint: [80, 140, 70], tintAmt: 0.10 },   // richer meadow green (still no neon)
+    dirt:   { sat: 1.06, light: 0.98, contrast: 1.04, tint: [150, 95, 50], tintAmt: 0.12 },    // warm rich soil
+    sand:   { sat: 1.04, light: 0.90, contrast: 1.05, tint: [205, 160, 90], tintAmt: 0.10 },   // warm sun-baked gold
+    ice:    { sat: 0.85, light: 0.95, contrast: 1.05, tint: [90, 180, 230], tintAmt: 0.28 },   // deeper blue, mute sparkle noise
+    lava:   { sat: 1.05, light: 0.95, contrast: 1.12, tint: [210, 70, 20], tintAmt: 0.10 },    // hotter, higher contrast
+    poison: { sat: 0.92, light: 0.96, contrast: 1.00 }  // lava's infection-round swap (unchanged)
 };
 
 function _rgbToHsl(r, g, b) {
@@ -287,4 +287,98 @@ function gradeTexture(image, key) {
     }
     ctx.putImageData(data, 0, 0);
     return finish();
+}
+
+// --- Boundary-only ambient-occlusion edge shading -----------------------
+// A soft inner shadow drawn ONLY along edges where a terrain cell meets a
+// DIFFERENT tile type (or the map's outer void). Edges shared with a same-type
+// neighbour are skipped, so a contiguous grass/dirt/etc region stays seamless
+// and only real terrain transitions read as depth. Shared by the game cache
+// (draw.js), the editor (create.js) and the thumbnails (gameboard.js/create.js)
+// so depth is identical everywhere. The shadow is tinted toward each tile's own
+// dark so the crevice between two terrains feels natural.
+var TILE_AO = {
+    normal: { rgb: "20,12,4", a: 0.42 },   // dirt
+    fast:   { rgb: "15,18,6", a: 0.40 },   // grass
+    slow:   { rgb: "40,28,8", a: 0.40 },   // sand
+    ice:    { rgb: "18,40,60", a: 0.38 },
+    lava:   { rgb: "50,8,2", a: 0.45 }
+};
+var TILE_AO_DEPTH = 11; // how far the inner shadow reaches in from the edge
+function tileAOEntry(id) {
+    if (typeof config === "undefined" || config == null || config.tileMap == null) {
+        return null;
+    }
+    var tm = config.tileMap;
+    if (id === tm.normal.id) { return TILE_AO.normal; }
+    if (id === tm.fast.id)   { return TILE_AO.fast; }
+    if (id === tm.slow.id)   { return TILE_AO.slow; }
+    if (id === tm.ice.id)    { return TILE_AO.ice; }
+    if (id === tm.lava.id)   { return TILE_AO.lava; }
+    return null; // goal / ability / bumper / random / background get no AO
+}
+// Map voronoiId -> tile id, so a cell's halfedge neighbours can be typed.
+function buildIdByVoronoi(cells) {
+    var m = {};
+    for (var i = 0; i < cells.length; i++) {
+        var c = cells[i];
+        if (c != null && c.site != null) { m[c.site.voronoiId] = c.id; }
+    }
+    return m;
+}
+// Draw the boundary AO for one cell. `idByVoronoi` types its neighbours. Draws
+// in whatever coords the caller's halfedge points use; leaves ctx unchanged.
+function paintCellEdgeAO(ctx, cell, idByVoronoi) {
+    if (cell == null || cell.site == null) { return; }
+    var id = idByVoronoi[cell.site.voronoiId];
+    var entry = tileAOEntry(id);
+    if (entry == null) { return; }
+    var he = cell.halfedges;
+    if (!he || he.length === 0) { return; }
+    var verts = [], i;
+    var v = getStartpoint(he[0]);
+    verts.push({ x: v.x, y: v.y });
+    for (i = 0; i < he.length; i++) { v = getEndpoint(he[i]); verts.push({ x: v.x, y: v.y }); }
+    var cx = 0, cy = 0;
+    for (i = 0; i < verts.length; i++) { cx += verts[i].x; cy += verts[i].y; }
+    cx /= verts.length; cy /= verts.length;
+    // Collect only the EXPOSED edges (neighbour is a different type / the void).
+    var exposed = [];
+    for (i = 0; i < he.length; i++) {
+        var e = he[i].edge;
+        var nb = compareSite(e.lSite, he[i].site) ? e.rSite : e.lSite;
+        var nbId = (nb != null) ? idByVoronoi[nb.voronoiId] : undefined;
+        if (nbId === id) { continue; } // same-type seam — keep the region seamless
+        exposed.push([getStartpoint(he[i]), getEndpoint(he[i])]);
+    }
+    if (exposed.length === 0) { return; }
+    var depth = TILE_AO_DEPTH;
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(verts[0].x, verts[0].y);
+    for (i = 1; i < verts.length; i++) { ctx.lineTo(verts[i].x, verts[i].y); }
+    ctx.closePath();
+    ctx.clip();
+    // Soft inner band built from a few concentric strokes of the exposed edges,
+    // widening + fading outward. Strokes are centred on the edge (outer half is
+    // clipped away), so only the interior darkens. Round caps/joins + one path
+    // per pass mean no corner-doubling "triangles". Layering ≈ a smooth falloff.
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    var passes = [
+        { w: depth * 2.0, a: entry.a * 0.22 },
+        { w: depth * 1.1, a: entry.a * 0.30 },
+        { w: depth * 0.5, a: entry.a * 0.34 }
+    ];
+    for (var p = 0; p < passes.length; p++) {
+        ctx.beginPath();
+        for (i = 0; i < exposed.length; i++) {
+            ctx.moveTo(exposed[i][0].x, exposed[i][0].y);
+            ctx.lineTo(exposed[i][1].x, exposed[i][1].y);
+        }
+        ctx.lineWidth = passes[p].w;
+        ctx.strokeStyle = "rgba(" + entry.rgb + "," + passes[p].a + ")";
+        ctx.stroke();
+    }
+    ctx.restore();
 }


### PR DESCRIPTION
## What & why

A visual refresh of the board, iterated with the operator from concept mockups to final.

### Static (bakes once at load → live play, editor, and thumbnails, free per frame)
- **Richer terrain grades** — warmer dirt/sand, lusher grass, deeper ice, hotter lava (`TILE_GRADE` in `utils.js`).
- **Boundary-only AO depth** — a soft inner shadow drawn *only* where a tile meets a different terrain type, so a contiguous region stays seamless and only real transitions read as depth. New `paintCellEdgeAO()`/`buildIdByVoronoi()` shared by the cache (`draw.js`), editor (`create.js`), and both thumbnail builders.

### Animated overlays (`client/scripts/terrainfx.js`, new)
Drawn per-frame after the map-cache blit and under the karts (`drawObjects`), in world space (`coord + camera.getCameraX/Y()`), with the per-map dataset rebuilt only on terrain change (`mapCacheRev`):
- **Goal beacon** — breathing core + expanding pulse ring, clipped to each goal-cell cluster (union-find adjacency). Always on (cheap, gameplay signal).
- **Lava convection** — slow rolling hot patches.
- **Ice reflections** — a flipped/squashed, low-alpha, blurred echo of each kart, clipped to ice. Skin-aware and future-proof via a centralized `cartSkinPainter()` + `drawKartAppearance()` (also now used by the live kart and the scoreboard notch icon).
- **Ability pickup icons** — now float/bob above the tile with a shadow (lobby-hub style) instead of baked flat; thumbnails/editor keep the baked-icon pattern.

Ambient lava/ice gated to `perfExtraFx()` (flat graded texture + AO on Low); beacon and ability icons always on. Also removed the faint lobby practice grid (kept the dashed frame).

## Perf
- Grades/AO are baked into the static map cache — zero per-frame cost, no change to cache size or GPU re-upload frequency.
- Overlays are soft gradients / a few draws, no `shadowBlur`, drawn after the cache blit so they never dirty/re-upload it. (A denser swaying-grass-blade system was prototyped and **cut** for not being worth the per-frame cost.)

## Test plan
- `npm run build` ✅, `node .github/scripts/smoke-test.js` ✅ (52 maps).
- Sandbox harnesses verified the FX code paths (cell classification, goal clustering, AO boundary skipping same-type edges, ability-icon hover) with no runtime errors.
- Codex review: one P2 (lobby ability pickups iconless) found and **fixed** — the lobby's 102–108 cells are real ability pickups (sites in `_lobbyTutorial.json`; AI/skin hubs are a separate non-cell `stations` field), so `terrainFXActive()` includes the lobby.
- Needs an in-browser playtest on a real race (FX require live karts) — grass/ice/lava map, goal beacon, drive onto ice for the reflection, and an ability tile for the hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)