### PR TITLE
fix(recap): replay punch/hit/reflection FX, candid clip starts, 'Sent Flying!' highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- The end-of-game recap now replays the action it was missing: punch lunges and their shockwaves, landed-hit sparks, parry clashes, and kart reflections on ice all show up in the highlight clips, matching what you saw live.
 
 ## v0.27.3 — 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
+### General
+
+- The end-of-game recap now opens each clip on the action already in motion — like a camera catching the moment — instead of starting from a frozen pose.
+- New recap highlight: when a punch sends a kart flying a long way (sliding across the ice, say), the recap turns it into its own "Sent Flying!" clip.
+
 ### Bug fixes
 
 - The end-of-game recap now replays the action it was missing: punch lunges and their shockwaves, landed-hit sparks, parry clashes, and kart reflections on ice all show up in the highlight clips, matching what you saw live.

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -1058,6 +1058,11 @@ function registerCombatHandlers(server) {
 		if (hitX != null && hitY != null) {
 			var sparkColor = playerList[owner] != null ? playerList[owner].color : "white";
 			spawnHitEffect(hitX, hitY, sparkColor);
+			// Watch a real player victim for a long knockback slide (e.g. flung across
+			// the ice) — the recap turns a big launch into its own highlight clip.
+			if (victimPlayer != null && typeof recapNotePunchLaunch === "function") {
+				recapNotePunchLaunch(victim, hitX, hitY);
+			}
 			// A fully-charged punch landing gets a meaty "thwack" (Smash-style charged
 			// bat) and an extra kick, on top of the normal swing/hit feedback.
 			if (payload != null && payload.charged) {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -4833,6 +4833,11 @@ function spawnPunchEffect(punch) {
             ctx.stroke();
         }
     });
+    // Log it for the end-of-game recap so the punch's shockwave replays in clips
+    // (the recap can't re-run live closures — it redraws from this effect record).
+    if (typeof recapMarkEffect === "function") {
+        recapMarkEffect("punch", px, py, { radius: baseRadius, color: color });
+    }
 }
 
 // Parry "clang" when two punches clash — a bright gold star-burst plus a double
@@ -4876,6 +4881,9 @@ function spawnClashEffect(x, y) {
             ctx.restore();
         }
     });
+    if (typeof recapMarkEffect === "function") {
+        recapMarkEffect("clash", x, y, {});
+    }
 }
 // Burst at the point of contact when a punch connects — a white flash ring
 // plus radiating sparks, so a landed hit has a visible payoff.
@@ -4909,6 +4917,9 @@ function spawnHitEffect(x, y, color) {
             ctx.restore();
         }
     });
+    if (typeof recapMarkEffect === "function") {
+        recapMarkEffect("hit", x, y, { color: color });
+    }
 }
 
 // Teleport flash for the swap ability — an expanding ring plus particles

--- a/client/scripts/recap.js
+++ b/client/scripts/recap.js
@@ -39,6 +39,10 @@ var RECAP_EXIT_FX_MS = 750;    // how long a death/goal poof lingers before the 
 var RECAP_EXPLOSION_MS = 430;  // explosion effect lifetime (matches spawnExplosion's maxAge)
 var RECAP_MUZZLE_MS = 160;     // muzzle-flash lifetime (matches spawnMuzzleFlash's maxAge)
 var RECAP_SHOCKWAVE_MS = 1100; // one collapse-shockwave ring pass (600px/s out to ~650px)
+var RECAP_PUNCH_MS = 220;      // punch shockwave lifetime (matches spawnPunchEffect's maxAge)
+var RECAP_HIT_MS = 220;        // landed-hit ring lifetime (matches spawnHitEffect's maxAge)
+var RECAP_CLASH_MS = 320;      // parry clash lifetime (matches spawnClashEffect's maxAge)
+var RECAP_PUNCH_ANIM_MS = 220; // cart-skin punch lunge window (matches drawCartSkin's /220)
 var RECAP_MAP_SNAP_MS = 450;   // min gap between dynamic-map snapshots (explosion/swap, slow racing changes)
 var RECAP_MAP_SNAP_COLLAPSE_MS = 110; // finer gap while collapsing — lava grows every tick, and a 450ms
                                // gap left the killing lava up to ~half a second behind the death frame
@@ -48,9 +52,10 @@ var RECAP_MAP_MAX = 48;        // cap rolling map snapshots per round (downscale
                                // hold a finely-sampled collapse window without evicting the pre-collapse
                                // baseline that earlier (racing) clips render from
 
-// per-player frame tuple: [id, x, y, angle, velX, velY, state, onFire, ability, infected, emote, speedFx]
-// emote = active emoji string or null; speedFx = 0 none / 1 buff / 2 debuff
-var RF_ID = 0, RF_X = 1, RF_Y = 2, RF_ANGLE = 3, RF_VX = 4, RF_VY = 5, RF_STATE = 6, RF_FIRE = 7, RF_ABILITY = 8, RF_INFECTED = 9, RF_EMOTE = 10, RF_SPEEDFX = 11;
+// per-player frame tuple: [id, x, y, angle, velX, velY, state, onFire, ability, infected, emote, speedFx, punchAge]
+// emote = active emoji string or null; speedFx = 0 none / 1 buff / 2 debuff;
+// punchAge = ms since this kart threw its melee punch (drives the cart-skin lunge), or -1 if not punching
+var RF_ID = 0, RF_X = 1, RF_Y = 2, RF_ANGLE = 3, RF_VX = 4, RF_VY = 5, RF_STATE = 6, RF_FIRE = 7, RF_ABILITY = 8, RF_INFECTED = 9, RF_EMOTE = 10, RF_SPEEDFX = 11, RF_PUNCH = 12;
 // per-frame screen-effect flag bit (blindfold ability — shown as a corner badge, not rendered)
 var RFX_BLIND = 1;
 // projectile tuple: [type, x, y, color, radius]; hazard tuple: [id, x, y, angle, railX, railY]
