### PR TITLE
fix(lobby): banner z-order over open station panel + AFK bypass requires active interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+- Idle-kick fix: flipping through a lobby station's menus keeps you active as intended, but simply parking your kart on a station pad and stepping away no longer makes you immune to the idle kick — you have to actually be using the menu.
 
 ## v0.26.1 — 2026-05-31
 

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -100,6 +100,17 @@ function clearSlotNearStation(slot, id) {
 
 // --- panel open / close / navigate / confirm (input-agnostic) ----------------
 
+// Tell the server the player is ACTIVELY using a hub station (open / navigate / tab /
+// page / confirm / close, from key, touch, or pad). This "pressing keys" signal defers
+// the lobby AFK kick — menu browsing emits no movement packets, so without it a player
+// flipping through the skin shop reads as idle. Merely standing in a station zone does
+// NOT call this, so a parked-and-walked-away kart still idles out normally.
+function noteHubActivity(lp) {
+    if (lp && lp.socket && typeof lp.socket.emit === "function") {
+        lp.socket.emit("lobbyActivity");
+    }
+}
+
 function openStationPanel(lp) {
     if (!lp || !lp.nearStation) {
         return;
@@ -108,6 +119,7 @@ function openStationPanel(lp) {
     if (!st) {
         return;
     }
+    noteHubActivity(lp);
     var cursor = 0;
     var tab = 'color';
     if (st.kind === "skin") {
@@ -130,6 +142,7 @@ function openStationPanel(lp) {
 
 function closeStationPanel(lp) {
     if (lp) {
+        noteHubActivity(lp);
         lp.stationPanel = null;
     }
 }
@@ -140,6 +153,7 @@ function stationPanelNav(lp, dx, dy) {
     if (!lp || !lp.stationPanel) {
         return;
     }
+    noteHubActivity(lp);
     if (lp.stationPanel.kind === "ai") {
         if (dx !== 0) {
             adjustAILevel(lp, dx > 0 ? 1 : -1);
@@ -225,7 +239,11 @@ function skinPanelConfirm(lp) {
 // Confirm (A / Enter): AI changes apply live as you step, so confirm just
 // dismisses; for the skin picker it commits the colour under the cursor.
 function stationPanelConfirm(lp) {
-    if (lp && lp.stationPanel && lp.stationPanel.kind === "skin") {
+    if (!lp || !lp.stationPanel) {
+        return;
+    }
+    noteHubActivity(lp);
+    if (lp.stationPanel.kind === "skin") {
         skinPanelConfirm(lp);
         return;
     }
@@ -236,6 +254,7 @@ function stationPanelConfirm(lp) {
 // the AI panel. Pages stay on the d-pad ◄ ► region.
 function stationPanelTab(lp, dir) {
     if (!lp || !lp.stationPanel || lp.stationPanel.kind !== "skin") { return; }
+    noteHubActivity(lp);
     var sp = lp.stationPanel;
     var tabs = skinTabs(lp);
     var idx = skinTabIndex(lp, sp.tab) + (dir < 0 ? -1 : 1);
@@ -248,6 +267,7 @@ function stationPanelTab(lp, dir) {
 
 // Map a pointer-hit action token to its effect. "pick:<hex>" commits a skin colour.
 function stationPanelAction(lp, action) {
+    noteHubActivity(lp); // pointer/tap interaction on the panel is activity (some branches re-ping via nav/close — harmless)
     if (action === "inc") {
         stationPanelNav(lp, 1, 0);
     } else if (action === "dec") {

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -739,9 +739,12 @@ function drawLobbyHubHud() {
     if (typeof localPlayers === "undefined" || typeof gameContext === "undefined" || !gameContext) {
         return;
     }
-    // Room-wide AI status banner, drawn FIRST so an open station panel layers on top of it
-    // (otherwise it z-orders over the picker near the top of the screen).
+    // The AI setting and playlist are both room-wide, so show them persistently to the
+    // whole lobby (not just inside a panel) — everyone sees a change before the race
+    // starts. Drawn FIRST so an open station panel layers on top of them, otherwise they
+    // z-order over the picker near the top of the screen.
     drawLobbyAIStatus();
+    drawLobbyPlaylistStatus();
     for (var slot = 0; slot < localPlayers.length; slot++) {
         var lp = localPlayers[slot];
         if (!lp) {
@@ -758,11 +761,6 @@ function drawLobbyHubHud() {
             drawStationPrompt(lp, sp);
         }
     }
-    // The AI setting and playlist are both room-wide, so show them persistently to
-    // the whole lobby (not just inside a panel) — everyone sees a change before the
-    // race starts.
-    drawLobbyAIStatus();
-    drawLobbyPlaylistStatus();
 }
 
 // A fixed top-centre banner showing the live room-wide playlist, just under the AI

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -625,15 +625,12 @@ class Player extends Circle {
 		}
 	}
 	checkForSleep(currentState) {
-		// Browsing a hub station (skin shop / AI / map picker) IS activity: keep the player
-		// awake while a station panel is open so menu navigation never reads as AFK — the
-		// lobby otherwise kicks an "awake" idler immediately, which made shop browsing (no
-		// movement packets) eject players. nearStation latches the parked station (cleared on
-		// exit), so this lapses the moment they leave the station.
-		if (this.nearStation != null && currentState == c.stateMap.lobby) {
-			this.wakeUp();
-			return;
-		}
+		// NOTE: merely standing in a hub station zone is NOT activity — proximity alone must
+		// still idle out normally. ACTIVELY using a station panel (open / navigate / tab /
+		// page / confirm / close, on key, touch, or pad) is what keeps a player awake: the
+		// client fires a `lobbyActivity` ping on each such interaction (see messenger.js),
+		// which calls wakeUp(). Shop browsing emits no movement packets, so without that ping
+		// it would read as AFK — but parking a kart on the pad and walking away should not.
 		if (this.sleepTimer != null) {
 			this.sleepTimeLeft = ((this.sleepWaitTime * 1000 - (Date.now() - this.sleepTimer)) / (1000)).toFixed(1);
 			if (this.sleepTimeLeft > 0) {

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -711,6 +711,23 @@ function checkForMail(client) {
 		}
 	});
 
+	// Lobby hub keepalive: the client fires this on any active station-panel interaction
+	// (open / navigate / tab / page / confirm / close — keyboard, touch, or pad). That is
+	// the "pressing keys" signal that defers the lobby AFK kick, since browsing the menus
+	// sends no movement packets. Proximity alone does NOT wake the player (see
+	// Player.checkForSleep): a kart parked in a station zone without touching the panel
+	// still idles out normally.
+	client.on('lobbyActivity', function () {
+		var room = hostess.getRoomBySig(roomMailList[client.id]);
+		if (room == undefined || room.game.currentState != c.stateMap.lobby) {
+			return;
+		}
+		var player = room.playerList[client.id];
+		if (player != null) {
+			player.wakeUp();
+		}
+	});
+
 	// Star-rate the map you just played. Allowed on the per-round OVERVIEW (rate it
 	// while fresh) and the match-over screen. Server-authoritative: the rated map is
 	// the room's current map (still the just-played map in both states — the next map


### PR DESCRIPTION
Two independent lobby fixes (both small, both confirmed against the current prod build).

## 1. Banner z-order over the open station panel
`drawLobbyHubHud()` drew the room-wide **AI-bots** and **playlist** banners *after* the per-slot station panels, so an open **Skins** panel (which sits near the top of the screen) was painted over by both banners — covering its tab row and first swatch row.

A prior fix had moved `drawLobbyAIStatus()` to the front but left a trailing duplicate block and never moved `drawLobbyPlaylistStatus()` at all, so on `main` (v0.26.0/v0.26.1) both banners still redrew on top.

**Fix:** draw both room-wide banners *first*, then the panel loop, so an open station panel correctly layers on top of them.

## 2. Lobby AFK bypass required proximity, not interaction
The lobby-station idle-kick exemption shipped in v0.26.1 keyed off `Player.nearStation` — pure **proximity**. A kart merely parked in a station zone was immune to the AFK kick even when the player never touched the menu. The intent (and the v0.26.1 changelog line) was that *flipping through the menus* counts as active, not standing nearby.

**Fix:**
- `player.js`: drop the `nearStation` proximity bypass in `checkForSleep`, so a parked-but-idle kart follows normal AFK rules again.
- `messenger.js`: add a `lobbyActivity` socket handler that `wakeUp()`s the player — the activity signal for hub browsing, which otherwise sends no movement packets.
- `lobbyHub.js`: emit `lobbyActivity` from every active station interaction (open / navigate / tab / page / confirm / close) across keyboard, touch, and gamepad, via a single `noteHubActivity()` helper.

## Verification
- `npm run build` OK, `.github/scripts/smoke-test.js` OK.
- Headless fake-clock test of `checkForSleep`/`wakeUp` — 3/3:
  1. Parked-in-zone idler **is** kicked after the 60s sleep window (proximity no longer immunizes).
  2. An interacting player (the `lobbyActivity`→`wakeUp` ping) is **never** kicked.
  3. A player who stops interacting **is** kicked after the window.
- Codex review: no actionable regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)