### PR TITLE
feat: in-browser feedback/bug-report widget → GitHub issues

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,7 @@ demand → each `Room` owns a `Game` + `GameBoard` + `World` + `Engine`.
 |---|---|---|
 | `game.js` | ~850 | Core orchestrators only: **`Room`** (per-room registry of player/projectile/aimer/hazard lists) and **`Game`** (the state machine over `c.stateMap`: waiting→lobby→overview→gated→racing→collapsing→gameOver; round/brutal/scoring rules; bot fill). Music & achievement methods are mixed into `Game.prototype` from `music.js`/`achievements.js`. **`GameBoard`** lives in `entities/gameBoard.js` (`Room` constructs it). Exports only `getRoom(sig,size)`. |
 | `engine.js` | ~730 | Physics & collision. Per-tick updates hazards/projectiles/players; `QuadTree` broadphase against active map tiles. Helpers used from game.js/entities: `preventEscape`, `checkCollideCells`, `punchPlayer`, `puckPlayer`, `explosion`, `bounceOffBoundry`, … |
-| `utils.js` | ~500 | Central config loader (`loadConfig()` returns cached `config.json`, `PORT` override), `dt` clock, math/RNG helpers; scans `client/{maps,assets}` at boot to build the `contentDelivery` manifests; `loadMaps()` reconstructs sites-only maps to full geometry (`mapFormat`); `submitPullRequest()` (octokit) reduces an editor-submitted map to sites-only and opens a GitHub PR; shared `validateMap()`. |
+| `utils.js` | ~500 | Central config loader (`loadConfig()` returns cached `config.json`, `PORT` override), `dt` clock, math/RNG helpers; scans `client/{maps,assets}` at boot to build the `contentDelivery` manifests; `loadMaps()` reconstructs sites-only maps to full geometry (`mapFormat`); `submitPullRequest()` (octokit) reduces an editor-submitted map to sites-only and opens a GitHub PR; `submitIssue()` (octokit) files an in-browser feedback/bug report as a GitHub issue (backs the `/feedback` route in `index.js`); shared `validateMap()`. |
 | `messenger.js` | ~210 | Socket.IO wrapper. Owns mailbox (client id→socket) and room-mailbox (id→room sig). `checkForMail()` registers every per-client handler (`enterGame`, `joinARoom`, `submitNewMap`, input events). The single place socket events are wired. |
 | `hostess.js` | ~140 | Room registry. Creates `Room`s on demand, matchmakes clients into rooms with space, drives `room.update(dt)` each tick, deletes empty rooms. |
 | `compressor.js` | ~230 | Serializes per-tick state into compact positional arrays (e.g. `[id,x,y,velX,velY,angle]`) before `gameUpdates`. **Edit client decoders in `client/scripts/client.js` in lockstep with any layout change.** |
