### PR TITLE
feat(ci): GA4 config-as-code pipeline (analytics/ga-config.json → prod via Actions)

### DIFF
--- a/.github/workflows/ga-config.yml
+++ b/.github/workflows/ga-config.yml
@@ -1,0 +1,71 @@
+name: GA config (prod)
+
+# Applies GA4 config-as-code (analytics/ga-config.json) to the PRODUCTION property
+# via the GA4 Admin API. Same model as db-migrate.yml: the GA property is hand-edited
+# nowhere; the only writer of GA custom dimensions/metrics/key events is this CI runner,
+# acting only on config that landed on main. See docs/ga-config.md.
+#
+# Required repo secrets (Settings -> Secrets and variables -> Actions):
+#   GA_SERVICE_ACCOUNT_KEY  - full JSON key of a GCP service account that has the
+#                             Editor role on the GA4 property (Admin -> Property Access
+#                             Management). Paste the entire key file as the secret value.
+
+on:
+  push:
+    branches: [main]
+    paths: ['analytics/ga-config.json', 'analytics/reconcile-ga.js']
+  pull_request:
+    paths: ['analytics/ga-config.json', 'analytics/reconcile-ga.js']
+
+# Never let two reconciles race against the same property.
+concurrency:
+  group: ga-config-prod
+  cancel-in-progress: false
+
+jobs:
+  # PR safety net: show exactly what would change in GA, without applying it.
+  # Skipped for fork PRs (secrets are not exposed to forks).
+  dry-run:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # The reconcile script needs only the GA Admin client — nothing from the app's
+      # own deps. Installing it standalone keeps this heavy Google library out of
+      # package.json (and off the Heroku dyno).
+      - run: npm install --no-save @google-analytics/admin@^9.1.0
+      - name: Write service-account key
+        env:
+          GA_SERVICE_ACCOUNT_KEY: ${{ secrets.GA_SERVICE_ACCOUNT_KEY }}
+        run: printf '%s' "$GA_SERVICE_ACCOUNT_KEY" > "$RUNNER_TEMP/ga-key.json"
+      - name: Preview GA config changes
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/ga-key.json
+        run: node analytics/reconcile-ga.js --dry-run
+
+  # On merge to main: apply config to the prod property.
+  apply:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # The reconcile script needs only the GA Admin client — nothing from the app's
+      # own deps. Installing it standalone keeps this heavy Google library out of
+      # package.json (and off the Heroku dyno).
+      - run: npm install --no-save @google-analytics/admin@^9.1.0
+      - name: Write service-account key
+        env:
+          GA_SERVICE_ACCOUNT_KEY: ${{ secrets.GA_SERVICE_ACCOUNT_KEY }}
+        run: printf '%s' "$GA_SERVICE_ACCOUNT_KEY" > "$RUNNER_TEMP/ga-key.json"
+      - name: Apply GA config to prod
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/ga-key.json
+        run: node analytics/reconcile-ga.js

--- a/analytics/ga-config.json
+++ b/analytics/ga-config.json
@@ -1,0 +1,46 @@
+{
+  "_comment": "Declarative GA4 config-as-code. Edited here, applied to PROD by .github/workflows/ga-config.yml via analytics/reconcile-ga.js. See docs/ga-config.md. The count*/average* metric variants seen in the GA reporting API are auto-derived by GA from the base custom metric and must NOT be listed here.",
+  "propertyId": "454757771",
+  "customDimensions": [
+    {
+      "parameterName": "map",
+      "displayName": "Map Name",
+      "scope": "EVENT",
+      "description": "Map name/id attached to gameplay events (e.g. match_start, round_complete)."
+    },
+    {
+      "parameterName": "target",
+      "displayName": "CTA Target",
+      "scope": "EVENT",
+      "description": "Which landing CTA was clicked: play | join | create."
+    },
+    {
+      "parameterName": "won",
+      "displayName": "Match Won",
+      "scope": "EVENT",
+      "description": "Whether the local player won the completed match (match_end)."
+    }
+  ],
+  "customMetrics": [
+    {
+      "parameterName": "players",
+      "displayName": "Players in match",
+      "scope": "EVENT",
+      "measurementUnit": "STANDARD",
+      "description": "Human players present in a match."
+    },
+    {
+      "parameterName": "bots",
+      "displayName": "Bots in a match",
+      "scope": "EVENT",
+      "measurementUnit": "STANDARD",
+      "description": "Bots present in a match (used to separate humans-only metrics)."
+    }
+  ],
+  "keyEvents": [
+    {
+      "eventName": "match_end",
+      "countingMethod": "ONCE_PER_EVENT"
+    }
+  ]
+}

