### PR TITLE
feat: fully charged punch hits harder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- A fully charged punch now hits noticeably harder — winding all the way up sends rivals flying much further than before.
 
 ## v0.25.4 — 2026-05-29
 

--- a/server/config.json
+++ b/server/config.json
@@ -355,7 +355,7 @@
     "punchCharge": {
         "_doc": "Hold-to-charge: holding punch for maxChargeMs reaches a full charge that multiplies the momentum-scaled knockback by maxChargeMult (final force = momentum bonus x charge). Charge is capped by the stamina you can afford. Overcharge: holding past overchargeAfterMs starts a danger phase whose dark-red meter fills over overchargeFillMs; if you don't release in time the charge is wasted and you're locked in the exhausted move-penalty for exhaustLockMs. chargedHitFrac = how full a charge counts as a 'fully charged' hit (drives the thwack SFX).",
         "maxChargeMs": 700,
-        "maxChargeMult": 2.0,
+        "maxChargeMult": 3.0,
         "overchargeAfterMs": 2000,
         "overchargeFillMs": 1500,
         "exhaustLockMs": 3000,


### PR DESCRIPTION
## What

A fully charged punch now hits noticeably harder. Bumps `punchCharge.maxChargeMult` from `2.0` → `3.0` in `server/config.json`, so a full wind-up multiplies the momentum-scaled knockback by 3× instead of 2×.

The charge curve is unchanged otherwise — `chargeMult = 1 + (maxChargeMult - 1) · frac`, so a partial charge still scales linearly and a tap (frac 0) is unaffected. Only the top end of the charge gets stronger.

## Why

Committing to a full charge (and paying its stamina/overcharge cost) felt underwhelming relative to a quick tap. This makes the full wind-up land with real weight.

## Testing

- `npm run build` — bundles produced cleanly.
- `.github/scripts/smoke-test.js` — engine booted and ticked all 52 maps through waiting→racing→collapsing with no throws.

Player-facing CHANGELOG bullet added under `## Unreleased` (game-mechanic change in `config.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)