### PR TITLE
fix(ci): make client-perf gate accurate (fixed scene + peak-relative median)

### DIFF
--- a/.github/scripts/perf-client.js
+++ b/.github/scripts/perf-client.js
@@ -10,10 +10,32 @@
 // frame-work and JS heap are reported as context only. See
 // docs/spikes/perf-and-input-ci.md (and CALIBRATION below) for the iPad mapping.
 //
-// SCENARIO: a 25-kart, stacked-brutal race (explosive/volcano/etc.), reached with
-// zero manual input via the editor preview-room path (preview skips the lobby
-// rally that otherwise traps a headless client in the lobby forever). The load is
-// forced through the CHAO_PERF_OVERRIDE config seam — no config.json edit.
+// SCENARIO: a 25-kart, stacked-brutal race (a FIXED brutal set, see OVERRIDE),
+// reached with zero manual input via the editor preview-room path (preview skips
+// the lobby rally that otherwise traps a headless client in the lobby forever).
+// The load is forced through the CHAO_PERF_OVERRIDE config seam — no config.json edit.
+//
+// ACCURACY DESIGN (why this is no longer a coin-flip): the old harness took ONE
+// 8s wall-clock window and divided ScriptDuration by however many frames happened
+// to render. On the shared CI runner that frame count swung ~10x with CPU
+// contention (12 frames/8s under load vs 180-260 healthy), so the per-frame
+// denominator — and thus the metric — swung several-fold on byte-identical code.
+// (The denominator carries a hidden per-WINDOW overhead term — socket handlers, GC,
+// which fire on wall-clock not per frame — so the fewer frames a contended window
+// renders, the more that overhead inflates the per-frame number.)
+// Three fixes, all here:
+//   1. FIXED SCENE — brutalTypesForce pins the exact brutal combo, so the base and
+//      PR halves render identical FX (the old unseeded shuffle gave each half a
+//      different combo with different cost).
+//   2. PEAK-RELATIVE FRAME FILTER — we measure each runner's OWN peak fps in-job and
+//      keep only windows within PEAK_FRACTION of it (the least-contended windows,
+//      where the per-window overhead is well-amortized and per-frame is stable). A
+//      fixed fps floor can't do this — the stable region depends on each runner's
+//      capacity. A starved/contended window is dropped, not misread as a regression.
+//   3. MEDIAN OF KEPT WINDOWS — report the median of the near-peak windows, so a
+//      single transient spike can't define the run. Too few near-peak windows (or a
+//      peak below the absolute floor) -> degenerate; compare calls it INCONCLUSIVE
+//      rather than inventing a regression.
 
 const { spawn } = require('child_process');
 const fs = require('fs');
@@ -24,15 +46,42 @@ const repoRoot = path.join(__dirname, '..', '..');
 const PORT = Number(process.env.PERF_PORT) || 28911;
 const ORIGIN = `http://localhost:${PORT}`;
 const MAP_FILE = process.env.PERF_MAP || '4suns!.json';
-const SAMPLE_SECONDS = Number(process.env.PERF_SAMPLE_SECONDS) || 8;
+const SAMPLE_SECONDS = Number(process.env.PERF_SAMPLE_SECONDS) || 6;
+// COLLECT: how many scene-valid windows we gather before filtering. We then keep the
+// ones rendered near the runner's own peak fps (see PEAK_FRACTION) and take the
+// MEDIAN of those. A single window was the old design's core flaw — one transient
+// CPU-contention spike skewed the whole gate; the median of several near-peak
+// windows is robust to a stray spike.
+const COLLECT = Number(process.env.PERF_COLLECT) || 7;
+// We need at least this many KEPT (near-peak) windows for the run to be trustworthy.
+// Fewer means the runner was too contended to measure cleanly — we report that
+// honestly (degenerate) so the compare step calls it INCONCLUSIVE rather than
+// inventing a regression from garbage.
+const MIN_VALID_REPS = Number(process.env.PERF_MIN_VALID_REPS) || 3;
 // A preview round can END mid-sample (a bot reaches the goal), which would
 // otherwise have us measuring the post-race overview/editor instead of the race.
 // We sample from race-start, validate the whole window stayed a full-grid race,
-// and retry on the next round if not. The metric itself is very stable once a
-// valid window is captured (~0.3% run-to-run).
-const MAX_ATTEMPTS = Number(process.env.PERF_MAX_ATTEMPTS) || 6;
+// and retry if not. Budget enough attempts to collect COLLECT scene-valid windows
+// even with some discards.
+const MAX_ATTEMPTS = Number(process.env.PERF_MAX_ATTEMPTS) || (COLLECT * 4);
 const MIN_KARTS = 20;  // a valid sample must keep at least this many karts throughout
