### PR TITLE
feat: medals screen upgrade + four new medals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- Four new end-of-match medals to chase: Zombie Slayer (most kills while infected), Heavy Hitter (most fully-charged punches), Pinball (most bumper bonks), and Ice Skater (furthest slide across ice).
+- The end-of-game medals are now shown on a polished award card — each medal has its own icon and a one-line description of how it was earned.
 
 ## v0.25.7 — 2026-05-30
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -734,6 +734,10 @@ function registerStateHandlers(server) {
 		myMapRating = 0;
 		ratingStarHits = [];
 		ratingPadCursor = 0;
+		// Bump the medals-card reveal nonce so its entrance animation replays for
+		// this match — even when the same player wins back-to-back (playerWon
+		// unchanged). drawGameOverScreen watches this (see draw.js).
+		if (typeof medalRevealNonce === "number") { medalRevealNonce++; }
 		recapHarvestRound();      // fold the final round's clips into the archive first
 		recapBuild(achievements); // then assemble the montage from the whole-match archive
 		stopAllSounds();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1915,7 +1915,16 @@ function drawGameOverScreen(dt) {
             var cardW = 430;
             var cardH = padTop + headH + earnedMedals.length * rowH + padBot;
             var cardX = LOGICAL_WIDTH - cardW - 40;
-            var cardY = Math.max(24, (LOGICAL_HEIGHT - cardH) / 2);
+            // Scale-to-fit: a full house of medals can be taller than the screen, so
+            // shrink the whole card uniformly to fit within top/bottom margins. The
+            // scale pivots on the card's right edge + vertical centre below, so it
+            // stays right-anchored and centred while it shrinks.
+            var topMargin = 24;
+            var availH = LOGICAL_HEIGHT - topMargin * 2;
+            var cardScale = (cardH > availH) ? (availH / cardH) : 1;
+            // Centre on-screen; when not scaling keep the old min-top-margin clamp.
+            var cardY = (LOGICAL_HEIGHT - cardH) / 2;
+            if (cardScale === 1) { cardY = Math.max(topMargin, cardY); }
 
             // Card entrance: quick fade + rise.
             var cardT = Math.min(1, medalRevealElapsed / 0.28);
@@ -1925,6 +1934,14 @@ function drawGameOverScreen(dt) {
             gameContext.textBaseline = "alphabetic";
             gameContext.globalAlpha = cardEase;
             gameContext.translate(0, (1 - cardEase) * 16);
+            // Apply the fit scale around the card's right edge + vertical centre.
+            if (cardScale !== 1) {
+                var pivotX = cardX + cardW;
+                var pivotY = LOGICAL_HEIGHT / 2;
+                gameContext.translate(pivotX, pivotY);
+                gameContext.scale(cardScale, cardScale);
+                gameContext.translate(-pivotX, -pivotY);
+            }
 
             // Panel: dark translucent so the fixed light text stays readable on
             // any winner colour, with a soft drop shadow.

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1729,6 +1729,21 @@ function drawBackground() {
 // (drawGameOverScreen runs every tick, so we can't restart on each frame).
 var medalRevealFor = null;
 var medalRevealElapsed = 0;
+// One-line, player-facing blurb shown under each medal name on the gameOver card.
+// Keyed by the achievement key the server sends (see server/achievements.js); the
+// meanings mirror how the stats are earned in server/{game,entities/player}.js.
+var MEDAL_DESC = {
+    mostKills: "Most eliminations",
+    savior: "Toppled a frontrunner",
+    survivalist: "Reached the most goals",
+    brutalist: "Most goals in brutal rounds",
+    mostMurdered: "Everyone's favourite target",
+    resourceful: "Used the most abilities",
+    bully: "Threw the most punches",
+    doubleKill: "Two kills in a flash",
+    tripleKill: "Three kills in a flash",
+    megaKill: "A relentless killing spree"
+};
 
 // Rounded-rect path builder (caller fills/strokes it).
 function gameOverRoundRect(ctx, x, y, w, h, r) {
@@ -1844,8 +1859,9 @@ function drawGameOverScreen(dt) {
         // sized + vertically centred around real content (skip empty medals).
         var earnedMedals = [];
         for (var medal in achievements) {
-            if (achievements[medal].ids && achievements[medal].ids.length > 0) {
-                earnedMedals.push(achievements[medal]);
+            var a = achievements[medal];
+            if (a.ids && a.ids.length > 0) {
+                earnedMedals.push({ title: a.title, ids: a.ids, desc: MEDAL_DESC[medal] || "" });
             }
         }
 
@@ -1860,7 +1876,7 @@ function drawGameOverScreen(dt) {
 
             // Card geometry, anchored to the right edge so it never overlaps the
             // recap montage (which owns the left/centre of the screen).
-            var rowH = 48;
+            var rowH = 58;
             var headH = 58;
             var padX = 24;
             var padTop = 20;
@@ -1929,11 +1945,22 @@ function drawGameOverScreen(dt) {
                 // Medal marker.
                 drawMedalDisc(gameContext, cardX + padX + 14, rowCy - 2, 13);
 
-                // Title.
+                // Title + one-line description. With a description, the two lines
+                // straddle the row centre; without one, the title sits centred.
+                var textX = cardX + padX + 38;
                 gameContext.textAlign = "left";
-                gameContext.fillStyle = "#eef2f8";
-                gameContext.font = "bold 19px Arial";
-                gameContext.fillText(earnedMedals[m].title, cardX + padX + 38, rowCy + 5);
+                if (earnedMedals[m].desc) {
+                    gameContext.fillStyle = "#eef2f8";
+                    gameContext.font = "bold 19px Arial";
+                    gameContext.fillText(earnedMedals[m].title, textX, rowCy - 3);
+                    gameContext.fillStyle = "rgba(220,226,236,0.6)";
+                    gameContext.font = "12px Arial";
+                    gameContext.fillText(earnedMedals[m].desc, textX, rowCy + 15);
+                } else {
+                    gameContext.fillStyle = "#eef2f8";
+                    gameContext.font = "bold 19px Arial";
+                    gameContext.fillText(earnedMedals[m].title, textX, rowCy + 5);
+                }
 
                 // Winner chips, right-aligned. Cap the visible chips and show a
                 // "+N" overflow tag so a popular medal can't run off the card.

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1724,9 +1724,12 @@ function drawBackground() {
     // rect fills the whole canvas, so there's no separate backdrop layer).
 }
 // --- gameOver medals card ------------------------------------------------
-// Persistent reveal clock for the end-of-game medals card. Keyed to the
-// winning player id so the staggered entrance replays exactly once per match
-// (drawGameOverScreen runs every tick, so we can't restart on each frame).
+// Persistent reveal clock for the end-of-game medals card. The startGameover
+// handler bumps `medalRevealNonce` each match; drawGameOverScreen restarts its
+// staggered entrance whenever the nonce it last drew differs (so even a repeat
+// winner replays the animation). drawGameOverScreen runs every tick, hence the
+// latch rather than a per-frame reset.
+var medalRevealNonce = 0;
 var medalRevealFor = null;
 var medalRevealElapsed = 0;
 // One-line, player-facing blurb shown under each medal name on the gameOver card.
@@ -1898,12 +1901,15 @@ function drawGameOverScreen(dt) {
 
         if (earnedMedals.length > 0) {
             // Reveal clock: reset when a new match's winner is shown so the
-            // staggered entrance replays each game; advance in seconds (dt).
-            if (medalRevealFor !== playerWon) {
-                medalRevealFor = playerWon;
+            // staggered entrance replays each game. `medalRevealNonce` is bumped by
+            // the startGameover handler so a repeat winner (same playerWon) still
+            // restarts the animation. dt is MILLISECONDS (Date.now() delta) — the
+            // thresholds below are in seconds, so convert here.
+            if (medalRevealFor !== medalRevealNonce) {
+                medalRevealFor = medalRevealNonce;
                 medalRevealElapsed = 0;
             }
-            medalRevealElapsed += (dt || 0);
+            medalRevealElapsed += (dt || 0) / 1000;
 
             // Card geometry, anchored to the right edge so it never overlaps the
             // recap montage (which owns the left/centre of the screen).

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1744,6 +1744,20 @@ var MEDAL_DESC = {
     tripleKill: "Three kills in a flash",
     megaKill: "A relentless killing spree"
 };
+// Per-medal glyph stamped into the gold disc, so each award reads at a glance.
+// Mirrors the icons on the Learn/Codex medals page (client/scripts/learn.js).
+var MEDAL_ICON = {
+    mostKills: "🔪",
+    savior: "🛡️",
+    survivalist: "🏁",
+    brutalist: "🔥",
+    mostMurdered: "🎯",
+    resourceful: "🧰",
+    bully: "👊",
+    doubleKill: "💥",
+    tripleKill: "💥",
+    megaKill: "💥"
+};
 
 // Rounded-rect path builder (caller fills/strokes it).
 function gameOverRoundRect(ctx, x, y, w, h, r) {
@@ -1759,7 +1773,7 @@ function gameOverRoundRect(ctx, x, y, w, h, r) {
 
 // A small gold medal disc with a ribbon + embossed star, used as the marker
 // on the medals card. cx/cy is the disc centre; r its radius.
-function drawMedalDisc(ctx, cx, cy, r) {
+function drawMedalDisc(ctx, cx, cy, r, icon) {
     ctx.save();
     // Ribbon tails tucked behind the disc.
     ctx.fillStyle = "#c8423a";
@@ -1790,19 +1804,28 @@ function drawMedalDisc(ctx, cx, cy, r) {
     ctx.lineWidth = Math.max(1.5, r * 0.12);
     ctx.strokeStyle = "rgba(120,80,10,0.85)";
     ctx.stroke();
-    // Embossed 5-point star.
-    ctx.fillStyle = "rgba(140,92,10,0.9)";
-    ctx.beginPath();
-    for (var s = 0; s < 5; s++) {
-        var ang = -Math.PI / 2 + s * (2 * Math.PI / 5);
-        var ax = cx + Math.cos(ang) * r * 0.5;
-        var ay = cy + Math.sin(ang) * r * 0.5;
-        if (s === 0) { ctx.moveTo(ax, ay); } else { ctx.lineTo(ax, ay); }
-        var ang2 = ang + Math.PI / 5;
-        ctx.lineTo(cx + Math.cos(ang2) * r * 0.22, cy + Math.sin(ang2) * r * 0.22);
+    // Center mark: the medal's own emoji glyph when given, else an embossed star.
+    if (icon) {
+        ctx.save();
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.font = (r * 1.4) + "px serif";
+        ctx.fillText(icon, cx, cy + r * 0.08);
+        ctx.restore();
+    } else {
+        ctx.fillStyle = "rgba(140,92,10,0.9)";
+        ctx.beginPath();
+        for (var s = 0; s < 5; s++) {
+            var ang = -Math.PI / 2 + s * (2 * Math.PI / 5);
+            var ax = cx + Math.cos(ang) * r * 0.5;
+            var ay = cy + Math.sin(ang) * r * 0.5;
+            if (s === 0) { ctx.moveTo(ax, ay); } else { ctx.lineTo(ax, ay); }
+            var ang2 = ang + Math.PI / 5;
+            ctx.lineTo(cx + Math.cos(ang2) * r * 0.22, cy + Math.sin(ang2) * r * 0.22);
+        }
+        ctx.closePath();
+        ctx.fill();
     }
-    ctx.closePath();
-    ctx.fill();
     ctx.restore();
 }
 // Pick a text colour + contrasting outline that stays readable on an arbitrary
@@ -1861,7 +1884,7 @@ function drawGameOverScreen(dt) {
         for (var medal in achievements) {
             var a = achievements[medal];
             if (a.ids && a.ids.length > 0) {
-                earnedMedals.push({ title: a.title, ids: a.ids, desc: MEDAL_DESC[medal] || "" });
+                earnedMedals.push({ title: a.title, ids: a.ids, desc: MEDAL_DESC[medal] || "", icon: MEDAL_ICON[medal] || "" });
             }
         }
 
@@ -1914,7 +1937,7 @@ function drawGameOverScreen(dt) {
 
             // Header: trophy disc + "MEDALS" + subtitle, divider beneath.
             var headBaseY = cardY + padTop;
-            drawMedalDisc(gameContext, cardX + padX + 15, headBaseY + 16, 15);
+            drawMedalDisc(gameContext, cardX + padX + 15, headBaseY + 16, 15, "🏆");
             gameContext.textAlign = "left";
             gameContext.fillStyle = "#f6c64b";
             gameContext.font = "bold 26px Arial";
@@ -1942,8 +1965,8 @@ function drawGameOverScreen(dt) {
                 gameContext.globalAlpha = cardEase * rowEase;
                 gameContext.translate((1 - rowEase) * 22, 0);
 
-                // Medal marker.
-                drawMedalDisc(gameContext, cardX + padX + 14, rowCy - 2, 13);
+                // Medal marker with the award's own icon.
+                drawMedalDisc(gameContext, cardX + padX + 14, rowCy - 2, 13, earnedMedals[m].icon);
 
                 // Title + one-line description. With a description, the two lines
                 // straddle the row centre; without one, the title sits centred.

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1742,7 +1742,11 @@ var MEDAL_DESC = {
     bully: "Threw the most punches",
     doubleKill: "Two kills in a flash",
     tripleKill: "Three kills in a flash",
-    megaKill: "A relentless killing spree"
+    megaKill: "A relentless killing spree",
+    zombieSlayer: "Most kills as a zombie",
+    heavyHitter: "Most charged-up punches",
+    pinball: "Bounced off the most bumpers",
+    iceSkater: "Slid the furthest on ice"
 };
 // Per-medal glyph stamped into the gold disc, so each award reads at a glance.
 // Mirrors the icons on the Learn/Codex medals page (client/scripts/learn.js).
@@ -1756,7 +1760,11 @@ var MEDAL_ICON = {
     bully: "👊",
     doubleKill: "💥",
     tripleKill: "💥",
-    megaKill: "💥"
+    megaKill: "💥",
+    zombieSlayer: "🧟",
+    heavyHitter: "🥊",
+    pinball: "🔵",
+    iceSkater: "⛸️"
 };
 
 // Rounded-rect path builder (caller fills/strokes it).

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -1723,6 +1723,73 @@ function drawBackground() {
     // The sky vista is painted as the play-field floor in drawWorld (the world
     // rect fills the whole canvas, so there's no separate backdrop layer).
 }
+// --- gameOver medals card ------------------------------------------------
+// Persistent reveal clock for the end-of-game medals card. Keyed to the
+// winning player id so the staggered entrance replays exactly once per match
+// (drawGameOverScreen runs every tick, so we can't restart on each frame).
+var medalRevealFor = null;
+var medalRevealElapsed = 0;
+
+// Rounded-rect path builder (caller fills/strokes it).
+function gameOverRoundRect(ctx, x, y, w, h, r) {
+    r = Math.min(r, w / 2, h / 2);
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x, y + h, r);
+    ctx.arcTo(x, y + h, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+}
+
+// A small gold medal disc with a ribbon + embossed star, used as the marker
+// on the medals card. cx/cy is the disc centre; r its radius.
+function drawMedalDisc(ctx, cx, cy, r) {
+    ctx.save();
+    // Ribbon tails tucked behind the disc.
+    ctx.fillStyle = "#c8423a";
+    ctx.beginPath();
+    ctx.moveTo(cx - r * 0.55, cy - r * 0.2);
+    ctx.lineTo(cx - r * 0.15, cy + r * 1.5);
+    ctx.lineTo(cx + r * 0.15, cy + r * 0.9);
+    ctx.lineTo(cx - r * 0.05, cy + r * 0.2);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = "#e0584f";
+    ctx.beginPath();
+    ctx.moveTo(cx + r * 0.55, cy - r * 0.2);
+    ctx.lineTo(cx + r * 0.15, cy + r * 1.5);
+    ctx.lineTo(cx - r * 0.15, cy + r * 0.9);
+    ctx.lineTo(cx + r * 0.05, cy + r * 0.2);
+    ctx.closePath();
+    ctx.fill();
+    // Disc: warm gold radial.
+    var grad = ctx.createRadialGradient(cx - r * 0.35, cy - r * 0.35, r * 0.2, cx, cy, r);
+    grad.addColorStop(0, "#fff2b0");
+    grad.addColorStop(0.5, "#f6c64b");
+    grad.addColorStop(1, "#b9831f");
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, 2 * Math.PI);
+    ctx.fillStyle = grad;
+    ctx.fill();
+    ctx.lineWidth = Math.max(1.5, r * 0.12);
+    ctx.strokeStyle = "rgba(120,80,10,0.85)";
+    ctx.stroke();
+    // Embossed 5-point star.
+    ctx.fillStyle = "rgba(140,92,10,0.9)";
+    ctx.beginPath();
+    for (var s = 0; s < 5; s++) {
+        var ang = -Math.PI / 2 + s * (2 * Math.PI / 5);
+        var ax = cx + Math.cos(ang) * r * 0.5;
+        var ay = cy + Math.sin(ang) * r * 0.5;
+        if (s === 0) { ctx.moveTo(ax, ay); } else { ctx.lineTo(ax, ay); }
+        var ang2 = ang + Math.PI / 5;
+        ctx.lineTo(cx + Math.cos(ang2) * r * 0.22, cy + Math.sin(ang2) * r * 0.22);
+    }
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+}
 // Pick a text colour + contrasting outline that stays readable on an arbitrary
 // background. The gameOver screen paints its backdrop in the winner's kart
 // colour (anything from near-black navy to bright yellow), so the old hard-coded
@@ -1773,52 +1840,133 @@ function drawGameOverScreen(dt) {
     gameContext.restore();
 
     if (achievements != null) {
-        var xOffset = 200;
-        var yOffset = -200;
-        var startingHeight = (LOGICAL_HEIGHT + 48) / 2;
-        gameContext.save();
-        gameContext.fillStyle = ink.fill;
-        gameContext.strokeStyle = ink.stroke;
-        gameContext.lineWidth = 3;
-        gameContext.lineJoin = "round";
-        gameContext.font = '28px serif';
-        gameContext.strokeText("-- Medals -- ", (LOGICAL_WIDTH / 2) + xOffset, startingHeight + yOffset);
-        gameContext.fillText("-- Medals -- ", (LOGICAL_WIDTH / 2) + xOffset, startingHeight + yOffset);
-
-
-        var lineHeight = 40;
-        var count = 1;
+        // Collect only the medals actually earned this match so the card can be
+        // sized + vertically centred around real content (skip empty medals).
+        var earnedMedals = [];
         for (var medal in achievements) {
-            if (achievements[medal].ids.length == 0) {
-                continue;
+            if (achievements[medal].ids && achievements[medal].ids.length > 0) {
+                earnedMedals.push(achievements[medal]);
             }
-            // Re-assert the ink each title: the medalist-dot loop below overwrites
-            // strokeStyle (to the dot's colour), so without this the 2nd+ title would
-            // be outlined in a leftover dot colour instead of the readable ink.
-            gameContext.fillStyle = ink.fill;
-            gameContext.strokeStyle = ink.stroke;
-            gameContext.strokeText(achievements[medal].title, (LOGICAL_WIDTH / 2) + xOffset, startingHeight + (lineHeight * count) + yOffset);
-            gameContext.fillText(achievements[medal].title, (LOGICAL_WIDTH / 2) + xOffset, startingHeight + (lineHeight * count) + yOffset);
-            count++;
-            for (var i = 0; i < achievements[medal].ids.length; i++) {
-                var player = playerList[achievements[medal].ids[i]];
-
-                gameContext.beginPath();
-                gameContext.arc((LOGICAL_WIDTH / 2) + (xOffset + (35 * (i + 1))), startingHeight + (lineHeight * count) - 15 + yOffset, 15, 0, 2 * Math.PI);
-                if (player != null) {
-                    gameContext.fillStyle = player.color;
-                    gameContext.strokeStyle = "black";
-                } else {
-                    gameContext.fillStyle = "grey";
-                    gameContext.strokeStyle = "grey";
-                }
-                gameContext.lineWidth = 3;
-                gameContext.fill();
-                gameContext.stroke();
-            }
-            count++;
         }
-        gameContext.restore();
+
+        if (earnedMedals.length > 0) {
+            // Reveal clock: reset when a new match's winner is shown so the
+            // staggered entrance replays each game; advance in seconds (dt).
+            if (medalRevealFor !== playerWon) {
+                medalRevealFor = playerWon;
+                medalRevealElapsed = 0;
+            }
+            medalRevealElapsed += (dt || 0);
+
+            // Card geometry, anchored to the right edge so it never overlaps the
+            // recap montage (which owns the left/centre of the screen).
+            var rowH = 48;
+            var headH = 58;
+            var padX = 24;
+            var padTop = 20;
+            var padBot = 22;
+            var cardW = 430;
+            var cardH = padTop + headH + earnedMedals.length * rowH + padBot;
+            var cardX = LOGICAL_WIDTH - cardW - 40;
+            var cardY = Math.max(24, (LOGICAL_HEIGHT - cardH) / 2);
+
+            // Card entrance: quick fade + rise.
+            var cardT = Math.min(1, medalRevealElapsed / 0.28);
+            var cardEase = 1 - Math.pow(1 - cardT, 3);
+
+            gameContext.save();
+            gameContext.textBaseline = "alphabetic";
+            gameContext.globalAlpha = cardEase;
+            gameContext.translate(0, (1 - cardEase) * 16);
+
+            // Panel: dark translucent so the fixed light text stays readable on
+            // any winner colour, with a soft drop shadow.
+            gameContext.save();
+            gameContext.shadowColor = "rgba(0,0,0,0.45)";
+            gameContext.shadowBlur = 24;
+            gameContext.shadowOffsetY = 8;
+            gameOverRoundRect(gameContext, cardX, cardY, cardW, cardH, 18);
+            gameContext.fillStyle = "rgba(18,20,28,0.86)";
+            gameContext.fill();
+            gameContext.restore();
+
+            // Gold border.
+            gameOverRoundRect(gameContext, cardX + 0.5, cardY + 0.5, cardW - 1, cardH - 1, 18);
+            gameContext.lineWidth = 1.5;
+            gameContext.strokeStyle = "rgba(246,198,75,0.55)";
+            gameContext.stroke();
+
+            // Header: trophy disc + "MEDALS" + subtitle, divider beneath.
+            var headBaseY = cardY + padTop;
+            drawMedalDisc(gameContext, cardX + padX + 15, headBaseY + 16, 15);
+            gameContext.textAlign = "left";
+            gameContext.fillStyle = "#f6c64b";
+            gameContext.font = "bold 26px Arial";
+            gameContext.fillText("MEDALS", cardX + padX + 42, headBaseY + 22);
+            gameContext.fillStyle = "rgba(220,226,236,0.6)";
+            gameContext.font = "13px Arial";
+            gameContext.fillText("Match awards", cardX + padX + 42, headBaseY + 40);
+            gameContext.beginPath();
+            gameContext.moveTo(cardX + padX, cardY + padTop + headH - 8);
+            gameContext.lineTo(cardX + cardW - padX, cardY + padTop + headH - 8);
+            gameContext.lineWidth = 1;
+            gameContext.strokeStyle = "rgba(255,255,255,0.12)";
+            gameContext.stroke();
+
+            // Medal rows: each fades + slides in, staggered after the card.
+            var rowTop = cardY + padTop + headH;
+            for (var m = 0; m < earnedMedals.length; m++) {
+                var rowT = Math.min(1, Math.max(0, (medalRevealElapsed - 0.18 - m * 0.09) / 0.34));
+                var rowEase = 1 - Math.pow(1 - rowT, 3);
+                if (rowEase <= 0) { continue; }
+
+                var rowCy = rowTop + m * rowH + rowH / 2;
+
+                gameContext.save();
+                gameContext.globalAlpha = cardEase * rowEase;
+                gameContext.translate((1 - rowEase) * 22, 0);
+
+                // Medal marker.
+                drawMedalDisc(gameContext, cardX + padX + 14, rowCy - 2, 13);
+
+                // Title.
+                gameContext.textAlign = "left";
+                gameContext.fillStyle = "#eef2f8";
+                gameContext.font = "bold 19px Arial";
+                gameContext.fillText(earnedMedals[m].title, cardX + padX + 38, rowCy + 5);
+
+                // Winner chips, right-aligned. Cap the visible chips and show a
+                // "+N" overflow tag so a popular medal can't run off the card.
+                var ids = earnedMedals[m].ids;
+                var chipR = 11;
+                var chipGap = 28;
+                var maxChips = 4;
+                var shown = Math.min(ids.length, maxChips);
+                var chipRight = cardX + cardW - padX - chipR;
+                for (var c = 0; c < shown; c++) {
+                    var chipX = chipRight - (shown - 1 - c) * chipGap;
+                    var cp = playerList[ids[c]];
+                    gameContext.beginPath();
+                    gameContext.arc(chipX, rowCy, chipR, 0, 2 * Math.PI);
+                    gameContext.fillStyle = (cp != null) ? cp.color : "#7a7a7a";
+                    gameContext.fill();
+                    gameContext.lineWidth = 2;
+                    gameContext.strokeStyle = "rgba(255,255,255,0.85)";
+                    gameContext.stroke();
+                }
+                if (ids.length > maxChips) {
+                    var firstChipX = chipRight - (shown - 1) * chipGap;
+                    gameContext.textAlign = "right";
+                    gameContext.fillStyle = "rgba(220,226,236,0.75)";
+                    gameContext.font = "bold 13px Arial";
+                    gameContext.fillText("+" + (ids.length - maxChips), firstChipX - chipR - 8, rowCy + 5);
+                }
+
+                gameContext.restore();
+            }
+
+            gameContext.restore();
+        }
     }
 
     // Recap montage overlay. Guarded so a replay-render error can never break

--- a/client/scripts/learn.js
+++ b/client/scripts/learn.js
@@ -223,7 +223,19 @@
                   detail: "Awarded for throwing more punches than anyone else — less interested in racing, more interested in shoving. Whether they connected is beside the point." },
                 { id: "medal-multikill", name: "Multi-Kills", icon: emoji("💥"), anim: "medalShine",
                   blurb: "Double, Triple and Mega Kills.",
-                  detail: "For stacking eliminations in a single breath: take out two in quick succession for a Double Kill, three for a Triple, and four or more for a Mega Kill. The more you fell before the dust settles, the louder the call-out." }
+                  detail: "For stacking eliminations in a single breath: take out two in quick succession for a Double Kill, three for a Triple, and four or more for a Mega Kill. The more you fell before the dust settles, the louder the call-out." },
+                { id: "medal-zombieslayer", name: "Zombie Slayer", icon: emoji("🧟"), anim: "medalShine",
+                  blurb: "Most kills while infected.",
+                  detail: "Earned during infection rounds for landing the most bites as a zombie — turning the tables and dragging the most rivals into undeath before the round ends." },
+                { id: "medal-heavyhitter", name: "Heavy Hitter", icon: emoji("🥊"), anim: "medalShine",
+                  blurb: "Most fully-charged punches.",
+                  detail: "For the racer who threw the most fully wound-up punches — holding the charge to the top before letting fly, again and again. Patience rewarded with knockback." },
+                { id: "medal-pinball", name: "Pinball", icon: emoji("🔵"), anim: "medalShine",
+                  blurb: "Bounced off the most bumpers.",
+                  detail: "Awarded to whoever got knocked around by bumpers more than anyone else — ricocheting across the arena like a ball in a pinball machine. Not necessarily on purpose." },
+                { id: "medal-iceskater", name: "Ice Skater", icon: emoji("⛸️"), anim: "medalShine",
+                  blurb: "Slid the furthest on ice.",
+                  detail: "For covering the most distance gliding across ice tiles — embracing the slip instead of fighting it, and racking up the longest total slide of the match." }
             ]
         }
     ];

--- a/server/achievements.js
+++ b/server/achievements.js
@@ -14,6 +14,10 @@ module.exports = {
 			doubleKill: { ids: [], value: 0, title: "Double Kill" },
 			tripleKill: { ids: [], value: 0, title: "Triple Kill" },
 			megaKill: { ids: [], value: 0, title: "Mega Kill" },
+			zombieSlayer: { ids: [], value: 0, title: "Zombie Slayer" },
+			heavyHitter: { ids: [], value: 0, title: "Heavy Hitter" },
+			pinball: { ids: [], value: 0, title: "Pinball" },
+			iceSkater: { ids: [], value: 0, title: "Ice Skater" },
 		};
 		for (var id in this.playerList) {
 			var player = this.playerList[id];
@@ -37,6 +41,19 @@ module.exports = {
 
 			//Resourceful
 			this.checkForNewMedalHolder(achievements.resourceful, id, player.resourceful);
+
+			//Zombie Slayer — most kills landed while infected (zombie bites)
+			this.checkForNewMedalHolder(achievements.zombieSlayer, id, player.zombieKillCount);
+
+			//Heavy Hitter — most fully-charged wind-up punches thrown
+			this.checkForNewMedalHolder(achievements.heavyHitter, id, player.heavyHitCount);
+
+			//Pinball — most bumper bonks taken
+			this.checkForNewMedalHolder(achievements.pinball, id, player.bumperHitCount);
+
+			//Ice Skater — most distance slid across ice (rounded so a hair's
+			//difference doesn't split the medal; integer keeps the tie logic clean)
+			this.checkForNewMedalHolder(achievements.iceSkater, id, Math.round(player.iceDistanceTravelled));
 
 			//Picked on
 			var mostKilled = null;

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -182,6 +182,13 @@ class Player extends Circle {
 		this.survivalist = 0;
 		this.resourceful = 0;
 		this.bully = 0;
+		// Per-match medal counters (reset at gameOver, see reset()). Named distinctly
+		// from the progression branch's lifetime medal_counts keys so the two never
+		// collide: these are per-match tallies that feed gatherAchievements().
+		this.zombieKillCount = 0;       // kills landed while infected -> Zombie Slayer
+		this.heavyHitCount = 0;         // fully-charged punches thrown -> Heavy Hitter
+		this.bumperHitCount = 0;        // bumper bonks taken -> Pinball
+		this.iceDistanceTravelled = 0;  // distance slid on ice tiles -> Ice Skater
 
 		//Engine Variables
 		this.newX = this.x;
@@ -411,6 +418,12 @@ class Player extends Circle {
 		// No scoring in the lobby (the bully stat isn't gated by checkForWinners).
 		if (currentState != c.stateMap.lobby) {
 			this.bully += 1;
+			// Heavy Hitter: a committed, fully-charged swing (same threshold the client
+			// uses for the charged-hit SFX). Counted on throw, like bully — a zombie's
+			// free bite never charges, so it's naturally excluded.
+			if (frac >= c.punchCharge.chargedHitFrac) {
+				this.heavyHitCount += 1;
+			}
 		}
 		messenger.messageRoomBySig(this.roomSig, "punch", compressor.sendPunch(this.punch));
 		this.cancelCharge();
@@ -730,6 +743,17 @@ class Player extends Circle {
 		// punches) — otherwise a punch thrown a tick earlier could both hit a victim AND
 		// reflect, so only truly simultaneous (same-tick) mutual punches clash.
 		object.landed = true;
+		// Pinball: a bumper bonk. The bumper's punch lingers ~100ms (re-overlapping the
+		// same victim across ticks), so dedupe per victim on the punch object — one
+		// bonk = one tally. Real play only (lobby bumpers are a teaching prop).
+		if (object.type === "bumper"
+			&& (this.currentState == c.stateMap.racing || this.currentState == c.stateMap.collapsing)) {
+			if (object.pinballCountedFor == null) { object.pinballCountedFor = {}; }
+			if (!object.pinballCountedFor[this.id]) {
+				object.pinballCountedFor[this.id] = true;
+				this.bumperHitCount += 1;
+			}
+		}
 		_engine.punchPlayer(this, object);
 		var charged = object.chargeFrac != null && object.chargeFrac >= c.punchCharge.chargedHitFrac;
 		messenger.messageRoomBySig(this.roomSig, "playerPunched", { owner: object.ownerId, victim: this.id, x: this.x, y: this.y, charged: charged });
@@ -860,6 +884,11 @@ class Player extends Circle {
 			this.acel = object.acel;
 			this.brakeCoeff = object.brakeCoeff;
 			this.dragCoeff = object.dragCoeff;
+			// Ice Skater: clock the distance slid while on ice (speed x dt this tick).
+			// Only in real play — lobby ice is a teaching prop, not scored.
+			if ((this.currentState == c.stateMap.racing || this.currentState == c.stateMap.collapsing) && this.dt) {
+				this.iceDistanceTravelled += utils.getMag(this.velX, this.velY) * this.dt;
+			}
 			return;
 		}
 		if (object.id == c.tileMap.goal.id) {
@@ -1069,6 +1098,10 @@ class Player extends Circle {
 			this.onFire = 0;
 			this.savior = 0;
 			this.killedPlayerList = [];
+			this.zombieKillCount = 0;
+			this.heavyHitCount = 0;
+			this.bumperHitCount = 0;
+			this.iceDistanceTravelled = 0;
 		}
 	}
 }

--- a/server/game.js
+++ b/server/game.js
@@ -384,6 +384,12 @@ class Game {
 					var killer = this.playerList[this.playerList[player].murderedBy];
 					if (killer != null) {
 						this.playerList[player].murderedBy = null;
+						// Zombie Slayer: addKill() ignores zombie attackers (zombies don't
+						// rack up the normal kill stat), so tally infected kills here where
+						// both killer and victim are in hand.
+						if (killer.isZombie) {
+							killer.zombieKillCount += 1;
+						}
 						killer.addKill(this.playerList[player]);
 						this.gameBoard.checkForFirstBlood();
 					}


### PR DESCRIPTION
## Medals screen upgrade + four new medals

Upgrades the end-of-game medals announcement into a polished award card, and adds four new end-of-match medals with full server-side tracking.

### Player-facing
- **Polished medals card** on the game-over screen: framed dark-translucent panel anchored to the right (never overlaps the recap montage), gold medal-disc icons, bold header + per-medal one-line description, kart-color winner chips (capped with a `+N` overflow tag), and a staggered fade/slide-in reveal.
- **Unique icon per medal** instead of a shared star.
- **Four new medals to chase:**
  - 🧟 **Zombie Slayer** — most kills landed while infected
  - 🥊 **Heavy Hitter** — most fully-charged wind-up punches
  - 🔵 **Pinball** — most bumper bonks taken
  - ⛸️ **Ice Skater** — furthest distance slid across ice
- The card **scales to fit** when a full house of medals would overflow the screen.
- All medals documented in the in-game Learn Codex.

### Server (game mechanic)
- `gatherAchievements()` adds the four new medals; per-match counters tracked server-side:
  - `zombieKillCount` — at the kill-attribution site in `game.js`, gated on `killer.isZombie` (the normal `addKill` ignores zombie attackers)
  - `heavyHitCount` — in `throwChargedPunch` when `frac >= chargedHitFrac`
  - `bumperHitCount` — in `handlePunchHit` for bumper punches, deduped per victim
  - `iceDistanceTravelled` — `speed × dt` accumulated in the ice cell branch
- All reset at gameOver alongside existing medal stats.
- **No collision with the in-flight progression branch**: these per-match medal keys are named distinctly from progression's lifetime `medal_counts` keys (`zombieKills`/`windupPunchHits`/`bumpersHit`/`iceDistance`), so the two systems coexist and merge additively.

### Codex review
Ran `/codex:review`; all three findings fixed in this branch:
- Reveal clock converted to seconds (dt is ms) so the animation actually plays in the real client.
- Reveal replays for back-to-back winners via a per-match nonce bumped on `startGameover`.
- New medals added to the Learn Codex.

### Testing
- `npm run build` — clean
- `node .github/scripts/unit-tests.js` — 151 assertions, 6 groups, all pass
- `node .github/scripts/smoke-test.js` — booted + ticked 52 maps through waiting→racing→collapsing, no crashes
- Unit-checked `gatherAchievements()` with mock players: all four new medals correctly select the leader (incl. tie handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
