### PR TITLE
fix(client): stop mouse-drive toggling on during lobby hub menus

### DIFF
--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -247,6 +247,18 @@ function handleDblClick(event) {
     if (isTouchScreen) {
         return;
     }
+    // A double-click landing on a lobby hub prompt/panel is the player operating
+    // the menu (e.g. tapping a stepper or swatch twice), not the "toggle mouse-drive"
+    // gesture. The mousedown path already routes these through the hub; the separate
+    // dblclick event must ignore them too, or mouse-drive silently flips on mid-menu.
+    if (typeof lobbyHubPointHitsActive === "function") {
+        var rect = gameCanvas.getBoundingClientRect();
+        var lx = ((event.clientX - rect.left) / newWidth) * LOGICAL_WIDTH;
+        var ly = ((event.clientY - rect.top) / newHeight) * LOGICAL_HEIGHT;
+        if (lobbyHubPointHitsActive(lx, ly)) {
+            return;
+        }
+    }
     claimPrimaryForKbm(); // mouse-move play claims P1 -> controllers are P2+
     if (movingByMouse) {
         cancelMovement(event);

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1058,6 +1058,29 @@ function lobbyHubHandlePrimaryPointer(lx, ly) {
     return false;
 }
 
+// Read-only mirror of lobbyHubHandlePrimaryPointer: returns true if a pointer at
+// (lx, ly) WOULD be consumed by the hub, WITHOUT mutating any panel state. Used by
+// handleDblClick so a rapid double-click on a hub prompt/panel doesn't get treated
+// as the desktop "toggle mouse-drive" gesture. While a panel is open every click is
+// captured by the hub (control, close, or dismiss-away), so any point counts.
+function lobbyHubPointHitsActive(lx, ly) {
+    if (typeof config === "undefined" || config == null || currentState !== config.stateMap.lobby) {
+        return false;
+    }
+    if (typeof localPlayers === "undefined") {
+        return false;
+    }
+    var lp = localPlayers[primarySlot];
+    if (!lp) {
+        return false;
+    }
+    if (lp.stationPanel) {
+        return true;
+    }
+    var hit = stationHudHit[lp.slot];
+    return !!(lp.nearStation && hit && lhPointIn(hit.prompt, lx, ly));
+}
+
 // --- keyboard (primary slot only) --------------------------------------------
 
 // Returns true if the key was consumed by the hub (so keyDown stops processing it


### PR DESCRIPTION
## Problem

While interacting with in-game lobby **hub menus** (the walk-up station panels for AI control / skins), desktop "mouse-drive" mode kept silently toggling on, sending the kart driving on its own.

## Root cause

The desktop mouse-drive toggle lives in `handleDblClick` (`input.js`), which flips `movingByMouse` on **any** double-click. The `mousedown` path (`handleClick`) correctly routes clicks through `lobbyHubHandlePrimaryPointer` so hub clicks become menu actions instead of driving — but the **separate `dblclick` listener had no hub awareness**. Clicking rapidly on a hub control (steppers, color swatches, the "press to open" prompt) produces a browser-synthesized `dblclick`, which toggled mouse-drive on mid-menu.

## Fix

- `lobbyHub.js` — add `lobbyHubPointHitsActive(lx, ly)`, a **read-only** mirror of `lobbyHubHandlePrimaryPointer` that reports whether a point would be consumed by the hub (panel open → always true; otherwise prompt hit-test) **without** mutating panel state.
- `input.js` — `handleDblClick` computes logical coords the same way `handleClick` does and returns early if `lobbyHubPointHitsActive` is true, so double-clicking a hub element no longer toggles mouse-drive.

Client input/UI only — no `config.json`/`game.js`/`engine.js` changes, so no CHANGELOG entry required.

## Verification

- `npm run build` succeeds; new helper bundled into `play.bundle.min.js` (definition + 2 call sites).
- `.github/scripts/smoke-test.js` passes (engine ticked 52 maps through all states without crashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)