--- a/analytics/reconcile-ga.js
+++ b/analytics/reconcile-ga.js
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * Reconcile GA4 config-as-code (analytics/ga-config.json) against a GA4 property
+ * using the GA4 Admin API. Idempotent: lists what exists, CREATEs what's missing,
+ * PATCHes what drifted, and (only with --prune) archives/deletes what was removed
+ * from the config file.
+ *
+ * This is the GA analogue of `supabase db push` in .github/workflows/db-migrate.yml.
+ * Prod is read-only from every interactive surface; the only thing that writes GA
+ * config is this script, running in CI on a commit that landed on main.
+ *
+ * Usage:
+ *   node analytics/reconcile-ga.js [--dry-run] [--prune] [--config <path>]
+ *
+ *   --dry-run   Print the plan (create / patch / archive / delete) and exit without
+ *               touching GA. Used for the PR safety-net preview.
+ *   --prune     Allow destructive ops (archive dimensions/metrics, delete key events)
+ *               for definitions present in GA but absent from the config. Off by
+ *               default so a normal apply can never silently drop a definition.
+ *
+ * Auth: standard Application Default Credentials. CI writes the service-account JSON
+ * key to a file and points GOOGLE_APPLICATION_CREDENTIALS at it. The service account
+ * needs the Editor role on the GA4 property (Admin -> Property Access Management).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { AnalyticsAdminServiceClient } = require('@google-analytics/admin');
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const PRUNE = args.includes('--prune');
+const configPath = (() => {
+  const i = args.indexOf('--config');
+  return i !== -1 && args[i + 1]
+    ? path.resolve(args[i + 1])
+    : path.join(__dirname, 'ga-config.json');
+})();
+
+// GitHub Actions log grouping (no-op locally — just prints the markers).
+const group = async (title, fn) => {
+  console.log(`::group::${title}`);
+  try {
+    return await fn();
+  } finally {
+    console.log('::endgroup::');
+  }
+};
+
+function loadConfig() {
+  const raw = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  const propertyId = String(raw.propertyId || '').replace(/^properties\//, '');
+  if (!/^\d+$/.test(propertyId)) {
+    throw new Error(`config.propertyId must be a numeric GA4 property id, got: ${raw.propertyId}`);
+  }
+  return {
+    parent: `properties/${propertyId}`,
+    propertyId,
+    customDimensions: raw.customDimensions || [],
+    customMetrics: raw.customMetrics || [],
+    keyEvents: raw.keyEvents || [],
+  };
+}
+
+// Accumulated plan, printed as a summary at the end (and the only output in dry-run).
+const plan = { create: [], patch: [], archive: [], delete: [], noop: 0 };
+const record = (bucket, line) => {
+  if (bucket === 'noop') plan.noop += 1;
+  else plan[bucket].push(line);
+};
+
+async function reconcileCustomDimensions(client, cfg) {
+  const [existing] = await client.listCustomDimensions({ parent: cfg.parent });
+  const byKey = new Map(existing.map((d) => [`${d.scope}:${d.parameterName}`, d]));
+
+  for (const want of cfg.customDimensions) {
+    const key = `${want.scope}:${want.parameterName}`;
+    const have = byKey.get(key);
+    if (!have) {
+      record('create', `customDimension ${key} ("${want.displayName}")`);
+      if (!DRY_RUN) {
+        await client.createCustomDimension({
+          parent: cfg.parent,
+          customDimension: {
+            parameterName: want.parameterName,
+            displayName: want.displayName,
+            scope: want.scope,
+            description: want.description || '',
+          },
+        });
+      }
+      continue;
+    }
+    byKey.delete(key); // mark as seen
+    const updateMask = [];
+    if ((have.displayName || '') !== (want.displayName || '')) updateMask.push('display_name');
+    if ((have.description || '') !== (want.description || '')) updateMask.push('description');
+    // parameterName and scope are immutable in GA4 — never patched.
+    if (updateMask.length === 0) {
+      record('noop');
+      continue;
+    }
+    record('patch', `customDimension ${key} [${updateMask.join(', ')}]`);
+    if (!DRY_RUN) {
+      await client.updateCustomDimension({
+        customDimension: { name: have.name, displayName: want.displayName, description: want.description || '' },
+        updateMask: { paths: updateMask },
+      });
+    }
+  }
+
+  // Anything left in byKey exists in GA but not in config.
+  for (const [key, have] of byKey) {
+    if (PRUNE) {
+      record('archive', `customDimension ${key} ("${have.displayName}")`);
+      if (!DRY_RUN) await client.archiveCustomDimension({ name: have.name });
+    } else {
+      record('noop');
+      console.log(`  · keeping un-managed customDimension ${key} (use --prune to archive)`);
+    }
+  }
+}
+
+async function reconcileCustomMetrics(client, cfg) {
+  const [existing] = await client.listCustomMetrics({ parent: cfg.parent });
+  const byKey = new Map(existing.map((m) => [`${m.scope}:${m.parameterName}`, m]));
+
+  for (const want of cfg.customMetrics) {
+    const key = `${want.scope}:${want.parameterName}`;
+    const have = byKey.get(key);
+    if (!have) {
+      record('create', `customMetric ${key} ("${want.displayName}")`);
+      if (!DRY_RUN) {
+        await client.createCustomMetric({
+          parent: cfg.parent,
+          customMetric: {
+            parameterName: want.parameterName,
+            displayName: want.displayName,
+            scope: want.scope,
+            measurementUnit: want.measurementUnit || 'STANDARD',
+            description: want.description || '',
+          },
+        });
+      }
+      continue;
+    }
+    byKey.delete(key);
+    const updateMask = [];
+    if ((have.displayName || '') !== (want.displayName || '')) updateMask.push('display_name');
+    if ((have.description || '') !== (want.description || '')) updateMask.push('description');
+    // parameterName, scope, measurementUnit are immutable in GA4 — never patched.
+    if (updateMask.length === 0) {
+      record('noop');
+      continue;
+    }
+    record('patch', `customMetric ${key} [${updateMask.join(', ')}]`);
+    if (!DRY_RUN) {
+      await client.updateCustomMetric({
+        customMetric: { name: have.name, displayName: want.displayName, description: want.description || '' },
+        updateMask: { paths: updateMask },
+      });
+    }
+  }
+
+  for (const [key, have] of byKey) {
+    if (PRUNE) {
+      record('archive', `customMetric ${key} ("${have.displayName}")`);
+      if (!DRY_RUN) await client.archiveCustomMetric({ name: have.name });
+    } else {
+      record('noop');
+      console.log(`  · keeping un-managed customMetric ${key} (use --prune to archive)`);
+    }
+  }
+}
+
+async function reconcileKeyEvents(client, cfg) {
+  const [existing] = await client.listKeyEvents({ parent: cfg.parent });
+  const byName = new Map(existing.map((e) => [e.eventName, e]));
+
+  for (const want of cfg.keyEvents) {
+    const have = byName.get(want.eventName);
+    if (!have) {
+      record('create', `keyEvent "${want.eventName}"`);
+      if (!DRY_RUN) {
+        await client.createKeyEvent({
+          parent: cfg.parent,
+          keyEvent: {
+            eventName: want.eventName,
+            countingMethod: want.countingMethod || 'ONCE_PER_EVENT',
+          },
+        });
+      }
+      continue;
+    }
+    byName.delete(want.eventName);
+    record('noop'); // countingMethod patch is rarely needed; treat presence as satisfied.
+  }
+
+  for (const [name, have] of byName) {
+    if (PRUNE) {
+      record('delete', `keyEvent "${name}"`);
+      if (!DRY_RUN) await client.deleteKeyEvent({ name: have.name });
+    } else {
+      record('noop');
+      console.log(`  · keeping un-managed keyEvent "${name}" (use --prune to delete)`);
+    }
+  }
+}
+
+async function main() {
+  const cfg = loadConfig();
+  console.log(`GA config-as-code → property ${cfg.parent}`);
+  console.log(`mode: ${DRY_RUN ? 'DRY RUN (no changes)' : 'APPLY'}${PRUNE ? ' +prune' : ''}`);
+  console.log(`config: ${configPath}\n`);
+
+  const client = new AnalyticsAdminServiceClient();
+
+  await group('Custom dimensions', () => reconcileCustomDimensions(client, cfg));
+  await group('Custom metrics', () => reconcileCustomMetrics(client, cfg));
+  await group('Key events', () => reconcileKeyEvents(client, cfg));
+
+  console.log('\n=== Plan ===');
+  const show = (label, arr) => arr.forEach((l) => console.log(`  ${label}  ${l}`));
+  show('CREATE ', plan.create);
+  show('PATCH  ', plan.patch);
+  show('ARCHIVE', plan.archive);
+  show('DELETE ', plan.delete);
+  const changes = plan.create.length + plan.patch.length + plan.archive.length + plan.delete.length;
+  console.log(
+    `\n${changes} change(s), ${plan.noop} already in sync.` +
+      (DRY_RUN && changes ? ' (dry run — nothing applied)' : '')
+  );
+}
+
+main().catch((err) => {
+  console.error('\nGA reconcile failed:', err && err.message ? err.message : err);
+  process.exit(1);
+});

--- a/docs/ga-config.md
+++ b/docs/ga-config.md
@@ -1,0 +1,83 @@
+# GA4 config-as-code (repo → prod via GitHub)
+
+Google Analytics **configuration** (custom dimensions, custom metrics, key events) for
+the prod property is applied **only** by CI, only from `analytics/ga-config.json`. The GA
+property is edited nowhere by hand for these definitions — the single thing with write
+access to GA config is the GitHub Actions runner in `.github/workflows/ga-config.yml`, and
+it acts only on config that landed on `main`. This is the GA analogue of the Supabase
+schema pipeline in [`db-migrations.md`](db-migrations.md).
+
+```
+agent / laptop ──(GA MCP, read-only)──► prod property        inspect only, never writes config
+you ──► edit analytics/ga-config.json ──► PR ──► merge to main
+                                                      │
+                                       GitHub Actions (holds the GA service-account key)
+                                                      │
+                                  node analytics/reconcile-ga.js ──► PROD property
+```
+
+This governs GA *config*, not the gameplay events themselves. The `gtag('event', …)` calls
+that fire the events live in the client code (`client/scripts/*`). A custom dimension/metric
+here only tells GA to **retain and expose** a parameter that those events already send.
+
+## What's managed (and what isn't)
+
+| GA config | Managed here |
+|---|---|
+| Custom dimensions | ✅ create / patch / archive |
+| Custom metrics | ✅ create / patch / archive |
+| Key events (conversions) | ✅ create / delete |
+| `gtag` event firing | ❌ — client code, already in the repo |
+| Saved Comparisons, Explorations, reports | ❌ — not Admin-API-manageable, stay manual |
+| Internal-traffic / data filters | ❌ here — partial Admin-API support; left manual for now |
+
+The `count*` / `average*` metric variants you see in the GA reporting API are **auto-derived
+by GA** from each base custom metric — do not list them in the config.
+
+## One-time operator setup
+
+1. **Create a GCP service account** (any GCP project) and download its **JSON key**.
+   - Enable the **Google Analytics Admin API** on that GCP project.
+2. **Grant it access to the GA4 property:** GA Admin → Property Access Management → add the
+   service account's email with the **Editor** role (Editor is required to write config;
+   Viewer/Analyst cannot). Property: `chaochaogame` (`454757771`).
+3. **Add one repo secret** (Settings → Secrets and variables → Actions → New secret):
+   - `GA_SERVICE_ACCOUNT_KEY` — paste the entire JSON key file as the value.
+
+Least privilege: scope the key to Editor on this one property only, mirroring the
+read-only-prod posture used for Supabase.
+
+## Day-to-day flow
+
+1. Edit `analytics/ga-config.json` (add a dimension/metric, mark a key event, fix a label).
+2. Open a PR. The **dry-run** job posts the exact plan (CREATE / PATCH / ARCHIVE / DELETE)
+   to the Actions log without touching GA. Fork PRs are skipped (no secret access).
+3. Merge to `main`. The **apply** job reconciles the prod property.
+
+The reconcile is idempotent — re-running with no config change is a no-op.
+
+## Safety: pruning is manual-only
+
+CI **never** passes `--prune`, so an apply can only CREATE or PATCH; it will **never**
+archive a dimension/metric or delete a key event, even if you remove it from the config
+(it logs `keeping un-managed …` instead). Destructive cleanup is a deliberate local action:
+
+```bash
+# Editor-grade key, locally:
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/ga-key.json
+node analytics/reconcile-ga.js --dry-run --prune   # review what would be removed
+node analytics/reconcile-ga.js --prune             # actually archive/delete
+```
+
+Note GA caps standard properties at **50 custom dimensions / 50 custom metrics**, and
+**archiving a definition does not always free its slot immediately** — prune with care.
+
+## Local dry-run (optional)
+
+You don't need CI to preview. With an Editor key on the property:
+
+```bash
+npm install --no-save @google-analytics/admin@^9.1.0
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/ga-key.json
+node analytics/reconcile-ga.js --dry-run
+```


