### PR TITLE
feat: seasonal Early Adopter cosmetic claim + Solar Flare trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- **Early Adopter trail — claim it before August!** Sign in to your account any time this summer to permanently unlock the exclusive **Solar Flare** trail: a molten-gold flare with drifting embers that everyone sees as you race. The claim closes August 1st and it's gone for good after that — sign in once and it's yours forever.
 
 ## v0.26.4 — 2026-05-31
 

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -260,9 +260,10 @@ nav .auth-control ~ .theme-toggle {
 .cc-toast-close:hover { opacity: 1; }
 
 /* progression celebration toast (client.js) — top-centre so it never collides with
-   the bottom login nudge, gold-accented, slides down from the top edge. */
+   the bottom login nudge, gold-accented, slides down from the top edge. `top` clears the
+   ~58px navbar so the toast sits in the canvas/play area rather than overlapping the header. */
 .cc-progression-toast {
-    top: 24px;
+    top: 72px;
     bottom: auto;
     transform: translateX(-50%) translateY(-20px);
     border-color: rgba(255, 211, 77, 0.85);

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -233,7 +233,7 @@ var myProgression = null;
 // layers over the canvas without touching the render loop.
 var progressionToastQueue = [];
 var progressionToastShowing = false;
-var PROGRESSION_TOAST_MS = 2600;
+var PROGRESSION_TOAST_MS = 5000; // applies to ALL progression toasts (xp / level-up / skin unlock / seasonal)
 
 function progressionToastText(ev) {
 	if (!ev || !ev.type) { return null; }
@@ -247,6 +247,14 @@ function progressionToastText(ev) {
 	// Name the cosmetic by its slot so the toast reads "New cart/pattern/trail unlocked".
 	var slot = (typeof getSkinSlot === "function") ? getSkinSlot(ev.id) : null;
 	var slotWord = slot === "cart" ? "cart" : slot === "pattern" ? "pattern" : slot === "trail" ? "trail" : "cosmetic";
+	if (ev.type === "seasonal") {
+		// A limited-time seasonal claim — a one-time, never-again cosmetic. The season's
+		// player-facing name comes from the registry entry's unlock.label (data-driven, so a
+		// future season needs no edit here); falls back to "Limited" if absent.
+		var sk = (typeof getSkin === "function") ? getSkin(ev.id) : null;
+		var label = (sk && sk.unlock && sk.unlock.label) ? sk.unlock.label : "Limited";
+		return "🌟 " + label + " " + slotWord + " claimed: " + nm;
+	}
 	if (ev.type === "skin") {
 		return "🎨 New " + slotWord + " unlocked: " + nm;
 	}
@@ -282,6 +290,19 @@ function showNextProgressionToast() {
 			showNextProgressionToast();
 		}, 400); // matches the cc-toast fade-out transition
 	}, PROGRESSION_TOAST_MS);
+}
+// Drop any queued/visible progression toasts. Called when the lobby ends (startGated) so a long
+// reward sequence (now ~5s each) can never keep popping over live gameplay — same rationale as
+// dismissing the between-matches ad at the gate. Pending fade timeouts no-op on the removed nodes.
+function clearProgressionToasts() {
+	progressionToastQueue.length = 0;
+	progressionToastShowing = false;
+	if (typeof document !== "undefined" && document.querySelectorAll) {
+		var open = document.querySelectorAll(".cc-progression-toast");
+		for (var i = 0; i < open.length; i++) {
+			if (open[i].parentNode) { open[i].parentNode.removeChild(open[i]); }
+		}
+	}
 }
 
 // Fire the `cosmetics_equipped` GA event once per MATCH (cosmetics are fixed for a match),