-const MIN_FRAMES = 10; // ...and must have actually rendered frames (else the render loop stalled)
+// PEAK-RELATIVE FRAME FILTER — the heart of the accuracy fix. The metric is
+// scripting-ms / FRAME, and that has a hidden per-WINDOW overhead term (socket
+// handlers, GC — they fire on wall-clock, not per frame); divided by the frame
+// count it inflates the metric whenever fps is low. A *fixed* fps floor can't fix
+// this because the "flat" region where per-frame is stable depends on each runner's
+// capacity (observed: even at 6fps a window read ~7-14 ms/frame while the same code
+// at 17fps read ~4.7). So instead we measure each runner's OWN peak fps in-job and
+// keep only windows within PEAK_FRACTION of it — the least-contended windows, where
+// the overhead is well-amortized and per-frame is stable and comparable. Base and PR
+// each filter to near their shared runner's peak, so they're compared on equal terms.
+const PEAK_FRACTION = Number(process.env.PERF_PEAK_FRACTION) || 0.7;
+// If even the BEST window can't clear this absolute fps, the whole runner was
+// contended for the entire job — nothing is trustworthy, so the run is degenerate.
+const ABS_MIN_PEAK_FPS = Number(process.env.PERF_ABS_MIN_PEAK_FPS) || 10;
+// A window this slow is a near-stall; skip measuring it (saves time) — it would be
+// filtered out by PEAK_FRACTION anyway and only wastes a sample window.
+const SKIP_BELOW_FPS = Number(process.env.PERF_SKIP_BELOW_FPS) || 4;
 // This is a MEASUREMENT tool — the real gate is the base-vs-PR delta in
 // perf-compare.js. An absolute ceiling here is meaningful only as a catastrophic
 // guard (e.g. an infinite render loop), since the software-raster baseline is
@@ -40,16 +89,23 @@ const MIN_FRAMES = 10; // ...and must have actually rendered frames (else the re
 const SCRIPT_CEILING_MS = process.env.PERF_SCRIPT_CEILING_MS ? Number(process.env.PERF_SCRIPT_CEILING_MS) : null;
 const OUT_JSON = process.env.PERF_OUT_JSON || '';
 
+// FIXED brutal set — volcano + explosive + infection + hockey. Pinned (not the
+// unseeded shuffle) so base and PR render an identical, heavy-FX scene. Numeric ids
+// from config.brutalRounds (see gameBoard.checkForBrutalRound, which short-circuits
+// on c.brutalTypesForce when this seam injects it).
+const FORCED_BRUTALS = [1007, 1010, 1008, 1009];
 const OVERRIDE = JSON.stringify({
     aiRacers: { minGrid: 25, maxGrid: 25, testForceBots: 24 }, // testForceBots pins the auto-fill at 24 bots (1H+24=25 karts)
     maxPlayersInRoom: 25,                                   // room cap must allow the full grid
     chanceOfBrutalRound: 100,
     chanceForAdditionalBrutal: 100,
     maxTotalBrutals: 4,
+    brutalTypesForce: FORCED_BRUTALS,                      // pin the exact brutal scene (test-only seam)
 });
 
 const f = (n) => (Number.isFinite(n) ? n.toFixed(2) : 'n/a');
 function pct(a, p) { if (!a.length) return NaN; const s = [...a].sort((x, y) => x - y); return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))]; }