### PR DESCRIPTION
## GA4 config-as-code → prod via GitHub Actions

Mirrors the Supabase `db-migrate.yml` flow for **Google Analytics** config. The prod GA
property's custom dimensions / custom metrics / key events are now declared in
`analytics/ga-config.json` and applied **only by CI** on merge to `main` — the property is
hand-edited nowhere for these definitions. This automates the "Part B" GA-config steps that
were previously manual operator clicks in `docs/analytics-instrumentation-plan.md`.

### What's here
- **`analytics/ga-config.json`** — declarative config, seeded from the property's live state:
  3 custom dimensions (`map`, `target`, `won`), 2 base custom metrics (`players`, `bots`),
  plus `match_end` as a key event (the still-pending operator task). The `count*`/`average*`
  metric variants are auto-derived by GA and intentionally not listed.
- **`analytics/reconcile-ga.js`** — idempotent reconcile over the GA4 Admin API
  (list → create / patch / archive|delete). `--dry-run` for the PR preview; `--prune` gates
  **all** destructive ops and is **never** used by CI.
- **`.github/workflows/ga-config.yml`** — dry-run plan on PR (skipped on forks), apply on push
  to `main`. Installs `@google-analytics/admin@^9` standalone, keeping the heavy Google lib out
  of `package.json` / the Heroku dyno. Auth via the `GA_SERVICE_ACCOUNT_KEY` secret.