@@ -90,6 +95,8 @@ var recapMeta = {};            // id -> { color, radius, name }; survives player
 var recapMaps = [];            // [{ t, image, pad, world, scale }] time-stamped map snapshots (dynamic map state)
 var recapMapDirty = false;     // a map-mutating event fired -> take a fresh snapshot soon
 var recapLastMapSnap = 0;      // throttle clock for map snapshots
+var recapIceCells = [];        // [[{x,y},...], ...] this round's ice-tile polygons (world coords), captured
+                               // at race start (clean map) so the replay can cast the same ice reflections
 // --- cross-round archive --------------------------------------------------
 var recapArchive = [];         // [{ title, type, priority, ids, frames, map, exits }] harvested clips
 // --- playback state -------------------------------------------------------
@@ -110,6 +117,10 @@ function recapReset() {
 	recapMaps = [];
 	recapMapDirty = false;
 	recapLastMapSnap = 0;
+	// Snapshot the ice footprint now, while the map is still clean — collapse later
+	// overwrites ice cells to lava (cell.id changes), so harvesting it at round end
+	// would miss them. Static for the round, so one capture covers every clip.
+	recapIceCells = recapCaptureIceCells();
 	if (typeof playerList !== "undefined" && playerList != null) {
 		for (var id in playerList) {
 			if (playerList[id] != null) {
@@ -117,6 +128,24 @@ function recapReset() {
 			}
 		}
 	}
+}
+
+// Collect this round's ice-tile polygons (world-coord vertex rings) from the live
+// map, reusing the terrainfx vertex helper so the footprint matches the rendered
+// terrain exactly. Returns [] if anything's unavailable (the reflection then no-ops).
+function recapCaptureIceCells() {
+	var out = [];
+	if (typeof currentMap === "undefined" || currentMap == null || currentMap.cells == null) { return out; }
+	if (typeof config === "undefined" || config == null || config.tileMap == null || config.tileMap.ice == null) { return out; }
+	if (typeof tfxCellVerts !== "function") { return out; }
+	var iceId = config.tileMap.ice.id;
+	for (var i = 0; i < currentMap.cells.length; i++) {
+		var cell = currentMap.cells[i];
+		if (cell == null || cell.id !== iceId) { continue; }
+		var verts = tfxCellVerts(cell);
+		if (verts && verts.length > 0) { out.push(verts); }
+	}
+	return out;
 }
 
 // Clear EVERYTHING for a brand-new match (called when the lobby/waiting screen
@@ -164,9 +193,13 @@ function recapCaptureFrame() {
 		var emote = (p.chatMessage != null)
 			? [p.chatMessage, now - (p.chatMessageAt || now), p.chatMessageDuration || 4000]
 			: null;
+		// Punch lunge: store how long ago this kart swung (drawCartSkin animates the
+		// forward lunge over RECAP_PUNCH_ANIM_MS). -1 once the window has passed.
+		var punchAge = (p.punchAnimAt != null) ? (now - p.punchAnimAt) : -1;
+		if (punchAge < 0 || punchAge >= RECAP_PUNCH_ANIM_MS) { punchAge = -1; }
 		players.push([p.id, p.x, p.y, p.angle, p.velX, p.velY, state,
 			(p.onFire != null ? p.onFire : 0), (p.ability != null ? p.ability : null), p.infected === true,
-			emote, speedFx]);
+			emote, speedFx, punchAge]);
 		// Keep the static per-player look so a clip can render even after the live
 		// playerList drops bots at the gameOver->waiting transition.
 		recapMeta[p.id] = {
@@ -449,6 +482,7 @@ function recapHarvestRound() {
 			brutal: brutal,
 			blind: recapBlindInFrames(frames),
 			effects: recapSliceEffects(startT, startT + RECAP_CLIP_MS),
+			ice: recapIceCells,
 			exits: recapComputeExits(frames)
 		});
 		takenTimes.push(mk.t);
@@ -462,7 +496,7 @@ function recapHarvestRound() {
 			recapArchive.push({
 				title: "Final Moments", type: "tail", priority: 0, ids: [],
 				frames: tailFrames, maps: recapMapsForWindow(endT - RECAP_CLIP_MS, endT), brutal: brutal,
-				blind: recapBlindInFrames(tailFrames),
+				blind: recapBlindInFrames(tailFrames), ice: recapIceCells,
 				effects: recapSliceEffects(endT - RECAP_CLIP_MS, endT), exits: recapComputeExits(tailFrames)
 			});
 		}
@@ -882,6 +916,9 @@ function recapRenderClip(item, winX, winY, winW, winH) {
 			for (var h = 0; h < frame.hazards.length; h++) { recapDrawHazard(frame.hazards[h]); }
 		}
 		recapDrawTrails(item, frameT);
+		// Ice reflections sit OVER the terrain and UNDER the karts (matches the live
+		// drawTerrainFX order), so cast them before drawing the karts themselves.
+		recapDrawIceReflections(item, frame);
 		for (var i = 0; i < frame.players.length; i++) {
 			recapDrawCar(frame.players[i], item.exits, frameT);
 		}
