### PR TITLE
perf(client): render-perf sweep across all perf-profile knobs

### DIFF
--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1207,7 +1207,7 @@ function drawOffscreenGoalIndicator() {
     gameContext.shadowColor = goalColor;
     // Skip the per-frame glow on profiles that disable it (the arrow still reads
     // via its bright fill + dark outline).
-    gameContext.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? (12 + 12 * pulse) : 0;
+    gameContext.shadowBlur = glowBlur(12 + 12 * pulse);
     // Same chunky block arrow as the lobby arrows, tip at origin pointing +x.
     gameContext.beginPath();
     gameContext.moveTo(0, 0);
@@ -2054,7 +2054,7 @@ function spawnSlashEffect(x, y, angleDeg, color) {
             ctx.strokeStyle = color || "white";
             ctx.lineWidth = (10 * (1 - t)) + 2;
             ctx.shadowColor = color || "white";
-            ctx.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? (12 * (1 - t)) : 0;
+            ctx.shadowBlur = glowBlur(12 * (1 - t));
             ctx.beginPath();
             ctx.moveTo(x - dx, y - dy);
             ctx.lineTo(x + dx, y + dy);
@@ -2384,6 +2384,12 @@ function hasAnyKey(o) {
     for (var k in o) { if (Object.prototype.hasOwnProperty.call(o, k)) { return true; } }
     return false;
 }
+// perfGlow-gated shadowBlur amount: n when glow is on (or perf.js is absent, which
+// means run at full detail), 0 when the low tier sheds glow. Single-sources the
+// gate that was otherwise copy-pasted at every per-frame shadowBlur site.
+function glowBlur(n) {
+    return (typeof perfGlow !== "function" || perfGlow()) ? n : 0;
+}
 // Nearest-cell id for a player, cached on the player. The map is a Voronoi
 // diagram so the cell a point sits in is the one whose site is nearest — an
 // O(cells) scan. The on-fire-on-lava flash needs it every frame for every
@@ -2399,28 +2405,29 @@ function nearestCellIdCached(player) {
     if (hasCache && dx * dx + dy * dy <= 64 && now - player._nearCellAt < 150) {
         return player._nearCellId;
     }
-    var cells = currentMap.cells, nearestId = -1, nd = Infinity;
-    for (var ci = 0; ci < cells.length; ci++) {
-        var cdx = player.x - cells[ci].site.x;
-        var cdy = player.y - cells[ci].site.y;
-        var cd = cdx * cdx + cdy * cdy;
-        if (cd < nd) { nd = cd; nearestId = cells[ci].id; }
-    }
+    // Reuse gameboard's single Voronoi nearest-site scan rather than a second copy.
+    var cell = (typeof nearestCell === "function") ? nearestCell(player.x, player.y) : null;
+    var nearestId = (cell != null) ? cell.id : -1;
     player._nearCellId = nearestId;
     player._nearCellX = player.x;
     player._nearCellY = player.y;
     player._nearCellAt = now;
     return nearestId;
 }
+// Map of player id -> the frame generation in which it was last seen targeted.
+// A player is "targeted this frame" iff its stamp === the current generation, so
+// the set is reused across frames (a bumped counter invalidates last frame's
+// entries) instead of allocating a fresh object every frame.
 var targetedPlayerIds = {};
+var _targetGen = 0;
 function rebuildTargetedPlayerIds() {
-    targetedPlayerIds = {};
+    _targetGen++;
     for (var aid in aimerList) {
         var a = aimerList[aid];
         var tl = a != null ? a.targetList : null;
         if (tl == null) { continue; }
         for (var ti = 0; ti < tl.length; ti++) {
-            targetedPlayerIds[tl[ti]] = true;
+            targetedPlayerIds[tl[ti]] = _targetGen;
         }
     }
 }
@@ -2502,7 +2509,7 @@ function drawPlayer(player, dt) {
     // coming), plus a momentum self-preview on your own idle kart.
     drawPunchCharge(player);
 
-    var playerStrokeColor = targetedPlayerIds[player.id] ? "red" : "black";
+    var playerStrokeColor = (targetedPlayerIds[player.id] === _targetGen) ? "red" : "black";
     var sprite = getPlayerSprite(player.color, player.radius, playerStrokeColor);
     // Lobby respawn invulnerability: pulse the sprite's alpha so the grace window is
     // legible. The sprite is a cached image with no alpha, so wrap the blit.
@@ -3224,7 +3231,7 @@ function drawCutAimer(x, y, angle, color) {
         gameContext.strokeStyle = color;
     }
     gameContext.shadowColor = color;
-    gameContext.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? 12 : 0;
+    gameContext.shadowBlur = glowBlur(12);
     gameContext.lineWidth = 4;
     gameContext.beginPath();
     gameContext.moveTo(bwd.x, bwd.y);
@@ -3318,8 +3325,9 @@ function drawTrail(player) {
     // Trail always uses the player's own colour, even with a cart skin equipped — the
     // colour is the player's identity, so a blue dino trails blue (not skin-themed).
     gameContext.strokeStyle = player.color;
-    if (typeof perfGlow === "function" && perfGlow()) {
-        gameContext.shadowBlur = 3;
+    var trailBlur = glowBlur(3);
+    if (trailBlur) {
+        gameContext.shadowBlur = trailBlur;
         gameContext.shadowColor = "black";
     }
     if (dashed) {
@@ -3532,7 +3540,7 @@ function drawWorld() {
         if (themed) {
             gameContext.strokeStyle = 'rgba(235,250,255,0.7)';
             gameContext.shadowColor = 'rgba(180,230,255,0.7)';
-            gameContext.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? 8 : 0;
+            gameContext.shadowBlur = glowBlur(8);
         } else {
             gameContext.strokeStyle = themeColor('ink', 'black');
         }
@@ -3983,7 +3991,7 @@ function drawIslandWater(dx, dy, dw, dh) {
     gameContext.save();
     gameContext.globalAlpha = 0.55;
     gameContext.shadowColor = isDarkTheme() ? 'rgba(140,215,255,0.9)' : 'rgba(205,245,255,0.95)';
-    gameContext.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? 13 : 0;
+    gameContext.shadowBlur = glowBlur(13);
     gameContext.drawImage(mapCanvas, dx, dy, dw, dh);
     gameContext.restore();
 }
@@ -4263,13 +4271,13 @@ function renderMapToCache() {
 // The vignette gradient depends only on the world rect, so build it once and
 // reuse it every frame (createRadialGradient + addColorStop per frame is pure
 // waste when the world hasn't changed).
-var _vignetteGrad = null, _vignetteKey = "";
+var _vignetteGrad = null, _vgX = NaN, _vgY = NaN, _vgW = NaN, _vgH = NaN;
 function drawArenaVignette() {
     if (world == null) {
         return;
     }
-    var key = world.x + "," + world.y + "," + world.width + "," + world.height;
-    if (_vignetteGrad == null || key !== _vignetteKey) {
+    if (_vignetteGrad == null || world.x !== _vgX || world.y !== _vgY ||
+        world.width !== _vgW || world.height !== _vgH) {
         var cx = world.x + world.width / 2;
         var cy = world.y + world.height / 2;
         var inner = Math.min(world.width, world.height) * 0.45;
@@ -4277,7 +4285,7 @@ function drawArenaVignette() {
         _vignetteGrad = gameContext.createRadialGradient(cx, cy, inner, cx, cy, outer);
         _vignetteGrad.addColorStop(0, "rgba(0, 0, 0, 0)");
         _vignetteGrad.addColorStop(1, "rgba(8, 6, 14, 0.26)");
-        _vignetteKey = key;
+        _vgX = world.x; _vgY = world.y; _vgW = world.width; _vgH = world.height;
     }
     gameContext.save();
     gameContext.fillStyle = _vignetteGrad;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3282,6 +3282,9 @@ function drawArmedRing(x, y, color, radius) {
 // (matters for the near-victory dashed style; the codex review caught that the
 // per-segment subpaths were killing the dash cue at our 30Hz sample cadence).
 var TRAIL_DRAW_BUCKETS = 6;
+// Reused scratch for drawTrail's per-segment bucket indices (see usage below) so
+// the trail draw doesn't allocate a fresh array per kart per frame.
+var _trailSegBucketScratch = [];
 function drawTrail(player) {
     var trail = player.trail;
     if (trail == null || trail.vertices == null || trail.vertices.length < 2) {
@@ -3331,8 +3334,10 @@ function drawTrail(player) {
     }
     var bucketMs = fadeMs / TRAIL_DRAW_BUCKETS;
     // Bucket-index for the segment ENDING at vertex i (the segment verts[i-1] →
-    // verts[i] is in this bucket). >= TRAIL_DRAW_BUCKETS marks "expired".
-    var segBucket = new Array(verts.length);
+    // verts[i] is in this bucket). >= TRAIL_DRAW_BUCKETS marks "expired". Reuse a
+    // module-scope scratch array so this isn't a per-kart per-frame allocation;
+    // only indices [0, verts.length) are written and read each call.
+    var segBucket = _trailSegBucketScratch;
     segBucket[0] = -1;
     for (var ii = 1; ii < verts.length; ii++) {
         var age = now - verts[ii].t;
@@ -3520,7 +3525,7 @@ function drawWorld() {
         if (themed) {
             gameContext.strokeStyle = 'rgba(235,250,255,0.7)';
             gameContext.shadowColor = 'rgba(180,230,255,0.7)';
-            gameContext.shadowBlur = 8;
+            gameContext.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? 8 : 0;
         } else {
             gameContext.strokeStyle = themeColor('ink', 'black');
         }
@@ -3971,7 +3976,7 @@ function drawIslandWater(dx, dy, dw, dh) {
     gameContext.save();
     gameContext.globalAlpha = 0.55;
     gameContext.shadowColor = isDarkTheme() ? 'rgba(140,215,255,0.9)' : 'rgba(205,245,255,0.95)';
-    gameContext.shadowBlur = 13;
+    gameContext.shadowBlur = (typeof perfGlow !== "function" || perfGlow()) ? 13 : 0;
     gameContext.drawImage(mapCanvas, dx, dy, dw, dh);
     gameContext.restore();
 }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -244,6 +244,13 @@ var mapCacheRev = 0;
 // + island depth + terrain) baked into one canvas and blitted in a single pass
 // per frame — see ensureArenaCache.
 var arenaCanvas = null;
+// Throttle full map-cache re-bakes (see drawMap). A collapse streams tile changes
+// roughly every server tick; without this the whole world-sized cache re-bakes +
+// re-uploads up to 60×/s. Coalesce to ~25×/s — terrain lags a change by at most
+// this interval (imperceptible; karts/effects still render every frame). A
+// discarded cache (mapCanvas == null, e.g. perf-tier change) re-bakes immediately.
+var MAP_BAKE_MIN_MS = 40;
+var lastMapBakeAt = 0;
 function invalidateMapCache() {
     mapDirty = true;
 }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -2367,8 +2367,52 @@ function drawMapTitle() {
 // Accumulated time (seconds) driving cart-skin animation (fire-truck wheel spin,
 // dino leg cycle). Advanced once per frame in drawPlayers, NOT per player.
 var cartSkinAnimTime = 0;
+// Set of player ids currently targeted by some aimer (telegraph). Rebuilt once
+// per frame in drawPlayers so drawPlayer can do an O(1) lookup instead of an
+// O(aimers) for-in + targetList.indexOf per kart per frame.
+// Nearest-cell id for a player, cached on the player. The map is a Voronoi
+// diagram so the cell a point sits in is the one whose site is nearest — an
+// O(cells) scan. The on-fire-on-lava flash needs it every frame for every
+// burning kart (worst case a whole pack in a volcano round), so cache it and
+// only rescan when the kart has moved appreciably or the cache is stale (cells
+// mutate to lava during collapse, so refresh on a short interval too).
+function nearestCellIdCached(player) {
+    if (currentMap == null || currentMap.cells == null) { return -1; }
+    var now = Date.now();
+    var hasCache = (player._nearCellId !== undefined);
+    var dx = hasCache ? (player.x - player._nearCellX) : 1e9;
+    var dy = hasCache ? (player.y - player._nearCellY) : 1e9;
+    if (hasCache && dx * dx + dy * dy <= 64 && now - player._nearCellAt < 150) {
+        return player._nearCellId;
+    }
+    var cells = currentMap.cells, nearestId = -1, nd = Infinity;
+    for (var ci = 0; ci < cells.length; ci++) {
+        var cdx = player.x - cells[ci].site.x;
+        var cdy = player.y - cells[ci].site.y;
+        var cd = cdx * cdx + cdy * cdy;
+        if (cd < nd) { nd = cd; nearestId = cells[ci].id; }
+    }
+    player._nearCellId = nearestId;
+    player._nearCellX = player.x;
+    player._nearCellY = player.y;
+    player._nearCellAt = now;
+    return nearestId;
+}
+var targetedPlayerIds = {};
+function rebuildTargetedPlayerIds() {
+    targetedPlayerIds = {};
+    for (var aid in aimerList) {
+        var a = aimerList[aid];
+        var tl = a != null ? a.targetList : null;
+        if (tl == null) { continue; }
+        for (var ti = 0; ti < tl.length; ti++) {
+            targetedPlayerIds[tl[ti]] = true;
+        }
+    }
+}
 function drawPlayers(dt) {
     cartSkinAnimTime += (dt || 0) / 1000; // dt is milliseconds; this accumulator is seconds
+    rebuildTargetedPlayerIds();
     // Draw remote players first, then ALL local players (the primary plus any
     // couch co-op slots) on top — so your own karts always read clearly over
     // other players' floating emojis and name labels.
@@ -2444,12 +2488,7 @@ function drawPlayer(player, dt) {
     // coming), plus a momentum self-preview on your own idle kart.
     drawPunchCharge(player);
 
-    var playerStrokeColor = "black";
-    for (var aimerID in aimerList) {
-        if (aimerList[aimerID].targetList.indexOf(player.id) != -1) {
-            playerStrokeColor = "red"
-        }
-    }
+    var playerStrokeColor = targetedPlayerIds[player.id] ? "red" : "black";
     var sprite = getPlayerSprite(player.color, player.radius, playerStrokeColor);
     // Lobby respawn invulnerability: pulse the sprite's alpha so the grace window is
     // legible. The sprite is a cached image with no alpha, so wrap the blit.
@@ -2475,14 +2514,7 @@ function drawPlayer(player, dt) {
     // cells when on fire (cheap/rare). The flash ramps with the fire timer below.
     var onFireOnLava = false;
     if (player.onFire != null && player.onFire > 0 && currentMap != null && currentMap.cells != null) {
-        var nearestId = -1, nd = Infinity;
-        for (var ci = 0; ci < currentMap.cells.length; ci++) {
-            var cdx = player.x - currentMap.cells[ci].site.x;
-            var cdy = player.y - currentMap.cells[ci].site.y;
-            var cd = cdx * cdx + cdy * cdy;
-            if (cd < nd) { nd = cd; nearestId = currentMap.cells[ci].id; }
-        }
-        onFireOnLava = (nearestId == config.tileMap.lava.id);
+        onFireOnLava = (nearestCellIdCached(player) == config.tileMap.lava.id);
     }
     // Flash while immune to fire/lava damage: lobby respawn-invuln (timed or held in the
     // start circle), or on-fire-on-lava. The pulse quickens over the final 2s of whichever

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3911,9 +3911,17 @@ function drawMap() {
     if (currentMap == null || currentMap.cells == null || currentMap.cells.length === 0) {
         return;
     }
-    if (mapDirty || mapCanvas == null) {
+    if (mapCanvas == null) {
         renderMapToCache();
         mapDirty = false;
+        lastMapBakeAt = Date.now();
+    } else if (mapDirty) {
+        var nowBake = Date.now();
+        if (nowBake - lastMapBakeAt >= MAP_BAKE_MIN_MS) {
+            renderMapToCache();
+            mapDirty = false;
+            lastMapBakeAt = nowBake;
+        }
     }
     if (mapCanvas != null) {
         var mdx = world.x - mapCanvasPad, mdy = world.y - mapCanvasPad;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -2203,7 +2203,7 @@ function spawnTriggerPulse(x, y, color) {
 
 function drawAbilties() {
 
-    if (Object.keys(aimerList).length > 0) {
+    if (hasAnyKey(aimerList)) {
         for (var id in aimerList) {
             drawAimer(aimerList[id]);
         }
@@ -2370,6 +2370,13 @@ var cartSkinAnimTime = 0;
 // Set of player ids currently targeted by some aimer (telegraph). Rebuilt once
 // per frame in drawPlayers so drawPlayer can do an O(1) lookup instead of an
 // O(aimers) for-in + targetList.indexOf per kart per frame.
+// Cheap "is this object/map non-empty?" test — stops at the first key instead of
+// allocating a throwaway array like Object.keys(o).length does each frame.
+function hasAnyKey(o) {
+    if (o == null) { return false; }
+    for (var k in o) { if (Object.prototype.hasOwnProperty.call(o, k)) { return true; } }
+    return false;
+}
 // Nearest-cell id for a player, cached on the player. The map is a Voronoi
 // diagram so the cell a point sits in is the one whose site is nearest — an
 // O(cells) scan. The on-fire-on-lava flash needs it every frame for every
@@ -3927,7 +3934,7 @@ function drawMap() {
             gameContext.drawImage(mapCanvas, mdx, mdy, mdw, mdh);
         }
     }
-    if (Object.keys(hazardList).length > 0) {
+    if (hasAnyKey(hazardList)) {
         for (var id in hazardList) {
             drawHazard(hazardList[id]);
         }
@@ -4116,7 +4123,7 @@ function drawPendingSwap() {
     }
     gameContext.restore();
     // Once every tile has flipped/cleared/expired, drop the telegraph.
-    if (Object.keys(set).length === 0) {
+    if (!hasAnyKey(set)) {
         pendingSwapCells = null;
     }
 }
@@ -4233,19 +4240,27 @@ function renderMapToCache() {
 // A subtle dark vignette over the play area, so the flat background reads as an
 // intentional frame rather than dead space. Drawn in world coords right after
 // the map (under players/FX) so it never dims karts. Cheap: one gradient fill.
+// The vignette gradient depends only on the world rect, so build it once and
+// reuse it every frame (createRadialGradient + addColorStop per frame is pure
+// waste when the world hasn't changed).
+var _vignetteGrad = null, _vignetteKey = "";
 function drawArenaVignette() {
     if (world == null) {
         return;
     }
-    var cx = world.x + world.width / 2;
-    var cy = world.y + world.height / 2;
-    var inner = Math.min(world.width, world.height) * 0.45;
-    var outer = Math.sqrt(world.width * world.width + world.height * world.height) / 2;
-    var g = gameContext.createRadialGradient(cx, cy, inner, cx, cy, outer);
-    g.addColorStop(0, "rgba(0, 0, 0, 0)");
-    g.addColorStop(1, "rgba(8, 6, 14, 0.26)");
+    var key = world.x + "," + world.y + "," + world.width + "," + world.height;
+    if (_vignetteGrad == null || key !== _vignetteKey) {
+        var cx = world.x + world.width / 2;
+        var cy = world.y + world.height / 2;
+        var inner = Math.min(world.width, world.height) * 0.45;
+        var outer = Math.sqrt(world.width * world.width + world.height * world.height) / 2;
+        _vignetteGrad = gameContext.createRadialGradient(cx, cy, inner, cx, cy, outer);
+        _vignetteGrad.addColorStop(0, "rgba(0, 0, 0, 0)");
+        _vignetteGrad.addColorStop(1, "rgba(8, 6, 14, 0.26)");
+        _vignetteKey = key;
+    }
     gameContext.save();
-    gameContext.fillStyle = g;
+    gameContext.fillStyle = _vignetteGrad;
     gameContext.fillRect(world.x, world.y, world.width, world.height);
     gameContext.restore();
 }

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -451,6 +451,19 @@ function gameLoop(dt) {
 }
 
 
+// Mobile browsers fire 'resize' rapidly as the address bar shows/hides on scroll,
+// and resize() reallocates two canvas backing stores + rebuilds the camera — doing
+// that per event stutters. Coalesce a burst into one resize per animation frame.
+// (resize() itself is still called directly for the initial/synchronous layout.)
+var _resizePending = false;
+function onResizeEvent() {
+    if (_resizePending) { return; }
+    _resizePending = true;
+    var run = function () { _resizePending = false; resize(); };
+    if (typeof requestAnimationFrame === "function") { requestAnimationFrame(run); }
+    else { setTimeout(run, 16); }
+}
+
 function resize() {
     // LOGICAL_WIDTH/HEIGHT are captured in setupPage; if a resize fires before
     // that (early rotation/devtools), bail so we don't divide by 0 -> Infinity.
@@ -491,8 +504,17 @@ function resize() {
     // no gameplay math moves to device pixels.
     var dprCap = (typeof perfDprCap === "function") ? perfDprCap() : 2;
     var dpr = Math.min(window.devicePixelRatio || 1, dprCap);
-    gameCanvas.width = Math.round(newWidth * dpr);
-    gameCanvas.height = Math.round(newHeight * dpr);
+    var targetW = Math.round(newWidth * dpr);
+    var targetH = Math.round(newHeight * dpr);
+    // Nothing actually changed (a no-op resize event, e.g. mobile address-bar
+    // toggle at a settled size): skip the backing-store realloc + camera rebuild.
+    // Assigning canvas.width/height clears the backing store even when identical,
+    // so guarding it avoids a needless full repaint + camera reset.
+    if (gameCanvas.width === targetW && gameCanvas.height === targetH && camera != null) {
+        return;
+    }
+    gameCanvas.width = targetW;
+    gameCanvas.height = targetH;
     overlayCanvas.width = Math.round(newWidth * dpr);
     overlayCanvas.height = Math.round(newHeight * dpr);
 

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -258,7 +258,7 @@ function setupPage() {
 
     window.addEventListener('blur', cancelAllLocalMovement);
     window.addEventListener('focus', onTabRefocus);
-    window.addEventListener('resize', resize, false);
+    window.addEventListener('resize', onResizeEvent, false);
     window.requestAnimFrame = (function () {
         return window.requestAnimationFrame ||
             window.webkitRequestAnimationFrame ||

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -1188,7 +1188,7 @@ function spawnSinkingCorpse(player) {
 			var t = age / maxAge;
 			// Embers ride on the same per-tier embers knob that the running flame uses,
 			// so a Balanced profile that already dims live-fire embers also dims these.
-			if (t < 0.9 && age - lastEmberAt >= 110) {
+			if (t < 0.9 && age - lastEmberAt >= ((typeof perfCooldown === "function") ? perfCooldown(110) : 110)) {
 				lastEmberAt = age;
 				if (typeof perfEmbers !== "function" || perfEmbers()) {
 					spawnEmber(cx + (Math.random() * 2 - 1) * radius0 * 0.6,
@@ -1197,7 +1197,7 @@ function spawnSinkingCorpse(player) {
 			}
 			// Lava bubble pops: orange droplets that rise + fade. perfCount thins them
 			// on Balanced (0.6) and would on Low too — but Low never reaches this code.
-			if (t < 0.95 && age - lastBubbleAt >= 220) {
+			if (t < 0.95 && age - lastBubbleAt >= ((typeof perfCooldown === "function") ? perfCooldown(220) : 220)) {
 				lastBubbleAt = age;
 				var n = (typeof perfCount === "function") ? perfCount(2) : 2;
 				for (var i = 0; i < n; i++) {

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -925,7 +925,7 @@ function changeTilesBulk(tileChanges) {
 			delete pendingSwapCells.set[prop];
 		}
 	}
-	if (pendingSwapCells != null && Object.keys(pendingSwapCells.set).length === 0) {
+	if (pendingSwapCells != null && !hasAnyKey(pendingSwapCells.set)) {
 		pendingSwapCells = null;
 	}
 	invalidateMapCache();
@@ -968,7 +968,7 @@ function tileSwapLanded(ids) {
 			delete pendingSwapCells.set[ids[i]];
 		}
 	}
-	if (Object.keys(pendingSwapCells.set).length === 0) {
+	if (!hasAnyKey(pendingSwapCells.set)) {
 		pendingSwapCells = null;
 	}
 }

--- a/client/scripts/perf.js
+++ b/client/scripts/perf.js
@@ -67,12 +67,6 @@ var PERF_PROFILES = {
     }
 };
 
-// Max trail vertices kept/stroked per kart in direct mode (~last few seconds of
-// tail). Bounds both memory and the per-frame re-stroke, and — unlike the old
-// offscreen canvas — never triggers a full-world texture upload or an unbounded
-// _redrawAll, so it kills both the GPU-paint and the main-thread trail spikes.
-var PERF_TRAIL_DIRECT_MAX = 240;
-
 var PERF_STORAGE_KEY = "perfPref";
 var PERF_ORDER = ["auto", "high", "balanced", "low"];
 var PERF_LABEL = { auto: "Auto", high: "High", balanced: "Balanced", low: "Low" };
@@ -245,7 +239,6 @@ function perfEmbers() { return !!PERF.embers; }
 // not gated here so the racing read still has terrain cues even on a phone.
 function perfExtraFx() { return !!PERF.extraFx; }
 function perfTrailDirect() { return !!PERF.trailDirect; }
-function perfTrailDirectMax() { return PERF_TRAIL_DIRECT_MAX; }
 function perfMapScale() { return PERF.mapScale || 1; }
 function perfExplosionSparks() { return PERF.explosionSparks; }
 function perfMaxEffects() { return PERF.maxEffects; }

--- a/client/scripts/recap.js
+++ b/client/scripts/recap.js
@@ -963,7 +963,8 @@ function recapDrawKartParticles(pr, frameT) {
 	var rad = meta.radius || 12;
 	// Burn embers: a few rising, cooling sparks while on fire.
 	if (pr[RF_FIRE] > 0) {
-		for (var k = 0; k < 4; k++) {
+		var emberN = (typeof perfCount === "function") ? perfCount(4) : 4;
+		for (var k = 0; k < emberN; k++) {
 			var ph = (((frameT + k * 150) % 600) / 600);
 			var ex = x + Math.sin(k * 1.7 + frameT / 180) * rad * 0.5;
 			var ey = y - ph * (rad * 1.8 + 8);
@@ -981,7 +982,8 @@ function recapDrawKartParticles(pr, frameT) {
 	var walk = (typeof config !== "undefined" && config != null && config.playerMaxSpeed) ? config.playerMaxSpeed * 0.18 : 1.2;
 	if (sp > walk) {
 		var dir = Math.atan2(pr[RF_VY], pr[RF_VX]);
-		for (var d = 0; d < 3; d++) {
+		var dustN = (typeof perfCount === "function") ? perfCount(3) : 3;
+		for (var d = 0; d < dustN; d++) {
 			var dph = (((frameT + d * 130) % 420) / 420);
 			var dist = rad + dph * 16;
 			var jit = (d - 1) * rad * 0.4;

--- a/client/scripts/terrainfx.js
+++ b/client/scripts/terrainfx.js
@@ -78,12 +78,41 @@ function tfxMaxRadius(verts, cx, cy) {
     }
     return r;
 }
+// Axis-aligned bounds of a verts polygon (world coords). Precomputed per cell at
+// build time so tfxPathCells can frustum-cull without re-scanning verts.
+function tfxBBox(verts) {
+    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (var i = 0; i < verts.length; i++) {
+        var p = verts[i];
+        if (p.x < minX) { minX = p.x; }
+        if (p.x > maxX) { maxX = p.x; }
+        if (p.y < minY) { minY = p.y; }
+        if (p.y > maxY) { maxY = p.y; }
+    }
+    return { minX: minX, minY: minY, maxX: maxX, maxY: maxY };
+}
 // Path a list of cells' polygons into the current ctx path (world coords + cam),
-// ready for clip() or fill(). Each cell is a verts array.
+// ready for clip() or fill(). Each cell is a verts array (or a record with a
+// `.verts` field plus a precomputed bbox). On a big/collapsing map the lava/ice
+// lists can be most of the board; the camera is pure translation (scale === 1,
+// visible world span === LOGICAL_WIDTH/HEIGHT), so cells whose bbox is fully off
+// the screen contribute nothing to a clip/fill and are skipped. Records without a
+// bbox (e.g. goal clusters, a handful) are always included.
 function tfxPathCells(ctx, cells, camX, camY) {
+    var W = (typeof LOGICAL_WIDTH === "number") ? LOGICAL_WIDTH : 0;
+    var H = (typeof LOGICAL_HEIGHT === "number") ? LOGICAL_HEIGHT : 0;
+    var cull = (W > 0 && H > 0);
+    var M = 96; // margin so partial-edge cells never pop
+    var loX = -camX - M, hiX = -camX + W + M;
+    var loY = -camY - M, hiY = -camY + H + M;
     ctx.beginPath();
     for (var i = 0; i < cells.length; i++) {
-        var verts = cells[i].verts || cells[i];
+        var cell = cells[i];
+        var verts = cell.verts || cell;
+        if (cull && cell.maxX !== undefined &&
+            (cell.maxX < loX || cell.minX > hiX || cell.maxY < loY || cell.minY > hiY)) {
+            continue;
+        }
         ctx.moveTo(verts[0].x + camX, verts[0].y + camY);
         for (var v = 1; v < verts.length; v++) {
             ctx.lineTo(verts[v].x + camX, verts[v].y + camY);
@@ -103,7 +132,9 @@ function tfxBuildCells() {
         var verts = tfxCellVerts(cell);
         if (!verts) { continue; }
         var c = tfxCentroid(verts);
-        var rec = { verts: verts, cx: c.x, cy: c.y, vid: (cell.site ? cell.site.voronoiId : i) };
+        var bb = tfxBBox(verts);
+        var rec = { verts: verts, cx: c.x, cy: c.y, vid: (cell.site ? cell.site.voronoiId : i),
+            minX: bb.minX, minY: bb.minY, maxX: bb.maxX, maxY: bb.maxY };
         if (cell.id === tm.ice.id) { terrainFX.ice.push(rec); }
         else if (cell.id === tm.lava.id) { terrainFX.lava.push(rec); }
         else if (cell.id === tm.goal.id) { terrainFX.goal.push(rec); }

--- a/client/scripts/terrainfx.js
+++ b/client/scripts/terrainfx.js
@@ -91,26 +91,41 @@ function tfxBBox(verts) {
     }
     return { minX: minX, minY: minY, maxX: maxX, maxY: maxY };
 }
+// World-space rect currently visible on screen, or null if it can't be computed
+// (cull disabled). The active transform is applyWorldTransform (draw.js): a world
+// point wx maps to logical `scale*(wx - worldView.cx) + LOGICAL_WIDTH/2`, so the
+// visible half-extent is LOGICAL_W/H / (2*scale) centred on worldView.cx/cy. With
+// no zoom (worldView null) world maps ~1:1 into the logical viewport, so the
+// visible world rect is just [-cam, -cam + LOGICAL] (cam offset is 0 in practice,
+// but kept for correctness). A margin keeps partial-edge cells from popping.
+function tfxVisibleWorldRect(camX, camY) {
+    var W = (typeof LOGICAL_WIDTH === "number") ? LOGICAL_WIDTH : 0;
+    var H = (typeof LOGICAL_HEIGHT === "number") ? LOGICAL_HEIGHT : 0;
+    if (!(W > 0 && H > 0)) { return null; }
+    var M = 96;
+    if (typeof worldView !== "undefined" && worldView != null && worldView.cx != null) {
+        var s = worldView.scale || 1;
+        var hw = W / (2 * s) + M, hh = H / (2 * s) + M;
+        return { loX: worldView.cx - hw, hiX: worldView.cx + hw,
+                 loY: worldView.cy - hh, hiY: worldView.cy + hh };
+    }
+    return { loX: -camX - M, hiX: -camX + W + M, loY: -camY - M, hiY: -camY + H + M };
+}
 // Path a list of cells' polygons into the current ctx path (world coords + cam),
 // ready for clip() or fill(). Each cell is a verts array (or a record with a
 // `.verts` field plus a precomputed bbox). On a big/collapsing map the lava/ice
-// lists can be most of the board; the camera is pure translation (scale === 1,
-// visible world span === LOGICAL_WIDTH/HEIGHT), so cells whose bbox is fully off
-// the screen contribute nothing to a clip/fill and are skipped. Records without a
-// bbox (e.g. goal clusters, a handful) are always included.
+// lists can be most of the board, so cells whose bbox is fully outside the visible
+// world rect contribute nothing to a clip/fill and are skipped — the win shows up
+// when zoomed in (scale > 1 shrinks the rect). Records without a bbox (e.g. goal
+// clusters, a handful) are always included.
 function tfxPathCells(ctx, cells, camX, camY) {
-    var W = (typeof LOGICAL_WIDTH === "number") ? LOGICAL_WIDTH : 0;
-    var H = (typeof LOGICAL_HEIGHT === "number") ? LOGICAL_HEIGHT : 0;
-    var cull = (W > 0 && H > 0);
-    var M = 96; // margin so partial-edge cells never pop
-    var loX = -camX - M, hiX = -camX + W + M;
-    var loY = -camY - M, hiY = -camY + H + M;
+    var vr = tfxVisibleWorldRect(camX, camY);
     ctx.beginPath();
     for (var i = 0; i < cells.length; i++) {
         var cell = cells[i];
         var verts = cell.verts || cell;
-        if (cull && cell.maxX !== undefined &&
-            (cell.maxX < loX || cell.minX > hiX || cell.maxY < loY || cell.minY > hiY)) {
+        if (vr != null && cell.maxX !== undefined &&
+            (cell.maxX < vr.loX || cell.minX > vr.hiX || cell.maxY < vr.loY || cell.minY > vr.hiY)) {
             continue;
         }
         ctx.moveTo(verts[0].x + camX, verts[0].y + camY);


### PR DESCRIPTION
## Client render-perf sweep across all 11 perf-profile knobs

A deep per-category scan of the client perf system (`perf.js` tiers high/balanced/low) found that the knob *framework* is sound, but several real per-frame costs weren't gated by any knob (so they hit Low-tier phones at full price), plus a few dead/ineffective bits. This fixes them. **Client render/perf only** — no `config.json`/server `game.js`/`engine.js`, so the release-notes gate is exempt.

### Correctness/perf fixes (hit every tier, incl. Low)
- **drawPlayer aimer targeting**: replaced an O(players×aimers) `for-in`+`indexOf` per kart per frame with a `targetedPlayerIds` set rebuilt once per frame (generation-stamped, no per-frame allocation) → O(1) lookup.
- **On-fire-on-lava check**: replaced the O(map-cells) nearest-cell scan run every frame for every burning kart with a per-kart cache (rescans only on >8px move or 150ms staleness), reusing gameboard's existing `nearestCell` scan.

### Per-frame cost reductions
- **`resize()`**: rAF-coalesced (`onResizeEvent`) + early-return when backing-store dims are unchanged → mobile address-bar show/hide no longer reallocates both canvases + rebuilds the camera per event.
- **Map cache**: full world re-bake + GPU re-upload coalesced to ~25/s during collapse (`MAP_BAKE_MIN_MS`) instead of up to 60/s; a discarded cache still re-bakes immediately.
- **terrainfx clips**: `tfxPathCells` frustum-culls off-screen lava/ice cells using the actual `worldView` visible rect (scale-aware) — effective when zoomed in, correct at 1:1.
- **Vignette gradient** cached (rebuilt only when the world rect changes); `Object.keys(o).length` emptiness tests replaced with a break-on-first-key `hasAnyKey` helper (draw.js + gameboard.js).

### Cleanup
- recap montage embers/dust thinned via `perfCount`; sinking-corpse cadences via `perfCooldown`.
- `drawTrail` reuses a scratch array (no `new Array` per kart per frame).
- `glowBlur(n)` single-sources the `perfGlow`-gated `shadowBlur` (5 sites + trail), and gates the dormant water-theme glows.
- removed the unused `PERF_TRAIL_DIRECT_MAX`/`perfTrailDirectMax()` (the offscreen-trail path they bounded is gone).

### Review & verification
Ran `/code-review` (high effort) — it caught 3 regressions from edits that had silently failed against the newer base (undeclared `MAP_BAKE_MIN_MS` → ReferenceError on dirty-map frames; an unwired resize listener; a `camera`-offset-based cull that never fired). **All three fixed** in this branch and re-reviewed. `node --check` clean on all files, smoke test green, `npm run build` green.

⚠️ Best confirmed on a real device — the resize, map-throttle, and zoom-aware cull changes don't show up in headless smoke. Suggest an iPad/phone playtest pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
