### PR TITLE
feat(analytics): add map + players params to round_complete and match_end

### DIFF
--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -557,7 +557,9 @@ function registerStateHandlers(server) {
 		mapLeaderboardData = null;
 		mapLeaderboardJustPlayed = null;
 		currentState = config.stateMap.overview;
-		trackEvent('round_complete');
+		trackEvent('round_complete', {
+			map: (currentMap && currentMap.name) || 'unknown'
+		});
 	});
 	// Map leaderboard for the JUST-PLAYED map (rank/time per logged-in racer in
 	// this room). Drives the inline rank/time shown alongside each notch row on
@@ -629,7 +631,11 @@ function registerStateHandlers(server) {
 			? Colors.decode((winner._serverColor != null) ? winner._serverColor : winner.color)
 			: "";
 		currentState = config.stateMap.gameOver;
-		trackEvent('match_end', { won: (packet.winner === myID) });
+		trackEvent('match_end', {
+			won: (packet.winner === myID),
+			map: (currentMap && currentMap.name) || 'unknown',
+			players: clientList ? Object.keys(clientList).length : 0
+		});
 		// Nudge signed-out players to log in (save progress / earn skins). No-op
 		// when auth is off or already signed in. Primary screen only.
 		if (window.chaochaoAuth && typeof window.chaochaoAuth.showLoginNudge === "function") {


### PR DESCRIPTION
## Summary
- Add `map` to `round_complete` so per-map completion rate (`round_complete ÷ round_start by map`) becomes queryable in GA4.
- Add `map` and `players` to `match_end` so "win rate by map" and "match size at finish" become queryable.

Surfaced by a GA4 MCP audit on 2026-05-29 against property `chaochaogame` / `G-832XFC4F84`: the custom dimensions `target`/`won`/`map` and metric `players` are already registered and capturing data (`round_start` populates them cleanly, 47 distinct map names, ~20 avg players/round across 201 events in the last 52h). The two events touched here were the only remaining gaps — they fired without the params needed to slice the dashboards.

Source `map` from `currentMap.name` and `players` from `clientList` (humans only) — same sources `round_start` already uses, so the dimensions match across events.

## Test plan
- [x] `npm run build` — all three bundles built clean
- [x] `node .github/scripts/smoke-test.js` — engine ticked through 52 maps without crash
- [x] Codex review on branch — no findings
- [ ] In-browser playtest on prod after deploy: open DevTools → Network → filter `collect?v=2`, finish a round and a match, confirm `round_complete` payload includes `ep.map` and `match_end` includes `ep.map` + `epn.players` (or `ep.players`)
- [ ] After ~24–48h, confirm GA4 Explorations can break `round_complete` and `match_end` down by `customEvent:map` (and `match_end` by `customEvent:players`)

## Operator follow-ups (not code)
- Star `match_end` as a **Key event** in Admin → Events (no events are currently flagged; the keyEvents metric is 0 across the board).
🤖 Generated with [Claude Code](https://claude.com/claude-code)