@@ -1040,7 +1077,155 @@ function recapDrawEffect(ef, frameT) {
 		if (age <= RECAP_SHOCKWAVE_MS) {
 			recapDrawShockwave(ef.x, ef.y, age / RECAP_SHOCKWAVE_MS);
 		}
+	} else if (ef.type === "punch") {
+		if (age <= RECAP_PUNCH_MS) {
+			recapDrawPunch(ef.x, ef.y, ef.params.radius || 24, ef.params.color || "white", age / RECAP_PUNCH_MS);
+		}
+	} else if (ef.type === "hit") {
+		if (age <= RECAP_HIT_MS) {
+			recapDrawHit(ef.x, ef.y, ef.params.color || "white", age / RECAP_HIT_MS);
+		}
+	} else if (ef.type === "clash") {
+		if (age <= RECAP_CLASH_MS) {
+			recapDrawClash(ef.x, ef.y, age / RECAP_CLASH_MS);
+		}
 	}
+}
+
+// Punch shockwave: an impact pop + expanding ring. Mirrors draw.js spawnPunchEffect
+// (the omnidirectional radial burst); t is 0..1 over its lifetime.
+function recapDrawPunch(x, y, baseRadius, color, t) {
+	var grow = 1 - Math.pow(1 - t, 3); // easeOutCubic
+	gameContext.save();
+	gameContext.lineCap = "round";
+	gameContext.globalAlpha = (1 - t) * 0.5;
+	gameContext.fillStyle = color;
+	gameContext.beginPath();
+	gameContext.arc(x, y, baseRadius * (0.55 + 0.75 * grow), 0, 2 * Math.PI);
+	gameContext.fill();
+	gameContext.globalAlpha = (1 - t);
+	gameContext.lineWidth = 2 * (1 - t) + 1;
+	gameContext.strokeStyle = color;
+	gameContext.beginPath();
+	gameContext.arc(x, y, baseRadius * (0.8 + 0.8 * grow), 0, 2 * Math.PI);
+	gameContext.stroke();
+	gameContext.restore();
+	gameContext.globalAlpha = 1;
+}
+
+// Landed-hit burst: a white flash ring + radiating sparks. Mirrors draw.js
+// spawnHitEffect; t is 0..1 over its lifetime.
+function recapDrawHit(x, y, color, t) {
+	var p = 1 - Math.pow(1 - t, 3); // easeOutCubic
+	gameContext.save();
+	gameContext.translate(x, y);
+	gameContext.lineCap = "round";
+	gameContext.globalAlpha = (1 - t);
+	gameContext.strokeStyle = "white";
+	gameContext.lineWidth = 3 * (1 - t) + 1;
+	gameContext.beginPath();
+	gameContext.arc(0, 0, 6 + 22 * p, 0, 2 * Math.PI);
+	gameContext.stroke();
+	gameContext.strokeStyle = color || "white";
+	gameContext.lineWidth = 2 * (1 - t) + 1;
+	for (var i = 0; i < 6; i++) {
+		var a = (i / 6) * Math.PI * 2 + 0.3;
+		var r0 = 2.8 + 8.4 * p;
+		var r1 = 8.4 + 18.2 * p;
+		gameContext.beginPath();
+		gameContext.moveTo(Math.cos(a) * r0, Math.sin(a) * r0);
+		gameContext.lineTo(Math.cos(a) * r1, Math.sin(a) * r1);
+		gameContext.stroke();
+	}
+	gameContext.restore();
+	gameContext.globalAlpha = 1;
+}
+
+// Parry clash: a gold-over-white double ring + four-point spark star. Mirrors
+// draw.js spawnClashEffect; t is 0..1 over its lifetime.
+function recapDrawClash(x, y, t) {
+	var p = 1 - Math.pow(1 - t, 3); // easeOutCubic
+	gameContext.save();
+	gameContext.translate(x, y);
+	gameContext.lineCap = "round";
+	gameContext.globalAlpha = (1 - t) * 0.9;
+	gameContext.strokeStyle = "#ffd34d";
+	gameContext.lineWidth = 3 * (1 - t) + 1.5;
+	gameContext.beginPath();
+	gameContext.arc(0, 0, 4 + 26 * p, 0, 2 * Math.PI);
+	gameContext.stroke();
+	gameContext.globalAlpha = (1 - t) * 0.7;
+	gameContext.strokeStyle = "white";
+	gameContext.lineWidth = 2 * (1 - t) + 1;
+	gameContext.beginPath();
+	gameContext.arc(0, 0, 2 + 16 * p, 0, 2 * Math.PI);
+	gameContext.stroke();
+	gameContext.globalAlpha = (1 - t);
+	gameContext.strokeStyle = "#fff4c2";
+	gameContext.lineWidth = 2 * (1 - t) + 1;
+	var reach = 8 + 20 * p;
+	for (var i = 0; i < 4; i++) {
+		var a = (Math.PI / 4) + i * (Math.PI / 2);
+		gameContext.beginPath();
+		gameContext.moveTo(Math.cos(a) * reach * 0.35, Math.sin(a) * reach * 0.35);
+		gameContext.lineTo(Math.cos(a) * reach, Math.sin(a) * reach);
+		gameContext.stroke();
+	}
+	gameContext.restore();
+	gameContext.globalAlpha = 1;
+}
+
+// Cast each alive kart's ice reflection, clipped to the round's ice footprint.
+// Mirrors terrainfx.js tfxDrawIceReflections, but reads buffered frame positions
+// (not the live playerList) and paths the captured ice verts directly (the live
+// frustum-cull path keys off the in-game camera, which is inactive on gameOver).
+function recapDrawIceReflections(item, frame) {
+	var ice = (item != null) ? item.ice : null;
+	if (ice == null || ice.length === 0 || frame == null || frame.players == null) {
+		return;
+	}
+	var ctx = gameContext;
+	ctx.save();
+	ctx.beginPath();
+	for (var c = 0; c < ice.length; c++) {
+		var verts = ice[c];
+		if (verts == null || verts.length === 0) { continue; }
+		ctx.moveTo(verts[0].x, verts[0].y);
+		for (var v = 1; v < verts.length; v++) { ctx.lineTo(verts[v].x, verts[v].y); }
+		ctx.closePath();
+	}
+	ctx.clip();
+	var useBlur = (typeof perfGlow === "function") ? perfGlow() : true;
+	for (var i = 0; i < frame.players.length; i++) {
+		var pr = frame.players[i];
+		if (pr[RF_STATE] !== RECAP_ALIVE) { continue; }
+		var p = recapAppearance(pr);
+		var rad = p.radius || 16;
+		var pivot = p.y + rad * 1.95;
+		ctx.save();
+		ctx.globalAlpha = 0.38;
+		if (useBlur && "filter" in ctx) { ctx.filter = "blur(2.5px)"; }
+		ctx.translate(p.x, pivot);
+		ctx.scale(1.0, -0.85);
+		ctx.translate(-p.x, -pivot);
+		if (typeof drawKartAppearance === "function") {
+			try { drawKartAppearance(p, p.x, pivot); } catch (e) { /* keep the montage alive */ }
+		}
+		ctx.restore();
+	}
+	ctx.restore();
+}
+
+// The minimal synthetic player the kart-appearance helpers need (skin-aware draw).
+// World coords; the helpers' internal camera offset is zero on the gameOver screen.
+function recapAppearance(pr) {
+	var meta = recapMeta[pr[RF_ID]] || { color: "grey", radius: 12 };
+	return {
+		id: pr[RF_ID], x: pr[RF_X], y: pr[RF_Y], angle: pr[RF_ANGLE],
+		velX: pr[RF_VX], velY: pr[RF_VY], color: meta.color,
+		radius: (meta.radius != null) ? meta.radius : 12, onFire: pr[RF_FIRE],
+		cart: meta.cart, pattern: meta.pattern, trailFx: meta.trailFx, border: meta.border
+	};
 }
 
 // Muzzle flash: a short flash cone + white streaks in the firing direction.
