### PR TITLE
feat(maps): rate the map on the round overview + controller support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- You can now rate the map you just played right on the round-results screen, while it's fresh — a 5-star strip above the next-map preview. Works with mouse, touch, and controller (◄ ► to pick a star, Ⓐ to confirm). It's still on the match-over screen too.
 
 ## v0.25.6 — 2026-05-30
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -18,7 +18,8 @@ var config,
 var ratingMapId = null,
 	ratingMapName = null,
 	myMapRating = 0,
-	ratingStarHits = [];
+	ratingStarHits = [],
+	ratingPadCursor = 0;   // gamepad-highlighted star (1..5; 0 = uninitialised)
 
 // The room's active playlist id for analytics, so rounds/matches can be segmented
 // by playlist (defaults to the configured default until a lobbyPlaylistChanged
@@ -653,6 +654,7 @@ function registerStateHandlers(server) {
 		ratingMapName = (packet.mapName != null) ? packet.mapName : ((currentMap && currentMap.name) || null);
 		myMapRating = 0;
 		ratingStarHits = [];
+		ratingPadCursor = 0;
 		trackEvent('round_complete', {
 			map: (currentMap && currentMap.name) || 'unknown',
 			playlist: currentPlaylistIdForMetrics()
@@ -728,6 +730,7 @@ function registerStateHandlers(server) {
 		ratingMapName = (packet.mapName != null) ? packet.mapName : ((currentMap && currentMap.name) || null);
 		myMapRating = 0;
 		ratingStarHits = [];
+		ratingPadCursor = 0;
 		recapHarvestRound();      // fold the final round's clips into the archive first
 		recapBuild(achievements); // then assemble the montage from the whole-match archive
 		stopAllSounds();

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -704,8 +704,11 @@ function registerStateHandlers(server) {
 		}
 	});
 	server.on("mapRated", function (payload) {
-		// Server confirmation of our star vote — reflect the acknowledged value.
-		if (payload != null && typeof payload.stars === "number") {
+		// Server confirmation of our star vote — reflect the acknowledged value, but
+		// only if it's for the map currently being rated. Ratings now happen every
+		// overview, so a slow ack from a previous round could otherwise resolve after
+		// ratingMapId moved on and overwrite the new map's selection with a stale one.
+		if (payload != null && typeof payload.stars === "number" && payload.mapId === ratingMapId) {
 			myMapRating = payload.stars;
 		}
 	});

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -11,9 +11,10 @@ var config,
 	nextFightReactionTime = 0,
 	playerWon = null;
 
-// Game-over map-rating widget state (see drawGameOverRating / handleClick).
-// ratingMapId/Name: which map the stars rate; myMapRating: stars this player
-// picked (0 = none yet); ratingStarHits: per-star screen rects for hit-testing.
+// Map-rating widget state (shown on the per-round overview + the match-over screen;
+// see drawMapRating / handleMapRatingTap). ratingMapId/Name: which map the stars
+// rate; myMapRating: stars this player picked (0 = none yet); ratingStarHits:
+// per-star screen rects for hit-testing.
 var ratingMapId = null,
 	ratingMapName = null,
 	myMapRating = 0,
@@ -27,11 +28,13 @@ function currentPlaylistIdForMetrics() {
 	return (typeof config !== "undefined" && config && config.defaultPlaylist) ? config.defaultPlaylist : "featured";
 }
 
-// Hit-test a pointer (logical coords) against the game-over star widget. On a hit,
+// Hit-test a pointer (logical coords) against the map-rating star widget. On a hit,
 // optimistically fills the stars and emits the vote (server confirms via mapRated).
-// Returns true if the tap was consumed by the widget.
-function handleGameOverRatingTap(lx, ly) {
-	if (typeof config === "undefined" || config == null || currentState !== config.stateMap.gameOver) {
+// Returns true if the tap was consumed by the widget. Shown on the per-round overview
+// (rate the map you just played) and the match-over screen.
+function handleMapRatingTap(lx, ly) {
+	if (typeof config === "undefined" || config == null ||
+		(currentState !== config.stateMap.overview && currentState !== config.stateMap.gameOver)) {
 		return false;
 	}
 	if (!ratingMapId || !Array.isArray(ratingStarHits)) {
@@ -643,6 +646,13 @@ function registerStateHandlers(server) {
 		mapLeaderboardData = null;
 		mapLeaderboardJustPlayed = null;
 		currentState = config.stateMap.overview;
+		// Set up the "rate this map" widget for the map JUST played (currentMap is
+		// still the played map here — the next map only loads at the next gate). Reset
+		// the picked stars so each round's overview rates its own map.
+		ratingMapId = (packet.mapId != null) ? packet.mapId : ((currentMap && currentMap.id) || null);
+		ratingMapName = (packet.mapName != null) ? packet.mapName : ((currentMap && currentMap.name) || null);
+		myMapRating = 0;
+		ratingStarHits = [];
 		trackEvent('round_complete', {
 			map: (currentMap && currentMap.name) || 'unknown',
 			playlist: currentPlaylistIdForMetrics()

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -5320,7 +5320,9 @@ function drawOverviewBoard() {
         var pvX = LOGICAL_WIDTH / 2 + 100;
         var pvY = (LOGICAL_HEIGHT / 2 - (world.height / 10)) - 100;
         var thumbCx = pvX + (world.width / 3) / 2;     // centre over the preview thumbnail
-        var stripBottom = pvY - 35 - 12;               // just above the "Next map" title
+        // Sit clear ABOVE the whole preview header ("Next map" is a 32px label at
+        // pvY-35, so its top is ~pvY-67) — clamp so it never runs off the top edge.
+        var stripBottom = Math.max(86, pvY - 80);
         drawMapRating(thumbCx, stripBottom);
     } catch (e) {
         debugLog("rating draw error", e);

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1832,23 +1832,26 @@ function drawGameOverScreen(dt) {
     // "Rate this map" star widget, pinned bottom-centre. Guarded for the same
     // reason as the recap — it must never take down the game-over screen.
     try {
-        drawGameOverRating();
+        drawMapRating();
     } catch (e) {
         debugLog("rating draw error", e);
     }
 
 }
 
-// A 5-star "rate this map" strip at the bottom of the game-over screen. Records
-// per-star hit rects into ratingStarHits (logical coords) for input.js to test.
-// Click/tap a star to vote (one vote per map; re-voting overwrites). No-op render
-// when the server didn't tell us which map to rate.
-function drawGameOverRating() {
+// A 5-star "rate this map" strip pinned bottom-centre. Shown on the per-round
+// overview (rate the map you just played) and the match-over screen. Records per-star
+// hit rects into ratingStarHits (logical coords) for input.js to test. Click/tap a
+// star to vote (one vote per map; re-voting overwrites). No-op render when the server
+// didn't tell us which map to rate.
+function drawMapRating(cxOverride) {
     if (typeof ratingMapId === "undefined" || ratingMapId == null) {
         ratingStarHits = [];
         return;
     }
-    var cx = LOGICAL_WIDTH / 2;
+    // Centre by default (game-over); callers can shift it (the overview shifts left so
+    // the strip clears the right-side next-map/leaderboard cards).
+    var cx = (typeof cxOverride === "number") ? cxOverride : LOGICAL_WIDTH / 2;
     var n = 5, starSize = 36, gap = 8;
     var rowW = n * starSize + (n - 1) * gap;
     var rated = (myMapRating > 0);
@@ -5309,6 +5312,14 @@ function drawOverviewBoard() {
     // them; this overview-context render catches them anchored to notch rows.
     drawRecordFloatsOverview();
     drawHUD();
+    // "Rate this map" star strip for the map just played — bottom, shifted left of
+    // centre so it clears the next-map/leaderboard cards on the right. Drawn last so it
+    // sits over the board; guarded so a render error can't break the overview.
+    try {
+        drawMapRating(LOGICAL_WIDTH / 2 - 150);
+    } catch (e) {
+        debugLog("rating draw error", e);
+    }
 }
 
 // Format an elapsed-race time (milliseconds) as "m:ss.SS" — minutes are only

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -5326,13 +5326,11 @@ function drawOverviewBoard() {
     // drawNextMap's previewWindow geometry. Drawn last so it sits over the board; guarded
     // so a render error can't break the overview.
     try {
-        var pvX = LOGICAL_WIDTH / 2 + 100;
         var pvY = (LOGICAL_HEIGHT / 2 - (world.height / 10)) - 100;
-        var thumbCx = pvX + (world.width / 3) / 2;     // centre over the preview thumbnail
-        // Sit clear ABOVE the whole preview header ("Next map" is a 32px label at
-        // pvY-35, so its top is ~pvY-67) — clamp so it never runs off the top edge.
+        // Centre on screen; sit clear ABOVE the preview header (the "Next map" 32px
+        // label is at pvY-35, top ~pvY-67) — clamp so it never runs off the top edge.
         var stripBottom = Math.max(86, pvY - 80);
-        drawMapRating(thumbCx, stripBottom);
+        drawMapRating(LOGICAL_WIDTH / 2, stripBottom);
     } catch (e) {
         debugLog("rating draw error", e);
     }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1854,10 +1854,13 @@ function drawMapRating(cxOverride, bottomY) {
     var cx = (typeof cxOverride === "number") ? cxOverride : LOGICAL_WIDTH / 2;
     var n = 5, starSize = 36, gap = 8;
     var rowW = n * starSize + (n - 1) * gap;
+    // Name the map explicitly so it's clear you're rating the map you JUST PLAYED,
+    // not the next-map preview shown right below on the overview.
     var rated = (myMapRating > 0);
+    var mapLabel = ratingMapName ? ("“" + ratingMapName + "”") : "the map you just played";
     var label = rated
-        ? ("Thanks — you rated this map " + myMapRating + "/5")
-        : ("Rate this map" + (ratingMapName ? ": " + ratingMapName : ""));
+        ? ("Thanks! You rated " + mapLabel + " " + myMapRating + "/5")
+        : (ratingMapName ? ("Rate the map you just played: " + mapLabel) : "Rate the map you just played");
 
     gameContext.save();
     gameContext.font = "bold 15px sans-serif";

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1887,14 +1887,23 @@ function drawMapRating(cxOverride, bottomY) {
     ratingStarHits = [];
     var startX = cx - rowW / 2;
     var starY = py + 50;
-    gameContext.textBaseline = "middle";
-    gameContext.textAlign = "center";
-    gameContext.font = (starSize - 4) + "px sans-serif";
+    // Controller mode: highlight the pad-selected star (◄ ► to move, Ⓐ to confirm) while
+    // it hasn't been voted yet. Touch/mouse users tap directly and see no cursor.
+    var padActive = (typeof activeInputMethod !== "undefined" && activeInputMethod === "pad");
+    var showCursor = padActive && myMapRating === 0 && ratingPadCursor >= 1 && ratingPadCursor <= 5;
     for (var i = 0; i < n; i++) {
         var sx = startX + i * (starSize + gap);
         var filled = (i < myMapRating);
+        gameContext.textBaseline = "middle";
+        gameContext.textAlign = "center";
+        gameContext.font = (starSize - 4) + "px sans-serif";
         gameContext.fillStyle = filled ? "#FFCB30" : "rgba(255,255,255,0.4)";
         gameContext.fillText(filled ? "★" : "☆", sx + starSize / 2, starY);
+        if (showCursor && (i + 1) === ratingPadCursor) {
+            gameContext.strokeStyle = "#FFCB30";
+            gameContext.lineWidth = 2;
+            gameContext.strokeRect(sx - 2, starY - starSize / 2 - 2, starSize + 4, starSize + 4);
+        }
         ratingStarHits.push({ x: sx, y: starY - starSize / 2, w: starSize, h: starSize, stars: i + 1 });
     }
     gameContext.restore();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1844,13 +1844,13 @@ function drawGameOverScreen(dt) {
 // hit rects into ratingStarHits (logical coords) for input.js to test. Click/tap a
 // star to vote (one vote per map; re-voting overwrites). No-op render when the server
 // didn't tell us which map to rate.
-function drawMapRating(cxOverride) {
+function drawMapRating(cxOverride, bottomY) {
     if (typeof ratingMapId === "undefined" || ratingMapId == null) {
         ratingStarHits = [];
         return;
     }
-    // Centre by default (game-over); callers can shift it (the overview shifts left so
-    // the strip clears the right-side next-map/leaderboard cards).
+    // Centre/bottom by default (game-over); callers can override both (the overview
+    // pins it above the next-map preview, clear of the controls glyph at the bottom).
     var cx = (typeof cxOverride === "number") ? cxOverride : LOGICAL_WIDTH / 2;
     var n = 5, starSize = 36, gap = 8;
     var rowW = n * starSize + (n - 1) * gap;
@@ -1866,7 +1866,7 @@ function drawMapRating(cxOverride) {
     var panelW = Math.max(tw + 44, rowW + 44);
     var panelH = 78;
     var px = cx - panelW / 2;
-    var py = LOGICAL_HEIGHT - panelH - 16;
+    var py = (typeof bottomY === "number") ? (bottomY - panelH) : (LOGICAL_HEIGHT - panelH - 16);
 
     // panel
     gameContext.globalAlpha = 0.88;
@@ -5312,11 +5312,16 @@ function drawOverviewBoard() {
     // them; this overview-context render catches them anchored to notch rows.
     drawRecordFloatsOverview();
     drawHUD();
-    // "Rate this map" star strip for the map just played — bottom, shifted left of
-    // centre so it clears the next-map/leaderboard cards on the right. Drawn last so it
-    // sits over the board; guarded so a render error can't break the overview.
+    // "Rate this map" star strip for the map just played — pinned ABOVE the next-map
+    // preview card (centred over it), clear of the controls glyph at the bottom. Mirrors
+    // drawNextMap's previewWindow geometry. Drawn last so it sits over the board; guarded
+    // so a render error can't break the overview.
     try {
-        drawMapRating(LOGICAL_WIDTH / 2 - 150);
+        var pvX = LOGICAL_WIDTH / 2 + 100;
+        var pvY = (LOGICAL_HEIGHT / 2 - (world.height / 10)) - 100;
+        var thumbCx = pvX + (world.width / 3) / 2;     // centre over the preview thumbnail
+        var stripBottom = pvY - 35 - 12;               // just above the "Next map" title
+        drawMapRating(thumbCx, stripBottom);
     } catch (e) {
         debugLog("rating draw error", e);
     }

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -526,6 +526,12 @@ function pollPadForSlot(pad, lp) {
         pollStationPanel(pad, lp);
     } else if (iOwnWheel) {
         pollEmojiWheel(pad, lp);
+    } else if (lp.isPrimary && typeof config !== "undefined" && config &&
+        (currentState === config.stateMap.overview || currentState === config.stateMap.gameOver) &&
+        pollMapRatingPad(pad, lp)) {
+        // Map-rating star strip (primary pad only — one shared widget). pollMapRatingPad
+        // returns true only when it consumed a D-pad/A press this frame, so B/Start/emoji
+        // still fall through to their branches at the overview.
     } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
         if (blocks) {
             openLeaveConfirm(lp);  // inline confirm in this player's block
@@ -853,6 +859,52 @@ function clearEmojiHighlight(items) {
 // stick, A confirms (dismisses — changes apply live as you step), B / emoji
 // closes. Per-slot, so two pads can configure two panels simultaneously. The
 // open/nav/confirm/close logic itself lives in lobbyHub.js (input-agnostic).
+// Drive the map-rating star strip with the pad: D-pad ◄ ► (or left stick) moves the
+// highlighted star, Ⓐ confirms the vote. Returns true ONLY when it consumed an input
+// this frame, so the caller's else-if chain still falls through to B/Start/emoji when
+// those are pressed instead. The cursor is lazily initialised to the middle star (or a
+// prior pick) so the first nav starts somewhere sensible.
+function pollMapRatingPad(pad, lp) {
+    if (typeof ratingMapId === "undefined" || ratingMapId == null) {
+        return false;
+    }
+    if (typeof ratingPadCursor === "undefined") {
+        return false;
+    }
+    if (ratingPadCursor < 1 || ratingPadCursor > 5) {
+        ratingPadCursor = (typeof myMapRating === "number" && myMapRating > 0) ? myMapRating : 3;
+    }
+    if (buttonPressedThisFrame(pad, GP_DPAD_LEFT, lp)) {
+        ratingPadCursor = Math.max(1, ratingPadCursor - 1);
+        return true;
+    }
+    if (buttonPressedThisFrame(pad, GP_DPAD_RIGHT, lp)) {
+        ratingPadCursor = Math.min(5, ratingPadCursor + 1);
+        return true;
+    }
+    if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
+        myMapRating = ratingPadCursor;
+        if (typeof server !== "undefined" && server) {
+            server.emit("rateMap", { stars: ratingPadCursor });
+        }
+        return true;
+    }
+    // Left stick: one step per push, throttled like the station panel.
+    var lx = pad.axes[0] || 0;
+    if (Math.abs(lx) > 0.6) {
+        var now = Date.now();
+        if (!lp._ratingStickActive || (now - (lp._ratingStickAt || 0)) > 250) {
+            ratingPadCursor = (lx > 0) ? Math.min(5, ratingPadCursor + 1) : Math.max(1, ratingPadCursor - 1);
+            lp._ratingStickActive = true;
+            lp._ratingStickAt = now;
+            return true;
+        }
+    } else {
+        lp._ratingStickActive = false;
+    }
+    return false;
+}
+
 function pollStationPanel(pad, lp) {
     if (typeof stationPanelNav !== "function") {
         return;

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -186,8 +186,8 @@ function handleClick(event) {
             var rect = gameCanvas.getBoundingClientRect();
             var lx = ((event.clientX - rect.left) / newWidth) * LOGICAL_WIDTH;
             var ly = ((event.clientY - rect.top) / newHeight) * LOGICAL_HEIGHT;
-            // Game-over screen: a click on the star widget rates the map — consume it.
-            if (typeof handleGameOverRatingTap === "function" && handleGameOverRatingTap(lx, ly)) {
+            // Overview / game-over screen: a click on the star widget rates the map.
+            if (typeof handleMapRatingTap === "function" && handleMapRatingTap(lx, ly)) {
                 event.preventDefault();
                 break;
             }
@@ -591,8 +591,8 @@ function onTouchStart(evt) {
         evt.preventDefault();
         return;
     }
-    // Game-over screen: a tap on the star widget rates the map.
-    if (typeof handleGameOverRatingTap === "function" && handleGameOverRatingTap(touchX, touchY)) {
+    // Overview / game-over screen: a tap on the star widget rates the map.
+    if (typeof handleMapRatingTap === "function" && handleMapRatingTap(touchX, touchY)) {
         evt.preventDefault();
         return;
     }

--- a/server/game.js
+++ b/server/game.js
@@ -839,7 +839,16 @@ class Game {
 		this.currentState = this.stateMap.overview;
 		var nextMapID = this.gameBoard.determineNextMap();
 		this.collapseInitated = false;
-		messenger.messageRoomBySig(this.roomSig, 'startOverview', { notchUpdates: compressor.sendNotchUpdates(this.playerList), nextMapID: nextMapID });
+		// currentMap is still the JUST-PLAYED map here (determineNextMap only stashes
+		// nextMap; loadNextMap advances currentMap later at the gate). Pass it so the
+		// overview's rating widget rates the map you just played, not the upcoming one.
+		var justPlayed = this.gameBoard.currentMap;
+		messenger.messageRoomBySig(this.roomSig, 'startOverview', {
+			notchUpdates: compressor.sendNotchUpdates(this.playerList),
+			nextMapID: nextMapID,
+			mapId: (justPlayed != null) ? justPlayed.id : null,
+			mapName: (justPlayed != null) ? justPlayed.name : null
+		});
 		this.publishMapLeaderboard();
 	}
 

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -552,14 +552,16 @@ function checkForMail(client) {
 		}
 	});
 
-	// Star-rate the map you just finished (game-over screen). Server-authoritative:
-	// the rated map is the room's current map, not a client-supplied id. One vote per
-	// voter per map (UPSERT); bots and identity-less sockets can't vote; a short
-	// per-socket cooldown stops spam. The write itself is gated on ALLOW_SUPABASE_WRITES
-	// inside ratings.recordRating, so this is a no-op locally.
+	// Star-rate the map you just played. Allowed on the per-round OVERVIEW (rate it
+	// while fresh) and the match-over screen. Server-authoritative: the rated map is
+	// the room's current map (still the just-played map in both states — the next map
+	// only loads at the gate), not a client-supplied id. One vote per voter per map
+	// (UPSERT); bots and identity-less sockets can't vote; a short per-socket cooldown
+	// stops spam. The write is gated on ALLOW_SUPABASE_WRITES inside recordRating.
 	client.on('rateMap', function (payload) {
 		var room = hostess.getRoomBySig(roomMailList[client.id]);
-		if (room == undefined || room.game.currentState != c.stateMap.gameOver) {
+		if (room == undefined ||
+			(room.game.currentState != c.stateMap.overview && room.game.currentState != c.stateMap.gameOver)) {
 			return;
 		}
 		var board = room.game.gameBoard;


### PR DESCRIPTION
Follow-up to the map-playlists + ratings feature (#240): move the star-rating widget onto the **per-round overview** so you rate the map you just played while it's fresh, and make it fully input-agnostic.

### What's in it
- **Rating on the overview screen** — the 5-star strip now appears on the round-results overview (above the next-map preview), not only at match end. It targets the **map you just played**: at the overview the server has *determined* the next map but not *loaded* it, so `currentMap` is still the just-played map; `startOverview` also passes the just-played `mapId`/`mapName` explicitly. The match-over screen keeps the strip too (the final map skips the overview). Renamed `drawGameOverRating`→`drawMapRating` / `handleGameOverRatingTap`→`handleMapRatingTap` since they serve both screens.
- **Controller support** — gamepad nav (primary pad) hooked into `pollGamepad`'s overview/game-over handling, mirroring the lobby station-panel pattern: **◄ ►** (D-pad or left stick) moves a highlighted star, **Ⓐ** confirms. Consumes input only when it handles a ◄►/Ⓐ press, so B/Start/emoji still work. A gold cursor ring shows on the selected star only when the active input is a controller; touch/mouse tap directly.
- **Placement** — strip pinned above the next-map preview header, horizontally centred on screen, clear of the bottom controls glyph and the (left-aligned) standings.
- **Clearer wording** — `Rate the map you just played: "<Name>"` / `Thanks! You rated "<Name>" N/5`, so it's unambiguous which map (not the next-map preview shown below).
- **Server** `rateMap` accepts the overview state too; preview-room + participation guards unchanged.

### Codex review
Both findings addressed: stale `mapRated` acks from a previous round are now ignored (guarded by `mapId`); the screen-centred placement is intentional per request and verified clear of the left-aligned standings.

### Testing
Build green; full headless suite (`smoke-test`, `classifier-test`, `ratings-test`, `playlist-selection-test`, `unit-tests`) all pass. Controller path verified live on localhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
