### PR TITLE
feat(analytics): add bots count to round_start and match_end

### DIFF
--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -430,6 +430,16 @@ function registerScoreHandlers(server) {
 
 	//Game State Map changes
 }
+// Bot count for analytics — playerList[id].name is the spawn-packet bot marker
+// (compressor.js sets player.name only on bot append; humans stay null).
+function countBotsInPlayerList() {
+	if (playerList == null) { return 0; }
+	var n = 0;
+	for (var id in playerList) {
+		if (playerList[id] != null && playerList[id].name != null) { n++; }
+	}
+	return n;
+}
 function registerStateHandlers(server) {
 	server.on("startWaiting", function (packet) {
 		debugLog("startWaiting");
@@ -516,10 +526,13 @@ function registerStateHandlers(server) {
 		raceStartTime = Date.now();
 		currentState = config.stateMap.racing;
 		// Fires once per round (racing state is re-entered each round), so this is a
-		// round-start signal. `players` counts humans only: clientList is the room's
-		// client roster and excludes bots (the per-tick compressor never sends isAI).
+		// round-start signal. `players` counts humans only (clientList = room's
+		// client roster, excludes bots); `bots` counts AI fill via the spawn-packet
+		// `name` marker (server compressor sets player.name only on bot append; humans
+		// stay null — see compressor.js gameState).
 		trackEvent('round_start', {
 			players: clientList ? Object.keys(clientList).length : 0,
+			bots: countBotsInPlayerList(),
 			map: (currentMap && currentMap.name) || 'unknown'
 		});
 	});
@@ -634,7 +647,8 @@ function registerStateHandlers(server) {
 		trackEvent('match_end', {
 			won: (packet.winner === myID),
 			map: (currentMap && currentMap.name) || 'unknown',
-			players: clientList ? Object.keys(clientList).length : 0
+			players: clientList ? Object.keys(clientList).length : 0,
+			bots: countBotsInPlayerList()
 		});
 		// Nudge signed-out players to log in (save progress / earn skins). No-op
 		// when auth is off or already signed in. Primary screen only.


### PR DESCRIPTION
## Summary
- Add a `bots` event parameter to `round_start` and `match_end` so GA4 can distinguish AI fill from real human players.
- Keeps `players` unchanged (humans only, sourced from `clientList`) so existing dashboards aren't broken.
- New helper `countBotsInPlayerList()` derives the count from the existing `playerList[id].name` spawn-packet bot marker (server `compressor.js` sets `player.name` only on bot append; humans stay null).

## Why
Yesterday's GA analysis flagged that `players` was being misread as "humans + AI" when it actually only counts humans. The fix surfaced a real gap: the dashboards have no way to know how many AI bots filled a room, which matters for analyzing match density vs real audience size. After this:

```
total      = players + bots    (match density)
players    = real human audience
bots       = AI fill (~ inversely correlated with traffic)
```

No rename of `players` — additive only, so the existing custom metric registration + populated history keeps working.

## Test plan
- [x] `npm run build` — bundles clean
- [x] `node .github/scripts/smoke-test.js` — engine ticked 52 maps no crash
- [ ] In-browser playtest on prod after deploy: DevTools → Network → filter `collect?v=2`, finish a round and a match, confirm `round_start` and `match_end` payloads now include `ep.bots` (string) or `epn.bots` (numeric depending on custom-metric registration)
- [ ] After ~24–48h, confirm `customEvent:bots` is queryable in GA4 Explorations

## Operator follow-up (not code)
Register **`bots`** as a custom metric in GA4 (Admin → Property → Data display → Custom definitions → Create custom metric → Event parameter = `bots`, Scope = Event, Unit = Standard). Without this, the param flows but isn't selectable in standard reports — same setup as `players` already has.
🤖 Generated with [Claude Code](https://claude.com/claude-code)