@@ -1184,6 +1369,12 @@ function recapDrawCar(pr, exits, frameT) {
 		speedBuffUntil: pr[RF_SPEEDFX] === 1 ? Date.now() + 99999 : null,
 		speedDebuffUntil: pr[RF_SPEEDFX] === 2 ? Date.now() + 99999 : null
 	};
+	// Punch lunge: drawCartSkin animates off (Date.now() - punchAnimAt), so anchor
+	// punchAnimAt the captured age back from now to replay the lunge at this frame.
+	var recapPunchAge = pr[RF_PUNCH];
+	if (recapPunchAge != null && recapPunchAge >= 0) {
+		p.punchAnimAt = Date.now() - recapPunchAge;
+	}
 	// Emote: captured as [msg, ageMs, durationMs] (or a plain string from the demo).
 	// Reconstruct chatMessageAt so drawEmoji applies its normal fade-out instead of a
 	// static full-strength bubble for the whole looped clip.

--- a/client/scripts/recap.js
+++ b/client/scripts/recap.js
@@ -32,6 +32,8 @@ var RECAP_LEADIN_MAX_MS = 800; // most of a clip's slow lead-in we'll skip so it
 var RECAP_LEADIN_FRAC = 0.4;   // open once the framed karts reach this fraction of the clip's peak speed
 var RECAP_SLIDE_DIST = 320;    // travel (world px, default-map scale) a punched kart must cover to count as "sent flying"
 var RECAP_SLIDE_WINDOW_MS = 1500; // window after the hit we watch for that travel before giving up
+var RECAP_SLIDE_SPEED_FACTOR = 1.1; // peak speed (× playerMaxSpeed) the victim must hit — proves it was a knockback
+                                    // launch (which adds velocity past the steer cap), not just fast normal driving
 var RECAP_DISPLAY_MS = RECAP_PLAY_MS; // hold each clip for one full (slowed) playthrough
 var RECAP_MAX_CLIPS = 4;       // keep the montage short within gameOverTime (20s)
 var RECAP_PER_ROUND = 2;       // most clips harvested from any single round (leave room for variety)
@@ -100,9 +102,7 @@ var recapMeta = {};            // id -> { color, radius, name }; survives player
 var recapMaps = [];            // [{ t, image, pad, world, scale }] time-stamped map snapshots (dynamic map state)
 var recapMapDirty = false;     // a map-mutating event fired -> take a fresh snapshot soon
 var recapLastMapSnap = 0;      // throttle clock for map snapshots
-var recapIceCells = [];        // [[{x,y},...], ...] this round's ice-tile polygons (world coords), captured
-                               // at race start (clean map) so the replay can cast the same ice reflections
-var recapSlideWatch = {};      // victimId -> { id, x, y, t }: punched karts being watched for a long knockback slide
+var recapSlideWatch = {};      // victimId -> { id, x, y, t, peak }: punched karts watched for a long knockback slide
 // --- cross-round archive --------------------------------------------------
 var recapArchive = [];         // [{ title, type, priority, ids, frames, map, exits }] harvested clips
 // --- playback state -------------------------------------------------------