@@ -690,6 +711,9 @@ function registerStateHandlers(server) {
 		if (window.ads && typeof window.ads.dismissInterstitial === "function") {
 			try { window.ads.dismissInterstitial(); } catch (e) { /* never block the gate */ }
 		}
+		// Same idea for celebration toasts: clear the queue so a long reward sequence doesn't
+		// keep popping over the race that's starting (toasts belong to the lobby).
+		if (typeof clearProgressionToasts === "function") { clearProgressionToasts(); }
 		setLobbySfxDampen(false); // restore full SFX before the game-start cue
 		stopSound(lobbyMusic);
 		playSound(gameStart);

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -763,6 +763,10 @@ function drawLobbyHubHud() {
     // whole lobby (not just inside a panel) — everyone sees a change before the race
     // starts. Drawn FIRST so an open station panel layers on top of them, otherwise they
     // z-order over the picker near the top of the screen.
+    // Resolve the active seasonal claim ONCE per HUD frame (it can't change within a frame);
+    // all three banners read this cached value instead of re-scanning the registry each.
+    lobbyBannerSeasonalClaim = activeSeasonalClaim();
+    drawSeasonalClaimBanner(); // top slot when active; AI + playlist drop a row below it
     drawLobbyAIStatus();
     drawLobbyPlaylistStatus();
     for (var slot = 0; slot < localPlayers.length; slot++) {
@@ -783,33 +787,91 @@ function drawLobbyHubHud() {
     }
 }
 
-// A fixed top-centre banner showing the live room-wide playlist, just under the AI
-// banner. Synced to every client via lobbyPlaylistChanged.
-function drawLobbyPlaylistStatus() {
-    if (!playlistDefList().length) { return; }
-    var count = playlistCount(currentPlaylistId());
-    var text = "🗺️ Playlist: " + currentPlaylistLabel() + (count != null ? " (" + count + ")" : "");
-    var ink = hubInk();
+// The active seasonal claim for THIS HUD frame (or null), cached by drawLobbyHubHud so the
+// registry isn't re-scanned by each banner. Read by all three lobby banners.
+var lobbyBannerSeasonalClaim = null;
+
+// Draws ONE fixed top-centre lobby banner (rounded pill, centered bold text) at row `y`. Backs
+// all three lobby banners so their geometry stays identical. theme overrides the neutral hub
+// panel look: { fill, ink (border), text (defaults to ink), alpha, pad, glow }.
+function drawLobbyBanner(text, y, theme) {
+    theme = theme || {};
+    var ink = theme.ink || hubInk();
+    var pad = (theme.pad != null) ? theme.pad : 30;
     gameContext.save();
     gameContext.font = "bold 16px sans-serif";
     var tw = gameContext.measureText(text).width;
-    var w = tw + 30;
+    var w = tw + pad;
     var h = 32;
     var x = (LOGICAL_WIDTH - w) / 2;
-    var y = 128; // just under the AI-bots banner (y=92, h=32)
-    gameContext.globalAlpha = 0.92;
-    gameContext.fillStyle = hubSurface();
+    if (theme.glow) { gameContext.shadowColor = theme.glow; gameContext.shadowBlur = 14; }
+    gameContext.globalAlpha = (theme.alpha != null) ? theme.alpha : 0.92;
+    gameContext.fillStyle = theme.fill || hubSurface();
     lhRoundRect(gameContext, x, y, w, h, 9);
     gameContext.fill();
+    gameContext.shadowBlur = 0;
     gameContext.globalAlpha = 1;
     gameContext.lineWidth = 2;
     gameContext.strokeStyle = ink;
     gameContext.stroke();
-    gameContext.fillStyle = ink;
+    gameContext.fillStyle = theme.text || ink;
     gameContext.textAlign = "center";
     gameContext.textBaseline = "middle";
     gameContext.fillText(text, LOGICAL_WIDTH / 2, y + h / 2);
     gameContext.restore();
+}
+
+// A fixed top-centre banner showing the live room-wide playlist. Sits under the AI banner,
+// dropping a row when the seasonal banner takes the top slot. Synced via lobbyPlaylistChanged.
+function drawLobbyPlaylistStatus() {
+    if (!playlistDefList().length) { return; }
+    var count = playlistCount(currentPlaylistId());
+    var text = "🗺️ Playlist: " + currentPlaylistLabel() + (count != null ? " (" + count + ")" : "");
+    drawLobbyBanner(text, lobbyBannerSeasonalClaim ? 164 : 128);
+}
+
+// The seasonal claim the LOCAL player can still act on this frame — the first open claim they
+// don't already own (mirrors the server, which grants ALL open claims, so if more than one
+// season is live the banner advances past ones already claimed). null = nothing to advertise.
+// Hidden once owned so it never nags a claimer.
+function activeSeasonalClaim() {
+    if (typeof currentSeasonalClaims !== "function") { return null; }
+    var open = currentSeasonalClaims(Date.now());
+    if (!open.length) { return null; }
+    var prog = (typeof myProgression !== "undefined") ? myProgression : null;
+    var owns = (prog && prog.unlocked_skins) ? prog.unlocked_skins : null;
+    for (var i = 0; i < open.length; i++) {
+        if (!owns || owns.indexOf(open[i].id) === -1) { return open[i]; }
+    }
+    return null; // every open claim already owned
+}
+
+// The player-facing noun for a cosmetic slot, used in the data-driven seasonal copy so a
+// future non-trail season ('cart'/'border'/'pattern') reads correctly without a code edit.
+function cosmeticSlotNoun(slot) {
+    return (slot === "cart" || slot === "pattern" || slot === "trail" || slot === "border") ? slot : "cosmetic";
+}
+
+// A limited-time, eye-catching GOLD banner advertising the open seasonal claim (Early Adopter
+// etc.), drawn as the TOP banner of the lobby stack (above the AI-bots banner) so the limited
+// CTA gets first billing; the AI + playlist banners drop one row while it's showing. Copy is
+// data-driven (season label + cosmetic name + slot noun) from the registry entry, so a future
+// season needs no edit here. Sign-in nudge for guests; "claim it / Nd left" for signed-in.
+function drawSeasonalClaimBanner() {
+    var claim = lobbyBannerSeasonalClaim;
+    if (!claim) { return; }
+    var signedIn = !!((typeof myProgression !== "undefined") ? myProgression : null);
+    var endMs = Date.parse(claim.unlock.claimEnd);
+    var daysLeft = isNaN(endMs) ? null : Math.max(1, Math.ceil((endMs - Date.now()) / 86400000));
+    var nm = (typeof skinDisplayName === "function") ? skinDisplayName(claim.id) : claim.name;
+    var label = (claim.unlock && claim.unlock.label) ? claim.unlock.label : "Limited";
+    var noun = cosmeticSlotNoun(claim.slot);
+    var tail = (daysLeft != null ? " — " + daysLeft + "d left" : "");
+    var text = signedIn
+        ? ("🌟 Claim your " + label + " " + nm + " " + noun + tail)
+        : ("🌟 Sign in to claim the limited " + label + " " + nm + " " + noun + tail);
+    // Gold theme + soft glow so it reads as premium/limited, not a routine status band.
+    drawLobbyBanner(text, 92, { fill: "#3a2b06", ink: "#ffb31f", text: "#ffe9a8", alpha: 0.96, pad: 34, glow: "rgba(255,179,31,0.7)" });
 }
 
 // Triangular-tier auto fill: a few bots scale up with humans (1H→1, 2-3H→2,
@@ -841,27 +903,8 @@ function drawLobbyAIStatus() {
         var eff = Math.min(lvl, aiMaxBots());
         text = "🤖 AI bots next race: " + eff + (eff === 1 ? " bot" : " bots");
     }
-    var ink = hubInk();
-    gameContext.save();
-    gameContext.font = "bold 16px sans-serif";
-    var tw = gameContext.measureText(text).width;
-    var w = tw + 30;
-    var h = 32;
-    var x = (LOGICAL_WIDTH - w) / 2;
-    var y = 92; // just under the GameID/Players/Round info row
-    gameContext.globalAlpha = 0.92;
-    gameContext.fillStyle = hubSurface();
-    lhRoundRect(gameContext, x, y, w, h, 9);
-    gameContext.fill();
-    gameContext.globalAlpha = 1;
-    gameContext.lineWidth = 2;
-    gameContext.strokeStyle = ink;
-    gameContext.stroke();
-    gameContext.fillStyle = ink;
-    gameContext.textAlign = "center";
-    gameContext.textBaseline = "middle";
-    gameContext.fillText(text, LOGICAL_WIDTH / 2, y + h / 2);
-    gameContext.restore();
+    // Under the GameID/Players/Round info row; +1 row when the seasonal banner takes the top slot.
+    drawLobbyBanner(text, lobbyBannerSeasonalClaim ? 128 : 92);
 }
 
 function lhRoundRect(ctx, x, y, w, h, r) {
@@ -1333,8 +1376,15 @@ function drawSkinCell(lp, item, cx, cy, cw, ch, focused, currentColor, hit) {
     gameContext.lineWidth = sel ? 2 : 1;
     gameContext.strokeStyle = sel ? "#ffd34d" : (lock.locked ? "rgba(255,255,255,0.12)" : "rgba(255,255,255,0.2)");
     lhRoundRect(gameContext, cx, cy, cw, ch, 6); gameContext.stroke();
+    // Seasonal-claim cosmetics (rarity:'seasonal') get a distinct GOLD frame so they read as
+    // special/limited in the locker. Skipped when the gold "selected" ring already shows.
+    var raritySkin = (typeof getSkin === "function") ? getSkin(opt.id) : null;
+    if (!sel && raritySkin && raritySkin.rarity === "seasonal") {
+        gameContext.lineWidth = 2; gameContext.strokeStyle = "#ffb31f";
+        lhRoundRect(gameContext, cx, cy, cw, ch, 6); gameContext.stroke();
+    }
     if (focused) { gameContext.strokeStyle = "#fff"; gameContext.lineWidth = 2.5; lhRoundRect(gameContext, cx - 1, cy - 1, cw + 2, ch + 2, 7); gameContext.stroke(); }
-    drawCosmeticPreview(opt, cx + cw / 2, cy + ch * 0.34, ch * 0.22, currentColor, lock.locked);
+    drawCosmeticPreview(opt, cx + cw / 2, cy + ch * 0.34, ch * 0.22, currentColor, lock.locked, { x: cx, y: cy, w: cw, h: ch });
     gameContext.fillStyle = lock.locked ? "rgba(255,255,255,0.5)" : "#fff";
     gameContext.font = "8.5px sans-serif"; gameContext.textAlign = "center"; gameContext.textBaseline = "middle";
     gameContext.fillText(opt.label, cx + cw / 2, cy + ch * 0.74);
@@ -1358,10 +1408,20 @@ function activateSkinItem(lp, item) {
 // colour and greyed when locked. Cart/pattern previews run the real registry painter
 // (pattern over a tinted disc so it reads as "on a body"); trail previews draw a short
 // stroke styled by the effect — so every cell previews close to how it drives.
-function drawCosmeticPreview(opt, cx, cy, r, paint, locked) {
+function drawCosmeticPreview(opt, cx, cy, r, paint, locked, cell) {
     var slot = opt.slot;
     var color = paint || "#cccccc";
     gameContext.save();
+    // Keep TRAIL previews inside their cell — particle trails (smoke/hearts/confetti/ripples)
+    // emit well beyond the synthetic ±40 space and would otherwise spill into neighbouring
+    // cells. Clip to the cell's content box, stopping above the label row (~0.62h). Only trails
+    // overflow; cart/pattern/border previews are discs that already fit, so they're left
+    // unclipped to avoid shaving a pattern disc's bottom edge.
+    if (cell && slot === "trail") {
+        var pad = 2;
+        lhRoundRect(gameContext, cell.x + pad, cell.y + pad, cell.w - pad * 2, cell.h * 0.62 - pad, 5);
+        gameContext.clip();
+    }
     if (locked) { gameContext.globalAlpha = 0.4; }
     if (opt.id == null) {
         // Slot default: a plain disc (cart/pattern) or a plain short stroke (trail).
@@ -1545,6 +1605,14 @@ function cartSkinUnlock(id, lp) {
         if (lvl >= skin.unlock.level) { return { locked: false }; }
         return { locked: true, text: "Lv " + skin.unlock.level };
     }
+    if (skin.unlock.kind === "seasonal") {
+        // Claimed seasonal cosmetics live in unlocked_skins (permanent). If not owned, show
+        // whether it's still claimable (sign in during the window) or gone for good.
+        var owns = !!(prog && prog.unlocked_skins && prog.unlocked_skins.indexOf(id) !== -1);
+        if (owns) { return { locked: false }; }
+        var open = (typeof isClaimWindowOpen === "function") && isClaimWindowOpen(skin.unlock, Date.now());
+        return { locked: true, text: open ? "Sign in to claim" : "Expired" };
+    }
     if (skin.unlock.kind !== "achievement") { return { locked: true, text: "?" }; }
     var owned = !!(prog && prog.unlocked_skins && prog.unlocked_skins.indexOf(id) !== -1);
     return owned ? { locked: false } : { locked: true, text: "🏆" };
@@ -1584,6 +1652,12 @@ function flagCosmeticRejected(slot, payload) {
         msg = "Unlock at Lv " + payload.required;
     } else if (payload && payload.reason === "achievement") {
         msg = "Earn the medal to unlock";
+    } else if (payload && payload.reason === "seasonal") {
+        // Seasonal claim the player never claimed in its window. Match the locker's own wording:
+        // still claimable -> "Sign in to claim"; window closed -> "Expired".
+        var sUnlock = (typeof getSkin === "function" && payload.id) ? (getSkin(payload.id) || {}).unlock : null;
+        var stillOpen = !!(sUnlock && typeof isClaimWindowOpen === "function" && isClaimWindowOpen(sUnlock, Date.now()));
+        msg = stillOpen ? "Sign in to claim" : "Expired";
     }
     lp._cartLockMsg = msg;
     lp._cartLockAt = Date.now();

--- a/client/scripts/skinRegistry.js
+++ b/client/scripts/skinRegistry.js
@@ -104,6 +104,13 @@ var SKINS = [
     { id: 'notes', name: 'Music Notes', slot: 'trail', rarity: 'uncommon', unlock: { kind: 'level', level: 92 }, effect: 'notes' },
     { id: 'neon', name: 'Neon Wall', slot: 'trail', rarity: 'epic', unlock: { kind: 'achievement' }, effect: 'neon' },
     { id: 'ripple', name: 'Ripples', slot: 'trail', rarity: 'rare', unlock: { kind: 'achievement' }, effect: 'ripple' },
+    // --- Seasonal claims (kind:'seasonal') — claimed once on sign-in during the window, then
+    // owned forever (in unlocked_skins, like an achievement skin). rarity:'seasonal' draws a
+    // distinct gold cell frame in the locker. `unlock.label` is the season's player-facing name,
+    // read by the lobby banner + claim toast (so a future season needs NO code edit — just a new
+    // entry). The 'founder gold' palette lives in the painter (drawFoundersFlareTrail,
+    // trailEffects.js). Keep IN LOCKSTEP with server/skinRegistry.js. ---
+    { id: 'founders_flare', name: 'Solar Flare', slot: 'trail', rarity: 'seasonal', unlock: { kind: 'seasonal', season: 'early_adopter_2026', label: 'Early Adopter', claimStart: '2026-06-01T00:00:00Z', claimEnd: '2026-08-01T00:00:00Z' }, effect: 'foundersFlare' },
     // --- Borders (rim cosmetic; painter tints to player color, drawn AROUND the rim). SHARE the
     // 2nd cosmetic slot with patterns (player.pattern field / selected_pattern column) — distinguished
     // by slot:'border'. ids are border_-prefixed because flames/scales/electric collide with pattern
@@ -177,4 +184,30 @@ function getSkinsForSlot(slot) {
 function skinDisplayName(id) {
     var s = getSkin(id);
     return s ? s.name : id;
+}
+// True if a seasonal-claim window is open at `now` (epoch ms). Mirrors the server's
+// isClaimWindowOpen so the lobby lock UI + claim banner read the SAME rule the server
+// grants on. Missing/invalid bounds read as closed.
+function isClaimWindowOpen(unlock, now) {
+    if (!unlock || unlock.kind !== 'seasonal') { return false; }
+    var start = Date.parse(unlock.claimStart);
+    var end = Date.parse(unlock.claimEnd);
+    if (isNaN(start) || isNaN(end)) { return false; }
+    return now >= start && now < end;
+}
+// Every seasonal cosmetic whose claim window is open right now — mirrors the server's
+// currentSeasonalClaims (which GRANTS all of them), so the lobby can reason about more than
+// one simultaneously-open season instead of seeing only the first.
+function currentSeasonalClaims(now) {
+    var out = [];
+    for (var i = 0; i < SKINS.length; i++) {
+        if (isClaimWindowOpen(SKINS[i].unlock, now)) { out.push(SKINS[i]); }
+    }
+    return out;
+}
+// The first seasonal cosmetic whose window is open right now (or null) — convenience for the
+// common single-season case. The banner uses the plural form so it can skip already-claimed ones.
+function currentSeasonalClaim(now) {
+    var open = currentSeasonalClaims(now);
+    return open.length ? open[0] : null;
 }

--- a/client/scripts/trailEffects.js
+++ b/client/scripts/trailEffects.js
@@ -820,6 +820,126 @@ function drawRippleTrail(ctx, verts, color, now, fadeMs, anim) {
   ctx.restore();
 }
 
+// ===========================================================================
+// SEASONAL: Solar Flare — the Early Adopter (Summer 2026) claim trail.
+// ---------------------------------------------------------------------------
+// DESIGN EXCEPTION (iteration knob): every OTHER trail renders in the player's
+// colour (the locked "color rule"). This one BLENDS gold with the player's colour
+// so it reads as a premium founder badge from across the map while still carrying a
+// hint of the player's identity. FOUNDERS_MIX = how far toward gold (0 = pure player
+// colour, 1 = pure gold). FOUNDERS_TAIL_PERSIST > 1 keeps the tail visible longer
+// (slower alpha falloff). FLARE_GOLD / FLARE_HOT are the iteration colours.
+var FOUNDERS_MIX = 0.38;                   // 0 = pure player colour … 1 = pure gold (0.38 = player-colour-dominant, gold-kissed)
+var FOUNDERS_TAIL_PERSIST = 1.6;           // >1 = tail fades out more slowly so the flare reads longer
+var FLARE_GOLD = '#ffae1f';               // molten body / embers
+var FLARE_HOT = '#fff3c8';               // white-hot core + specular
+// Blend the player's colour toward FLARE_GOLD by FOUNDERS_MIX, returning an "rgb()" string.
+// Memoised per player colour (one parse + one blend per colour, then zero-alloc) so the body
+// fill / embers / head can all reuse it cheaply each frame.
+var _foundersBlend = {};
+function foundersGold(color) {
+  var k = color + '|' + FOUNDERS_MIX;
+  var s = _foundersBlend[k];
+  if (s != null) return s;
+  var pc = tfxRGB(color), gc = tfxRGB(FLARE_GOLD), m = FOUNDERS_MIX;
+  s = "rgb(" + Math.round(pc.r + (gc.r - pc.r) * m) + "," +
+    Math.round(pc.g + (gc.g - pc.g) * m) + "," +
+    Math.round(pc.b + (gc.b - pc.b) * m) + ")";
+  _foundersBlend[k] = s; return s;
+}
+// A radiant, sun-like flare: a tapered molten-gold ribbon body, a white-hot core
+// stroke, drifting ember flecks (deterministic per vertex), and a glowing head blob.
+// Structure mirrors drawCometTrail (sampled-vertex ribbon) so perf/feel match the set.
+function drawFoundersFlareTrail(ctx, verts, color, now, fadeMs, anim) {
+  var n = verts.length;
+  if (n < 2) return;
+  var gold = foundersGold(color); // gold blended with the player's colour
+  // Slow the age-fade so the tail stays lit toward the buffer's end (reads as a longer flare).
+  // Geometry still spans the real buffer; this only softens how fast each segment dims out.
+  var fadeEff = fadeMs * TP('founders_flare', 'TAIL_PERSIST', FOUNDERS_TAIL_PERSIST);
+  var WIDTH = TP('founders_flare', 'WIDTH', 24), GLOW = TP('founders_flare', 'GLOW', 26), TAPER = TP('founders_flare', 'TAPER', 0.75);
+  var stride = Math.max(1, Math.floor(n / 50));
+  var idx = [];
+  for (var i = 0; i < n; i += stride) idx.push(i);
+  if (idx[idx.length - 1] !== n - 1) idx.push(n - 1);
+  var m = idx.length;
+  var hw = new Array(m), nx = new Array(m), ny = new Array(m), af = new Array(m);
+  for (var j = 0; j < m; j++) {
+    var ii = idx[j];
+    var f = tfxAgeAlpha(verts[ii].t, now, fadeEff);
+    af[j] = f;
+    // Flicker the half-width slightly so the flare licks like fire (anim-driven, vertex-stable).
+    var flick = 0.85 + 0.15 * Math.sin(anim * 0.012 + verts[ii].t * 0.02);
+    hw[j] = (WIDTH * 0.5) * Math.pow(f, TAPER) * flick;
+    var tan = tfxTangent(verts, ii);
+    nx[j] = -tan.y; ny[j] = tan.x;
+  }
+  ctx.save();
+  if (tfxGlow()) { ctx.shadowColor = gold; ctx.shadowBlur = GLOW; }
+  ctx.lineJoin = "round";
+  ctx.fillStyle = gold;
+  // Molten body ribbon.
+  for (var s = 1; s < m; s++) {
+    var alpha = af[s] * 0.55;
+    if (alpha <= 0.02) continue;
+    var p0 = verts[idx[s - 1]], p1 = verts[idx[s]];
+    tfxAlpha(ctx, alpha);
+    ctx.beginPath();
+    ctx.moveTo(p0.x + nx[s - 1] * hw[s - 1], p0.y + ny[s - 1] * hw[s - 1]);
+    ctx.lineTo(p1.x + nx[s] * hw[s], p1.y + ny[s] * hw[s]);
+    ctx.lineTo(p1.x - nx[s] * hw[s], p1.y - ny[s] * hw[s]);
+    ctx.lineTo(p0.x - nx[s - 1] * hw[s - 1], p0.y - ny[s - 1] * hw[s - 1]);
+    ctx.closePath();
+    ctx.fill();
+  }
+  // White-hot inner core.
+  if (tfxGlow()) ctx.shadowBlur = GLOW * 0.45;
+  var coreStart = -1;
+  for (var c = 0; c < m; c++) { if (af[c] > 0.3) { coreStart = c; break; } }
+  if (coreStart >= 0 && coreStart < m - 1) {
+    tfxAlpha(ctx, 0.9);
+    ctx.strokeStyle = FLARE_HOT;
+    ctx.lineCap = "round";
+    ctx.lineWidth = Math.max(0.9, WIDTH * 0.16);
+    ctx.beginPath();
+    ctx.moveTo(verts[idx[coreStart]].x, verts[idx[coreStart]].y);
+    for (var cc = coreStart + 1; cc < m; cc++) ctx.lineTo(verts[idx[cc]].x, verts[idx[cc]].y);
+    ctx.stroke();
+  }
+  // Drifting ember flecks — deterministic per vertex (tfxHash), rising as they age.
+  ctx.fillStyle = gold;
+  for (var e = 1; e < m; e += 1) {
+    var fe = af[e];
+    if (fe <= 0.05) continue;
+    var h1 = tfxHash(verts[idx[e]].t);
+    if (h1 < 0.45) continue; // sparse — only some segments spit an ember
+    var age = 1 - fe;
+    var ev = verts[idx[e]];
+    var perp = (h1 - 0.5) * WIDTH * 1.6;
+    var rise = age * WIDTH * 1.1;
+    var ex = ev.x + nx[e] * perp;
+    var ey = ev.y + ny[e] * perp - rise;
+    var twinkle = 0.5 + 0.5 * Math.sin(anim * 0.02 + h1 * 31.0);
+    tfxAlpha(ctx, fe * twinkle * 0.9);
+    var er = Math.max(0.6, (1.8 * fe) * (0.6 + 0.4 * h1));
+    ctx.beginPath(); ctx.arc(ex, ey, er, 0, TFX_TAU); ctx.fill();
+  }
+  // Radiant head — bright sun-like blob.
+  var head = verts[n - 1];
+  var R = WIDTH * 1.0;
+  tfxAlpha(ctx, 1);
+  if (tfxGlow()) ctx.shadowBlur = 0;
+  ctx.save();
+  ctx.translate(head.x, head.y); ctx.scale(R, R);
+  ctx.fillStyle = tfxBlobGrad(ctx, gold);
+  ctx.beginPath(); ctx.arc(0, 0, 1, 0, TFX_TAU); ctx.fill();
+  ctx.restore();
+  // Hot pinpoint at the very head.
+  tfxAlpha(ctx, 0.95); ctx.fillStyle = FLARE_HOT;
+  ctx.beginPath(); ctx.arc(head.x, head.y, Math.max(1.2, WIDTH * 0.1), 0, TFX_TAU); ctx.fill();
+  ctx.restore();
+}
+
 /* ============================================================================
  * WIRING — how the main session ports these into draw.js drawTrail()
  * ----------------------------------------------------------------------------
@@ -875,5 +995,6 @@ var TRAIL_FX = {
   survivor: drawSurvivorTrail, ribbon: drawRibbonTrail, bolt: drawBoltTrail,
   hearts: drawHeartsTrail, smoke: drawSmokeTrail, confetti: drawConfettiTrail,
   snow: drawSnowTrail, tracks: drawTracksTrail, notes: drawNotesTrail,
-  neon: drawNeonTrail, ripple: drawRippleTrail
+  neon: drawNeonTrail, ripple: drawRippleTrail,
+  foundersFlare: drawFoundersFlareTrail
 };

--- a/server/auth.js
+++ b/server/auth.js
@@ -350,42 +350,91 @@ async function saveCosmetic(userId, slot, id) {
     }
 }
 
-// Apply a match's XP / medal / win deltas to a user's progression row and persist.
-// Behind the global writes gate (ALLOW_SUPABASE_WRITES) like every other writer —
-// a no-op locally so dev never seeds the shared DB. Re-reads the row so the stored
-// value is authoritative (not the caller's possibly-stale cache), recomputes level
-// + achievement unlocks via the pure progression helpers, and writes the whole
-// columns back. Returns the new normalized row (so the caller can emit it), or null
-// when writes are gated/disabled.
+// Shared optimistic-concurrency writer for the single-row `progression` table. Reads the row
+// (selectCols), lets `computeFn(existingDataOrNull, rowExists)` derive the new column values,
+// then writes them CONDITIONED on updated_at being unchanged since the read — retrying on a
+// concurrent write (0 rows updated) or an insert race (23505) up to 5 times. Centralises the
+// subtle CAS/insert-race protocol so addProgression and grantSeasonalClaims can't drift apart.
 //
-// Not atomic (read-modify-write) — but a user only finishes one match at a time, so
-// contention is effectively nil; matches the same pragmatic stance as
-// ensureProgressionRow. The fully-atomic fix is a Postgres RPC if this ever races.
-async function addProgression(userId, opts) {
-    opts = opts || {};
+// computeFn must return either:
+//   null                 -> nothing to write; the helper returns null (a no-op).
+//   { payload, result }  -> `payload` (must include user_id + updated_at) is written; `result`
+//                           is returned to the caller on a successful write.
+// computeFn is re-invoked with freshly-read data on every retry, so derived totals are always
+// computed against the latest row. Returns the chosen `result`, or null when gated/aborted/failed.
+async function casUpdateProgression(userId, selectCols, computeFn) {
     if (!writesEnabled || !userId || !supabase) {
         return null;
     }
-    // Compare-and-swap retry: read the row (incl. updated_at), compute the derived totals
-    // in JS, then write CONDITIONED on updated_at being unchanged. If the same account
-    // finished concurrently (two tabs/devices) and wrote in between, the conditional update
-    // touches 0 rows and we retry against fresh values — so XP/medals/wins/unlocks/toasts are
-    // never silently discarded by a last-writer-wins upsert.
     var MAX_ATTEMPTS = 5;
     try {
         for (var attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
             var existing = await supabase
                 .from('progression')
-                .select('xp, level, unlocked_skins, medal_counts, wins, pending_toasts, unlock_dates, updated_at')
+                .select(selectCols)
                 .eq('user_id', userId)
                 .maybeSingle();
             if (existing.error) {
-                console.log('[auth] addProgression select failed:', existing.error.message);
+                console.log('[auth] casUpdateProgression select failed:', existing.error.message);
                 return null;
             }
             var rowExists = !!existing.data;
-            var oldUpdatedAt = rowExists ? existing.data.updated_at : null;
-            var cur = normalizeProgression(existing.data || {});
+            var computed = computeFn(existing.data || null, rowExists);
+            if (!computed) {
+                return null; // computeFn decided there's nothing to write
+            }
+            if (rowExists) {
+                // CAS: only succeeds if no one else wrote since our read.
+                var upd = await supabase
+                    .from('progression')
+                    .update(computed.payload)
+                    .eq('user_id', userId)
+                    .eq('updated_at', existing.data.updated_at)
+                    .select('user_id');
+                if (upd.error) {
+                    console.log('[auth] casUpdateProgression update failed:', upd.error.message);
+                    return null;
+                }
+                if (upd.data && upd.data.length > 0) {
+                    return computed.result;
+                }
+                // 0 rows updated -> a concurrent writer moved updated_at; retry against fresh values.
+            } else {
+                var ins = await supabase
+                    .from('progression')
+                    .insert(computed.payload)
+                    .select('user_id');
+                if (!ins.error) {
+                    return computed.result;
+                }
+                // Unique-violation -> someone inserted the row first; retry as an update.
+                if (ins.error.code === '23505' || /duplicate|unique/i.test(ins.error.message || '')) {
+                    continue;
+                }
+                console.log('[auth] casUpdateProgression insert failed:', ins.error.message);
+                return null;
+            }
+        }
+        console.log('[auth] casUpdateProgression: gave up after', MAX_ATTEMPTS, 'contended attempts for', userId);
+        return null;
+    } catch (e) {
+        console.log('[auth] casUpdateProgression error:', e.message);
+        return null;
+    }
+}
+
+// Apply a match's XP / medal / win deltas to a user's progression row and persist. Behind the
+// global writes gate (ALLOW_SUPABASE_WRITES) like every other writer — a no-op locally so dev
+// never seeds the shared DB. Recomputes level + achievement unlocks via the pure progression
+// helpers against the freshly-read row (CAS-guarded by casUpdateProgression). Returns the new
+// normalized row (so the caller can emit it) + newToasts, or null when writes are gated/disabled.
+async function addProgression(userId, opts) {
+    opts = opts || {};
+    return casUpdateProgression(
+        userId,
+        'xp, level, unlocked_skins, medal_counts, wins, pending_toasts, unlock_dates, updated_at',
+        function (existingData) {
+            var cur = normalizeProgression(existingData || {});
             var oldLevel = cur.level;
             var newXp = cur.xp + (opts.xpDelta || 0);
             var newWins = cur.wins + (opts.win ? 1 : 0);
@@ -408,8 +457,8 @@ async function addProgression(userId, opts) {
                 levelSkinsUnlocked: skinRegistry.levelSkinsUnlockedBetween,
                 freshAchievementSkins: freshAchievementSkins
             });
-            var existingToasts = (existing.data && Array.isArray(existing.data.pending_toasts))
-                ? existing.data.pending_toasts : [];
+            var existingToasts = (existingData && Array.isArray(existingData.pending_toasts))
+                ? existingData.pending_toasts : [];
             var mergedToasts = existingToasts.concat(newToasts);
             // Stamp the first-unlock date for every cosmetic newly earned this match (level
             // skins + achievement skins). Never overwrite an existing date. Analytics only.
@@ -432,48 +481,63 @@ async function addProgression(userId, opts) {
                 unlock_dates: unlockDates,
                 updated_at: new Date().toISOString()
             };
-            if (rowExists) {
-                // CAS: only succeeds if no one else wrote since our read.
-                var upd = await supabase
-                    .from('progression')
-                    .update(payload)
-                    .eq('user_id', userId)
-                    .eq('updated_at', oldUpdatedAt)
-                    .select('user_id');
-                if (upd.error) {
-                    console.log('[auth] addProgression update failed:', upd.error.message);
-                    return null;
-                }
-                if (upd.data && upd.data.length > 0) {
-                    var out = normalizeProgression(payload);
-                    out.newToasts = newToasts; // durable copy is in pending_toasts
-                    return out;
-                }
-                // 0 rows updated -> a concurrent writer moved updated_at; retry.
-            } else {
-                var ins = await supabase
-                    .from('progression')
-                    .insert(payload)
-                    .select('user_id');
-                if (!ins.error) {
-                    var outIns = normalizeProgression(payload);
-                    outIns.newToasts = newToasts;
-                    return outIns;
-                }
-                // Unique-violation -> someone inserted the row first; retry as an update.
-                if (ins.error.code === '23505' || /duplicate|unique/i.test(ins.error.message || '')) {
-                    continue;
-                }
-                console.log('[auth] addProgression insert failed:', ins.error.message);
-                return null;
-            }
+            var out = normalizeProgression(payload);
+            out.newToasts = newToasts; // durable copy is in pending_toasts
+            return { payload: payload, result: out };
         }
-        console.log('[auth] addProgression: gave up after', MAX_ATTEMPTS, 'contended attempts for', userId);
-        return null;
-    } catch (e) {
-        console.log('[auth] addProgression error:', e.message);
+    );
+}
+
+// Grant any OPEN seasonal-claim cosmetics (skinRegistry kind:'seasonal' whose window is
+// live) to a signed-in user, ONCE. The id lands in unlocked_skins — permanent ownership,
+// identical to an achievement skin — and a {type:'seasonal'} celebration toast is queued so
+// the claim is announced on the player's next lobby arrival. Idempotent: an id already owned
+// is skipped, so repeat sign-ins never re-toast. After a window's claimEnd the registry
+// returns it no longer, so the grant simply stops — nothing is ever revoked. Behind the global
+// writes gate, CAS-guarded against a concurrent match-end write (both via casUpdateProgression).
+// Returns the array of newly granted ids (possibly empty), or null when writes are gated/disabled.
+async function grantSeasonalClaims(userId) {
+    if (!writesEnabled || !userId || !supabase) {
         return null;
     }
+    var open = skinRegistry.currentSeasonalClaims(Date.now());
+    if (!open.length) {
+        return [];
+    }
+    var granted = await casUpdateProgression(
+        userId,
+        'unlocked_skins, unlock_dates, pending_toasts, updated_at',
+        function (existingData) {
+            var unlocked = (existingData && Array.isArray(existingData.unlocked_skins))
+                ? existingData.unlocked_skins.slice() : [];
+            var fresh = [];
+            for (var i = 0; i < open.length; i++) {
+                if (unlocked.indexOf(open[i]) === -1) { unlocked.push(open[i]); fresh.push(open[i]); }
+            }
+            if (!fresh.length) {
+                return null; // already claimed everything currently open — nothing to write
+            }
+            var unlockDates = (existingData && existingData.unlock_dates && typeof existingData.unlock_dates === 'object')
+                ? Object.assign({}, existingData.unlock_dates) : {};
+            var nowIso = new Date().toISOString();
+            var claimToasts = [];
+            for (var g = 0; g < fresh.length; g++) {
+                if (!unlockDates[fresh[g]]) { unlockDates[fresh[g]] = nowIso; }
+                claimToasts.push({ type: 'seasonal', id: fresh[g] });
+            }
+            var existingToasts = (existingData && Array.isArray(existingData.pending_toasts))
+                ? existingData.pending_toasts : [];
+            var payload = {
+                user_id: userId,
+                unlocked_skins: unlocked,
+                unlock_dates: unlockDates,
+                pending_toasts: existingToasts.concat(claimToasts),
+                updated_at: new Date().toISOString()
+            };
+            return { payload: payload, result: fresh };
+        }
+    );
+    return granted || []; // casUpdateProgression returns null on abort/failure; callers expect an array
 }
 
 // Read and CLEAR a user's pending celebration toasts (shown on lobby arrival).
@@ -563,6 +627,7 @@ exports.ensureProgressionRow = ensureProgressionRow;
 exports.getProgression = getProgression;
 exports.addProgression = addProgression;
 exports.saveCosmetic = saveCosmetic;
+exports.grantSeasonalClaims = grantSeasonalClaims;
 exports.drainPendingToasts = drainPendingToasts;
 exports.getDisplayName = getDisplayName;
 // Public, browser-safe config to inject into served pages. Returns null unless

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -36,6 +36,15 @@ function persistCosmetic(userId, slot, id) {
 	});
 }
 
+// Unlock kinds whose ownership is recorded PERMANENTLY in progression.unlocked_skins once
+// earned: achievement medals and seasonal claims (and any future grant-based kind — gift/paid/
+// event cosmetics). Both gate the same way: equippable iff the id is in unlocked_skins. Keeping
+// this in one predicate (consulted by cosmeticUnlocked + the setCosmetic handler) means a new
+// such kind only has to be added here, not in two switch arms that could drift apart.
+function unlockIsOwnedKind(kind) {
+	return kind === 'achievement' || kind === 'seasonal';
+}
+
 // Returns true if a player with the given progression row qualifies to equip `id`
 // (exists, belongs to `slot`, and the level/achievement unlock is met). Shared by the
 // restore path; the live setCosmetic handler inlines the same checks (it also emits
@@ -51,7 +60,7 @@ function cosmeticUnlocked(prog, slot, id) {
 	if (skin.unlock.kind === 'level') {
 		return (prog ? (prog.level || 1) : 1) >= skin.unlock.level;
 	}
-	if (skin.unlock.kind === 'achievement') {
+	if (unlockIsOwnedKind(skin.unlock.kind)) {
 		var unlocked = (prog && Array.isArray(prog.unlocked_skins)) ? prog.unlocked_skins : [];
 		return unlocked.indexOf(id) !== -1;
 	}
@@ -651,10 +660,14 @@ function checkForMail(client) {
 				client.emit("cosmeticRejected", { slot: slot, id: id, reason: "level", required: skin.unlock.level });
 				return;
 			}
-		} else if (skin.unlock.kind === "achievement") {
+		} else if (unlockIsOwnedKind(skin.unlock.kind)) {
+			// Seasonal claims live in unlocked_skins once granted (auth.grantSeasonalClaims),
+			// so ownership is permanent — equippable even after the claim window closes. A player
+			// who never claimed during the window simply never has the id and is rejected here.
+			// reason carries the kind ('achievement' | 'seasonal') so the client can word the lock.
 			var unlocked = (prog && Array.isArray(prog.unlocked_skins)) ? prog.unlocked_skins : [];
 			if (unlocked.indexOf(id) === -1) {
-				client.emit("cosmeticRejected", { slot: slot, id: id, reason: "achievement" });
+				client.emit("cosmeticRejected", { slot: slot, id: id, reason: skin.unlock.kind });
 				return;
 			}
 		} else if (skin.unlock.kind === "open") {
@@ -807,7 +820,13 @@ function loadPlayerProgression(client, player) {
 	}
 	player.progression = progression.defaultProgression();
 	player.progressionLoaded = false;
-	auth.getProgression(client.userId).then(function (row) {
+	// Grant any OPEN seasonal claim (Early Adopter etc.) BEFORE the read, so the row we load
+	// already reflects the new unlock and the queued claim toast is in pending_toasts for the
+	// drain at the end of the chain. No-op for guests / writes-off / outside any window; never
+	// blocks the load (a grant failure still falls through to getProgression).
+	Promise.resolve(auth.grantSeasonalClaims(client.userId)).catch(function () { return null; }).then(function () {
+		return auth.getProgression(client.userId);
+	}).then(function (row) {
 		var prog = row || progression.defaultProgression();
 		player.progression = prog;
 		player.progressionLoaded = true;
@@ -826,14 +845,17 @@ function loadPlayerProgression(client, player) {
 		// treating it as still-loading.
 		player.progressionLoaded = true;
 		console.log('[progression] load failed:', e && e.message);
+	}).then(function () {
+		// Drain + deliver pending celebration toasts — chained AFTER the grant resolves so a
+		// just-granted seasonal claim toast is already in pending_toasts (a synchronous drain
+		// here would race the grant's write and miss it). Only when actually arriving in the
+		// lobby: joining a racing/collapsing room mid-match must not overlay rewards during play;
+		// the next startLobby's deliverRoomToasts delivers them at the right moment.
+		var toastRoom = hostess.getRoomBySig(roomMailList[client.id]);
+		if (toastRoom && toastRoom.game && toastRoom.game.currentState === c.stateMap.lobby) {
+			deliverPendingToasts(client);
+		}
 	});
-	// Drain + deliver any celebration toasts earned in a prior match — but ONLY when actually
-	// arriving in the lobby. Joining a racing/collapsing room mid-match must not overlay rewards
-	// during play; the next startLobby's deliverRoomToasts delivers them at the right moment.
-	var toastRoom = hostess.getRoomBySig(roomMailList[client.id]);
-	if (toastRoom && toastRoom.game && toastRoom.game.currentState === c.stateMap.lobby) {
-		deliverPendingToasts(client);
-	}
 }
 // Collect a signed-in client's pending toasts (durable DB queue + dev in-memory
 // queue) and emit them as one ordered `progressionToasts` batch. The client

--- a/server/skinRegistry.js
+++ b/server/skinRegistry.js
@@ -106,6 +106,14 @@ var SKINS = [
     { id: 'notes', slot: 'trail', unlock: { kind: 'level', level: 92 } },
     { id: 'neon', slot: 'trail', unlock: { kind: 'achievement' } },
     { id: 'ripple', slot: 'trail', unlock: { kind: 'achievement' } },
+    // --- Seasonal claims (kind:'seasonal') — granted ONCE on sign-in while the claim window
+    // is open; OWNERSHIP IS PERMANENT (the id lands in unlocked_skins, exactly like an
+    // achievement skin, so it stays equippable forever, even after the window closes). After
+    // claimEnd the grant path simply stops firing, so the cosmetic can never be obtained
+    // again — a true "founder" badge. To add a FUTURE season: append another entry with its
+    // own id + window (no schema/migration change needed). Times are ISO-8601 UTC; keep these
+    // IN LOCKSTEP with client/scripts/skinRegistry.js. ---
+    { id: 'founders_flare', slot: 'trail', unlock: { kind: 'seasonal', season: 'early_adopter_2026', label: 'Early Adopter', claimStart: '2026-06-01T00:00:00Z', claimEnd: '2026-08-01T00:00:00Z' } },
     // --- Borders (rim cosmetic; SHARE the 2nd slot with patterns). border_-prefixed ids
     // (flames/scales/electric collide with pattern ids). All kind:'open' for testing. ---
     { id: 'border_ring', slot: 'border', unlock: { kind: 'level', level: 10 } },
@@ -157,10 +165,34 @@ function levelSkinsUnlockedBetween(oldLevel, newLevel) {
     return out;
 }
 
+// True if `unlock` is a seasonal-claim rule whose window is currently open (claimStart <=
+// now < claimEnd). Missing/invalid bounds read as closed so a malformed entry can't grant
+// forever. `now` is epoch ms (pass Date.now()); injected so callers/tests stay deterministic.
+function isClaimWindowOpen(unlock, now) {
+    if (!unlock || unlock.kind !== 'seasonal') { return false; }
+    var start = Date.parse(unlock.claimStart);
+    var end = Date.parse(unlock.claimEnd);
+    if (isNaN(start) || isNaN(end)) { return false; }
+    return now >= start && now < end;
+}
+
+// Every seasonal cosmetic id whose claim window is open right now — the set a signing-in
+// player should be granted (the grant path then skips any already owned). Empty outside any
+// window. Drives auth.grantSeasonalClaims; future seasons are picked up automatically.
+function currentSeasonalClaims(now) {
+    var out = [];
+    for (var i = 0; i < SKINS.length; i++) {
+        if (isClaimWindowOpen(SKINS[i].unlock, now)) { out.push(SKINS[i].id); }
+    }
+    return out;
+}
+
 module.exports = {
     SLOTS: SLOTS,
     SKINS: SKINS,
     getSkin: getSkin,
     getSkinSlot: getSkinSlot,
-    levelSkinsUnlockedBetween: levelSkinsUnlockedBetween
+    levelSkinsUnlockedBetween: levelSkinsUnlockedBetween,
+    isClaimWindowOpen: isClaimWindowOpen,
+    currentSeasonalClaims: currentSeasonalClaims
 };


### PR DESCRIPTION
## Summary

A reusable **seasonal cosmetic-claim system** plus its first claim — the gold **Solar Flare** trail for early adopters.

**How it works:** a cosmetic with `unlock.kind: 'seasonal'` is granted **once** when a signed-in player loads during its claim window, and is then **owned permanently** — the id lands in `progression.unlocked_skins`, exactly like an achievement skin. So the claim window closing never revokes it from holders; the grant path simply stops firing, making it a true "founder" badge. **No DB migration** — it reuses `unlocked_skins` / `unlock_dates` / `pending_toasts`. Future seasons are one registry entry (id + window + label), no code edits.

First claim: **Solar Flare**, a molten-gold trail (blended with the player's colour) claimable **Jun 1 – Aug 1 2026**.

## What's included
- **Registry** — `founders_flare` trail in both client + server registries (kept in lockstep) + `isClaimWindowOpen` / `currentSeasonalClaims` window helpers.
- **Server** — `grantSeasonalClaims()` on login (behind `ALLOW_SUPABASE_WRITES`); a shared `casUpdateProgression()` helper now backs both `addProgression` and the grant; seasonal equip validation via one `unlockIsOwnedKind()` predicate.
- **Client** — the Solar Flare trail effect; a gold lobby **claim banner** (top banner slot, data-driven copy, days-left countdown, sign-in nudge for guests); the claim **toast**; a gold **locker frame** for `rarity:'seasonal'`; and a fix so particle trail previews stay clipped inside their picker cells.
- **Toasts** — dwell bumped 2.6s → 5s and nudged into the canvas; the queue is flushed at the race gate so a long reward sequence never overlays gameplay. *(Affects all progression toasts, by design.)*

## Testing
- `npm run build`, `smoke-test.js`, and `progression-test.js` all green.
- Banner (guest + signed-in), claim toast, and reordered banner stack verified live in the lobby; trail effect verified in-game.
- Boundary tests added for the claim-window math; client/server registry confirmed in lockstep.
- Self-reviewed via high-effort `/code-review`; all 10 findings fixed in this branch (toast-delivery race, seasonal reject wording, data-driven copy, toast-queue flush, client/server claim parity, gold locker frame, ownership predicate, shared CAS helper, per-frame cache, shared banner helper).

## Operator follow-ups
- Set `ALLOW_SUPABASE_WRITES=true` on Heroku for the grant to persist (it's a no-op locally / with writes off).
- Verify the real grant + toast against a writes-enabled Supabase before relying on it in prod.
- Banner/copy are data-driven from `unlock.label`; tweak freely. The CHANGELOG bullet is intentionally **not** flagged `[headline]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