- **`docs/ga-config.md`** — operator setup + daily flow, mirroring `docs/db-migrations.md`.

### Expected dry-run result on this PR
```
CREATE   keyEvent "match_end"
1 change(s), 5 already in sync.
```
The "5 already in sync" is the end-to-end proof that the service-account auth + property
access + Admin API all work (it successfully read the 3 live dimensions + 2 metrics).

### Verification done locally
- Confirmed all 11 Admin-API methods used exist on the v9 client.
- Mocked the live property state → dry-run reports exactly the plan above.
- Mocked drift/empty/stray-definition states → patch, create-all, and prune-archive branches all behave.
- Config JSON + script syntax + workflow YAML validate. `package.json` / lock untouched.
- Rebased on `origin/main`; `npm run build` + `npm run test:smoke` green (additive change, 52 maps ticked).

### Operator setup (one-time) — status
- [x] GCP service account `ga-config-ci` + JSON key created; **Google Analytics Admin API enabled** on project `chaochao-497520`.
- [x] Editor access binding on property `454757771` (added via `properties.accessBindings.create`, since the GA UI rejects service-account emails).
- [x] Repo secret `GA_SERVICE_ACCOUNT_KEY` added (full JSON key).

### Notes
- Not a game-mechanic change (no `server/game.js` / `engine.js` / `config.json`), so no CHANGELOG entry required.
- Pruning (archive/delete) is deliberately manual-only — see `docs/ga-config.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