+function median(a) { if (!a.length) return NaN; const s = [...a].sort((x, y) => x - y); const m = Math.floor(s.length / 2); return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2; }
 function metric(metrics, name) { const m = metrics.metrics.find(x => x.name === name); return m ? m.value : 0; }
 
 function bootServer() {
@@ -95,7 +151,7 @@ function writeSummary(lines) {
     let srv, browser, exitCode = 0;
     const errors = [];
     try {
-        console.log(`[1/5] Booting server on :${PORT} (CHAO_PERF_OVERRIDE: 25-kart grid + forced brutal) ...`);
+        console.log(`[1/5] Booting server on :${PORT} (CHAO_PERF_OVERRIDE: 25-kart grid + fixed brutal [${FORCED_BRUTALS.join(', ')}]) ...`);
         srv = await bootServer();
         console.log('      listening.');
 
@@ -137,18 +193,23 @@ function writeSummary(lines) {
                 done: racing != null && window.currentState === racing && karts >= 20 };
         };
 
-        console.log('[5/5] Capturing a full-grid racing window (retry until valid) ...');
-        let cap = null;
-        for (let attempt = 1; attempt <= MAX_ATTEMPTS && cap == null; attempt++) {
+        console.log(`[5/5] Collecting up to ${COLLECT} scene-valid ${SAMPLE_SECONDS}s windows, then keeping those >= ${(PEAK_FRACTION * 100).toFixed(0)}% of the runner's peak fps (median of >= ${MIN_VALID_REPS}) ...`);
+        const windows = [];          // every scene-valid window: { scriptPerFrame, taskPerFrame, frames, fps, frameWorkP95, heapMB, brutal, karts }
+        let tracedOne = false;
+        let nearStall = 0, badWindow = 0, reachedRace = false;
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS && windows.length < COLLECT; attempt++) {
             const reached = await poll(page, racingFn, 45000, `attempt ${attempt}`);
             if (!reached) { console.log(`  attempt ${attempt}: no full-grid racing reached`); continue; }
+            reachedRace = true;
             // Stop the preview auto-return so a round that ends mid-window cycles to the
             // next round (staying on play.html) rather than bouncing to the editor —
             // a bad window is then caught by post-validation, never silently measured.
             await page.evaluate(() => { try { previewReturnScheduled = true; } catch (e) { window.previewReturnScheduled = true; } });
 
             await page.evaluate(() => window.__resetFrames());
-            await context.tracing.start({ screenshots: false, snapshots: false });
+            // Trace only the FIRST window we keep, for the uploaded artifact.
+            const wantTrace = !tracedOne;
+            if (wantTrace) await context.tracing.start({ screenshots: false, snapshots: false });
             const m0 = await cdp.send('Performance.getMetrics');
             const t0 = Date.now();
             await page.waitForTimeout(SAMPLE_SECONDS * 1000);
@@ -168,52 +229,106 @@ function writeSummary(lines) {
             // overview/editor mid-sample, the render loop stalled, or the brutal round
             // silently failed to engage — in all cases the numbers are meaningless.
             const brutalActive = Array.isArray(after.brutal) && after.brutal.length > 0;
-            const valid = after.onPlay && after.state === after.racing &&
-                after.karts != null && after.karts >= MIN_KARTS &&
-                after.frames.length >= MIN_FRAMES && brutalActive;
-            if (!valid) {
-                await context.tracing.stop().catch(() => {}); // discard this window's trace
-                console.log(`  attempt ${attempt}: discarded (onPlay=${after.onPlay} state=${after.state} karts=${after.karts} frames=${after.frames.length} brutal=${brutalActive}) — not a clean full-grid brutal window; retrying`);
+            const frameCount = after.frames.length;
+            const fps = frameCount / (wallMs / 1000);
+            const sceneOk = after.onPlay && after.state === after.racing &&
+                after.karts != null && after.karts >= MIN_KARTS && brutalActive;
+            if (!sceneOk) {
+                if (wantTrace) await context.tracing.stop().catch(() => {}); // discard this window's trace
+                badWindow++;
+                console.log(`  attempt ${attempt}: discarded scene (onPlay=${after.onPlay} state=${after.state} karts=${after.karts} brutal=${brutalActive}) — not a clean full-grid brutal window`);
                 continue;
             }
-            await context.tracing.stop({ path: path.join(repoRoot, 'perf-trace.zip') }).catch(() => {});
-            cap = { m0, m1, wallMs, ...after };
-            console.log(`  attempt ${attempt}: captured ${after.karts} karts over ${after.frames.length} frames`);
+            // Near-stall: too contended to be even a peak candidate; skip without keeping
+            // (it would be filtered by PEAK_FRACTION anyway and only wastes a window).
+            if (fps < SKIP_BELOW_FPS) {
+                if (wantTrace) await context.tracing.stop().catch(() => {});
+                nearStall++;
+                console.log(`  attempt ${attempt}: skipped near-stall (${frameCount} frames = ${fps.toFixed(1)}fps < ${SKIP_BELOW_FPS}fps) — runner heavily contended this window`);
+                continue;
+            }
+            if (wantTrace) { await context.tracing.stop({ path: path.join(repoRoot, 'perf-trace.zip') }).catch(() => {}); tracedOne = true; }
+
+            const dScript = (metric(m1, 'ScriptDuration') - metric(m0, 'ScriptDuration')) * 1000; // s -> ms
+            const dTask = (metric(m1, 'TaskDuration') - metric(m0, 'TaskDuration')) * 1000;
+            const dLayout = (metric(m1, 'LayoutDuration') - metric(m0, 'LayoutDuration')) * 1000;
+            const dStyle = (metric(m1, 'RecalcStyleDuration') - metric(m0, 'RecalcStyleDuration')) * 1000;
+            windows.push({
+                scriptPerFrame: dScript / frameCount,
+                taskPerFrame: dTask / frameCount,
+                layoutMs: dLayout, styleMs: dStyle,
+                frames: frameCount, fps,
+                frameWorkP95: pct(after.frames, 95),
+                heapMB: after.heapMB, karts: after.karts, brutal: after.brutal,
+            });
+            console.log(`  window ${windows.length}/${COLLECT}: ${after.karts} karts, ${frameCount} frames (${fps.toFixed(1)}fps), scripting ${f(dScript / frameCount)} ms/frame`);
         }
-        if (cap == null) {
+
+        // PEAK-RELATIVE FILTER: keep only windows rendered near this runner's own peak
+        // fps — the least-contended ones, where the per-frame metric is stable and
+        // base/PR are comparable. If even the peak is below the absolute floor, or too
+        // few windows survive, the run is degenerate -> compare calls it INCONCLUSIVE.
+        const peakFps = windows.length ? Math.max(...windows.map(w => w.fps)) : 0;
+        const keepThreshold = peakFps * PEAK_FRACTION;
+        const reps = windows.filter(w => w.fps >= keepThreshold);
+        const validReps = reps.length;
+        const peakTooLow = peakFps < ABS_MIN_PEAK_FPS;
+        const degenerate = validReps < MIN_VALID_REPS || peakTooLow;
+
+        if (windows.length === 0) {
+            // No scene-valid, non-stalled window at all. Only ONE shape of this is true
+            // contention: we reached a race and every miss was a near-stall (too few
+            // frames to trust) with ZERO scene-invalid windows — report degenerate so
+            // compare calls it inconclusive rather than failing the build. ANY badWindow
+            // (round left racing mid-sample, karts dropped, or the forced brutal never
+            // engaged) means the perf SCENARIO is broken, not that the runner was slow —
+            // that must fail loudly, otherwise a broken gate reads as a quiet pass. A run
+            // that never reached a race at all is likewise real breakage.
             if (errors.length) console.log('  errors:\n   - ' + errors.slice(0, 8).join('\n   - '));
-            throw new Error('could not capture a full-grid racing window in ' + MAX_ATTEMPTS + ' attempts');
+            const pureContention = reachedRace && nearStall > 0 && badWindow === 0;
+            if (pureContention) {
+                console.log(`\n::warning::All ${nearStall} window(s) were near-stalls under contention (0 scene-invalid) — reporting INCONCLUSIVE (no regression).`);
+                const degResult = { karts: null, brutalTypes: FORCED_BRUTALS, validReps: 0, requestedReps: COLLECT,
+                    degenerate: true, peakFps: +peakFps.toFixed(1), scriptMsPerFrame: null, frameWorkP95Ms: null, heapMB: null, fpsActual: +peakFps.toFixed(1) };
+                if (OUT_JSON) fs.writeFileSync(OUT_JSON, JSON.stringify(degResult, null, 2));
+                console.log('\nMeasurement inconclusive (runner contended).');
+                if (browser) await browser.close().catch(() => {});
+                if (srv) srv.kill('SIGKILL');
+                process.exit(0);
+            }
+            throw new Error(`no usable perf window in ${MAX_ATTEMPTS} attempts (reachedRace=${reachedRace} nearStall=${nearStall} badScene=${badWindow}) — ${badWindow > 0 ? 'scene/scenario broke (not contention)' : 'never reached a full-grid race'}; failing rather than masking as contention`);
         }
 
-        const frames = cap.frames.length || 1;
-        const dScript = (metric(cap.m1, 'ScriptDuration') - metric(cap.m0, 'ScriptDuration')) * 1000; // s -> ms
-        const dLayout = (metric(cap.m1, 'LayoutDuration') - metric(cap.m0, 'LayoutDuration')) * 1000;
-        const dStyle = (metric(cap.m1, 'RecalcStyleDuration') - metric(cap.m0, 'RecalcStyleDuration')) * 1000;
-        const dTask = (metric(cap.m1, 'TaskDuration') - metric(cap.m0, 'TaskDuration')) * 1000;
-        const scriptPerFrame = dScript / frames;
-        const taskPerFrame = dTask / frames;
-        const frameWorkP95 = pct(cap.frames, 95);
-        const fpsActual = frames / (cap.wallMs / 1000);
-        const ctx = { karts: cap.karts, brutal: cap.brutal, heapMB: cap.heapMB };
+        const scriptPerFrame = median(reps.map(r => r.scriptPerFrame));
+        const taskPerFrame = median(reps.map(r => r.taskPerFrame));
+        const frameWorkP95 = median(reps.map(r => r.frameWorkP95));
+        const fpsActual = median(reps.map(r => r.fps));
+        const framesMed = Math.round(median(reps.map(r => r.frames)));
+        const heapMB = median(reps.map(r => r.heapMB).filter(Number.isFinite));
+        const last = reps[reps.length - 1] || windows[windows.length - 1];
 
-        const ceilingBreached = SCRIPT_CEILING_MS != null && scriptPerFrame > SCRIPT_CEILING_MS;
+        const ceilingBreached = SCRIPT_CEILING_MS != null && Number.isFinite(scriptPerFrame) && scriptPerFrame > SCRIPT_CEILING_MS;
         const result = {
-            karts: ctx.karts, brutalTypes: ctx.brutal, frames,
-            scriptMsPerFrame: +scriptPerFrame.toFixed(3),
-            taskMsPerFrame: +taskPerFrame.toFixed(3),
-            layoutMsTotal: +dLayout.toFixed(1), styleMsTotal: +dStyle.toFixed(1),
-            frameWorkP95Ms: +frameWorkP95.toFixed(2),
-            heapMB: ctx.heapMB ? +ctx.heapMB.toFixed(1) : null,
-            fpsActual: +fpsActual.toFixed(1),
+            karts: last.karts, brutalTypes: last.brutal,
+            validReps, collected: windows.length, requestedReps: COLLECT, degenerate,
+            peakFps: +peakFps.toFixed(1), keepFpsThreshold: +keepThreshold.toFixed(1),
+            framesMedian: Number.isFinite(framesMed) ? framesMed : null,
+            scriptMsPerFrame: Number.isFinite(scriptPerFrame) ? +scriptPerFrame.toFixed(3) : null,
+            scriptMsPerFrameReps: reps.map(r => +r.scriptPerFrame.toFixed(3)),
+            taskMsPerFrame: Number.isFinite(taskPerFrame) ? +taskPerFrame.toFixed(3) : null,
+            frameWorkP95Ms: Number.isFinite(frameWorkP95) ? +frameWorkP95.toFixed(2) : null,
+            heapMB: Number.isFinite(heapMB) ? +heapMB.toFixed(1) : null,
+            fpsActual: Number.isFinite(fpsActual) ? +fpsActual.toFixed(1) : null,
         };
 
         console.log('\n=== CLIENT PERF (measurement — gate is base-vs-PR delta) ===');
-        console.log(`  karts=${result.karts}  brutal=[${(result.brutalTypes || []).join(', ')}]  frames=${frames}`);
-        console.log(`  HEADLINE  scripting ms/frame : ${f(scriptPerFrame)}   (≈ full frame; software raster counts as script)`);
-        console.log(`  context   task ms/frame      : ${f(taskPerFrame)}`);
-        console.log(`  context   frame-work p95     : ${f(frameWorkP95)} ms  (NOT an iPad FPS — env-dependent)`);
-        console.log(`  context   layout/style tot   : ${f(dLayout)} / ${f(dStyle)} ms`);
-        console.log(`  context   JS heap            : ${result.heapMB} MB`);
+        console.log(`  karts=${result.karts}  brutal=[${(result.brutalTypes || []).join(', ')}]  kept ${validReps}/${windows.length} windows >= ${keepThreshold.toFixed(1)}fps (peak ${peakFps.toFixed(1)}fps)  framesMed=${result.framesMedian}  (nearStall=${nearStall}, badScene=${badWindow})`);
+        console.log(`  HEADLINE  scripting ms/frame (median) : ${f(scriptPerFrame)}   kept=[${result.scriptMsPerFrameReps.join(', ')}]`);
+        console.log(`  context   task ms/frame (median)      : ${f(taskPerFrame)}`);
+        console.log(`  context   frame-work p95 (median)     : ${f(frameWorkP95)} ms  (NOT an iPad FPS — env-dependent)`);
+        console.log(`  context   fps (median kept)           : ${f(fpsActual)}`);
+        console.log(`  context   JS heap (median)            : ${result.heapMB} MB`);
+        if (degenerate) console.log(`  WARN: ${peakTooLow ? `peak fps ${peakFps.toFixed(1)} < ${ABS_MIN_PEAK_FPS} (runner contended all job)` : `only ${validReps} near-peak window(s) (< ${MIN_VALID_REPS})`} — compare will mark INCONCLUSIVE.`);
         if (errors.length) console.log(`  NOTE: ${errors.length} non-benign page error(s): ${errors[0]}`);
         console.log('============================================================');
 
@@ -222,15 +337,15 @@ function writeSummary(lines) {
         writeSummary([
             '### Client render-perf (P1b) — measurement',
             '',
-            `Scenario: **${result.karts} karts**, brutal \`[${(result.brutalTypes || []).join(', ')}]\`, map \`${MAP_FILE}\`. _Headless software raster: absolute ms is env-dependent and **not** an iPad FPS — the gate is the **base-vs-PR delta** (see perf-compare)._`,
-            '',
+            `Scenario: **${result.karts} karts**, fixed brutal \`[${(result.brutalTypes || []).join(', ')}]\`, map \`${MAP_FILE}\`. Median of **${validReps}/${windows.length}** near-peak windows (kept >= ${keepThreshold.toFixed(1)}fps of ${peakFps.toFixed(1)}fps peak). _Headless software raster: absolute ms is env-dependent and **not** an iPad FPS — the gate is the **base-vs-PR delta** (see perf-compare)._`,
+            degenerate ? `\n> ⚠️ Only ${validReps} near-peak window(s) — runner too contended; treated as **inconclusive**.\n` : '',
             '| metric | value | note |',
             '| --- | --- | --- |',
-            `| **scripting ms/frame** | **${f(scriptPerFrame)}** | headline (≈ full frame) |`,
-            `| task ms/frame | ${f(taskPerFrame)} | context |`,
-            `| frame-work p95 | ${f(frameWorkP95)} ms | env-dependent, context |`,
-            `| JS heap | ${result.heapMB} MB | context |`,
-            `| frames sampled | ${frames} | over ${SAMPLE_SECONDS}s |`,
+            `| **scripting ms/frame** (median) | **${f(scriptPerFrame)}** | headline (≈ full frame) |`,
+            `| task ms/frame (median) | ${f(taskPerFrame)} | context |`,
+            `| frame-work p95 (median) | ${f(frameWorkP95)} ms | env-dependent, context |`,
+            `| JS heap (median) | ${result.heapMB} MB | context |`,
+            `| kept windows | ${validReps} / ${windows.length} | ${result.framesMedian} frames/window @ ${f(fpsActual)}fps |`,
         ]);
 
         if (ceilingBreached) { console.log(`\n::error::Catastrophic ceiling breached: ${f(scriptPerFrame)} ms/frame > ${f(SCRIPT_CEILING_MS)} ms.`); exitCode = 1; }

--- a/.github/scripts/perf-compare.js
+++ b/.github/scripts/perf-compare.js
@@ -7,16 +7,19 @@
 // sticky PR-comment body (marker so CI can update one comment in place).
 //
 // Usage: node perf-compare.js <base.json> <pr.json>
-// Env: PERF_REGRESS_PCT (default 15) — fail if scripting ms/frame regresses more
-//      than this % over base. PERF_COMMENT_OUT — path to write the comment body.
+// Env: PERF_REGRESS_PCT (default 20) — fail if scripting ms/frame regresses more
+//      than this % over base. PERF_MIN_VALID_REPS (default 3) — a half measured
+//      from fewer valid windows is treated as INCONCLUSIVE, not a regression.
+//      PERF_COMMENT_OUT — path to write the comment body.
 //      PERF_GATE_SOFT=1 — report only, always exit 0 (non-blocking job).
 
 const fs = require('fs');
 
 const [, , basePath, prPath] = process.argv;
-// Number.isFinite check (not `|| 15`) so PERF_REGRESS_PCT=0 — "fail on ANY
-// regression" — is honored rather than silently reset to 15%.
-const REGRESS_PCT = Number.isFinite(Number(process.env.PERF_REGRESS_PCT)) ? Number(process.env.PERF_REGRESS_PCT) : 15;
+// Number.isFinite check (not `|| 20`) so PERF_REGRESS_PCT=0 — "fail on ANY
+// regression" — is honored rather than silently reset to the default.
+const REGRESS_PCT = Number.isFinite(Number(process.env.PERF_REGRESS_PCT)) ? Number(process.env.PERF_REGRESS_PCT) : 20;
+const MIN_VALID_REPS = Number(process.env.PERF_MIN_VALID_REPS) || 3;
 const SOFT = process.env.PERF_GATE_SOFT === '1';
 const COMMENT_OUT = process.env.PERF_COMMENT_OUT || '';
 const MARKER = '<!-- chaochao-perf -->';
@@ -29,47 +32,83 @@ const pr = read(prPath);
 const f = (n) => (Number.isFinite(n) ? n.toFixed(2) : 'n/a');
 function deltaPct(b, p) { return (b && Number.isFinite(b) && Number.isFinite(p)) ? ((p - b) / b) * 100 : NaN; }
 function sign(n) { return n > 0 ? '+' : ''; }
+// A half is degenerate when the harness couldn't collect enough valid windows
+// (runner too contended). Honor the explicit flag the harness writes, falling back
+// to the rep count for older payloads. A degenerate half makes the run INCONCLUSIVE
+// rather than a regression — the whole point of the accuracy rework is to never
+// invent a regression out of a starved measurement.
+function degenerate(m) {
+    if (!m) return true;
+    if (typeof m.degenerate === 'boolean') return m.degenerate;
+    if (Number.isFinite(m.validReps)) return m.validReps < MIN_VALID_REPS;
+    return false; // pre-rep schema: assume the single sample stands
+}
 
 if (!pr) { console.error('::error::missing PR metrics (' + prPath + ')'); process.exit(2); }
+
+// New-schema = produced by the median/rep harness (carries validReps). Comparing a
+// MEDIAN to an old single-window sample is apples-to-oranges in EITHER direction:
+// during rollout the base (merge-base checkout) may still run the old harness, and a
+// PR could equally revert/modify perf-client.js to emit the old schema against a new
+// base. So treat ANY disagreement between the two halves' schema versions as
+// inconclusive — not just the new-PR/old-base case.
+const newSchema = (m) => !!m && Number.isFinite(m.validReps);
+const schemaMismatch = !!base && (newSchema(pr) !== newSchema(base));
 
 // The gate can only run if there's a base WITH a usable scripting metric. A
 // missing base (predates this job) OR a present-but-degenerate base (missing/zero
 // scriptMsPerFrame from an old schema or a failed baseline run) both mean "cannot
 // compare" — report that honestly instead of letting a NaN delta read as "✅".
 const haveBase = !!base;
-const baseUsable = haveBase && Number.isFinite(base.scriptMsPerFrame) && base.scriptMsPerFrame > 0;
+const baseDegenerate = degenerate(base);
+const prDegenerate = degenerate(pr);
+const inconclusive = baseDegenerate || prDegenerate || schemaMismatch;
+const baseUsable = haveBase && !baseDegenerate && Number.isFinite(base.scriptMsPerFrame) && base.scriptMsPerFrame > 0;
+const canGate = baseUsable && !prDegenerate && !schemaMismatch;
 const scriptDelta = baseUsable ? deltaPct(base.scriptMsPerFrame, pr.scriptMsPerFrame) : NaN;
 const heapDelta = baseUsable ? deltaPct(base.heapMB, pr.heapMB) : NaN;
 const frameDelta = baseUsable ? deltaPct(base.frameWorkP95Ms, pr.frameWorkP95Ms) : NaN;
 
+// "compared" = we actually have a base-vs-PR delta to show. "regressed" gates ONLY
+// when both halves were measured cleanly (canGate) — a contended/degenerate half
+// shows the delta for context but never fails the build.
 const compared = Number.isFinite(scriptDelta);
-const regressed = compared && scriptDelta > REGRESS_PCT;
+const regressed = canGate && compared && scriptDelta > REGRESS_PCT;
 
 function row(label, b, p, d, unit) {
     const dStr = Number.isFinite(d) ? `${sign(d)}${d.toFixed(1)}%` : 'n/a';
-    return `| ${label} | ${baseUsable ? f(b) + unit : '—'} | ${f(p)}${unit} | ${dStr} |`;
+    return `| ${label} | ${Number.isFinite(b) ? f(b) + unit : '—'} | ${f(p)}${unit} | ${dStr} |`;
 }
 
+const icon = regressed ? '❌ regression' : (inconclusive ? 'ℹ️ inconclusive' : (canGate ? '✅' : 'ℹ️'));
+// Spell out WHY a run is inconclusive so a degenerate half never reads as a pass.
+const degenWho = baseDegenerate && prDegenerate ? 'both halves' : (baseDegenerate ? 'the base half' : 'the PR half');
+const repsNote = (m) => (m && Number.isFinite(m.validReps)) ? `${m.validReps}/${m.requestedReps || m.validReps} valid windows` : 'single window';
+
 const lines = [
-    `### Client render-perf — base vs PR ${regressed ? '❌ regression' : (compared ? '✅' : 'ℹ️')}`,
+    `### Client render-perf — base vs PR ${icon}`,
     '',
-    compared
-        ? `Gate: scripting ms/frame must not regress **> ${REGRESS_PCT}%** vs \`main\`. _(Headless software raster — absolute ms is not an iPad FPS; only the delta is meaningful. Calibrate absolute mobile perf on a real iPad — see docs/spikes/perf-and-input-ci.md.)_`
-        : (haveBase
-            ? `_Base metrics present but unusable (missing/zero scripting field) — the gate could not run; showing PR measurement only._`
-            : `_No base metrics found (base branch predates this job) — showing PR measurement only._`),
+    canGate
+        ? `Gate: median scripting ms/frame must not regress **> ${REGRESS_PCT}%** vs \`main\`. _(Headless software raster — absolute ms is not an iPad FPS; only the delta is meaningful. Calibrate absolute mobile perf on a real iPad — see docs/spikes/perf-and-input-ci.md.)_`
+        : (inconclusive
+            ? (schemaMismatch
+                ? `_Inconclusive: the two halves were produced by different perf-harness versions (${newSchema(base) ? 'base=median' : 'base=single-window'} vs ${newSchema(pr) ? 'PR=median' : 'PR=single-window'}), so their numbers aren't comparable. During rollout this is the base half still on the old harness and resolves once this change is on \`main\`; otherwise check whether the PR changed \`perf-client.js\`. **Not** treated as a regression._`
+                : `_Inconclusive: ${degenWho} could not collect ≥ ${MIN_VALID_REPS} clean windows (the CI runner was too CPU-contended to measure render perf this run). **Not** treated as a regression — re-run to retry. Base: ${repsNote(base)}; PR: ${repsNote(pr)}._`)
+            : (haveBase
+                ? `_Base metrics present but unusable (missing/zero scripting field) — the gate could not run; showing PR measurement only._`
+                : `_No base metrics found (base branch predates this job) — showing PR measurement only._`)),
     '',
-    `Scenario: **${pr.karts} karts**, forced brutal round.`,
+    `Scenario: **${pr.karts} karts**, fixed brutal \`[${(pr.brutalTypes || []).join(', ')}]\`. Median of ${repsNote(pr)} (base: ${repsNote(base)}).`,
     '',
     '| metric | base (`main`) | PR | Δ |',
     '| --- | --- | --- | --- |',
-    row('**scripting ms/frame** (gated)', base && base.scriptMsPerFrame, pr.scriptMsPerFrame, scriptDelta, ''),
+    row('**scripting ms/frame** (gated, median)', base && base.scriptMsPerFrame, pr.scriptMsPerFrame, scriptDelta, ''),
     row('frame-work p95 (ms, context)', base && base.frameWorkP95Ms, pr.frameWorkP95Ms, frameDelta, ''),
     row('JS heap (MB, context)', base && base.heapMB, pr.heapMB, heapDelta, ''),
     '',
     regressed
-        ? `⚠️ **scripting ms/frame regressed ${sign(scriptDelta)}${scriptDelta.toFixed(1)}%** (> ${REGRESS_PCT}% threshold). A change made the per-frame render/JS work heavier.`
-        : (compared ? `Within threshold.` : ''),
+        ? `⚠️ **median scripting ms/frame regressed ${sign(scriptDelta)}${scriptDelta.toFixed(1)}%** (> ${REGRESS_PCT}% threshold). A change made the per-frame render/JS work heavier.`
+        : (canGate ? `Within threshold.` : ''),
 ];
 
 const body = lines.join('\n');

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -232,6 +232,15 @@ jobs:
     # PR that can't touch client render would still trip the gate). Measuring both
     # halves on the same runner in the same job cancels the shared runner-speed
     # term out of the ratio, so only a real code-driven delta survives.
+    #
+    # Same-runner alone wasn't enough — the metric is scripting-ms/FRAME, and under
+    # CPU contention the software rasterizer renders ~10x fewer frames, so the
+    # per-frame denominator (and the metric) swung several-fold on identical code.
+    # perf-client.js now: (1) pins the brutal scene so both halves render identical
+    # FX, (2) DISCARDS any window below an fps floor (a starved window = contended
+    # runner, not a regression), and (3) reports the MEDIAN of several valid windows.
+    # If a half can't collect enough clean windows, perf-compare calls the run
+    # INCONCLUSIVE instead of inventing a regression.
     # continue-on-error keeps it advisory while CI variance is learned.
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -288,7 +297,8 @@ jobs:
         run: node head/.github/scripts/perf-compare.js perf-baseline.json perf-pr.json
         env:
           PERF_COMMENT_OUT: perf-comment.md
-          PERF_REGRESS_PCT: "15"
+          PERF_REGRESS_PCT: "20"
+          PERF_MIN_VALID_REPS: "3"
       - name: Upload perf trace
         if: always()
         uses: actions/upload-artifact@v7

--- a/server/entities/gameBoard.js
+++ b/server/entities/gameBoard.js
@@ -1712,6 +1712,16 @@ class GameBoard {
 			this.brutalRound = true;
 			return { brutal: true, brutalTypes: [c.brutalRounds.blackout.id] };
 		}
+		// CI perf harness only: pin the exact brutal set so the base and PR halves
+		// of the render-perf gate measure an IDENTICAL scene (otherwise the unseeded
+		// shuffle below hands each half a different brutal combo with different FX
+		// cost, which the gate misreads as a regression). `brutalTypesForce` only
+		// exists when injected via the CHAO_PERF_OVERRIDE seam — never in prod, and
+		// not present in config.json — so normal play is unaffected.
+		if (Array.isArray(c.brutalTypesForce) && c.brutalTypesForce.length > 0) {
+			this.brutalRound = true;
+			return { brutal: true, brutalTypes: c.brutalTypesForce.slice() };
+		}
 		var brutalChance = utils.getRandomInt(1, 100);
 
 		//console.log("Initial roll: " + brutalChance);


### PR DESCRIPTION
## Why

The `client-perf` PR check failed on ~half of all PRs with **phantom regressions** — on branches that can't touch client render (DB-migration, analytics). It became noise everyone ignores.

**Root cause (from CI logs):** the metric is `scripting-ms ÷ rendered-frame-count`, and that denominator carries a hidden per-**window** overhead term (socket handlers, GC — they fire on wall-clock, not per frame). On a CPU-contended shared runner the software rasterizer renders ~10× fewer frames (observed **12 vs 180–260 frames/8s**), so that overhead divided by a tiny frame count inflates the per-frame metric several-fold — a pure artifact. The base number swung **2.98 → 62.73 ms/frame (21×)** on essentially-`main` code, and base/PR also rendered *different* random brutal scenes. Recent examples: a `db-migrate` branch showed +27.5%, an analytics branch +680%.

## What changed

- **`server/entities/gameBoard.js`** — `checkForBrutalRound` honors a test-only `c.brutalTypesForce` short-circuit, injected only via the `CHAO_PERF_OVERRIDE` seam (absent from `config.json`, never applied in prod). Base and PR now render an **identical** brutal scene instead of an unseeded shuffle. Inert in normal play (smoke green).
- **`.github/scripts/perf-client.js`** — collect several scene-valid windows, measure the runner's **own peak fps in-job**, and keep only windows within 70% of it (the least-contended windows, where the per-window overhead is amortized and per-frame is stable). A *fixed* fps floor can't do this — the stable region depends on each runner's capacity. Report the **median** of kept windows. Genuine contention (reached a race, all windows starved) → inconclusive (exit 0); a broken **scenario** (any scene-invalid window) or never reaching a race → **fails loudly**.
- **`.github/scripts/perf-compare.js`** — a degenerate / too-few-windows half is reported **INCONCLUSIVE (exit 0), never ❌**. Symmetric schema-mismatch guard (either half on a different harness version → inconclusive) so this rollout PR — whose merge-base still runs the old single-window harness — doesn't phantom-fail. Threshold 15 → 20%.
- **`.github/workflows/pr-validation.yml`** — `PERF_REGRESS_PCT=20`, `PERF_MIN_VALID_REPS=3`, methodology comment updated.

Gate stays advisory (`continue-on-error`) — this makes the number *trustworthy* so it can be relied on, not silenced.

## Rollout note

This PR's own `client-perf` check will report **ℹ️ inconclusive** (its merge-base predates the new harness — the schema-mismatch guard handles that). Every PR opened **after** this merges will have a new-harness base and gate normally.

## Verification

- `perf-compare` unit-tested across all gate paths: clean +10% → ✅, real +40% → ❌ (exit 1), contended/degenerate half with +900% delta → inconclusive, old-base mismatch → inconclusive, reverse new-base/old-PR mismatch → inconclusive.
- Harness runs end-to-end with the forced scene engaged (`brutalTypes [1007,1010,1008,1009]`); contended local runs correctly self-report inconclusive (exit 0); broken-scenario decision table verified.
- Smoke test green; `npm run build` green.
- Addressed both Codex P2 review findings (broken-scenario-vs-contention distinction; symmetric schema guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)