### PR TITLE
balance(punch): buff fully-charged punch knockback (3.0 → 4.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- Fully charged punches now land harder — a maxed charge hits about 50% stronger than before, so committing to the full wind-up pays off, especially from a standstill.
 
 ## v0.27.2 — 2026-06-01
 

--- a/server/config.json
+++ b/server/config.json
@@ -389,7 +389,7 @@
     "punchCharge": {
         "_doc": "Hold-to-charge: holding punch for maxChargeMs reaches a full charge that multiplies the momentum-scaled knockback by maxChargeMult (final force = momentum bonus x charge). Charge is capped by the stamina you can afford. Overcharge: holding past overchargeAfterMs starts a danger phase whose dark-red meter fills over overchargeFillMs; if you don't release in time the charge is wasted and you're locked in the exhausted move-penalty for exhaustLockMs. chargedHitFrac = how full a charge counts as a 'fully charged' hit (drives the thwack SFX).",
         "maxChargeMs": 700,
-        "maxChargeMult": 3.0,
+        "maxChargeMult": 4.5,
         "overchargeAfterMs": 2000,
         "overchargeFillMs": 1500,
         "exhaustLockMs": 3000,


### PR DESCRIPTION
## What

Raises `punchCharge.maxChargeMult` from **3.0 → 4.5** in `server/config.json`.

## Why

Player feedback: *"charged punch doesn't hit hard enough for the commitment."*

A full charge multiplies the momentum-scaled knockback by `maxChargeMult`. At 3.0, a full charge **from a standstill** (momentum at its `floor` of 0.5) landed at `0.5 × 3.0 = 1.5×` force — *softer* than a quick tap while moving (`1.9×`). So the 700 ms wind-up, full stamina drain, velocity brake, and overcharge-lock risk could pay off worse than just tapping.

| Scenario | Before | After |
|---|---|---|
| Quick tap, moving fast | 1.9× | 1.9× (unchanged) |
| Full charge, standing still | 1.5× | **2.25×** |
| Full charge + full momentum | 5.7× | **8.55×** |

Charge time, stamina cost, overcharge timings, and the "charged hit" SFX threshold are all unchanged — only the payoff goes up.

## Intentional side-effect

The charge bonus also feeds **punch-clash** resolution, so a fully-committed charge now wins head-on clashes harder and the standoff/tie window shrinks (recoil 399→598.5, tie tolerance ~0.092→~0.053 at full speed). Confirmed intended — committing to a charge should win clashes too.

## Review / testing

- Codex review: no correctness regressions. `calcPunchBonus()` still caps momentum at 1.9 before the charge multiplier; zombie bites stay isolated at infection radius with bonus 1; overcharge timings unchanged.
- `node .github/scripts/smoke-test.js` ✅ (52 maps)
- `node .github/scripts/punch-rework-test.js` ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)