@@ -124,10 +124,6 @@ function recapReset() {
 	recapMapDirty = false;
 	recapLastMapSnap = 0;
 	recapSlideWatch = {};
-	// Snapshot the ice footprint now, while the map is still clean — collapse later
-	// overwrites ice cells to lava (cell.id changes), so harvesting it at round end
-	// would miss them. Static for the round, so one capture covers every clip.
-	recapIceCells = recapCaptureIceCells();
 	if (typeof playerList !== "undefined" && playerList != null) {
 		for (var id in playerList) {
 			if (playerList[id] != null) {
@@ -137,9 +133,10 @@ function recapReset() {
 	}
 }
 
-// Collect this round's ice-tile polygons (world-coord vertex rings) from the live
+// Collect the CURRENT ice-tile polygons (world-coord vertex rings) from the live
 // map, reusing the terrainfx vertex helper so the footprint matches the rendered
-// terrain exactly. Returns [] if anything's unavailable (the reflection then no-ops).
+// terrain exactly. Called per map snapshot so the reflection mask tracks tile
+// changes. Returns [] if anything's unavailable (the reflection then no-ops).
 function recapCaptureIceCells() {
 	var out = [];
 	if (typeof currentMap === "undefined" || currentMap == null || currentMap.cells == null) { return out; }
@@ -287,7 +284,11 @@ function recapCaptureMap() {
 	recapMaps.push({
 		t: now, image: snap, scale: scale,
 		pad: (typeof mapCanvasPad !== "undefined") ? mapCanvasPad : 8,
-		world: { x: world.x, y: world.y, width: world.width, height: world.height }
+		world: { x: world.x, y: world.y, width: world.width, height: world.height },
+		// Ice footprint AS OF this snapshot — ice isn't static (snowflakes freeze tiles,
+		// swaps flip them, bombs clear them, collapse buries them in lava), and snapshots
+		// are taken on every such change, so the reflection mask tracks the terrain.
+		iceCells: recapCaptureIceCells()
 	});
 	recapMapDirty = false;
 	recapLastMapSnap = now;
@@ -381,22 +382,34 @@ function recapMarkHighlightAt(type, ids, t) {
 }
 
 // A punch landed on `victimId` at (x,y): start/refresh a watch. If that kart then
-// travels RECAP_SLIDE_DIST within RECAP_SLIDE_WINDOW_MS, recapCheckSlides marks a
-// "Sent Flying!" highlight at the hit time (so the clip catches the launch + slide).
+// travels RECAP_SLIDE_DIST within RECAP_SLIDE_WINDOW_MS *and* its speed spiked past the
+// steer cap (so it was launched, not just driving), recapCheckSlides marks a "Sent
+// Flying!" highlight at the hit time (so the clip catches the launch + slide).
 function recapNotePunchLaunch(victimId, x, y) {
 	if (victimId == null || x == null || y == null) {
 		return;
 	}
-	recapSlideWatch[victimId] = { id: victimId, x: x, y: y, t: Date.now() };
+	recapSlideWatch[victimId] = { id: victimId, x: x, y: y, t: Date.now(), peak: 0 };
 }
 
-// Per-tick: resolve pending knockback watches against the live positions. Fired far
-// enough → a highlight; window elapsed or victim gone/dead → dropped (a slide INTO
-// a hazard is already covered by the 'death' marker).
+// Speed above which a kart must have been LAUNCHED (not driven): knockback adds
+// velocity outside the engine's steer clamp at playerMaxSpeed, while normal driving
+// — even speed-buffed, which only raises acceleration — never exceeds that cap.
+function recapLaunchSpeed() {
+	var cap = (typeof config !== "undefined" && config != null && config.playerMaxSpeed != null)
+		? config.playerMaxSpeed : 500;
+	return cap * RECAP_SLIDE_SPEED_FACTOR;
+}
+
+// Per-tick: resolve pending knockback watches against the live positions. Needs BOTH a
+// long travel AND a launch-level speed spike (else a moving racer taking a light tap
+// would clip as "Sent Flying!"). Window elapsed or victim gone/dead → dropped (a slide
+// INTO a hazard is already covered by the 'death' marker).
 function recapCheckSlides(now) {
 	if (typeof playerList === "undefined" || playerList == null) {
 		return;
 	}
+	var launch = recapLaunchSpeed();
 	for (var id in recapSlideWatch) {
 		var w = recapSlideWatch[id];
 		var p = playerList[id];
@@ -404,8 +417,10 @@ function recapCheckSlides(now) {
 			delete recapSlideWatch[id];
 			continue;
 		}
+		var spd = Math.sqrt((p.velX || 0) * (p.velX || 0) + (p.velY || 0) * (p.velY || 0));
+		if (spd > w.peak) { w.peak = spd; }
 		var dx = p.x - w.x, dy = p.y - w.y;
-		if (dx * dx + dy * dy >= RECAP_SLIDE_DIST * RECAP_SLIDE_DIST) {
+		if (w.peak >= launch && dx * dx + dy * dy >= RECAP_SLIDE_DIST * RECAP_SLIDE_DIST) {
 			recapMarkHighlightAt("slide", [w.id], w.t);
 			delete recapSlideWatch[id];
 		} else if (now - w.t > RECAP_SLIDE_WINDOW_MS) {
@@ -532,7 +547,6 @@ function recapHarvestRound() {
 			brutal: brutal,
 			blind: recapBlindInFrames(frames),
 			effects: recapSliceEffects(startT, startT + RECAP_CLIP_MS),
-			ice: recapIceCells,
 			exits: recapComputeExits(frames)
 		});
 		takenTimes.push(mk.t);
@@ -546,7 +560,7 @@ function recapHarvestRound() {
 			recapArchive.push({
 				title: "Final Moments", type: "tail", priority: 0, ids: [],
 				frames: tailFrames, maps: recapMapsForWindow(endT - RECAP_CLIP_MS, endT), brutal: brutal,
-				blind: recapBlindInFrames(tailFrames), ice: recapIceCells,
+				blind: recapBlindInFrames(tailFrames),
 				effects: recapSliceEffects(endT - RECAP_CLIP_MS, endT), exits: recapComputeExits(tailFrames)
 			});
 		}
@@ -967,8 +981,9 @@ function recapRenderClip(item, winX, winY, winW, winH) {
 		}
 		recapDrawTrails(item, frameT);
 		// Ice reflections sit OVER the terrain and UNDER the karts (matches the live
-		// drawTerrainFX order), so cast them before drawing the karts themselves.
-		recapDrawIceReflections(item, frame);
+		// drawTerrainFX order), so cast them before drawing the karts themselves. The
+		// footprint rides on the map snapshot, so it tracks tile changes over the clip.
+		recapDrawIceReflections(map, frame);
 		for (var i = 0; i < frame.players.length; i++) {
 			recapDrawCar(frame.players[i], item.exits, frameT);
 		}
@@ -1229,8 +1244,8 @@ function recapDrawClash(x, y, t) {
 // Mirrors terrainfx.js tfxDrawIceReflections, but reads buffered frame positions
 // (not the live playerList) and paths the captured ice verts directly (the live
 // frustum-cull path keys off the in-game camera, which is inactive on gameOver).
-function recapDrawIceReflections(item, frame) {
-	var ice = (item != null) ? item.ice : null;
+function recapDrawIceReflections(map, frame) {
+	var ice = (map != null) ? map.iceCells : null;
 	if (ice == null || ice.length === 0 || frame == null || frame.players == null) {
 		return;
 	}
@@ -1270,12 +1285,19 @@ function recapDrawIceReflections(item, frame) {
 // World coords; the helpers' internal camera offset is zero on the gameOver screen.
 function recapAppearance(pr) {
 	var meta = recapMeta[pr[RF_ID]] || { color: "grey", radius: 12 };
-	return {
+	var obj = {
 		id: pr[RF_ID], x: pr[RF_X], y: pr[RF_Y], angle: pr[RF_ANGLE],
 		velX: pr[RF_VX], velY: pr[RF_VY], color: meta.color,
 		radius: (meta.radius != null) ? meta.radius : 12, onFire: pr[RF_FIRE],
 		cart: meta.cart, pattern: meta.pattern, trailFx: meta.trailFx, border: meta.border
 	};
+	// Carry the punch lunge so a reflected kart lunges in step with its body (drawCartSkin
+	// animates off Date.now() - punchAnimAt) — matches the live ice reflection.
+	var pAge = pr[RF_PUNCH];
+	if (pAge != null && pAge >= 0) {
+		obj.punchAnimAt = Date.now() - pAge;
+	}
+	return obj;
 }
 
 // Muzzle flash: a short flash cone + white streaks in the firing direction.

--- a/client/scripts/recap.js
+++ b/client/scripts/recap.js
@@ -28,6 +28,10 @@ var RECAP_CLIP_MS = 3000;      // length of real footage captured per clip (the 
 var RECAP_SLOWMO = 1.3;        // playback time-stretch: >1 = cinematic slow-mo, 1.0 = real-time
 var RECAP_PLAY_MS = RECAP_CLIP_MS * RECAP_SLOWMO; // on-screen playback duration of one clip (slowed)
 var RECAP_PRE_MS = 1400;       // portion of the captured footage BEFORE the highlight moment
+var RECAP_LEADIN_MAX_MS = 800; // most of a clip's slow lead-in we'll skip so it opens mid-action
+var RECAP_LEADIN_FRAC = 0.4;   // open once the framed karts reach this fraction of the clip's peak speed
+var RECAP_SLIDE_DIST = 320;    // travel (world px, default-map scale) a punched kart must cover to count as "sent flying"
+var RECAP_SLIDE_WINDOW_MS = 1500; // window after the hit we watch for that travel before giving up
 var RECAP_DISPLAY_MS = RECAP_PLAY_MS; // hold each clip for one full (slowed) playthrough
 var RECAP_MAX_CLIPS = 4;       // keep the montage short within gameOverTime (20s)
 var RECAP_PER_ROUND = 2;       // most clips harvested from any single round (leave room for variety)
@@ -81,6 +85,7 @@ var RECAP_TYPE_INFO = {
 	godlike: { title: "Godlike!", priority: 5 },
 	rampage: { title: "Rampage!", priority: 4 },
 	spree: { title: "Killing Spree!", priority: 3 },
+	slide: { title: "Sent Flying!", priority: 4 },
 	goal: { title: "Goal!", priority: 2 },
 	death: { title: "Eliminated", priority: 1 }
 };
@@ -97,6 +102,7 @@ var recapMapDirty = false;     // a map-mutating event fired -> take a fresh sna
 var recapLastMapSnap = 0;      // throttle clock for map snapshots
 var recapIceCells = [];        // [[{x,y},...], ...] this round's ice-tile polygons (world coords), captured
                                // at race start (clean map) so the replay can cast the same ice reflections
+var recapSlideWatch = {};      // victimId -> { id, x, y, t }: punched karts being watched for a long knockback slide
 // --- cross-round archive --------------------------------------------------
 var recapArchive = [];         // [{ title, type, priority, ids, frames, map, exits }] harvested clips
 // --- playback state -------------------------------------------------------
@@ -117,6 +123,7 @@ function recapReset() {
 	recapMaps = [];
 	recapMapDirty = false;
 	recapLastMapSnap = 0;
+	recapSlideWatch = {};
 	// Snapshot the ice footprint now, while the map is still clean — collapse later
 	// overwrites ice cells to lava (cell.id changes), so harvesting it at round end
 	// would miss them. Static for the round, so one capture covers every clip.
@@ -214,6 +221,8 @@ function recapCaptureFrame() {
 			border: (p.border != null) ? p.border : null
 		};
 	}
+	// Resolve any pending knockback-slide watches against this tick's live positions.
+	recapCheckSlides(now);
 	if (players.length === 0) {
 		return;
 	}
@@ -361,7 +370,48 @@ function recapCaptureAimers() {
 // Record a highlight moment (from an existing client event). `ids` are the
 // players the moment involves, used to caption + focus the clip.
 function recapMarkHighlight(type, ids) {
-	recapMarkers.push({ t: Date.now(), type: type, ids: ids || [] });
+	recapMarkHighlightAt(type, ids, Date.now());
+}
+
+// Same, but stamped at an explicit time `t` — used when the moment is RECOGNISED
+// later than it HAPPENED (a knockback slide is only confirmed once the kart has
+// finished travelling), so the clip still centres on the original hit.
+function recapMarkHighlightAt(type, ids, t) {
+	recapMarkers.push({ t: (t != null ? t : Date.now()), type: type, ids: ids || [] });
+}
+
+// A punch landed on `victimId` at (x,y): start/refresh a watch. If that kart then
+// travels RECAP_SLIDE_DIST within RECAP_SLIDE_WINDOW_MS, recapCheckSlides marks a
+// "Sent Flying!" highlight at the hit time (so the clip catches the launch + slide).
+function recapNotePunchLaunch(victimId, x, y) {
+	if (victimId == null || x == null || y == null) {
+		return;
+	}
+	recapSlideWatch[victimId] = { id: victimId, x: x, y: y, t: Date.now() };
+}
+
+// Per-tick: resolve pending knockback watches against the live positions. Fired far
+// enough → a highlight; window elapsed or victim gone/dead → dropped (a slide INTO
+// a hazard is already covered by the 'death' marker).
+function recapCheckSlides(now) {
+	if (typeof playerList === "undefined" || playerList == null) {
+		return;
+	}
+	for (var id in recapSlideWatch) {
+		var w = recapSlideWatch[id];
+		var p = playerList[id];
+		if (p == null || p.x == null || p.alive === false) {
+			delete recapSlideWatch[id];
+			continue;
+		}
+		var dx = p.x - w.x, dy = p.y - w.y;
+		if (dx * dx + dy * dy >= RECAP_SLIDE_DIST * RECAP_SLIDE_DIST) {
+			recapMarkHighlightAt("slide", [w.id], w.t);
+			delete recapSlideWatch[id];
+		} else if (now - w.t > RECAP_SLIDE_WINDOW_MS) {
+			delete recapSlideWatch[id];
+		}
+	}
 }
 
 // Record a one-shot world effect (an explosion) so the clip can replay it in the
@@ -824,7 +874,7 @@ function recapRenderClip(item, winX, winY, winW, winH) {
 	if (item.maps == null || item.maps.length === 0 || item.maps[0].world == null || item.maps[0].world.width == null) {
 		return;
 	}
-	var frame = recapFrameAt(item.frames, recapElapsed);
+	var frame = recapFrameAt(item.frames, recapElapsed, recapEffectiveStartT(item));
 	if (frame == null) {
 		return;
 	}
@@ -1577,21 +1627,84 @@ function recapFocusCenter(item, frame, w) {
 // Pick the frame for the current loop position. The clip loops every
 // RECAP_PLAY_MS (the slow-mo-stretched window); we map progress onto the frames'
 // own timestamps, so the captured footage replays slower than real-time.
-function recapFrameAt(frames, elapsedMs) {
+// Speed signal for lead-in trimming: the fastest FRAMED kart this frame (the
+// subject ids the camera follows, or the whole alive field if none are present).
+// Squared comparison internally; returns the real speed.
+function recapClipSpeedSignal(frame, ids) {
+	if (frame == null || frame.players == null) {
+		return 0;
+	}
+	var subjMax = 0, sceneMax = 0, sawSubj = false;
+	for (var i = 0; i < frame.players.length; i++) {
+		var pr = frame.players[i];
+		if (pr[RF_STATE] !== RECAP_ALIVE) { continue; }
+		var vx = pr[RF_VX] || 0, vy = pr[RF_VY] || 0;
+		var sp = vx * vx + vy * vy;
+		if (sp > sceneMax) { sceneMax = sp; }
+		if (ids != null && ids.length) {
+			for (var k = 0; k < ids.length; k++) {
+				if (pr[RF_ID] === ids[k]) { sawSubj = true; if (sp > subjMax) { subjMax = sp; } break; }
+			}
+		}
+	}
+	return Math.sqrt(sawSubj ? subjMax : sceneMax);
+}
+
+// The timestamp a clip should OPEN on: skip leading frames where the framed karts
+// are barely moving, so the replay feels like a camera catching live action rather
+// than a sim un-pausing from a frozen first frame. Bounded by RECAP_LEADIN_MAX_MS
+// (and a fraction of the clip) so the highlight + its lead-up always survive.
+// Memoized on the item — the speed scan is otherwise repeated every render frame.
+function recapEffectiveStartT(item) {
+	if (item == null || item.frames == null || item.frames.length < 2) {
+		return (item != null && item.frames != null && item.frames.length) ? item.frames[0].t : null;
+	}
+	if (item._startT != null) {
+		return item._startT;
+	}
+	var frames = item.frames;
+	var t0 = frames[0].t;
+	var span = frames[frames.length - 1].t - t0;
+	var ids = (item.focusIds != null) ? item.focusIds : (item.ids != null ? item.ids : null);
+	var speeds = [], peak = 0;
+	for (var i = 0; i < frames.length; i++) {
+		var s = recapClipSpeedSignal(frames[i], ids);
+		speeds.push(s);
+		if (s > peak) { peak = s; }
+	}
+	var startT = t0;
+	if (peak > 0.1 && span > 0) { // there IS motion to find; a frozen scrum stays as-is
+		var thresh = peak * RECAP_LEADIN_FRAC;
+		var maxTrim = Math.min(RECAP_LEADIN_MAX_MS, span * 0.33);
+		for (var j = 0; j < frames.length; j++) {
+			if ((frames[j].t - t0) > maxTrim) { break; }
+			if (speeds[j] >= thresh) { startT = frames[j].t; break; }
+		}
+	}
+	item._startT = startT;
+	return startT;
+}
+
+function recapFrameAt(frames, elapsedMs, startT) {
 	if (frames == null || frames.length === 0) {
 		return null;
 	}
 	if (frames.length === 1) {
 		return frames[0];
 	}
-	var span = frames[frames.length - 1].t - frames[0].t;
+	// Open from the motion-onset time (startT) rather than the buffer's first frame,
+	// so a clip catches the action already in progress (candid) instead of appearing
+	// to start a fresh sim from a near-frozen pose. Defaults to frames[0].t.
+	var t0 = (startT != null && startT >= frames[0].t && startT < frames[frames.length - 1].t)
+		? startT : frames[0].t;
+	var span = frames[frames.length - 1].t - t0;
 	if (span <= 0) {
-		return frames[0];
+		return frames[frames.length - 1];
 	}
 	// Stretch playback: the captured span (~RECAP_CLIP_MS of real footage) is mapped
 	// onto a longer RECAP_PLAY_MS window, so the action replays in slow motion.
 	var progress = (elapsedMs % RECAP_PLAY_MS) / RECAP_PLAY_MS; // 0..1, loops
-	var targetT = frames[0].t + progress * span;
+	var targetT = t0 + progress * span;
 	// frames are time-ordered; linear scan (a clip is only ~90 frames)
 	var best = frames[0];
 	var bestDiff = Math.abs(best.t - targetT);


### PR DESCRIPTION
## What

Fixes several gaps in the end-of-game recap so the highlight clips actually look like what you saw live, improves how each clip is framed, and adds a new highlight type.

### Recap FX that were missing
The recap redraws buffered frames through the live draw helpers, but a few effects were never captured/replayed:
- **Punch shockwave, landed-hit sparks, parry clashes** — these ran only as live `addEffect()` closures, so the recap had nothing to draw. Now recorded via `recapMarkEffect` (`punch`/`hit`/`clash`) and mirrored in `recapDrawEffect`, matching the existing explosion/muzzle/shockwave path.
- **Cart-skin punch lunge** — captured per-frame in a new `RF_PUNCH` tuple slot and re-anchored at replay so the kart body lunges per frame.
- **Ice reflections** — re-cast from buffered positions via `drawKartAppearance`, clipped to the round's ice footprint and drawn under the karts (matching live `drawTerrainFX` order).

### Candid clip starts
Clips opened on the buffer's first frame, which is often a near-stationary pose, so the replay looked like a sim un-pausing. `recapEffectiveStartT` now skips the slow lead-in (bounded so the highlight always survives) and opens once the framed karts are actually moving — a candid, mid-action start.

### New highlight: "Sent Flying!"
When a punch sends a kart a long way (e.g. sliding across the ice), the recap turns it into its own clip. Gated on **both** a long post-hit travel **and** a launch-level speed spike past the steer cap (`playerMaxSpeed`), so a moving racer taking a light tap doesn't qualify — only a real knockback (which adds velocity outside the engine clamp) does.

## Review notes

This branch was reviewed by Codex; all three findings were addressed in the final commit:
- **Slide attribution** — added the knockback speed-spike gate (was displacement-only, which misfired since normal driving covers the threshold in-window).
- **Time-varying ice** — the ice footprint now rides on each map snapshot instead of a one-time race-start capture, so it tracks freezes / swaps / bomb-clears / collapse over the clip.
- **Reflected lunge** — the reflection's synthetic player now reconstructs `punchAnimAt` too.

## Testing

- `npm run build` — clean (all three bundles).
- Headless smoke test — passes (engine booted + ticked across 52 maps).
- Sandboxed recap-logic test — 19/19 assertions (speed-signal, lead-in trim + memoization, `recapFrameAt` windowing, and the slide fire / normal-driving-no-misfire / retained-peak / death-drop / expiry paths).

Note: the recap is client-only with no in-browser harness, so the visuals are build- and logic-verified but not runtime-verified on an actual game-over screen. Tunables most likely to want a real-game tweak: `RECAP_SLIDE_DIST` (320px), `RECAP_SLIDE_SPEED_FACTOR` (1.1×), and `RECAP_LEADIN_FRAC` (0.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
