### PR TITLE
fix(camera): play the race-start zoom-in intro on the first race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- The start of a race opens on the whole-map overview again and smoothly zooms in on your kart during the countdown, instead of snapping straight to a full close-up.
 
 ## v0.26.4 — 2026-05-31
 

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3921,10 +3921,20 @@ function computeWorldViewTarget(dt) {
         worldGoalEngaged = false;
         return wholeMap;
     }
-    // Advance the focus-phase clock by the (already-clamped) frame dt rather than
-    // wall-clock, so backgrounding the tab pauses the ramp (rAF stops) and the
-    // catch-up frame on refocus can't snap the zoom to the end.
-    worldViewFocusedElapsed += (dt || 16);
+    // Advance the gate-intro clock ONLY while in the gated countdown, and zero it
+    // on every other frame. The lobby/racing/collapsing follow-camera also counts
+    // as "focused", so a single shared clock would keep ticking the whole time you
+    // sit in the lobby — and the first race goes straight lobby -> gated with no
+    // overview to reset it, saturating the ramp below so the camera opens already
+    // fully zoomed instead of easing in from the whole-map overview. Zeroing it
+    // whenever we're not gated makes the intro play on EVERY entry into the gate
+    // (first race out of the lobby, and later rounds out of overview alike).
+    // Frame-dt (already clamped) not wall-clock, so a backgrounded tab pauses it.
+    if (currentState === config.stateMap.gated) {
+        worldViewFocusedElapsed += (dt || 16);
+    } else {
+        worldViewFocusedElapsed = 0;
+    }
     var focusedView = computeFocusedView();
 
     // During the gate countdown, run a slow, eased zoom timed to the countdown:


### PR DESCRIPTION
## What

The race-start camera intro — whole-map overview holding briefly, then smoothly easing down onto your kart over the gate countdown — was being skipped on the **first race out of the lobby**. The camera opened already fully zoomed in, with no intro.

## Root cause

The countdown ramp is driven by `worldViewFocusedElapsed`, which it expects to be ~0 when the `gated` state begins so it can play the full smoothstep from whole-map (scale 1) to focused zoom.

Since commit `6ae3e4d` ("lobby follow-camera on desktop") the **lobby** counts as a "focused" camera state, so that clock accumulated the entire time a player sat in the lobby. The first race transitions **lobby → gated directly** (no `overview` state in between to reset the clock), so by the time `gated` began the ramp's progress `p` was already pinned at `1.0` — instant full zoom, no intro. Later rounds went through `overview` (not focused, so it reset the clock there), which is why it looked intermittent.

## Fix

Advance `worldViewFocusedElapsed` **only** while `currentState === config.stateMap.gated`, and zero it on every other frame. The intro now plays on every entry into the gate — first race out of the lobby and later rounds out of overview alike. The lobby/racing follow-camera is unaffected (it doesn't depend on this clock).

## Testing

- Confirmed in-browser (dev server): first-race intro now opens on the whole-map overview and zooms in over the countdown; later-round intros and the lobby follow-camera still behave correctly.
- `npm run build` — bundles produced OK
- `npm run smoke-test` — passed (real engine ticked 52 maps through waiting→racing→collapsing)
- Codex review — clean, no findings
- CHANGELOG `## Unreleased` entry added (game-mechanic notes gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)