@@ -107,7 +107,11 @@ block. Dev (`npm start`) serves the raw `<script>` tags; prod swaps in the bundl
 **Shared across pages** (in multiple bundle lists): `theme.js` (light/dark/auto
 toggle), `controllerHeader.js` (controller-detection header for index/join/create),
 `osk.js` (on-screen keyboard wrapping simple-keyboard), `menuGamepad.js` (DOM-menu
-controller navigation for landing/join).
+controller navigation for landing/join; scopes nav to an open `[data-gp-modal]`),
+`feedback.js` (floating Feedback button + modal on index/join/learn; POSTs to the
+`/feedback` endpoint → `utils.submitIssue` → a GitHub issue. Touch- and
+controller-friendly: tags its controls `data-gp-nav` and routes text fields through
+`osk.js`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- New **Feedback** button on the menu pages — report a bug or pitch an idea right from the site, and it lands straight in the dev's inbox. Works with touch and controller (on-screen keyboard) too.
 
 ## v0.26.2 — 2026-05-31
 

--- a/client/index.html
+++ b/client/index.html
@@ -52,6 +52,8 @@
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="css/styles.css">
+    <!-- On-screen keyboard styles, so the feedback widget is typeable by controller here too. -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/css/index.css">
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <title>Chao Chao — Free Multiplayer Browser Arena Racing</title>
     <!-- isEmbedded() + portal-embed chrome trimming; standalone (not bundled) so
@@ -116,9 +118,14 @@
     </section>
 
     <script src="scripts/controllerIdentity.js"></script>
+    <!-- On-screen keyboard for controller text entry (used by the feedback widget). -->
+    <script src="https://cdn.jsdelivr.net/npm/simple-keyboard@3/build/index.js"></script>
+    <script src="scripts/osk.js"></script>
     <script src="scripts/menuGamepad.js"></script>
     <script src="scripts/controllerHeader.js"></script>
     <script src="scripts/theme.js"></script>
+    <!-- Feedback / bug-report widget (floating button + modal → POST /feedback → GitHub issue). -->
+    <script src="scripts/feedback.js"></script>
     <script src="scripts/landingTips.js" defer></script>
     <!-- Auth: browser-safe Supabase config injected server-side; stripped when disabled. -->
     <!-- SUPABASE_CONFIG -->

--- a/client/join.html
+++ b/client/join.html
@@ -101,5 +101,7 @@
     <script src="scripts/menuGamepad.js"></script>
     <script src="scripts/controllerHeader.js"></script>
     <!-- BUILD: bundle-end -->
+    <!-- Feedback / bug-report widget (floating button + modal → POST /feedback → GitHub issue). -->
+    <script src="scripts/feedback.js"></script>
 </body>
 </html>

--- a/client/learn.html
+++ b/client/learn.html
@@ -94,5 +94,7 @@
     <script src="scripts/menuGamepad.js"></script>
     <script src="scripts/controllerHeader.js"></script>
     <script src="scripts/theme.js"></script>
+    <!-- Feedback / bug-report widget (floating button + modal → POST /feedback → GitHub issue). -->
+    <script src="scripts/feedback.js"></script>
   </body>
 </html>

--- a/client/scripts/feedback.js
+++ b/client/scripts/feedback.js
@@ -1,0 +1,237 @@
+// In-browser feedback / bug-report widget. Injects a small fixed "Feedback"
+// button into every page that loads this script; clicking it opens a modal that
+// POSTs to the server's /feedback endpoint, which files a GitHub issue on the
+// repo (server/utils.js submitIssue). Self-contained: it injects its own styles
+// (themed via the shared CSS variables in css/styles.css) and DOM so it can be
+// dropped onto any page with a single <script> tag, independent of the bundles.
+(function () {
+    "use strict";
+
+    // Don't show the widget when the game is embedded in a portal iframe
+    // (CrazyGames / Poki / itch.io) — those hosts have their own reporting and a
+    // floating button would clutter their frame. isEmbedded is set by the page's
+    // embed detection; fall back to a plain top-vs-self check if it's absent.
+    function isEmbedded() {
+        if (typeof window.isEmbedded === "boolean") { return window.isEmbedded; }
+        try { return window.self !== window.top; } catch (e) { return true; }
+    }
+
+    function injectStyles() {
+        if (document.getElementById("feedbackWidgetStyles")) { return; }
+        var css =
+            "#feedbackFab{position:fixed;right:14px;bottom:14px;z-index:2147483000;" +
+            "min-height:44px;padding:10px 18px;border:none;border-radius:999px;cursor:pointer;" +
+            "font:600 14px/1 inherit;background:#4363d8;color:#fff;" +
+            "box-shadow:0 2px 10px var(--card-shadow,rgba(0,0,0,.3));" +
+            "display:flex;align-items:center;justify-content:center;gap:6px;}" +
+            "#feedbackFab:hover{filter:brightness(1.08);}" +
+            "#feedbackFab:focus-visible{outline:3px solid #ffe119;outline-offset:2px;}" +
+            "#feedbackOverlay{position:fixed;inset:0;z-index:2147483001;display:none;" +
+            "align-items:center;justify-content:center;background:rgba(0,0,0,.5);padding:16px;}" +
+            "#feedbackOverlay.open{display:flex;}" +
+            "#feedbackModal .fb-types{display:flex;gap:8px;}" +
+            "#feedbackModal .fb-type{flex:1;min-height:44px;text-align:center;padding:9px 6px;border-radius:8px;" +
+            "border:1px solid var(--border,#ccc);background:var(--surface-2,#f6f6f6);" +
+            "color:var(--text,#212529);cursor:pointer;font:600 13px inherit;}" +
+            "#feedbackModal .fb-type[aria-pressed=true]{background:#4363d8;color:#fff;border-color:#4363d8;}" +
+            "#feedbackModal{width:100%;max-width:420px;max-height:90vh;overflow:auto;" +
+            "background:var(--surface,#fff);color:var(--text,#212529);" +
+            "border:1px solid var(--border,#e6e6e6);border-radius:12px;padding:18px 18px 16px;" +
+            "box-shadow:0 8px 40px var(--card-shadow,rgba(0,0,0,.4));font:14px/1.4 inherit;}" +
+            "#feedbackModal h2{margin:0 0 4px;font-size:18px;}" +
+            "#feedbackModal p.fb-sub{margin:0 0 14px;color:var(--text-muted,#6c757d);font-size:13px;}" +
+            "#feedbackModal label{display:block;font-weight:600;margin:12px 0 4px;font-size:13px;}" +
+            "#feedbackModal select,#feedbackModal textarea,#feedbackModal input[type=email]{" +
+            "width:100%;box-sizing:border-box;padding:8px 10px;border-radius:8px;" +
+            "border:1px solid var(--border,#ccc);background:var(--surface-2,#f6f6f6);" +
+            "color:var(--text,#212529);font:14px inherit;}" +
+            "#feedbackModal textarea{resize:vertical;min-height:90px;}" +
+            "#fbHoneypot{position:absolute;left:-9999px;top:-9999px;width:1px;height:1px;opacity:0;}" +
+            "#feedbackModal .fb-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:16px;}" +
+            "#feedbackModal .fb-actions button{min-height:44px;padding:10px 18px;border-radius:8px;cursor:pointer;font:600 14px inherit;border:1px solid var(--border,#ccc);}" +
+            "#fbCancel{background:transparent;color:var(--text,#212529);}" +
+            "#fbSubmit{background:#3cb44b;color:#fff;border-color:#3cb44b;}" +
+            "#fbSubmit:disabled{opacity:.6;cursor:default;}" +
+            "#feedbackModal .fb-status{margin-top:12px;font-size:13px;min-height:1em;}" +
+            "#feedbackModal .fb-status.err{color:#e6194B;}" +
+            "#feedbackModal .fb-status.ok{color:#3cb44b;}" +
+            "#feedbackModal .fb-status a{color:inherit;}";
+        var style = document.createElement("style");
+        style.id = "feedbackWidgetStyles";
+        style.textContent = css;
+        document.head.appendChild(style);
+    }
+
+    var overlay, statusEl, submitBtn, msgEl, emailEl, honeypotEl;
+    var selectedType = "bug";
+
+    function buildModal() {
+        overlay = document.createElement("div");
+        overlay.id = "feedbackOverlay";
+        // data-gp-modal: while this overlay has .open, menuGamepad.js scopes
+        // controller navigation to the controls inside it (not the page behind).
+        overlay.setAttribute("data-gp-modal", "");
+        overlay.setAttribute("role", "dialog");
+        overlay.setAttribute("aria-modal", "true");
+        overlay.setAttribute("aria-label", "Send feedback");
+        overlay.innerHTML =
+            '<div id="feedbackModal">' +
+            '<h2>Send feedback</h2>' +
+            '<p class="fb-sub">Found a bug or have an idea? Your description opens a <strong>public</strong> issue on GitHub, so don\'t include anything private.</p>' +
+            '<label>Type</label>' +
+            // Type picker as buttons (not a <select>) so it works the same by tap and
+            // by controller — each is a data-gp-nav target the pad can land on.
+            '<div class="fb-types" role="group" aria-label="Feedback type">' +
+            '<button type="button" class="fb-type" data-gp-nav data-type="bug" aria-pressed="true">Bug</button>' +
+            '<button type="button" class="fb-type" data-gp-nav data-type="idea" aria-pressed="false">Idea</button>' +
+            '<button type="button" class="fb-type" data-gp-nav data-type="other" aria-pressed="false">Other</button>' +
+            '</div>' +
+            '<label for="fbMessage">Description</label>' +
+            '<textarea id="fbMessage" data-gp-nav maxlength="5000" placeholder="What happened, or what would you like to see?"></textarea>' +
+            '<label for="fbEmail">Email <span style="font-weight:400;color:var(--text-muted,#6c757d)">(optional, kept private — not shown on the issue)</span></label>' +
+            '<input id="fbEmail" type="email" data-gp-nav maxlength="254" placeholder="you@example.com">' +
+            // Honeypot: hidden from humans, no data-gp-nav, autocomplete off. A bot
+            // that fills every field trips it; the server drops anything with it set.
+            '<input id="fbHoneypot" type="text" tabindex="-1" autocomplete="off" aria-hidden="true" name="website">' +
+            '<div class="fb-status" id="fbStatus" aria-live="polite"></div>' +
+            '<div class="fb-actions">' +
+            '<button id="fbCancel" type="button" data-gp-nav data-gp-modal-close>Cancel</button>' +
+            '<button id="fbSubmit" type="button" data-gp-nav>Send</button>' +
+            '</div>' +
+            '</div>';
+        document.body.appendChild(overlay);
+
+        statusEl = overlay.querySelector("#fbStatus");
+        submitBtn = overlay.querySelector("#fbSubmit");
+        msgEl = overlay.querySelector("#fbMessage");
+        emailEl = overlay.querySelector("#fbEmail");
+        honeypotEl = overlay.querySelector("#fbHoneypot");
+
+        // Type buttons act as a single-select radio group.
+        var typeBtns = overlay.querySelectorAll(".fb-type");
+        Array.prototype.forEach.call(typeBtns, function (btn) {
+            btn.addEventListener("click", function () {
+                selectedType = btn.getAttribute("data-type");
+                Array.prototype.forEach.call(typeBtns, function (b) {
+                    b.setAttribute("aria-pressed", b === btn ? "true" : "false");
+                });
+            });
+        });
+
+        overlay.querySelector("#fbCancel").addEventListener("click", close);
+        submitBtn.addEventListener("click", submit);
+        // Click on the dimmed backdrop (but not the modal itself) closes it.
+        overlay.addEventListener("click", function (e) {
+            if (e.target === overlay) { close(); }
+        });
+        document.addEventListener("keydown", function (e) {
+            if (e.key === "Escape" && overlay.classList.contains("open")) { close(); }
+        });
+        // Focus trap: keep Tab / Shift+Tab cycling within the modal so a keyboard
+        // user can't tab onto the navbar / page controls hidden behind the backdrop.
+        // (aria-modal alone doesn't enforce this.)
+        overlay.addEventListener("keydown", function (e) {
+            if (e.key !== "Tab" || !overlay.classList.contains("open")) { return; }
+            var list = focusables();
+            if (list.length === 0) { return; }
+            var first = list[0];
+            var last = list[list.length - 1];
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault();
+                first.focus();
+            }
+        });
+    }
+
+    // Visible, tabbable controls inside the modal, in DOM order (honeypot excluded).
+    function focusables() {
+        var sel = 'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])';
+        return Array.prototype.filter.call(overlay.querySelectorAll(sel), function (el) {
+            return el.id !== "fbHoneypot" && el.offsetParent !== null && !el.disabled;
+        });
+    }
+
+    function open() {
+        if (!overlay) { buildModal(); }
+        setStatus("", "");
+        overlay.classList.add("open");
+        msgEl.focus();
+    }
+
+    function close() {
+        if (overlay) { overlay.classList.remove("open"); }
+    }
+
+    function setStatus(text, kind) {
+        statusEl.className = "fb-status" + (kind ? " " + kind : "");
+        if (kind === "ok" && text && text.indexOf("http") === 0) {
+            statusEl.innerHTML = 'Thanks! <a href="' + text + '" target="_blank" rel="noopener">Track it on GitHub</a>.';
+        } else {
+            statusEl.textContent = text || "";
+        }
+    }
+
+    function submit() {
+        var message = (msgEl.value || "").trim();
+        if (message.length < 5) {
+            setStatus("Please add a few more words so it's actionable.", "err");
+            msgEl.focus();
+            return;
+        }
+        submitBtn.disabled = true;
+        setStatus("Sending…", "");
+        var payload = {
+            type: selectedType,
+            message: message,
+            email: (emailEl.value || "").trim(),
+            page: location.pathname + location.search,
+            context: (navigator.userAgent || "").slice(0, 300),
+            website: honeypotEl.value // honeypot — empty for real users
+        };
+        fetch("/feedback", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload)
+        }).then(function (res) {
+            return res.json().catch(function () { return { status: false, message: "" }; });
+        }).then(function (result) {
+            submitBtn.disabled = false;
+            if (result && result.status) {
+                setStatus(result.message || "Thanks for the feedback!", "ok");
+                msgEl.value = "";
+                emailEl.value = "";
+                // Auto-close shortly after a successful send.
+                setTimeout(close, 2500);
+            } else {
+                setStatus((result && result.message) || "Couldn't send your feedback. Please try again.", "err");
+            }
+        }).catch(function () {
+            submitBtn.disabled = false;
+            setStatus("Couldn't reach the server. Please try again in a moment.", "err");
+        });
+    }
+
+    function init() {
+        if (isEmbedded()) { return; }
+        if (document.getElementById("feedbackFab")) { return; }
+        injectStyles();
+        var fab = document.createElement("button");
+        fab.id = "feedbackFab";
+        fab.type = "button";
+        fab.setAttribute("data-gp-nav", "");
+        fab.setAttribute("aria-label", "Send feedback");
+        fab.title = "Send feedback or report a bug";
+        fab.innerHTML = '<span aria-hidden="true">💬</span><span>Feedback</span>';
+        fab.addEventListener("click", open);
+        document.body.appendChild(fab);
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/client/scripts/menuGamepad.js
+++ b/client/scripts/menuGamepad.js
@@ -131,7 +131,11 @@
 
     // Visible, actionable elements in document order.
     function collectItems() {
-        var all = document.querySelectorAll(NAV_SELECTOR);
+        // When a gamepad-aware modal is open (e.g. the feedback widget), scope
+        // navigation to the controls inside it so the pad can't reach the page
+        // behind the dimmed backdrop. Falls back to the whole document otherwise.
+        var modal = document.querySelector("[data-gp-modal].open");
+        var all = (modal || document).querySelectorAll(NAV_SELECTOR);
         var items = [];
         for (var i = 0; i < all.length; i++) {
             var el = all[i];
@@ -230,7 +234,8 @@
         if (!focusEl) {
             return;
         }
-        if (focusEl.tagName.toLowerCase() === "input") {
+        var tag = focusEl.tagName.toLowerCase();
+        if (tag === "input" || tag === "textarea") {
             // Pop the on-screen keyboard so the field is typeable with a pad;
             // fall back to a plain focus if the OSK module isn't present.
             if (typeof oskOpen === "function") {
@@ -244,6 +249,15 @@
     }
 
     function back() {
+        // If a gamepad-aware modal is open, B dismisses IT (not the page) so the
+        // draft isn't thrown away by navigating to index.html. Click its declared
+        // close control if present; otherwise just drop the .open class.
+        var modal = document.querySelector("[data-gp-modal].open");
+        if (modal) {
+            var closeBtn = modal.querySelector("[data-gp-modal-close]");
+            if (closeBtn) { closeBtn.click(); } else { modal.classList.remove("open"); }
+            return;
+        }
         var path = location.pathname;
         if (/index\.html$/.test(path) || path === "/" || path === "") {
             return; // already at the top of the menu tree

--- a/index.js
+++ b/index.js
@@ -235,6 +235,65 @@ var hostess = require('./server/hostess.js');
 var botGuard = require('./server/botGuard.js');
 var c = utils.loadConfig();
 
+// In-browser feedback / bug-report endpoint. The widget (client/scripts/feedback.js)
+// POSTs here and utils.submitIssue files it as a GitHub issue using the server's
+// GITHUB_AUTH token (same credential map-submit uses). Because it's unauthenticated
+// and writes to GitHub, it's guarded by: a tight JSON body cap, a hidden honeypot
+// field (any value = a bot, silently accepted-and-dropped), and a per-IP rate limit.
+var feedbackHits = {}; // ip -> [timestamps] within the window
+var FEEDBACK_WINDOW_MS = 10 * 60 * 1000;
+var FEEDBACK_MAX_PER_WINDOW = 5;
+function feedbackRateLimited(ip) {
+    var now = Date.now();
+    var hits = (feedbackHits[ip] || []).filter(function (t) { return now - t < FEEDBACK_WINDOW_MS; });
+    if (hits.length >= FEEDBACK_MAX_PER_WINDOW) {
+        feedbackHits[ip] = hits;
+        return true;
+    }
+    hits.push(now);
+    feedbackHits[ip] = hits;
+    return false;
+}
+// Sweep expired keys so a public endpoint hit by many distinct IPs can't grow
+// feedbackHits without bound (entries are otherwise only pruned when that same IP
+// submits again). Cheap (runs once per window) and harmless while the server sleeps.
+setInterval(function () {
+    var now = Date.now();
+    for (var ip in feedbackHits) {
+        var hits = feedbackHits[ip].filter(function (t) { return now - t < FEEDBACK_WINDOW_MS; });
+        if (hits.length === 0) { delete feedbackHits[ip]; }
+        else { feedbackHits[ip] = hits; }
+    }
+}, FEEDBACK_WINDOW_MS).unref();
+app.post('/feedback', express.json({ limit: '16kb' }), function (req, res) {
+    var body = req.body || {};
+    // Honeypot: a real form leaves `website` empty (it's hidden off-screen). Any
+    // value means a bot filled every field — respond 200 so it thinks it worked,
+    // but file nothing.
+    if (body.website) {
+        return res.json({ status: true, message: "" });
+    }
+    // Resolve the client IP from the TRUSTED proxy hop (counting in from the right),
+    // not the left-most X-Forwarded-For entry — a caller can forge that and rotate it
+    // every request to bypass the limit. Reuses the same resolver the socket path uses.
+    var ip = botGuard.resolveClientIp(req.headers['x-forwarded-for'], req.ip) || 'unknown';
+    if (feedbackRateLimited(ip)) {
+        return res.status(429).json({ status: false, message: "You've sent a lot of feedback — please wait a few minutes and try again." });
+    }
+    utils.submitIssue({
+        type: body.type,
+        message: body.message,
+        email: body.email,
+        page: body.page,
+        context: body.context
+    }).then(function (result) {
+        res.json(result);
+    }).catch(function (e) {
+        console.log(e);
+        res.json({ status: false, message: "Couldn't send your feedback right now. Please try again in a moment." });
+    });
+});
+
 //Base Server vars
 var serverSleeping = true,
     pendingReboot = false,

--- a/index.js
+++ b/index.js
@@ -240,18 +240,21 @@ var c = utils.loadConfig();
 // GITHUB_AUTH token (same credential map-submit uses). Because it's unauthenticated
 // and writes to GitHub, it's guarded by: a tight JSON body cap, a hidden honeypot
 // field (any value = a bot, silently accepted-and-dropped), and a per-IP rate limit.
-var feedbackHits = {}; // ip -> [timestamps] within the window
+// Keyed by client IP. A Map (not a plain object) so a hostile IP string can never
+// be a special property name (__proto__, constructor, …) — there's no prototype to
+// pollute and key lookups stay O(1) on arbitrary strings.
+var feedbackHits = new Map(); // ip -> [timestamps] within the window
 var FEEDBACK_WINDOW_MS = 10 * 60 * 1000;
 var FEEDBACK_MAX_PER_WINDOW = 5;
 function feedbackRateLimited(ip) {
     var now = Date.now();
-    var hits = (feedbackHits[ip] || []).filter(function (t) { return now - t < FEEDBACK_WINDOW_MS; });
+    var hits = (feedbackHits.get(ip) || []).filter(function (t) { return now - t < FEEDBACK_WINDOW_MS; });
     if (hits.length >= FEEDBACK_MAX_PER_WINDOW) {
-        feedbackHits[ip] = hits;
+        feedbackHits.set(ip, hits);
         return true;
     }
     hits.push(now);
-    feedbackHits[ip] = hits;
+    feedbackHits.set(ip, hits);
     return false;
 }
 // Sweep expired keys so a public endpoint hit by many distinct IPs can't grow
@@ -259,11 +262,11 @@ function feedbackRateLimited(ip) {
 // submits again). Cheap (runs once per window) and harmless while the server sleeps.
 setInterval(function () {
     var now = Date.now();
-    for (var ip in feedbackHits) {
-        var hits = feedbackHits[ip].filter(function (t) { return now - t < FEEDBACK_WINDOW_MS; });
-        if (hits.length === 0) { delete feedbackHits[ip]; }
-        else { feedbackHits[ip] = hits; }
-    }
+    feedbackHits.forEach(function (timestamps, ip) {
+        var hits = timestamps.filter(function (t) { return now - t < FEEDBACK_WINDOW_MS; });
+        if (hits.length === 0) { feedbackHits.delete(ip); }
+        else { feedbackHits.set(ip, hits); }
+    });
 }, FEEDBACK_WINDOW_MS).unref();
 app.post('/feedback', express.json({ limit: '16kb' }), function (req, res) {
     var body = req.body || {};

--- a/server/utils.js
+++ b/server/utils.js
@@ -384,8 +384,13 @@ exports.submitIssue = async function (feedback) {
             returnToClient.status = true;
             returnToClient.message = issue.data.html_url;
             // Operator-only contact trail: never goes into the public issue body.
+            // email already has all control chars stripped above and must pass the
+            // strict regex to get here, so it can't contain CR/LF — strip them again
+            // explicitly at the log site as a defense-in-depth barrier against log
+            // forging (and so static analysis can see the sanitization).
             if (email !== "") {
-                console.log("[feedback] contact email for " + issue.data.html_url + ": " + email);
+                var safeEmail = email.replace(/[\r\n]/g, "");
+                console.log("[feedback] contact email for " + issue.data.html_url + ": " + safeEmail);
             }
             return returnToClient;
         }

--- a/server/utils.js
+++ b/server/utils.js
@@ -290,6 +290,116 @@ exports.submitPullRequest = async function (map) {
 
 }
 
+// In-browser feedback / bug report → a GitHub issue on the repo, using the same
+// server-side credentials (GITHUB_AUTH) that submitPullRequest uses for map PRs.
+// The submitter is unauthenticated and untrusted, so everything is length-capped
+// and control-char-stripped here at the trust boundary; the client's <input>/
+// <textarea> caps are a courtesy, the only enforcement that matters is below.
+// `feedback` = { type, message, email?, page?, context? }. Returns the same
+// { status, message } shape as submitPullRequest (message is the issue URL on
+// success, or a player-actionable reason on failure).
+exports.submitIssue = async function (feedback) {
+    var returnToClient = { status: false, message: "" };
+    if (process.env.GITHUB_AUTH == null) {
+        console.log("github auth env variable not set; cannot file feedback issue");
+        returnToClient.message = "Feedback isn't available right now. Please try again later.";
+        return returnToClient;
+    }
+    if (feedback == null || typeof feedback !== "object") {
+        returnToClient.message = "Could not read your feedback.";
+        return returnToClient;
+    }
+
+    // Type drives the issue label so you can triage bug vs idea vs other in the
+    // GitHub issues list. Anything unrecognised falls back to "other".
+    var TYPES = { bug: "bug", idea: "enhancement", other: "feedback" };
+    var type = String(feedback.type || "").toLowerCase();
+    if (!Object.prototype.hasOwnProperty.call(TYPES, type)) {
+        type = "other";
+    }
+
+    // Strip C0 control chars + DEL from single-line fields (email, page) so a
+    // crafted payload can't smuggle newlines into the title/metadata. The body
+    // keeps newlines (it's a multi-line description) but still drops the other
+    // control bytes.
+    var message = String(feedback.message == null ? "" : feedback.message)
+        .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "").trim();
+    var email = String(feedback.email == null ? "" : feedback.email)
+        .replace(/[\x00-\x1f\x7f]/g, "").trim();
+    var page = String(feedback.page == null ? "" : feedback.page)
+        .replace(/[\x00-\x1f\x7f]/g, "").trim();
+    var context = String(feedback.context == null ? "" : feedback.context)
+        .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "").trim();
+
+    if (message.length < 5) {
+        returnToClient.message = "Please describe the bug or idea (at least a few words).";
+        return returnToClient;
+    }
+    if (message.length > 5000) {
+        returnToClient.message = "That's a lot of feedback — please keep it under 5000 characters.";
+        return returnToClient;
+    }
+    // Email is optional (lets you follow up). When given, mirror submitPullRequest's
+    // non-backtracking pattern so an invalid address is rejected with a clear reason.
+    if (email !== "") {
+        if (email.length > 254 || !/^[\w.+-]+@[\w-]+(\.[\w-]+)+$/.test(email)) {
+            returnToClient.message = "That email address looks invalid (leave it blank to skip).";
+            return returnToClient;
+        }
+    }
+    if (page.length > 200) { page = page.slice(0, 200); }
+    if (context.length > 500) { context = context.slice(0, 500); }
+
+    const owner = 'sjdodge123';
+    const repo = 'chaochao';
+
+    // Title: first line of the message, trimmed to a sane length, prefixed by type.
+    var firstLine = message.split("\n")[0].slice(0, 80).trim();
+    if (firstLine === "") { firstLine = "Player feedback"; }
+    var prefix = type === "bug" ? "Bug" : (type === "idea" ? "Idea" : "Feedback");
+    var title = "[" + prefix + "] " + firstLine;
+
+    // Body: the full message plus the small metadata footer the widget collected.
+    // Everything here is already control-char-stripped and length-capped above.
+    // NOTE: the optional contact email is deliberately NOT written here — the repo
+    // issues are public and scrapeable. It's logged server-side below (operator-only)
+    // so follow-up is still possible without publishing the address.
+    var bodyLines = [message, "", "---"];
+    if (page !== "") { bodyLines.push("**Page:** " + page); }
+    if (context !== "") { bodyLines.push("**Context:** " + context); }
+    if (email !== "") { bodyLines.push("_Reporter left a contact email (kept private; see server logs)._"); }
+    bodyLines.push("_Submitted from the in-game feedback widget._");
+    var body = bodyLines.join("\n");
+
+    try {
+        const octokit = await getOctokit();
+        var issue = await octokit.request('POST /repos/{owner}/{repo}/issues', {
+            owner,
+            repo,
+            title,
+            body,
+            labels: [TYPES[type]]
+        });
+        if (issue.status === 201) {
+            returnToClient.status = true;
+            returnToClient.message = issue.data.html_url;
+            // Operator-only contact trail: never goes into the public issue body.
+            if (email !== "") {
+                console.log("[feedback] contact email for " + issue.data.html_url + ": " + email);
+            }
+            return returnToClient;
+        }
+        returnToClient.message = "Couldn't send your feedback right now. Please try again in a moment.";
+        return returnToClient;
+    } catch (e) {
+        // Same policy as submitPullRequest: log the real GitHub/network error for
+        // debugging, return a friendly generic to the player.
+        console.log(e);
+        returnToClient.message = "Couldn't send your feedback right now. Please try again in a moment.";
+        return returnToClient;
+    }
+};
+
 function getRandomBranchCode() {
     const codeLength = 6;
     var code = [];


### PR DESCRIPTION
## What

Adds the first in-browser way for players to report a bug or pitch an idea. A floating **Feedback** button on the menu pages (index, join, learn) opens a modal that `POST`s to a new `/feedback` endpoint, which files a **GitHub issue** on this repo via `utils.submitIssue` — reusing the same `GITHUB_AUTH` token map-submit already uses, so it works in prod with no new config.

Previously there was no feedback path at all; the only GitHub integration was map-submit → PR.

## How

- **`server/utils.js` `submitIssue()`** — octokit `POST /issues`, mirroring `submitPullRequest`'s validation/security (control-char stripping, length caps, email regex, friendly generic errors). Labels each issue `bug` / `enhancement` / `feedback` for triage. The optional contact email is kept **out** of the public issue body and logged server-side (operator-only) instead.
- **`index.js` `POST /feedback`** — scoped 16 KB JSON parser, per-IP rate limit (5 / 10 min) with the IP resolved via `botGuard.resolveClientIp` so a forged `X-Forwarded-For` can't bypass it, a honeypot field, and a sweep that expires inactive rate-limit keys.
- **`client/scripts/feedback.js`** (new) — self-contained, themed floating button + modal. Touch- and controller-friendly: 44px touch targets, `data-gp-nav` controls, text fields routed through the existing on-screen keyboard (`osk.js`), a keyboard focus trap, and a clear "this opens a public GitHub issue" disclaimer.
- **`menuGamepad.js`** — scopes controller navigation to an open `[data-gp-modal]`, and makes controller **B** dismiss the modal instead of navigating away.

## Scope notes

- Wired onto the three menu pages (index/join/learn) — the "website" surface. Not added to in-game `play.html` (mid-race driving) or the editor `create.html` (own input loop); easy follow-up if wanted.
- `GITHUB_AUTH` is already set in prod (map-submit uses it), so issues will file immediately on deploy.

## Verification

- `npm run build` ✅, `smoke-test.js` ✅ (52 maps) — re-run after rebase onto `origin/main`
- `button-gate.js` ✅ (FAB meets the 44px / reachability gate), `lint-button-input.js` ✅, `lint-input-validation.js` ✅
- Live endpoint tests: validation messages, honeypot drop, and a prod-topology XFF rate-limit sim (6th request → 429) ✅
- All six findings from a Codex review addressed (2×P1 security/privacy, 1×P1 touch-target, 3×P2 UX/memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)