### PR TITLE
Rewarded video: Watch to 2× match XP (ads PR2)

### DIFF
--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -241,7 +241,8 @@ function makeRecordingSocket(id) {
 // path so the room is hostess-registered and roomMailList is wired), set notches, force
 // the winner, and drive gameOver — which fires startGameover and so the rewarded stash.
 let matchSeq = 0;
-function setupMatch(prefix) {
+function setupMatch(prefix, opts) {
+    opts = opts || {};
     matchSeq++;
     const s1 = makeRecordingSocket(prefix + '-s1');
     const s2 = makeRecordingSocket(prefix + '-s2');
@@ -262,7 +263,9 @@ function setupMatch(prefix) {
     const p1 = room.playerList[s1.id];
     const p2 = room.playerList[s2.id];
     p1.isAI = false; p1.verifiedUserId = s1.userId; p1.notches = 5; p1.racedCurrentMap = true;
-    p2.isAI = false; p2.verifiedUserId = s2.userId; p2.notches = 2; p2.racedCurrentMap = true;
+    // opts.p2Spectator: p2 is a signed-in late-joiner who never raced this match — server must
+    // NOT credit them, so they must NOT be told they're eligible for the rewarded claim.
+    p2.isAI = false; p2.verifiedUserId = s2.userId; p2.notches = 2; p2.racedCurrentMap = !opts.p2Spectator;
     p1.progression = progression.defaultProgression(); p1.progressionLoaded = true;
     p2.progression = progression.defaultProgression(); p2.progressionLoaded = true;
     room.game.firstPlaceSig = s1.id;
@@ -295,7 +298,10 @@ async function testStashMatchesEngineAward() {
     const rm = m.room.rewardedMatch;
     check(!!rm && !!rm.matchId, 'startGameover stashed a rewardedMatch with a matchId');
     const packet = ioEvents.filter(function (e) { return e.header === 'startGameover'; }).pop();
-    check(packet && packet.payload.matchId === rm.matchId, 'the startGameover packet carries the same matchId (echoed to the client)');
+    check(packet && packet.payload.matchId == null, 'the broadcast startGameover packet does NOT carry matchId (eligibility is targeted, not broadcast)');
+    // Eligibility is delivered targeted, only to the credited racers.
+    check(m.s1.lastEmit('rewardedEligible') && m.s1.lastEmit('rewardedEligible').matchId === rm.matchId, 'winner received a targeted rewardedEligible with this matchId');
+    check(m.s2.lastEmit('rewardedEligible') && m.s2.lastEmit('rewardedEligible').matchId === rm.matchId, 'runner-up received a targeted rewardedEligible with this matchId');
     // Compare per-user stash to the engine's own awarded XP.
     const eng1 = engineXp(m.s1.userId);
     const eng2 = engineXp(m.s2.userId);
@@ -304,6 +310,25 @@ async function testStashMatchesEngineAward() {
     // Sanity: matches the documented breakdown for a 5-notch win / 2-notch runner-up.
     check(eng1 === c.xpParticipate + c.xpPerNotch * 5 + c.xpWinBonus, 'winner award = participation + 5 notches + win bonus');
     check(eng2 === c.xpParticipate + c.xpPerNotch * 2 + c.xpRunnerUpBonus, 'runner-up award = participation + 2 notches + runner-up bonus');
+    teardown(m);
+}
+
+// A signed-in late-joiner who never raced (spectator) is excluded server-side (no claims entry)
+// and must NOT be told they're eligible — so they're never offered an ad the server would reject.
+async function testSpectatorNotOfferedEligibility() {
+    console.log('Server — a signed-in spectator (never raced) is NOT sent rewardedEligible:');
+    const m = setupMatch('rw-spec', { p2Spectator: true });
+    if (!m) { check(false, 'room set up'); return; }
+    const rm = m.room.rewardedMatch;
+    check(!rm.claims[m.s2.userId], 'spectator has no server claim entry (excluded by racedCurrentMap)');
+    check(!!m.s1.lastEmit('rewardedEligible'), 'the racer IS told they are eligible');
+    check(!m.s2.lastEmit('rewardedEligible'), 'the spectator is NOT told they are eligible (no wasted-ad offer)');
+    // And a forged claim from the spectator is rejected (no entry).
+    await withFakeAddProgression(async function (calls) {
+        m.s2.fire('claimXpMultiplier', { matchId: rm.matchId, multiplier: 2 });
+        await Promise.resolve(); await Promise.resolve();
+        check(calls.length === 0, "a spectator's forged claim is rejected (no entry to credit)");
+    });
     teardown(m);
 }
 
@@ -415,6 +440,7 @@ function testMultiplierConstant() {
     // Part B
     testMultiplierConstant();
     await testStashMatchesEngineAward();
+    await testSpectatorNotOfferedEligibility();
     await testCreditAndSingleClaim();
     await testRejections();
     await testWriteFailureNotAcked();

--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -1,0 +1,329 @@
+'use strict';
+
+// Headless rewarded-video ("Watch to 2× match XP") test. Two parts:
+//
+//   PART A — client ad layer (client/scripts/ads.js) in a fake-window sandbox:
+//     - isRewardedAvailable() is false for provider 'none' and before the SDK is ready,
+//       true once a real network's SDK reports ready ("not-available" coverage).
+//     - showRewarded() grants onReward ONLY on a confirmed full watch (an ad started AND
+//       completed); a no-fill (complete with no start) is a skip, not a reward; an SDK
+//       throw / request timeout is an error. The right GA events fire (type:'rewarded').
+//
+//   PART B — server claim path (the REAL engine + messenger.claimXpMultiplier handler),
+//     mirroring progression-test.js's "boot the real modules" approach:
+//     - The per-user match-XP stash recomputed at startGameover EQUALS the engine's own
+//       award (the duplicated breakdown in messenger can't silently drift).
+//     - A signed-in claim credits exactly the bonus (2× total = +1× original) via
+//       auth.addProgression and acks with xpBonus.
+//     - Single-claim, wrong-matchId, expired-TTL, and anonymous claims are all rejected.
+//
+// No network, no browser, no Supabase writes (the local default).
+
+const path = require('path');
+const fs = require('fs');
+const vm = require('vm');
+const repoRoot = path.join(__dirname, '..', '..');
+
+let failures = 0;
+function check(cond, msg) {
+    if (cond) { console.log('  ok: ' + msg); }
+    else { failures++; console.log('::error::FAIL: ' + msg); }
+}
+
+// ---------------------------------------------------------------------------
+// PART A — ads.js in a sandbox
+// ---------------------------------------------------------------------------
+
+// Load client/scripts/ads.js into a fresh fake-window context. Returns handles to drive it:
+// the public window.ads, the recorded GA events, a way to fire provider SDK events, and a
+// fireTimers() that runs pending setTimeout callbacks (so the hard timeout is deterministic).
+function loadAds(adsConfig) {
+    const tracked = [];
+    const timers = [];
+    let timerSeq = 1;
+    const lsStore = {};
+    const fakeWin = {
+        __ADS__: adsConfig,
+        localStorage: {
+            getItem: function (k) { return (k in lsStore) ? lsStore[k] : null; },
+            setItem: function (k, v) { lsStore[k] = String(v); }
+        },
+        trackEvent: function (name, params) { tracked.push({ name: name, params: params || {} }); },
+        // no isEmbedded -> treated as not embedded
+        sdk: null
+    };
+    const fakeDoc = {
+        createElement: function () { return { setAttribute: function () {}, src: '', async: false, id: '', onload: null, onerror: null, style: {} }; },
+        getElementById: function () { return null; },
+        head: { appendChild: function () {} },
+        documentElement: { appendChild: function () {} },
+        body: null
+    };
+    const ctx = {
+        window: fakeWin,
+        document: fakeDoc,
+        console: console,
+        encodeURIComponent: encodeURIComponent,
+        setTimeout: function (fn, ms) { const id = timerSeq++; timers.push({ id: id, fn: fn }); return id; },
+        clearTimeout: function (id) { for (let i = 0; i < timers.length; i++) { if (timers[i].id === id) { timers.splice(i, 1); break; } } },
+        Date: { now: function () { return 1000; } }
+    };
+    vm.createContext(ctx);
+    vm.runInContext(fs.readFileSync(path.join(repoRoot, 'client', 'scripts', 'ads.js'), 'utf8'), ctx);
+    return {
+        ads: fakeWin.ads,
+        win: fakeWin,
+        tracked: tracked,
+        // GameMonetize routes everything through window.SDK_OPTIONS.onEvent.
+        fireSdk: function (name) { fakeWin.SDK_OPTIONS.onEvent({ name: name }); },
+        fireTimers: function () { const due = timers.splice(0, timers.length); due.forEach(function (t) { t.fn(); }); },
+        hasEvent: function (name, type) { return tracked.some(function (e) { return e.name === name && (!type || e.params.type === type); }); }
+    };
+}
+
+function testAdsNoneProvider() {
+    console.log('ads.js — provider "none":');
+    const h = loadAds({ provider: 'none' });
+    check(h.ads.isRewardedAvailable() === false, 'isRewardedAvailable() is false for provider none (button never renders)');
+    let rewarded = false, skipped = false, errored = false;
+    h.ads.showRewarded({ placement: 'xp_2x', onReward: function () { rewarded = true; }, onSkip: function () { skipped = true; }, onError: function () { errored = true; } });
+    check(skipped && !rewarded && !errored, 'showRewarded() fails open as a SKIP (no reward, no error) when no network is wired');
+    check(!h.hasEvent('ad_shown'), 'no ad_shown emitted for provider none');
+}
+
+function testAdsGameMonetizeRewarded() {
+    console.log('ads.js — GameMonetize rewarded flow:');
+    const h = loadAds({ provider: 'gamemonetize', publisherId: 'test-game-id' });
+    check(h.ads.isRewardedAvailable() === false, 'not available before SDK_READY');
+    h.fireSdk('SDK_READY');
+    check(h.ads.isRewardedAvailable() === true, 'available after SDK_READY');
+    h.win.sdk = { showBanner: function () {} }; // SDK object the adapter calls
+
+    // Confirmed full watch: PAUSE (impression) then START (done) -> reward granted.
+    let rewarded = false, skipped = false, errored = false;
+    h.ads.showRewarded({ placement: 'xp_2x', onReward: function () { rewarded = true; }, onSkip: function () { skipped = true; }, onError: function () { errored = true; } });
+    h.fireSdk('SDK_GAME_PAUSE');
+    h.fireSdk('SDK_GAME_START');
+    check(rewarded && !skipped && !errored, 'PAUSE->START grants onReward exactly once');
+    check(h.hasEvent('ad_shown', 'rewarded'), 'ad_shown {type:rewarded} fired on impression');
+    check(h.hasEvent('ad_complete', 'rewarded'), 'ad_complete {type:rewarded} fired on completion');
+
+    // No-fill: START with NO preceding PAUSE -> NOT watched -> skip, never reward.
+    const h2 = loadAds({ provider: 'gamemonetize', publisherId: 'test-game-id' });
+    h2.fireSdk('SDK_READY');
+    h2.win.sdk = { showBanner: function () {} };
+    let r2 = false, s2 = false;
+    h2.ads.showRewarded({ placement: 'xp_2x', onReward: function () { r2 = true; }, onSkip: function () { s2 = true; } });
+    h2.fireSdk('SDK_GAME_START'); // no PAUSE first
+    check(!r2 && s2, 'no-fill (START without PAUSE) is a SKIP, never a reward');
+    check(!h2.hasEvent('ad_complete'), 'no ad_complete on a no-fill');
+    check(h2.hasEvent('ad_skipped', 'rewarded'), 'ad_skipped {type:rewarded} fired on no-fill');
+
+    // SDK throw -> error, no reward.
+    const h3 = loadAds({ provider: 'gamemonetize', publisherId: 'test-game-id' });
+    h3.fireSdk('SDK_READY');
+    h3.win.sdk = { showBanner: function () { throw new Error('boom'); } };
+    let r3 = false, e3 = false;
+    h3.ads.showRewarded({ placement: 'xp_2x', onReward: function () { r3 = true; }, onError: function () { e3 = true; } });
+    check(!r3 && e3, 'an SDK throw is an ERROR, never a reward');
+    check(h3.hasEvent('ad_error', 'rewarded'), 'ad_error {type:rewarded} fired on SDK throw');
+
+    // Request timeout (no ad ever starts) -> error via the hard timeout.
+    const h4 = loadAds({ provider: 'gamemonetize', publisherId: 'test-game-id' });
+    h4.fireSdk('SDK_READY');
+    h4.win.sdk = { showBanner: function () {} }; // never fires PAUSE/START
+    let r4 = false, e4 = false;
+    h4.ads.showRewarded({ placement: 'xp_2x', onReward: function () { r4 = true; }, onError: function () { e4 = true; } });
+    h4.fireTimers(); // fire the 8s watchdog
+    check(!r4 && e4, 'no ad starting before the timeout is an ERROR');
+    check(h4.tracked.some(function (ev) { return ev.name === 'ad_error' && ev.params.reason === 'timeout'; }), 'ad_error reason=timeout on request timeout');
+}
+
+// ---------------------------------------------------------------------------
+// PART B — server claim path (real engine + messenger handler)
+// ---------------------------------------------------------------------------
+const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
+const hostess = require(path.join(repoRoot, 'server', 'hostess.js'));
+const utils = require(path.join(repoRoot, 'server', 'utils.js'));
+const progression = require(path.join(repoRoot, 'server', 'progression.js'));
+const auth = require(path.join(repoRoot, 'server', 'auth.js'));
+const c = utils.loadConfig();
+
+const ioEvents = [];
+messenger.build({ to: function () { return { emit: function (header, payload) { ioEvents.push({ header: header, payload: payload }); } }; }, sockets: { emit: function () {} } });
+
+// Recording socket.io stand-in (mirrors progression-test.js).
+function makeRecordingSocket(id) {
+    const handlers = {};
+    const emits = [];
+    return {
+        id: id, userId: null, deviceId: null, handlers: handlers, emits: emits,
+        on: function (e, fn) { handlers[e] = fn; },
+        emit: function (h, p) { emits.push({ header: h, payload: p }); },
+        join: function () {}, leave: function () {},
+        broadcast: { to: function () { return { emit: function () {} }; } },
+        fire: function (e, p) { if (handlers[e]) { handlers[e](p); } },
+        lastEmit: function (h) { for (let i = emits.length - 1; i >= 0; i--) { if (emits[i].header === h) { return emits[i].payload; } } return null; }
+    };
+}
+
+// Stand up a real hostess room with two signed-in humans (via the enterGame matchmaking
+// path so the room is hostess-registered and roomMailList is wired), set notches, force
+// the winner, and drive gameOver — which fires startGameover and so the rewarded stash.
+let matchSeq = 0;
+function setupMatch(prefix) {
+    matchSeq++;
+    const s1 = makeRecordingSocket(prefix + '-s1');
+    const s2 = makeRecordingSocket(prefix + '-s2');
+    s1.userId = prefix + '-u1';
+    s2.userId = prefix + '-u2';
+    messenger.addMailBox(s1.id, s1, { userId: s1.userId, deviceId: null });
+    messenger.addMailBox(s2.id, s2, { userId: s2.userId, deviceId: null });
+    s1.fire('enterGame', -1);
+    s2.fire('enterGame', -1);
+
+    // Both should have matchmade into the same room.
+    let room = null;
+    for (const sig of Object.keys(hostess.getRooms())) {
+        const rm = hostess.getRoomBySig(sig);
+        if (rm && rm.playerList[s1.id] && rm.playerList[s2.id]) { room = rm; break; }
+    }
+    if (!room) { return null; }
+    const p1 = room.playerList[s1.id];
+    const p2 = room.playerList[s2.id];
+    p1.isAI = false; p1.verifiedUserId = s1.userId; p1.notches = 5; p1.racedCurrentMap = true;
+    p2.isAI = false; p2.verifiedUserId = s2.userId; p2.notches = 2; p2.racedCurrentMap = true;
+    p1.progression = progression.defaultProgression(); p1.progressionLoaded = true;
+    p2.progression = progression.defaultProgression(); p2.progressionLoaded = true;
+    room.game.firstPlaceSig = s1.id;
+    room.game.secondPlaceSig = s2.id;
+    // Drain any toasts queued by joins so our post-gameOver drain reads only this match.
+    messenger._drainToastsInMemoryForTest(s1.userId);
+    messenger._drainToastsInMemoryForTest(s2.userId);
+    room.game.gameOver(s1.id); // -> awardProgression + startGameover (stamps + stashes)
+    return { room: room, s1: s1, s2: s2 };
+}
+
+function teardown(m) {
+    hostess.kickFromRoom(m.s1.id);
+    hostess.kickFromRoom(m.s2.id);
+    messenger.removeMailBox(m.s1.id);
+    messenger.removeMailBox(m.s2.id);
+}
+
+// The xp amount the engine actually awarded a user (from the writes-off in-memory toast queue).
+function engineXp(userId) {
+    const toasts = messenger._drainToastsInMemoryForTest(userId) || [];
+    const xp = toasts.filter(function (e) { return e.type === 'xp'; });
+    return xp.length ? xp[0].amount : null;
+}
+
+async function testStashMatchesEngineAward() {
+    console.log('Server — match-XP stash equals the engine award (no drift):');
+    const m = setupMatch('rw-drift');
+    if (!m) { check(false, 'two signed-in players matchmade into one room'); return; }
+    const rm = m.room.rewardedMatch;
+    check(!!rm && !!rm.matchId, 'startGameover stashed a rewardedMatch with a matchId');
+    const packet = ioEvents.filter(function (e) { return e.header === 'startGameover'; }).pop();
+    check(packet && packet.payload.matchId === rm.matchId, 'the startGameover packet carries the same matchId (echoed to the client)');
+    // Compare per-user stash to the engine's own awarded XP.
+    const eng1 = engineXp(m.s1.userId);
+    const eng2 = engineXp(m.s2.userId);
+    check(rm.claims[m.s1.userId] && rm.claims[m.s1.userId].xpDelta === eng1, 'winner stash xpDelta == engine award (' + (rm.claims[m.s1.userId] || {}).xpDelta + ' === ' + eng1 + ')');
+    check(rm.claims[m.s2.userId] && rm.claims[m.s2.userId].xpDelta === eng2, 'runner-up stash xpDelta == engine award (' + (rm.claims[m.s2.userId] || {}).xpDelta + ' === ' + eng2 + ')');
+    // Sanity: matches the documented breakdown for a 5-notch win / 2-notch runner-up.
+    check(eng1 === c.xpParticipate + c.xpPerNotch * 5 + c.xpWinBonus, 'winner award = participation + 5 notches + win bonus');
+    check(eng2 === c.xpParticipate + c.xpPerNotch * 2 + c.xpRunnerUpBonus, 'runner-up award = participation + 2 notches + runner-up bonus');
+    teardown(m);
+}
+
+// Patch auth.addProgression so we can assert the credited bonus without Supabase writes.
+function withFakeAddProgression(fn) {
+    const orig = auth.addProgression;
+    const calls = [];
+    auth.addProgression = function (userId, opts) {
+        calls.push({ userId: userId, opts: opts });
+        // Return a plausible normalized-ish row so buildProgressionPayload + the ack work.
+        return Promise.resolve({ xp: 9999, level: 7, unlocked_skins: [], medal_counts: {}, wins: 0 });
+    };
+    return Promise.resolve(fn(calls)).finally(function () { auth.addProgression = orig; });
+}
+
+async function testCreditAndSingleClaim() {
+    console.log('Server — signed-in claim credits the bonus, then single-claim blocks a repeat:');
+    const m = setupMatch('rw-credit');
+    if (!m) { check(false, 'room set up'); return; }
+    const matchId = m.room.rewardedMatch.matchId;
+    const expectedBonus = m.room.rewardedMatch.claims[m.s1.userId].xpDelta; // 2x -> +1x original
+    await withFakeAddProgression(async function (calls) {
+        m.s1.fire('claimXpMultiplier', { matchId: matchId, multiplier: 2 });
+        await Promise.resolve(); await Promise.resolve();
+        check(calls.length === 1, 'addProgression called exactly once');
+        check(calls[0] && calls[0].userId === m.s1.userId && calls[0].opts.xpDelta === expectedBonus, 'credited xpDelta == original match XP (2x total): ' + (calls[0] && calls[0].opts.xpDelta) + ' === ' + expectedBonus);
+        check(calls[0].opts.suppressToasts === true, 'suppressToasts set (client shows its own xpBonus toast, no duplicate lobby toast)');
+        check(progression.rewardedBonusXp(expectedBonus * 1) >= 0, 'rewardedBonusXp helper present');
+        const ack = m.s1.lastEmit('xpBonus');
+        check(!!ack && ack.bonus === expectedBonus && ack.matchId === matchId && ack.multiplier === 2, 'xpBonus ack carries bonus + matchId + server multiplier');
+
+        // Single-claim: a second emit for the same match credits nothing more.
+        const before = calls.length;
+        m.s1.fire('claimXpMultiplier', { matchId: matchId, multiplier: 2 });
+        await Promise.resolve(); await Promise.resolve();
+        check(calls.length === before, 'a SECOND claim for the same match is rejected (single-claim guard)');
+    });
+    teardown(m);
+}
+
+async function testRejections() {
+    console.log('Server — wrong-match / expired / anonymous claims are rejected:');
+    const m = setupMatch('rw-reject');
+    if (!m) { check(false, 'room set up'); return; }
+    const matchId = m.room.rewardedMatch.matchId;
+    await withFakeAddProgression(async function (calls) {
+        // Wrong matchId.
+        m.s1.fire('claimXpMultiplier', { matchId: 'not-a-real-match', multiplier: 2 });
+        // Missing matchId.
+        m.s1.fire('claimXpMultiplier', { multiplier: 2 });
+        await Promise.resolve(); await Promise.resolve();
+        check(calls.length === 0, 'a wrong / missing matchId is rejected');
+
+        // Anonymous (no userId on the socket) — even with the correct matchId.
+        const savedUid = m.s1.userId; m.s1.userId = null;
+        m.s1.fire('claimXpMultiplier', { matchId: matchId, multiplier: 2 });
+        await Promise.resolve(); await Promise.resolve();
+        check(calls.length === 0, 'an anonymous (no userId) claim is rejected server-side');
+        m.s1.userId = savedUid;
+
+        // Expired TTL.
+        m.room.rewardedMatch.gameOverTs = Date.now() - (1000 * 1000); // way past the 90s TTL
+        m.s1.fire('claimXpMultiplier', { matchId: matchId, multiplier: 2 });
+        await Promise.resolve(); await Promise.resolve();
+        check(calls.length === 0, 'a claim past the TTL is rejected');
+    });
+    teardown(m);
+}
+
+function testMultiplierConstant() {
+    console.log('Server — multiplier constant + bonus helper live in progression.js:');
+    check(progression.XP_MULTIPLIER_REWARDED === 2, 'XP_MULTIPLIER_REWARDED === 2');
+    check(progression.rewardedBonusXp(150) === 150, 'rewardedBonusXp(150) === 150 (2x total = +1x original)');
+    check(progression.rewardedBonusXp(0) === 0 && progression.rewardedBonusXp(-5) === 0, 'rewardedBonusXp clamps non-positive deltas to 0');
+}
+
+(async function run() {
+    // Part A
+    testAdsNoneProvider();
+    testAdsGameMonetizeRewarded();
+    // Part B
+    testMultiplierConstant();
+    await testStashMatchesEngineAward();
+    await testCreditAndSingleClaim();
+    await testRejections();
+
+    if (failures > 0) {
+        console.log('\nRewarded-ads test FAILED with ' + failures + ' error(s).');
+        process.exit(1);
+    }
+    console.log('\nRewarded-ads test passed.');
+    process.exit(0);
+})();

--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -60,6 +60,7 @@ function loadAds(adsConfig) {
         documentElement: { appendChild: function () {} },
         body: null
     };
+    let clock = 1000;
     const ctx = {
         window: fakeWin,
         document: fakeDoc,
@@ -67,7 +68,7 @@ function loadAds(adsConfig) {
         encodeURIComponent: encodeURIComponent,
         setTimeout: function (fn, ms) { const id = timerSeq++; timers.push({ id: id, fn: fn }); return id; },
         clearTimeout: function (id) { for (let i = 0; i < timers.length; i++) { if (timers[i].id === id) { timers.splice(i, 1); break; } } },
-        Date: { now: function () { return 1000; } }
+        Date: { now: function () { return clock; } }
     };
     vm.createContext(ctx);
     vm.runInContext(fs.readFileSync(path.join(repoRoot, 'client', 'scripts', 'ads.js'), 'utf8'), ctx);
@@ -80,6 +81,7 @@ function loadAds(adsConfig) {
         // AdinPlay marks the SDK ready via the injected script's onload — fire it.
         fireScriptLoads: function () { createdScripts.forEach(function (s) { if (typeof s.onload === "function") { s.onload(); } }); },
         fireTimers: function () { const due = timers.splice(0, timers.length); due.forEach(function (t) { t.fn(); }); },
+        setNow: function (v) { clock = v; },
         hasEvent: function (name, type) { return tracked.some(function (e) { return e.name === name && (!type || e.params.type === type); }); }
     };
 }
@@ -174,6 +176,37 @@ function testAdsAdinPlayEarlyCloseIsSkip() {
     b.cfg().AIP_REMOVE();   // close after a real completion — must not double-fire
     check(rewardedFull, 'AIP_COMPLETE grants the reward (full watch)');
     check(b.h.tracked.filter(function (e) { return e.name === 'ad_complete' && e.params.type === 'rewarded'; }).length === 1, 'exactly one ad_complete — the post-complete AIP_REMOVE is a no-op');
+}
+
+// The interstitial and rewarded paths share GameMonetize's single showBanner()/PAUSE/START
+// slot. dismissInterstitial() runs at race start; it must tear down an in-flight INTERSTITIAL
+// but must NOT drop an in-flight REWARDED ad the player opted into (that would clear its
+// completion and silently deny the credit).
+function testDismissDoesNotKillRewarded() {
+    console.log('ads.js — dismissInterstitial() leaves an in-flight rewarded ad alone, but tears down an interstitial:');
+
+    // Rewarded in flight + race starts (dismissInterstitial) -> reward STILL granted on completion.
+    var h = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h.fireSdk('SDK_READY');
+    h.win.sdk = { showBanner: function () {} };
+    var rewarded = false;
+    h.ads.showRewarded({ placement: 'xp_2x', onReward: function () { rewarded = true; }, onSkip: function () {} });
+    h.fireSdk('SDK_GAME_PAUSE');     // rewarded ad actually started (adInFlight = 'rewarded')
+    h.ads.dismissInterstitial();      // next race starting — must be a no-op for a rewarded ad
+    h.fireSdk('SDK_GAME_START');     // ad finishes
+    check(rewarded, 'rewarded ad survives a race-start dismiss and still grants the reward');
+
+    // Interstitial in flight + race starts -> torn down (onClose fires).
+    var h2 = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h2.fireSdk('SDK_READY');
+    h2.win.sdk = { showBanner: function () {} };
+    h2.setNow(1000000);               // clear the 90s cooldown (last_ts = 0)
+    h2.ads.onMatchEnded();            // seed the cadence so canShowInterstitial() is true
+    var closed = false;
+    h2.ads.showInterstitial({ placement: 'between_matches', onClose: function () { closed = true; } });
+    h2.fireSdk('SDK_GAME_PAUSE');     // interstitial started (adInFlight = 'interstitial')
+    h2.ads.dismissInterstitial();     // race starting — tears it down
+    check(closed, 'an in-flight interstitial IS torn down at race start (onClose fires)');
 }
 
 // ---------------------------------------------------------------------------
@@ -378,6 +411,7 @@ function testMultiplierConstant() {
     testAdsNoneProvider();
     testAdsGameMonetizeRewarded();
     testAdsAdinPlayEarlyCloseIsSkip();
+    testDismissDoesNotKillRewarded();
     // Part B
     testMultiplierConstant();
     await testStashMatchesEngineAward();

--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -52,8 +52,9 @@ function loadAds(adsConfig) {
         // no isEmbedded -> treated as not embedded
         sdk: null
     };
+    const createdScripts = [];
     const fakeDoc = {
-        createElement: function () { return { setAttribute: function () {}, src: '', async: false, id: '', onload: null, onerror: null, style: {} }; },
+        createElement: function () { const el = { setAttribute: function () {}, src: '', async: false, id: '', onload: null, onerror: null, style: {} }; createdScripts.push(el); return el; },
         getElementById: function () { return null; },
         head: { appendChild: function () {} },
         documentElement: { appendChild: function () {} },
@@ -76,6 +77,8 @@ function loadAds(adsConfig) {
         tracked: tracked,
         // GameMonetize routes everything through window.SDK_OPTIONS.onEvent.
         fireSdk: function (name) { fakeWin.SDK_OPTIONS.onEvent({ name: name }); },
+        // AdinPlay marks the SDK ready via the injected script's onload — fire it.
+        fireScriptLoads: function () { createdScripts.forEach(function (s) { if (typeof s.onload === "function") { s.onload(); } }); },
         fireTimers: function () { const due = timers.splice(0, timers.length); due.forEach(function (t) { t.fn(); }); },
         hasEvent: function (name, type) { return tracked.some(function (e) { return e.name === name && (!type || e.params.type === type); }); }
     };
@@ -137,6 +140,40 @@ function testAdsGameMonetizeRewarded() {
     h4.fireTimers(); // fire the 8s watchdog
     check(!r4 && e4, 'no ad starting before the timeout is an ERROR');
     check(h4.tracked.some(function (ev) { return ev.name === 'ad_error' && ev.params.reason === 'timeout'; }), 'ad_error reason=timeout on request timeout');
+}
+
+function testAdsAdinPlayEarlyCloseIsSkip() {
+    console.log('ads.js — AdinPlay rewarded: an early close (AIP_REMOVE before COMPLETE) is a SKIP:');
+    // Mock the AdinPlay SDK: a cmd.player queue that runs callbacks immediately, and an aipPlayer
+    // constructor that captures the AIP_* config so we can drive the ad lifecycle by hand.
+    function setup() {
+        const h = loadAds({ provider: 'adinplay', publisherId: 'pub' });
+        let cfg = null;
+        h.win.aiptag = { cmd: { player: { push: function (fn) { fn(); } } } };
+        h.win.aipPlayer = function (c) { cfg = c; this.startPreRoll = function () {}; this.destroy = function () {}; };
+        h.fireScriptLoads();        // AdinPlay sets sdkReady on the script onload
+        return { h: h, cfg: function () { return cfg; } };
+    }
+
+    // Early close: AIP_START (impression) then AIP_REMOVE WITHOUT AIP_COMPLETE -> skip, no reward.
+    var a = setup();
+    check(a.h.ads.isRewardedAvailable() === true, 'rewarded available once the AdinPlay script loads');
+    var rewardedEarly = false, skippedEarly = false;
+    a.h.ads.showRewarded({ placement: 'xp_2x', onReward: function () { rewardedEarly = true; }, onSkip: function () { skippedEarly = true; } });
+    a.cfg().AIP_START();
+    a.cfg().AIP_REMOVE();   // closed before completing
+    check(!rewardedEarly && skippedEarly, 'AIP_REMOVE before AIP_COMPLETE grants NO reward (it is a skip)');
+    check(a.h.tracked.some(function (e) { return e.name === 'ad_skipped' && e.params.type === 'rewarded'; }), 'ad_skipped emitted on the early close');
+
+    // Full watch: AIP_START then AIP_COMPLETE -> reward. (A trailing AIP_REMOVE after complete is a no-op.)
+    var b = setup();
+    var rewardedFull = false;
+    b.h.ads.showRewarded({ placement: 'xp_2x', onReward: function () { rewardedFull = true; }, onSkip: function () {} });
+    b.cfg().AIP_START();
+    b.cfg().AIP_COMPLETE();
+    b.cfg().AIP_REMOVE();   // close after a real completion — must not double-fire
+    check(rewardedFull, 'AIP_COMPLETE grants the reward (full watch)');
+    check(b.h.tracked.filter(function (e) { return e.name === 'ad_complete' && e.params.type === 'rewarded'; }).length === 1, 'exactly one ad_complete — the post-complete AIP_REMOVE is a no-op');
 }
 
 // ---------------------------------------------------------------------------
@@ -260,7 +297,7 @@ async function testCreditAndSingleClaim() {
         await Promise.resolve(); await Promise.resolve();
         check(calls.length === 1, 'addProgression called exactly once');
         check(calls[0] && calls[0].userId === m.s1.userId && calls[0].opts.xpDelta === expectedBonus, 'credited xpDelta == original match XP (2x total): ' + (calls[0] && calls[0].opts.xpDelta) + ' === ' + expectedBonus);
-        check(calls[0].opts.suppressToasts === true, 'suppressToasts set (client shows its own xpBonus toast, no duplicate lobby toast)');
+        check(calls[0].opts.suppressXpToast === true, 'suppressXpToast set (client shows its own xpBonus toast; level-up/skin toasts are preserved)');
         check(progression.rewardedBonusXp(expectedBonus * 1) >= 0, 'rewardedBonusXp helper present');
         const ack = m.s1.lastEmit('xpBonus');
         check(!!ack && ack.bonus === expectedBonus && ack.matchId === matchId && ack.multiplier === 2, 'xpBonus ack carries bonus + matchId + server multiplier');
@@ -295,11 +332,37 @@ async function testRejections() {
         m.s1.userId = savedUid;
 
         // Expired TTL.
-        m.room.rewardedMatch.gameOverTs = Date.now() - (1000 * 1000); // way past the 90s TTL
+        m.room.rewardedMatch.gameOverTs = Date.now() - (1000 * 1000); // way past the 180s TTL
         m.s1.fire('claimXpMultiplier', { matchId: matchId, multiplier: 2 });
         await Promise.resolve(); await Promise.resolve();
         check(calls.length === 0, 'a claim past the TTL is rejected');
     });
+    teardown(m);
+}
+
+// P1-b: with writes ENABLED, a failed persist (addProgression resolves null) must NOT be acked
+// as success — no xpBonus, and the single-claim flag is reset so the watched ad can be retried.
+async function testWriteFailureNotAcked() {
+    console.log('Server — a failed persist (writes on) is not acked, claim resets for retry:');
+    const m = setupMatch('rw-fail');
+    if (!m) { check(false, 'room set up'); return; }
+    const matchId = m.room.rewardedMatch.matchId;
+    const origWrites = auth.writesEnabled;
+    const origAdd = auth.addProgression;
+    let calls = 0;
+    auth.writesEnabled = true;                 // pretend prod writes are on
+    auth.addProgression = function () { calls++; return Promise.resolve(null); }; // simulate DB failure
+    try {
+        m.s1.emits.length = 0;
+        m.s1.fire('claimXpMultiplier', { matchId: matchId, multiplier: 2 });
+        await Promise.resolve(); await Promise.resolve();
+        check(calls === 1, 'addProgression was attempted');
+        check(!m.s1.lastEmit('xpBonus'), 'NO xpBonus ack emitted on a failed write (ad not falsely credited)');
+        check(m.room.rewardedMatch.claims[m.s1.userId].claimed === false, 'single-claim flag reset -> the watched ad can be retried');
+    } finally {
+        auth.writesEnabled = origWrites;
+        auth.addProgression = origAdd;
+    }
     teardown(m);
 }
 
@@ -314,11 +377,13 @@ function testMultiplierConstant() {
     // Part A
     testAdsNoneProvider();
     testAdsGameMonetizeRewarded();
+    testAdsAdinPlayEarlyCloseIsSkip();
     // Part B
     testMultiplierConstant();
     await testStashMatchesEngineAward();
     await testCreditAndSingleClaim();
     await testRejections();
+    await testWriteFailureNotAcked();
 
     if (failures > 0) {
         console.log('\nRewarded-ads test FAILED with ' + failures + ' error(s).');

--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -299,8 +299,11 @@ async function testStashMatchesEngineAward() {
     check(!!rm && !!rm.matchId, 'startGameover stashed a rewardedMatch with a matchId');
     const packet = ioEvents.filter(function (e) { return e.header === 'startGameover'; }).pop();
     check(packet && packet.payload.matchId == null, 'the broadcast startGameover packet does NOT carry matchId (eligibility is targeted, not broadcast)');
-    // Eligibility is delivered targeted, only to the credited racers.
-    check(m.s1.lastEmit('rewardedEligible') && m.s1.lastEmit('rewardedEligible').matchId === rm.matchId, 'winner received a targeted rewardedEligible with this matchId');
+    // Eligibility is delivered targeted, only to the credited racers, and carries the server
+    // gameOverTs so the client anchors its offer window to the server clock (not receipt time).
+    var elig1 = m.s1.lastEmit('rewardedEligible');
+    check(elig1 && elig1.matchId === rm.matchId, 'winner received a targeted rewardedEligible with this matchId');
+    check(elig1 && elig1.gameOverTs === rm.gameOverTs, 'rewardedEligible carries the server gameOverTs (offer window anchored to server clock, not client receipt)');
     check(m.s2.lastEmit('rewardedEligible') && m.s2.lastEmit('rewardedEligible').matchId === rm.matchId, 'runner-up received a targeted rewardedEligible with this matchId');
     // Compare per-user stash to the engine's own awarded XP.
     const eng1 = engineXp(m.s1.userId);

--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -142,6 +142,14 @@ function testAdsGameMonetizeRewarded() {
     h4.fireTimers(); // fire the 8s watchdog
     check(!r4 && e4, 'no ad starting before the timeout is an ERROR');
     check(h4.tracked.some(function (ev) { return ev.name === 'ad_error' && ev.params.reason === 'timeout'; }), 'ad_error reason=timeout on request timeout');
+    // A SLOW provider that starts an ad AFTER the timeout must not sneak through: the timeout
+    // tore down the provider request (cleared the pending PAUSE/START), so a late PAUSE/START
+    // grants no reward and fires no late ad_shown.
+    var shownBefore = h4.tracked.filter(function (ev) { return ev.name === 'ad_shown'; }).length;
+    h4.fireSdk('SDK_GAME_PAUSE');
+    h4.fireSdk('SDK_GAME_START');
+    check(!r4, 'a late ad after timeout grants NO reward (provider request was torn down)');
+    check(h4.tracked.filter(function (ev) { return ev.name === 'ad_shown'; }).length === shownBefore, 'a late ad after timeout fires no ad_shown');
 }
 
 function testAdsAdinPlayEarlyCloseIsSkip() {
@@ -299,11 +307,11 @@ async function testStashMatchesEngineAward() {
     check(!!rm && !!rm.matchId, 'startGameover stashed a rewardedMatch with a matchId');
     const packet = ioEvents.filter(function (e) { return e.header === 'startGameover'; }).pop();
     check(packet && packet.payload.matchId == null, 'the broadcast startGameover packet does NOT carry matchId (eligibility is targeted, not broadcast)');
-    // Eligibility is delivered targeted, only to the credited racers, and carries the server
-    // gameOverTs so the client anchors its offer window to the server clock (not receipt time).
+    // Eligibility is delivered targeted, only to the credited racers, and carries the REMAINING
+    // claim lifetime as a duration (ttlMs) so the client deadline stays on a single clock.
     var elig1 = m.s1.lastEmit('rewardedEligible');
     check(elig1 && elig1.matchId === rm.matchId, 'winner received a targeted rewardedEligible with this matchId');
-    check(elig1 && elig1.gameOverTs === rm.gameOverTs, 'rewardedEligible carries the server gameOverTs (offer window anchored to server clock, not client receipt)');
+    check(elig1 && typeof elig1.ttlMs === 'number' && elig1.ttlMs > 0 && elig1.ttlMs <= 180000, 'rewardedEligible carries a remaining-lifetime duration (ttlMs), not a server timestamp');
     check(m.s2.lastEmit('rewardedEligible') && m.s2.lastEmit('rewardedEligible').matchId === rm.matchId, 'runner-up received a targeted rewardedEligible with this matchId');
     // Compare per-user stash to the engine's own awarded XP.
     const eng1 = engineXp(m.s1.userId);
@@ -313,6 +321,30 @@ async function testStashMatchesEngineAward() {
     // Sanity: matches the documented breakdown for a 5-notch win / 2-notch runner-up.
     check(eng1 === c.xpParticipate + c.xpPerNotch * 5 + c.xpWinBonus, 'winner award = participation + 5 notches + win bonus');
     check(eng2 === c.xpParticipate + c.xpPerNotch * 2 + c.xpRunnerUpBonus, 'runner-up award = participation + 2 notches + runner-up bonus');
+    teardown(m);
+}
+
+// A rewarded ad can finish during (or after) the NEXT match. The prior match's claim record
+// must survive a later match's stamp (kept per-matchId, pruned only past the TTL) so the
+// watched ad still pays out.
+async function testPriorMatchStillClaimable() {
+    console.log('Server — a prior match stays claimable after the next match ends (per-matchId records):');
+    const m = setupMatch('rw-prior');
+    if (!m) { check(false, 'room set up'); return; }
+    const matchA = m.room.rewardedMatch.matchId;
+    // Simulate a SECOND match ending in the same room (an ad from match A still in flight).
+    m.room.playerList[m.s1.id].notches = 3; m.room.playerList[m.s1.id].racedCurrentMap = true;
+    m.room.playerList[m.s2.id].notches = 1; m.room.playerList[m.s2.id].racedCurrentMap = true;
+    m.room.game.firstPlaceSig = m.s1.id; m.room.game.secondPlaceSig = m.s2.id;
+    m.room.game.gameOver(m.s1.id); // stamps match B; A must remain in the map
+    const matchB = m.room.rewardedMatch.matchId;
+    check(matchA !== matchB, 'the second match got a distinct matchId');
+    check(!!(m.room.rewardedMatches[matchA] && m.room.rewardedMatches[matchB]), 'both the prior (A) and current (B) match records are retained within the TTL');
+    await withFakeAddProgression(async function (calls) {
+        m.s1.fire('claimXpMultiplier', { matchId: matchA, multiplier: 2 });
+        await Promise.resolve(); await Promise.resolve();
+        check(calls.length === 1, "the PRIOR match's claim still succeeds after the next match ended");
+    });
     teardown(m);
 }
 
@@ -443,6 +475,7 @@ function testMultiplierConstant() {
     // Part B
     testMultiplierConstant();
     await testStashMatchesEngineAward();
+    await testPriorMatchStillClaimable();
     await testSpectatorNotOfferedEligibility();
     await testCreditAndSingleClaim();
     await testRejections();

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -160,6 +160,9 @@ jobs:
       - name: Headless progression test (XP / levels / achievement unlocks)
         run: node .github/scripts/progression-test.js
 
+      - name: Headless rewarded-ads test (2x XP claim: credit / anti-abuse / ad layer)
+        run: node .github/scripts/ads-rewarded-test.js
+
   perf-tick-budget:
     # Server-side worst-case load: a full 25-kart grid in a stacked brutal round.
     # Proves one room still ticks well within the 30 Hz interval. Zero new deps —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### General
 
-- Watch a short ad on the results screen to **double the XP you earned that match** — handy when you're close to a level-up. Signed-in players only; the bonus is credited once per match.
+- After a match you can watch a short ad to **double the XP you earned that match** — handy when you're close to a level-up. It's a quick optional prompt as you head back to the lobby (it never interrupts the results/recap screen). Signed-in players only; the bonus is credited once per match.
 
 ## v0.27.4 — 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- Watch a short ad on the results screen to **double the XP you earned that match** — handy when you're close to a level-up. Signed-in players only; the bonus is credited once per match.
 
 ## v0.27.4 — 2026-06-01
 

--- a/analytics/ga-config.json
+++ b/analytics/ga-config.json
@@ -31,6 +31,24 @@
       "displayName": "Bot Trap Source",
       "scope": "EVENT",
       "description": "Which page's invisible honeypot decoy a bot tripped (landing | play). Attached to bot_trap events."
+    },
+    {
+      "parameterName": "type",
+      "displayName": "Ad Type",
+      "scope": "EVENT",
+      "description": "Ad format on ad_shown/ad_complete/ad_skipped/ad_error: interstitial | rewarded."
+    },
+    {
+      "parameterName": "placement",
+      "displayName": "Ad Placement",
+      "scope": "EVENT",
+      "description": "Where the ad fired on ad_* events: between_matches (interstitial) | xp_2x (rewarded results-screen reward)."
+    },
+    {
+      "parameterName": "bonus",
+      "displayName": "Reward Bonus",
+      "scope": "EVENT",
+      "description": "Which rewarded bonus a player claimed on reward_claimed: xp_2x (double match XP). Extensible to future rewarded options."
     }
   ],
   "customMetrics": [

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -272,6 +272,23 @@ nav .auth-control ~ .theme-toggle {
 .cc-progression-toast.visible {
     transform: translateX(-50%) translateY(0);
 }
+/* "2× your match XP" offer — the last item in the progression-toast stream. Persistent
+   (no auto-dismiss) actionable toast with a gold "Watch" CTA sized for touch (≥44px). */
+.cc-reward-offer .cc-toast-action {
+    height: 44px;
+    padding: 0 16px;
+    font-size: 15px;
+    font-weight: 600;
+    background: #f6c64b;
+    border-color: #f6c64b;
+    color: #1a1a1a;
+}
+.cc-reward-offer .cc-toast-action:hover { background: #ffd45e; }
+.cc-reward-offer .cc-toast-close {
+    width: 44px;
+    height: 44px;
+    font-size: 20px;
+}
 .cc-progression-toast .cc-toast-msg {
     font-size: 15px;
     font-weight: 600;
@@ -1281,18 +1298,6 @@ body.osk-open .gamepad-prompts {
     background: #c87f8a;
     border-color: #c87f8a;
     color: #fff;
-}
-/* Reward prompt ("2× your match XP"): a subtitle line + a gold accent on the opt-in CTA. */
-.confirm-subtitle {
-    font-size: 0.95rem;
-    color: var(--text);
-    opacity: 0.8;
-    margin: -0.5rem 0 1.1rem;
-}
-.confirm-btn.confirm-watch {
-    background: #f6c64b;
-    border-color: #f6c64b;
-    color: #1a1a1a;
 }
 
 /* in-game settings panel (controller-navigable; mirrors the navbar toggles).

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -289,6 +289,21 @@ nav .auth-control ~ .theme-toggle {
     height: 44px;
     font-size: 20px;
 }
+/* Controller/keyboard focus state: the first Ⓐ/Enter focuses the toast (this highlight + the
+   hint), the second watches — so a bare gameplay press can never launch an ad. */
+.cc-reward-offer.gp-focus {
+    outline: 3px solid #f6c64b;
+    outline-offset: 2px;
+}
+.cc-reward-offer.gp-focus .cc-toast-action {
+    box-shadow: 0 0 0 3px rgba(246, 198, 75, 0.6);
+}
+.cc-reward-hint {
+    font-size: 12px;
+    opacity: 0.85;
+    white-space: nowrap;
+}
+.cc-reward-hint:empty { display: none; }
 .cc-progression-toast .cc-toast-msg {
     font-size: 15px;
     font-weight: 600;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1282,6 +1282,18 @@ body.osk-open .gamepad-prompts {
     border-color: #c87f8a;
     color: #fff;
 }
+/* Reward prompt ("2× your match XP"): a subtitle line + a gold accent on the opt-in CTA. */
+.confirm-subtitle {
+    font-size: 0.95rem;
+    color: var(--text);
+    opacity: 0.8;
+    margin: -0.5rem 0 1.1rem;
+}
+.confirm-btn.confirm-watch {
+    background: #f6c64b;
+    border-color: #f6c64b;
+    color: #1a1a1a;
+}
 
 /* in-game settings panel (controller-navigable; mirrors the navbar toggles).
    Unlike the leave modal it does NOT dim the whole screen — in local co-op the

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -199,12 +199,13 @@
         s.onerror = function () { sdkReady = false; }; // fail-open: stays no-op
         (document.head || document.documentElement).appendChild(s);
 
-        // One preroll routine for both interstitial and rewarded. AdinPlay is NOT the chosen
-        // network (GameMonetize is) so this path is wired-but-untested; a dedicated rewarded
-        // zone is configured on the operator's AdinPlay dashboard, but the SDK shape (AIP_START
-        // impression, AIP_COMPLETE/REMOVE done) is identical, so the public layer's PAUSE->START
-        // reward discipline applies unchanged.
-        function aipShowAd(onStart, onComplete, onError) {
+        // AdinPlay is NOT the chosen network (GameMonetize is) so this path is wired-but-untested.
+        // INTERSTITIAL: a close (AIP_REMOVE) and a full play (AIP_COMPLETE) both just mean "the
+        // ad is done" — either resolves it. REWARDED is stricter: the reward must be granted ONLY
+        // on a full watch (AIP_COMPLETE); an early close (AIP_REMOVE before COMPLETE) is a SKIP,
+        // not a reward — otherwise dismissing a preroll would pay out 2× XP. AIP_START is the
+        // impression signal for both (no-fill never fires it).
+        function aipShowInterstitial(onStart, onComplete, onError) {
             try {
                 window.aiptag.cmd.player.push(function () {
                     try {
@@ -213,11 +214,33 @@
                             AD_HEIGHT: 540,
                             AD_DISPLAY: "fullscreen",
                             LOADING_TEXT: "Advertisement",
-                            // AIP_START fires only when an ad actually renders —
-                            // our impression signal. No-fill skips it.
                             AIP_START: function () { onStart(); },
                             AIP_COMPLETE: function () { onComplete(); },
-                            AIP_REMOVE: function () { onComplete(); }
+                            AIP_REMOVE: function () { onComplete(); } // close == done for an interstitial
+                        });
+                        window.aiptag.adplayer.startPreRoll();
+                    } catch (e) { onError(); }
+                });
+            } catch (e) { onError(); }
+        }
+        function aipShowRewarded(onStart, onComplete, onError, onSkip) {
+            try {
+                window.aiptag.cmd.player.push(function () {
+                    try {
+                        var completed = false;
+                        window.aiptag.adplayer = new window.aipPlayer({
+                            AD_WIDTH: 960,
+                            AD_HEIGHT: 540,
+                            AD_DISPLAY: "fullscreen",
+                            LOADING_TEXT: "Advertisement",
+                            AIP_START: function () { onStart(); },
+                            AIP_COMPLETE: function () { completed = true; onComplete(); }, // full watch -> reward
+                            AIP_REMOVE: function () {
+                                // Close: only a no-op AFTER a real completion. A close BEFORE complete
+                                // is an early dismiss -> SKIP (no reward), never onComplete.
+                                if (completed) { return; }
+                                if (typeof onSkip === "function") { onSkip(); } else { onError(); }
+                            }
                         });
                         window.aiptag.adplayer.startPreRoll();
                     } catch (e) { onError(); }
@@ -225,8 +248,8 @@
             } catch (e) { onError(); }
         }
         adapter = {
-            showInterstitial: aipShowAd,
-            showRewarded: aipShowAd,
+            showInterstitial: aipShowInterstitial,
+            showRewarded: aipShowRewarded,
             // Best-effort teardown if we must reclaim the screen for the next race.
             dismiss: function () {
                 try {
@@ -555,7 +578,11 @@
             adapter.showRewarded(
                 onStart,
                 function () { settle("complete"); },
-                function () { settle("error"); }
+                function () { settle("error"); },
+                // Adapter-signalled SKIP (e.g. AdinPlay AIP_REMOVE before AIP_COMPLETE = early
+                // close): NOT a reward. GameMonetize has no early-close event, so its adapter
+                // ignores this 4th arg (a no-fill is detected in settle() as complete-without-start).
+                function () { settle("skipped"); }
             );
         } catch (e) {
             settle("error");

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -1,13 +1,17 @@
-// ads.js — network-agnostic ad layer for ChaoChao (interstitial half).
+// ads.js — network-agnostic ad layer for ChaoChao.
 //
-// SCOPE (this chunk): interstitials at the gameOver state transition,
-// frequency-capped. The rewarded-video "Watch to 2× XP" half is DEFERRED until
-// the cosmetics progression engine (server/progression.js + auth.addProgression)
-// lands in main — see docs/ads-monetization-plan.md, "Dependency". The rewarded
-// API surface below is present but stubbed (isRewardedAvailable() === false,
-// showRewarded() fails open) so the forward-compatible interface exists without
-// any progression dependency. Do NOT render the rewarded button until the
-// server-side claim handler ships.
+// SCOPE: interstitials at the gameOver state transition (frequency-capped) AND the
+// rewarded-video "Watch to 2× match XP" reward on the results screen. The rewarded
+// reward is credited server-side (server/messenger.js claimXpMultiplier +
+// auth.addProgression, gated on writesEnabled); the client onReward below is only the
+// signal — see docs/ads-monetization-plan.md, "Rewarded video".
+//
+// GameMonetize note: their HTML5 SDK exposes only showBanner() + the
+// SDK_GAME_PAUSE/START events — NO dedicated rewarded unit, no reward-granted event,
+// and no server-to-server completion postback. So a rewarded ad reuses showBanner() and
+// a CONFIRMED full play (PAUSE -> START) is treated as the reward signal; the server's
+// single-claim + TTL + fixed-multiplier guards are the anti-abuse. A true rewarded unit /
+// S2S postback is a documented follow-up if the network later supports it.
 //
 // DESIGN CONTRACT
 //   - Network-agnostic. Only this file knows which ad network is wired. The rest
@@ -163,27 +167,34 @@
         s.onerror = function () { sdkReady = false; }; // fail-open: stays no-op
         (document.head || document.documentElement).appendChild(s);
 
+        // One preroll routine for both interstitial and rewarded. AdinPlay is NOT the chosen
+        // network (GameMonetize is) so this path is wired-but-untested; a dedicated rewarded
+        // zone is configured on the operator's AdinPlay dashboard, but the SDK shape (AIP_START
+        // impression, AIP_COMPLETE/REMOVE done) is identical, so the public layer's PAUSE->START
+        // reward discipline applies unchanged.
+        function aipShowAd(onStart, onComplete, onError) {
+            try {
+                window.aiptag.cmd.player.push(function () {
+                    try {
+                        window.aiptag.adplayer = new window.aipPlayer({
+                            AD_WIDTH: 960,
+                            AD_HEIGHT: 540,
+                            AD_DISPLAY: "fullscreen",
+                            LOADING_TEXT: "Advertisement",
+                            // AIP_START fires only when an ad actually renders —
+                            // our impression signal. No-fill skips it.
+                            AIP_START: function () { onStart(); },
+                            AIP_COMPLETE: function () { onComplete(); },
+                            AIP_REMOVE: function () { onComplete(); }
+                        });
+                        window.aiptag.adplayer.startPreRoll();
+                    } catch (e) { onError(); }
+                });
+            } catch (e) { onError(); }
+        }
         adapter = {
-            showInterstitial: function (onStart, onComplete, onError) {
-                try {
-                    window.aiptag.cmd.player.push(function () {
-                        try {
-                            window.aiptag.adplayer = new window.aipPlayer({
-                                AD_WIDTH: 960,
-                                AD_HEIGHT: 540,
-                                AD_DISPLAY: "fullscreen",
-                                LOADING_TEXT: "Advertisement",
-                                // AIP_START fires only when an ad actually renders —
-                                // our impression signal. No-fill skips it.
-                                AIP_START: function () { onStart(); },
-                                AIP_COMPLETE: function () { onComplete(); },
-                                AIP_REMOVE: function () { onComplete(); }
-                            });
-                            window.aiptag.adplayer.startPreRoll();
-                        } catch (e) { onError(); }
-                    });
-                } catch (e) { onError(); }
-            },
+            showInterstitial: aipShowAd,
+            showRewarded: aipShowAd,
             // Best-effort teardown if we must reclaim the screen for the next race.
             dismiss: function () {
                 try {
@@ -255,33 +266,41 @@
             }
         } catch (e) { sdkReady = false; }
 
-        adapter = {
-            showInterstitial: function (onStart, onComplete, onError) {
-                try {
-                    // Stash the start/complete cbs for the next PAUSE/START. If a
-                    // previous interstitial is somehow still pending, clear its slots
-                    // first (don't replay its start — that would double-count an
-                    // impression; the public timeout already settled the game side).
-                    gmPendingStart = null;
-                    if (typeof gmPendingComplete === "function") {
-                        var stale = gmPendingComplete; gmPendingComplete = null; stale();
-                    }
-                    gmPendingStart = onStart;
-                    gmPendingComplete = onComplete;
-                    if (window.sdk && typeof window.sdk.showBanner === "function") {
-                        window.sdk.showBanner();
-                    } else {
-                        // SDK object missing despite sdkReady — treat as error.
-                        gmPendingStart = null;
-                        gmPendingComplete = null;
-                        onError();
-                    }
-                } catch (e) {
+        // One ad-show routine for BOTH interstitial and rewarded. GameMonetize's HTML5 SDK
+        // exposes only showBanner() and the SDK_GAME_PAUSE/START events — there is NO dedicated
+        // rewarded unit, no "reward granted" event, and no server-to-server completion postback
+        // (verified against their SDK source). So a rewarded ad is the same showBanner() video;
+        // the public layer treats a CONFIRMED full play (PAUSE -> START) as the reward signal
+        // and a START with no prior PAUSE as a no-fill (skip). Interstitial and rewarded never
+        // overlap in time (lobby gate vs results screen), so sharing the pending slots is safe.
+        function gmShowAd(onStart, onComplete, onError) {
+            try {
+                // Stash the start/complete cbs for the next PAUSE/START. If a previous ad is
+                // somehow still pending, clear its slots first (don't replay its start — that
+                // would double-count an impression; the public timeout already settled it).
+                gmPendingStart = null;
+                if (typeof gmPendingComplete === "function") {
+                    var stale = gmPendingComplete; gmPendingComplete = null; stale();
+                }
+                gmPendingStart = onStart;
+                gmPendingComplete = onComplete;
+                if (window.sdk && typeof window.sdk.showBanner === "function") {
+                    window.sdk.showBanner();
+                } else {
+                    // SDK object missing despite sdkReady — treat as error.
                     gmPendingStart = null;
                     gmPendingComplete = null;
                     onError();
                 }
-            },
+            } catch (e) {
+                gmPendingStart = null;
+                gmPendingComplete = null;
+                onError();
+            }
+        }
+        adapter = {
+            showInterstitial: gmShowAd,
+            showRewarded: gmShowAd,
             // Best-effort teardown for race-start cancellation. NOTE: the GameMonetize
             // preroll SDK exposes no documented programmatic close, so we can only
             // drop our pending callbacks here — visually dismissing an already-playing
@@ -303,7 +322,12 @@
             // impression). (In practice unreachable via showInterstitial(), which
             // early-returns when canShowInterstitial() is false for provider 'none'.)
             sdkReady = false;
-            adapter = { showInterstitial: function (onStart, onComplete) { onComplete(); } };
+            adapter = {
+                showInterstitial: function (onStart, onComplete) { onComplete(); },
+                // Unreachable in practice (isRewardedAvailable() is false for provider 'none',
+                // so showRewarded() short-circuits to onSkip before reaching the adapter).
+                showRewarded: function (onStart, onComplete) { onComplete(); }
+            };
         }
     }
 
@@ -414,16 +438,84 @@
         if (typeof activeSettle === "function") { activeSettle("cancelled"); }
     }
 
-    // ---- Rewarded (DEFERRED — stubbed until progression engine lands) ----------
-    // The forward-compatible surface exists so callers can be written against the
-    // final API, but it reports unavailable and fails open. Do NOT render the
-    // "Watch to 2× XP" button: it requires server/progression.js +
-    // auth.addProgression + the claimXpMultiplier handler, which are not in main.
-    function isRewardedAvailable() { return false; }
+    // ---- Rewarded video — "Watch to 2× match XP" ------------------------------
+    // True once a real network's SDK is ready (and we're allowed to show ads at all:
+    // not embedded, provider != 'none'). The UI gates the results-screen reward button
+    // on this — so locally / when embedded / when no network is wired, the button never
+    // renders and gameplay is untouched. GameMonetize has no separate "rewarded loaded"
+    // signal, so readiness == SDK ready.
+    function isRewardedAvailable() {
+        if (!shouldShow()) { return false; }  // provider 'none' or embedded -> not available
+        return !!sdkReady;
+    }
+
+    // Show a rewarded ad. onReward fires ONLY on a confirmed full watch (an ad actually
+    // started AND completed); onSkip on a no-fill or a close-before-complete; onError on
+    // an SDK throw or the request timing out before any ad starts. Single settle authority
+    // + hard timeout + exactly-once, mirroring showInterstitial's discipline — the reward is
+    // never credited on a mere attempt or a no-fill, so the GA funnel and the XP grant stay
+    // honest. Fail-open: if no real ad path exists, we skip (no reward, no error noise).
     function showRewarded(args) {
         args = args || {};
-        // No reward path wired yet — treat as a skip so any caller fails open.
-        if (typeof args.onSkip === "function") { args.onSkip(); }
+        var placement = args.placement || "xp_2x";
+        var onReward = (typeof args.onReward === "function") ? args.onReward : function () {};
+        var onSkip = (typeof args.onSkip === "function") ? args.onSkip : function () {};
+        var onError = (typeof args.onError === "function") ? args.onError : function () {};
+
+        // No real, ready network (local 'none' / embedded / SDK not loaded) — fail open as a
+        // skip so the caller leaves the button up for a retry and never credits a reward.
+        if (!isRewardedAvailable() || !adapter || typeof adapter.showRewarded !== "function") {
+            onSkip();
+            return;
+        }
+
+        var started = false;
+        function onStart() {
+            if (started) { return; }
+            started = true;
+            // The watchdog guards the REQUEST (waiting for an ad to begin), not playback —
+            // a rewarded video runs well past AD_TIMEOUT_MS. Clear it now that an ad is on
+            // screen; from here we wait for the provider's complete/error.
+            clearTimeout(timer);
+            track("ad_shown", { type: "rewarded", placement: placement });
+        }
+
+        var settled = false;
+        var timer = setTimeout(function () { settle("timeout"); }, AD_TIMEOUT_MS);
+        function settle(status) {
+            if (settled) { return; }
+            settled = true;
+            clearTimeout(timer);
+            if (status === "complete") {
+                if (started) {
+                    // Confirmed full watch -> grant the reward.
+                    track("ad_complete", { type: "rewarded", placement: placement });
+                    try { onReward(); } catch (e) { /* caller must not break the screen */ }
+                } else {
+                    // "complete" with no start = no-fill (GameMonetize signals it as
+                    // SDK_GAME_START without a prior PAUSE). Not watched -> no reward, just skip.
+                    track("ad_skipped", { type: "rewarded", placement: placement });
+                    try { onSkip(); } catch (e) {}
+                }
+            } else if (status === "skipped") {
+                track("ad_skipped", { type: "rewarded", placement: placement });
+                try { onSkip(); } catch (e) {}
+            } else {
+                // "error" (SDK threw) or "timeout" (no ad started in time): no reward.
+                track("ad_error", { type: "rewarded", placement: placement, reason: status });
+                try { onError(); } catch (e) {}
+            }
+        }
+
+        try {
+            adapter.showRewarded(
+                onStart,
+                function () { settle("complete"); },
+                function () { settle("error"); }
+            );
+        } catch (e) {
+            settle("error");
+        }
     }
 
     window.ads = {

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -570,6 +570,14 @@
             settled = true;
             clearTimeout(timer);
             adInFlight = null;
+            if (status === "timeout") {
+                // The request is still pending in the provider (no ad started in time). Tear it
+                // down so a slow ad can't appear AFTER we've given up — otherwise it would cover
+                // the screen, fire a late ad_shown, and complete with no credit (this settle is
+                // already closed). dismiss() clears GameMonetize's pending PAUSE/START callbacks
+                // and destroys AdinPlay's player. No interstitial can be in flight here.
+                try { if (adapter && typeof adapter.dismiss === "function") { adapter.dismiss(); } } catch (e) {}
+            }
             if (status === "complete") {
                 if (started) {
                     // Confirmed full watch -> grant the reward.

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -57,6 +57,14 @@
     // dismissInterstitial() tear down an ad that's still up when the next race
     // starts, so an interstitial can never sit over live gameplay.
     var activeSettle = null;
+    // Which kind of ad is currently in flight: "interstitial" | "rewarded" | null.
+    // The interstitial and rewarded paths SHARE the provider plumbing (GameMonetize's
+    // single showBanner()/PAUSE/START slots; AdinPlay's single adplayer). They never run
+    // at the same time (mutually exclusive at the gameOver->lobby edge), but
+    // dismissInterstitial() runs at race start and must NOT tear down an in-flight REWARDED
+    // ad the player opted into — that would drop its completion and silently deny the credit.
+    // So dismiss only acts when an interstitial is in flight; a rewarded ad is left to finish.
+    var adInFlight = null;
 
     // ---- Small safe helpers ---------------------------------------------------
     function lsGet(key) {
@@ -444,6 +452,7 @@
             settled = true;
             clearTimeout(timer);
             activeSettle = null;
+            adInFlight = null;
             if (status === "complete") {
                 // Completion is only an impression if the ad actually started.
                 // A "complete" with no start is a NO-FILL (GameMonetize signals it
@@ -469,6 +478,7 @@
         // Expose this in-flight settle so dismissInterstitial() can tear it down if
         // the next race starts before the ad closes on its own.
         activeSettle = settle;
+        adInFlight = "interstitial";
 
         try {
             adapter.showInterstitial(
@@ -481,12 +491,18 @@
         }
     }
 
-    // Tear down any in-flight interstitial so it can't sit over live gameplay.
-    // Called when the next race is about to start (startGated / startRace). Asks the
-    // provider to drop the ad (best-effort — see each adapter's dismiss note), then
-    // settles the in-flight request as "cancelled" (no telemetry, fires onClose).
-    // No-op when nothing is showing.
+    // Tear down any in-flight INTERSTITIAL so it can't sit over live gameplay. Called when
+    // the next race is about to start (startGated / startRace). Asks the provider to drop the
+    // ad (best-effort — see each adapter's dismiss note), then settles the in-flight request as
+    // "cancelled" (no telemetry, fires onClose). No-op when nothing is showing.
+    //
+    // IMPORTANT: this must NOT touch an in-flight REWARDED ad. The two share the provider's
+    // single ad slot, but the rewarded one was opted into for a reward — dropping it at race
+    // start would clear its completion callback and silently deny the credit (and strand the
+    // client awaiting an ack). So we only tear down when an interstitial is what's in flight;
+    // a rewarded ad is left to finish on its own and pay out, even if the race has begun.
     function dismissInterstitial() {
+        if (adInFlight !== "interstitial") { return; }
         try {
             if (adapter && typeof adapter.dismiss === "function") { adapter.dismiss(); }
         } catch (e) { /* best-effort */ }
@@ -553,6 +569,7 @@
             if (settled) { return; }
             settled = true;
             clearTimeout(timer);
+            adInFlight = null;
             if (status === "complete") {
                 if (started) {
                     // Confirmed full watch -> grant the reward.
@@ -574,6 +591,7 @@
             }
         }
 
+        adInFlight = "rewarded";   // so dismissInterstitial() leaves this opted-in ad alone
         try {
             adapter.showRewarded(
                 onStart,

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -75,6 +75,38 @@
         } catch (e) { /* analytics must never break gameplay */ }
     }
 
+    // ===== DEV-ONLY — STRIP BEFORE PR (rewarded playtest override) =============
+    // `?testrewarded=1` on localhost makes the rewarded path testable with NO ad
+    // network: isRewardedAvailable() reports true and showRewarded() simulates a full
+    // watch (a brief overlay, then onReward) so you can exercise the results-screen
+    // button + the REAL server claim/credit/toast flow locally. HARD-gated to localhost
+    // so it's inert anywhere else; must never reach prod (see the playtest-restart-button
+    // convention in CLAUDE.md / memory). NOTE: the button still requires being signed in
+    // (the claim needs a userId) — sign in against the DEV Supabase to see it.
+    function devRewardedOverride() {
+        try {
+            if (location.hostname !== "localhost" && location.hostname !== "127.0.0.1") { return false; }
+            return /[?&]testrewarded=1(?:&|$)/.test(location.search);
+        } catch (e) { return false; }
+    }
+    function showDevAdOverlay(done) {
+        var el = null;
+        try {
+            el = document.createElement("div");
+            el.setAttribute("data-dev-rewarded", "1");
+            el.style.cssText = "position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.85);" +
+                "display:flex;align-items:center;justify-content:center;color:#FFE08A;" +
+                "font:bold 28px sans-serif;text-align:center;padding:24px;";
+            el.textContent = "Simulated rewarded ad (dev) — granting 2× XP…";
+            (document.body || document.documentElement).appendChild(el);
+        } catch (e) { el = null; }
+        setTimeout(function () {
+            try { if (el && el.parentNode) { el.parentNode.removeChild(el); } } catch (e) {}
+            done();
+        }, 1500);
+    }
+    // ===== END DEV-ONLY =========================================================
+
     function embedded() {
         // isEmbedded() ships in embed.js (loaded before the bundle). Treat its
         // absence as "not embedded" so a load-order hiccup can't suppress ads.
@@ -445,6 +477,7 @@
     // renders and gameplay is untouched. GameMonetize has no separate "rewarded loaded"
     // signal, so readiness == SDK ready.
     function isRewardedAvailable() {
+        if (devRewardedOverride()) { return true; }   // DEV-ONLY — STRIP BEFORE PR
         if (!shouldShow()) { return false; }  // provider 'none' or embedded -> not available
         return !!sdkReady;
     }
@@ -466,6 +499,17 @@
         // skip so the caller leaves the button up for a retry and never credits a reward.
         if (!isRewardedAvailable() || !adapter || typeof adapter.showRewarded !== "function") {
             onSkip();
+            return;
+        }
+
+        // DEV-ONLY — STRIP BEFORE PR: simulate a full watch with no ad network so the
+        // real onReward -> claimXpMultiplier -> xpBonus flow can be exercised locally.
+        if (devRewardedOverride()) {
+            track("ad_shown", { type: "rewarded", placement: placement });
+            showDevAdOverlay(function () {
+                track("ad_complete", { type: "rewarded", placement: placement });
+                try { onReward(); } catch (e) { /* caller must not break the screen */ }
+            });
             return;
         }
 
@@ -527,6 +571,7 @@
         shouldShow: shouldShow,
         isRewardedAvailable: isRewardedAvailable,
         showRewarded: showRewarded,
+        _devRewarded: devRewardedOverride,   // DEV-ONLY — STRIP BEFORE PR
         // Exposed for headless tests / debugging.
         _config: function () { return { provider: provider, sdkReady: sdkReady }; }
     };

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -83,38 +83,6 @@
         } catch (e) { /* analytics must never break gameplay */ }
     }
 
-    // ===== DEV-ONLY — STRIP BEFORE PR (rewarded playtest override) =============
-    // `?testrewarded=1` on localhost makes the rewarded path testable with NO ad
-    // network: isRewardedAvailable() reports true and showRewarded() simulates a full
-    // watch (a brief overlay, then onReward) so you can exercise the results-screen
-    // button + the REAL server claim/credit/toast flow locally. HARD-gated to localhost
-    // so it's inert anywhere else; must never reach prod (see the playtest-restart-button
-    // convention in CLAUDE.md / memory). NOTE: the button still requires being signed in
-    // (the claim needs a userId) — sign in against the DEV Supabase to see it.
-    function devRewardedOverride() {
-        try {
-            if (location.hostname !== "localhost" && location.hostname !== "127.0.0.1") { return false; }
-            return /[?&]testrewarded=1(?:&|$)/.test(location.search);
-        } catch (e) { return false; }
-    }
-    function showDevAdOverlay(done) {
-        var el = null;
-        try {
-            el = document.createElement("div");
-            el.setAttribute("data-dev-rewarded", "1");
-            el.style.cssText = "position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.85);" +
-                "display:flex;align-items:center;justify-content:center;color:#FFE08A;" +
-                "font:bold 28px sans-serif;text-align:center;padding:24px;";
-            el.textContent = "Simulated rewarded ad (dev) — granting 2× XP…";
-            (document.body || document.documentElement).appendChild(el);
-        } catch (e) { el = null; }
-        setTimeout(function () {
-            try { if (el && el.parentNode) { el.parentNode.removeChild(el); } } catch (e) {}
-            done();
-        }, 1500);
-    }
-    // ===== END DEV-ONLY =========================================================
-
     function embedded() {
         // isEmbedded() ships in embed.js (loaded before the bundle). Treat its
         // absence as "not embedded" so a load-order hiccup can't suppress ads.
@@ -516,7 +484,6 @@
     // renders and gameplay is untouched. GameMonetize has no separate "rewarded loaded"
     // signal, so readiness == SDK ready.
     function isRewardedAvailable() {
-        if (devRewardedOverride()) { return true; }   // DEV-ONLY — STRIP BEFORE PR
         if (!shouldShow()) { return false; }  // provider 'none' or embedded -> not available
         return !!sdkReady;
     }
@@ -538,17 +505,6 @@
         // skip so the caller leaves the button up for a retry and never credits a reward.
         if (!isRewardedAvailable() || !adapter || typeof adapter.showRewarded !== "function") {
             onSkip();
-            return;
-        }
-
-        // DEV-ONLY — STRIP BEFORE PR: simulate a full watch with no ad network so the
-        // real onReward -> claimXpMultiplier -> xpBonus flow can be exercised locally.
-        if (devRewardedOverride()) {
-            track("ad_shown", { type: "rewarded", placement: placement });
-            showDevAdOverlay(function () {
-                track("ad_complete", { type: "rewarded", placement: placement });
-                try { onReward(); } catch (e) { /* caller must not break the screen */ }
-            });
             return;
         }
 
@@ -624,7 +580,6 @@
         shouldShow: shouldShow,
         isRewardedAvailable: isRewardedAvailable,
         showRewarded: showRewarded,
-        _devRewarded: devRewardedOverride,   // DEV-ONLY — STRIP BEFORE PR
         // Exposed for headless tests / debugging.
         _config: function () { return { provider: provider, sdkReady: sdkReady }; }
     };

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -61,11 +61,7 @@ function rewardClaimable() {
 	// on the CLIENT clock (receipt-now + server-sent remaining lifetime), so a client/server
 	// clock skew can't hide a valid offer or launch an expired one. Keep ad-playback headroom.
 	if (Date.now() > rewardOfferExpiresAt - REWARD_AD_HEADROOM_MS) { return false; }
-	// DEV-ONLY — STRIP BEFORE PR: the localhost ?testrewarded=1 override also offers it to
-	// guests (so it's testable without local Supabase auth); the reward is then simulated
-	// client-side in triggerRewardWatch (no server credit — guests have no XP).
-	var devR = (window.ads && typeof window.ads._devRewarded === "function" && window.ads._devRewarded());
-	if (!devR && !(window.chaochaoAuth && typeof window.chaochaoAuth.isSignedIn === "function" && window.chaochaoAuth.isSignedIn())) { return false; }
+	if (!(window.chaochaoAuth && typeof window.chaochaoAuth.isSignedIn === "function" && window.chaochaoAuth.isSignedIn())) { return false; }
 	if (!(window.ads && typeof window.ads.isRewardedAvailable === "function" && window.ads.isRewardedAvailable())) { return false; }
 	return true;
 }
@@ -80,17 +76,6 @@ function triggerRewardWatch() {
 	window.ads.showRewarded({
 		placement: "xp_2x",
 		onReward: function () {
-			// DEV-ONLY — STRIP BEFORE PR: under the localhost ?testrewarded=1 override the ad is
-			// SIMULATED (no real network), so we must NEVER drive the real server claim — that
-			// would persist bonus XP without an actual ad watch. Keep it purely client-side
-			// (visual toast + GA only), regardless of sign-in, so the override can't credit XP.
-			var devR = (window.ads && typeof window.ads._devRewarded === "function" && window.ads._devRewarded());
-			if (devR) {
-				rewardedClaimState = "claimed";
-				if (typeof enqueueProgressionToasts === "function") { enqueueProgressionToasts([{ type: "xp_bonus", amount: 0 }]); }
-				if (typeof trackEvent === "function") { trackEvent('reward_claimed', { bonus: 'xp_2x', match_id: matchId || '' }); }
-				return;
-			}
 			// Ad watched in full — ask the server to credit the bonus. Stay PENDING (not 'claimed')
 			// until the server's xpBonus ack — the server can still reject (TTL / transient DB
 			// failure), and marking 'claimed' now would consume the watched ad with no credit and

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -45,8 +45,10 @@ var rewardOfferToastEl = null,
 // Stop OFFERING / launching an ad once the match is this old, so a full watch always finishes
 // inside the server's claim TTL (180s) — never let a player burn an ad on a claim the server
 // will reject as expired. currentMatchOfferTs is stamped when the match id is set (startGameover).
-var REWARD_OFFER_WINDOW_MS = 120 * 1000,
-	currentMatchOfferTs = 0,       // anchored to the SERVER gameOver time (from rewardedEligible)
+// Don't offer (or launch) an ad unless at least this much of the claim's lifetime remains, so a
+// full watch + claim finishes before the server TTL — never burn an ad on a doomed claim.
+var REWARD_AD_HEADROOM_MS = 60 * 1000,
+	rewardOfferExpiresAt = 0,      // client-clock deadline = receipt Date.now() + server ttlMs
 	rewardClaimAckTimer = null,    // awaiting the server's xpBonus ack after a watch
 	pendingClaimMatchId = null;    // the matchId of the claim we're awaiting an ack for
 
@@ -55,8 +57,10 @@ var REWARD_OFFER_WINDOW_MS = 120 * 1000,
 // claim, and it isn't already being watched / claimed.
 function rewardClaimable() {
 	if (!currentMatchId || rewardedClaimState !== "idle") { return false; }
-	// Expire the offer before launch: never start an ad we can't claim in time (server TTL).
-	if (Date.now() - currentMatchOfferTs > REWARD_OFFER_WINDOW_MS) { return false; }
+	// Expire the offer before launch: never start an ad we can't claim in time. The deadline is
+	// on the CLIENT clock (receipt-now + server-sent remaining lifetime), so a client/server
+	// clock skew can't hide a valid offer or launch an expired one. Keep ad-playback headroom.
+	if (Date.now() > rewardOfferExpiresAt - REWARD_AD_HEADROOM_MS) { return false; }
 	// DEV-ONLY — STRIP BEFORE PR: the localhost ?testrewarded=1 override also offers it to
 	// guests (so it's testable without local Supabase auth); the reward is then simulated
 	// client-side in triggerRewardWatch (no server credit — guests have no XP).
@@ -100,8 +104,16 @@ function triggerRewardWatch() {
 			}
 		},
 		onSkip: function () {
-			// No-fill / closed before completing — no toast, no credit.
+			// No-fill / closed before completing — no ad shown, no credit, the claim is unused.
 			if (rewardedClaimState === "watching") { rewardedClaimState = "idle"; }
+			// Re-offer so the eligible player can try again (the Watch click already removed the
+			// toast). Only in the lobby + still claimable — never pop a Watch prompt over a live
+			// race (the ad request can resolve after the next race has started).
+			var inLobby = (typeof config !== "undefined" && config && currentState === config.stateMap.lobby);
+			if (inLobby && rewardClaimable() && typeof flushRewardOffer === "function") {
+				rewardOfferPending = true;
+				flushRewardOffer();
+			}
 		},
 		onError: function () {
 			// SDK error / timeout — soft toast.
@@ -578,11 +590,12 @@ function registerConnectionHandlers(server) {
 	server.on('rewardedEligible', function (payload) {
 		if (!payload || payload.matchId == null) { return; }
 		currentMatchId = payload.matchId;
-		// Anchor the offer window to the SERVER's gameOver timestamp (not client receipt time):
-		// if this event is delivered late (suspended/backgrounded tab), the window must still
-		// reflect how long the SERVER has had the claim open, so we don't offer an ad for a
-		// claim that has already expired against the server TTL. Fall back to local now if absent.
-		currentMatchOfferTs = (typeof payload.gameOverTs === "number") ? payload.gameOverTs : Date.now();
+		// The server sends the REMAINING claim lifetime as a DURATION (ttlMs); turn it into a
+		// deadline on OUR clock. Single-clock, so no skew issue — and because it's a remaining
+		// lifetime (not a fixed window from "now"), a late-delivered event already reflects the
+		// time the server has burned. Default to a modest window if an older server omits it.
+		var ttlMs = (typeof payload.ttlMs === "number") ? payload.ttlMs : 90000;
+		rewardOfferExpiresAt = Date.now() + ttlMs;
 		rewardedClaimState = "idle";
 	});
 	server.on('xpBonus', function (payload) {
@@ -1202,7 +1215,7 @@ function registerStateHandlers(server) {
 		// an ad the claim handler would reject. currentMatchId is set by that handler; the prompt
 		// fires at the next startLobby (gameOver -> lobby edge), not here on the results screen.
 		currentMatchId = null;
-		currentMatchOfferTs = 0;
+		rewardOfferExpiresAt = 0;
 		rewardedClaimState = "idle";
 		// Bump the medals-card reveal nonce so its entrance animation replays for
 		// this match — even when the same player wins back-to-back (playerWon

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -30,10 +30,17 @@ var ratingMapId = null,
 // Rewarded "2× match XP" state. currentMatchId: the server-stamped id of the just-finished
 // match (echoed back in claimXpMultiplier). rewardedClaimState: 'idle' | 'watching' (ad up) |
 // 'claimed'. The offer is NOT shown on the results screen (it would compete with the recap/
-// stats); it's a one-tap prompt at the gameOver -> lobby edge (see the startLobby handler +
-// the reward modal in gamepad.js).
+// stats); it's the LAST item in the lobby-arrival progression-toast stream (an actionable
+// "📺 Watch" toast), so it sequences cleanly AFTER the XP/level/skin celebration toasts.
 var currentMatchId = null,
 	rewardedClaimState = "idle";
+// The live offer-toast element (null when none is showing). rewardOfferPending: an offer
+// should be appended once this match's celebration toasts are queued (they arrive via the
+// progressionToasts event, possibly just after startLobby); the fallback timer covers the
+// no-celebration-toasts case (e.g. a guest under the dev override).
+var rewardOfferToastEl = null,
+	rewardOfferPending = false,
+	rewardOfferFallbackTimer = null;
 
 // True when the "2× your match XP" offer can be made: signed-in (anonymous players have no
 // server XP to multiply — never offered), a rewarded ad is loaded, we know which match to
@@ -91,18 +98,71 @@ function triggerRewardWatch() {
 	});
 }
 
-// Offer the 2× XP prompt at the gameOver -> lobby edge, if claimable. Returns true if the
-// prompt was shown (so the caller can skip the interstitial — never stack two ad surfaces).
-// The modal (gamepad.js) is mouse/touch/keyboard/gamepad navigable; "Watch" -> triggerRewardWatch,
-// "No thanks" -> just closes. Fail-open: if the modal helper is missing, no-op (returns false).
+// Arm the 2× XP offer at the gameOver -> lobby edge, if claimable. Returns true if an offer
+// is now pending (so the caller skips the interstitial — never stack two ad surfaces). The
+// offer itself is appended to the END of the progression-toast stream (after the celebration
+// toasts) by flushRewardOffer — either right after those toasts are queued (progressionToasts
+// handler) or via a short fallback when none arrive (guest / no-XP match).
 function maybeOfferRewardedXp() {
 	if (!rewardClaimable()) { return false; }
-	if (typeof openRewardModal !== "function") { return false; }
-	openRewardModal({
-		onWatch: function () { triggerRewardWatch(); },
-		onDecline: function () { /* dismissed — nothing to do */ }
-	});
+	rewardOfferPending = true;
+	if (rewardOfferFallbackTimer) { clearTimeout(rewardOfferFallbackTimer); }
+	rewardOfferFallbackTimer = setTimeout(flushRewardOffer, 1500);
 	return true;
+}
+
+// Append the pending 2× offer as the LAST item in the progression-toast queue (so it shows
+// after the celebration toasts). Called once per match — right after the celebration toasts
+// are queued, or by the fallback timer when none arrive. Re-checks claimability at flush time.
+function flushRewardOffer() {
+	if (rewardOfferFallbackTimer) { clearTimeout(rewardOfferFallbackTimer); rewardOfferFallbackTimer = null; }
+	if (!rewardOfferPending) { return; }
+	rewardOfferPending = false;
+	if (!rewardClaimable()) { return; }
+	progressionToastQueue.push({ kind: "reward-offer" });
+	if (!progressionToastShowing) { showNextProgressionToast(); }
+}
+
+// The persistent, actionable offer toast (reuses the "Log in" nudge's .cc-toast-action /
+// .cc-toast-close pattern). Unlike celebration toasts it does NOT auto-dismiss — it waits
+// for Watch / dismiss / next-race teardown. Exposed open/watch/dismiss for keyboard + gamepad
+// (gamepad.js): Enter/Ⓐ watches, Esc/Ⓑ dismisses; mouse/touch tap the buttons.
+function showRewardOfferToast() {
+	if (!document.body) { showNextProgressionToast(); return; }
+	var el = document.createElement("div");
+	el.className = "cc-toast cc-progression-toast cc-reward-offer";
+	el.setAttribute("role", "status");
+	el.innerHTML =
+		'<span class="cc-toast-msg"></span>' +
+		'<button class="cc-toast-action" type="button"></button>' +
+		'<button class="cc-toast-close" type="button" aria-label="Dismiss">×</button>';
+	el.querySelector(".cc-toast-msg").textContent = "⭐ Double the XP you just earned?";
+	el.querySelector(".cc-toast-action").textContent = "📺 Watch";
+	document.body.appendChild(el);
+	rewardOfferToastEl = el;
+	el.querySelector(".cc-toast-action").addEventListener("click", rewardOfferWatch);
+	el.querySelector(".cc-toast-close").addEventListener("click", rewardOfferDismiss);
+	requestAnimationFrame(function () { el.classList.add("visible"); });
+}
+function removeRewardOfferToast() {
+	var el = rewardOfferToastEl;
+	rewardOfferToastEl = null;
+	if (!el) { return; }
+	el.classList.remove("visible");
+	setTimeout(function () {
+		if (el.parentNode) { el.parentNode.removeChild(el); }
+		showNextProgressionToast(); // advance the (now usually empty) stream
+	}, 400);
+}
+function rewardOfferToastOpen() { return !!rewardOfferToastEl; }
+function rewardOfferWatch() {
+	if (!rewardOfferToastEl) { return; }
+	removeRewardOfferToast();
+	triggerRewardWatch(); // shows the ad; onReward -> claim -> xpBonus toast
+}
+function rewardOfferDismiss() {
+	if (!rewardOfferToastEl) { return; }
+	removeRewardOfferToast();
 }
 
 // The room's active playlist id for analytics, so rounds/matches can be segmented
@@ -361,6 +421,13 @@ function showNextProgressionToast() {
 	if (!document.body) { progressionToastShowing = false; return; }
 	progressionToastShowing = true;
 	var txt = progressionToastQueue.shift();
+	// The 2× XP offer is a special queue item: a persistent actionable toast that waits for
+	// the player instead of auto-advancing. It's always the last item, so the stream resumes
+	// (and ends) when they Watch/dismiss it.
+	if (txt && typeof txt === "object" && txt.kind === "reward-offer") {
+		showRewardOfferToast();
+		return;
+	}
 	var el = document.createElement("div");
 	el.className = "cc-toast cc-progression-toast";
 	el.setAttribute("role", "status");
@@ -383,6 +450,11 @@ function showNextProgressionToast() {
 function clearProgressionToasts() {
 	progressionToastQueue.length = 0;
 	progressionToastShowing = false;
+	// Tear down the 2× offer too (its DOM node carries .cc-progression-toast, so it's removed
+	// below) and drop any armed/pending offer so it can't pop after the race has started.
+	rewardOfferToastEl = null;
+	rewardOfferPending = false;
+	if (rewardOfferFallbackTimer) { clearTimeout(rewardOfferFallbackTimer); rewardOfferFallbackTimer = null; }
 	if (typeof document !== "undefined" && document.querySelectorAll) {
 		var open = document.querySelectorAll(".cc-progression-toast");
 		for (var i = 0; i < open.length; i++) {
@@ -419,6 +491,9 @@ function registerConnectionHandlers(server) {
 	server.on('progressionToasts', function (payload) {
 		var events = (payload && Array.isArray(payload.events)) ? payload.events : [];
 		if (events.length) { enqueueProgressionToasts(events); }
+		// If a 2× offer is armed for this match, append it now so it lands right AFTER these
+		// celebration toasts (the natural "here's your XP → want to double it?" beat).
+		if (rewardOfferPending) { flushRewardOffer(); }
 	});
 	// Rewarded "2× match XP" claim acked by the server (after it validated + credited the
 	// bonus). Announce it immediately on the results screen and fire the reward_claimed GA
@@ -818,14 +893,11 @@ function registerStateHandlers(server) {
 		if (window.ads && typeof window.ads.dismissInterstitial === "function") {
 			try { window.ads.dismissInterstitial(); } catch (e) { /* never block the gate */ }
 		}
-		// Same idea for celebration toasts: clear the queue so a long reward sequence doesn't
-		// keep popping over the race that's starting (toasts belong to the lobby).
+		// Same idea for celebration toasts AND the 2× offer toast: clear the queue + tear down
+		// any visible toast so a long reward sequence (or the offer) doesn't keep popping over
+		// the race that's starting (they belong to the lobby). clearProgressionToasts removes
+		// the offer toast too (it carries .cc-progression-toast) and drops any armed offer.
 		if (typeof clearProgressionToasts === "function") { clearProgressionToasts(); }
-		// Tear down the "2× your match XP" prompt if it's still up — the next round is starting,
-		// so the offer window is over (it belongs to the lobby). Counts as a decline.
-		if (typeof closeRewardModal === "function" && typeof rewardModalIsOpen === "function" && rewardModalIsOpen()) {
-			try { closeRewardModal(true); } catch (e) { /* never block the gate */ }
-		}
 		setLobbySfxDampen(false); // restore full SFX before the game-start cue
 		stopSound(lobbyMusic);
 		playSound(gameStart);

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -44,7 +44,11 @@ var currentMatchId = null,
 function rewardButtonAvailable() {
 	if (typeof config === "undefined" || config == null || currentState !== config.stateMap.gameOver) { return false; }
 	if (!currentMatchId || rewardedClaimState !== "idle") { return false; }
-	if (!(window.chaochaoAuth && typeof window.chaochaoAuth.isSignedIn === "function" && window.chaochaoAuth.isSignedIn())) { return false; }
+	// DEV-ONLY — STRIP BEFORE PR: the localhost ?testrewarded=1 override also shows the
+	// button for guests (so it's testable without local Supabase auth); the reward is then
+	// simulated client-side in triggerRewardButton (no server credit — guests have no XP).
+	var devR = (window.ads && typeof window.ads._devRewarded === "function" && window.ads._devRewarded());
+	if (!devR && !(window.chaochaoAuth && typeof window.chaochaoAuth.isSignedIn === "function" && window.chaochaoAuth.isSignedIn())) { return false; }
 	if (!(window.ads && typeof window.ads.isRewardedAvailable === "function" && window.ads.isRewardedAvailable())) { return false; }
 	return true;
 }
@@ -62,6 +66,16 @@ function triggerRewardButton() {
 			// matchId + TTL + single-claim and replies with `xpBonus` (multiplier is server-fixed;
 			// we send it only as a courtesy — the server ignores the client value).
 			rewardedClaimState = "claimed";
+			// DEV-ONLY — STRIP BEFORE PR: under the localhost override a GUEST has no server
+			// progression to credit, so the server would reject the claim. Fake the ack locally
+			// so the toast/flow is visible. Signed-in players always take the real server path.
+			var signedIn = (window.chaochaoAuth && typeof window.chaochaoAuth.isSignedIn === "function" && window.chaochaoAuth.isSignedIn());
+			var devR = (window.ads && typeof window.ads._devRewarded === "function" && window.ads._devRewarded());
+			if (devR && !signedIn) {
+				if (typeof enqueueProgressionToasts === "function") { enqueueProgressionToasts([{ type: "xp_bonus", amount: 0 }]); }
+				if (typeof trackEvent === "function") { trackEvent('reward_claimed', { bonus: 'xp_2x', match_id: matchId || '' }); }
+				return;
+			}
 			if (typeof server !== "undefined" && server) {
 				server.emit("claimXpMultiplier", { matchId: matchId, multiplier: 2 });
 			}

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -40,7 +40,8 @@ var currentMatchId = null,
 // no-celebration-toasts case (e.g. a guest under the dev override).
 var rewardOfferToastEl = null,
 	rewardOfferPending = false,
-	rewardOfferFallbackTimer = null;
+	rewardOfferFallbackTimer = null,
+	rewardOfferFocused = false;   // controller/keyboard focus state (1st press focuses, 2nd watches)
 // Stop OFFERING / launching an ad once the match is this old, so a full watch always finishes
 // inside the server's claim TTL (180s) — never let a player burn an ad on a claim the server
 // will reject as expired. currentMatchOfferTs is stamped when the match id is set (startGameover).
@@ -164,17 +165,26 @@ function flushRewardOffer() {
 
 // The persistent, actionable offer toast (reuses the "Log in" nudge's .cc-toast-action /
 // .cc-toast-close pattern). Unlike celebration toasts it does NOT auto-dismiss — it waits
-// for Watch / dismiss / next-race teardown. Exposed open/watch/dismiss for keyboard + gamepad
-// (gamepad.js): Enter/Ⓐ watches, Esc/Ⓑ dismisses; mouse/touch tap the buttons.
+// for Watch / dismiss / next-race teardown.
+//
+// Input model:
+//   - Mouse / touch: tap "📺 Watch" or "×" directly.
+//   - Controller / keyboard: a deliberate TWO-STEP focus so a bare gameplay press can never
+//     launch a full-screen ad. The toast starts UNFOCUSED; the first Ⓐ/Enter focuses it
+//     (highlights, shows the Ⓐ/Ⓑ hint), and only a SECOND Ⓐ/Enter watches. Ⓑ/Esc declines
+//     at any time (a safe action). gamepad.js drives this via rewardOfferToastOpen() /
+//     rewardOfferIsFocused() / rewardOfferFocus() / rewardOfferWatch() / rewardOfferDismiss().
 function showRewardOfferToast() {
 	if (!document.body) { showNextProgressionToast(); return; }
+	rewardOfferFocused = false;
 	var el = document.createElement("div");
 	el.className = "cc-toast cc-progression-toast cc-reward-offer";
 	el.setAttribute("role", "status");
 	el.innerHTML =
 		'<span class="cc-toast-msg"></span>' +
 		'<button class="cc-toast-action" type="button"></button>' +
-		'<button class="cc-toast-close" type="button" aria-label="Dismiss">×</button>';
+		'<button class="cc-toast-close" type="button" aria-label="Dismiss">×</button>' +
+		'<span class="cc-reward-hint"></span>';
 	el.querySelector(".cc-toast-msg").textContent = "⭐ Double the XP you just earned?";
 	el.querySelector(".cc-toast-action").textContent = "📺 Watch";
 	document.body.appendChild(el);
@@ -186,12 +196,24 @@ function showRewardOfferToast() {
 function removeRewardOfferToast() {
 	var el = rewardOfferToastEl;
 	rewardOfferToastEl = null;
+	rewardOfferFocused = false;
 	if (!el) { return; }
 	el.classList.remove("visible");
 	setTimeout(function () {
 		if (el.parentNode) { el.parentNode.removeChild(el); }
 		showNextProgressionToast(); // advance the (now usually empty) stream
 	}, 400);
+}
+function rewardOfferToastOpen() { return !!rewardOfferToastEl; }
+function rewardOfferIsFocused() { return !!rewardOfferToastEl && rewardOfferFocused; }
+// First controller/keyboard step: focus the toast (no ad launch). Highlights it + shows the
+// Ⓐ Watch / Ⓑ No thanks hint so the second press is clearly a deliberate confirmation.
+function rewardOfferFocus() {
+	if (!rewardOfferToastEl) { return; }
+	rewardOfferFocused = true;
+	rewardOfferToastEl.classList.add("gp-focus");
+	var hint = rewardOfferToastEl.querySelector(".cc-reward-hint");
+	if (hint) { hint.textContent = "Ⓐ Watch · Ⓑ No thanks"; }
 }
 function rewardOfferWatch() {
 	if (!rewardOfferToastEl) { return; }

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -27,38 +27,35 @@ var ratingMapId = null,
 	ratingStarHits = [],
 	ratingPadCursor = 0;   // gamepad-highlighted star (1..5; 0 = uninitialised)
 
-// Rewarded "2× match XP" results-screen button state. currentMatchId: the server-stamped
-// id of the just-finished match (echoed back in claimXpMultiplier). rewardedClaimState:
-// 'idle' (button shown) | 'watching' (ad up — button hidden) | 'claimed' (done, button gone).
-// rewardButtonHit: the canvas hit-rect drawn by draw.js for input.js to test; rewardPadFocused:
-// the gamepad has the button highlighted (lets Ⓐ trigger it on the results screen).
+// Rewarded "2× match XP" state. currentMatchId: the server-stamped id of the just-finished
+// match (echoed back in claimXpMultiplier). rewardedClaimState: 'idle' | 'watching' (ad up) |
+// 'claimed'. The offer is NOT shown on the results screen (it would compete with the recap/
+// stats); it's a one-tap prompt at the gameOver -> lobby edge (see the startLobby handler +
+// the reward modal in gamepad.js).
 var currentMatchId = null,
-	rewardedClaimState = "idle",
-	rewardButtonHit = null,
-	rewardPadFocused = false;
+	rewardedClaimState = "idle";
 
-// True when the "📺 Watch ad to 2× your XP" button should render on the results screen:
-// signed-in (anonymous players have no server XP to multiply — hidden OUTRIGHT, never shown-
-// then-failed), a rewarded ad is loaded, we know which match to claim, and it isn't already
-// being watched / claimed.
-function rewardButtonAvailable() {
-	if (typeof config === "undefined" || config == null || currentState !== config.stateMap.gameOver) { return false; }
+// True when the "2× your match XP" offer can be made: signed-in (anonymous players have no
+// server XP to multiply — never offered), a rewarded ad is loaded, we know which match to
+// claim, and it isn't already being watched / claimed.
+function rewardClaimable() {
 	if (!currentMatchId || rewardedClaimState !== "idle") { return false; }
-	// DEV-ONLY — STRIP BEFORE PR: the localhost ?testrewarded=1 override also shows the
-	// button for guests (so it's testable without local Supabase auth); the reward is then
-	// simulated client-side in triggerRewardButton (no server credit — guests have no XP).
+	// DEV-ONLY — STRIP BEFORE PR: the localhost ?testrewarded=1 override also offers it to
+	// guests (so it's testable without local Supabase auth); the reward is then simulated
+	// client-side in triggerRewardWatch (no server credit — guests have no XP).
 	var devR = (window.ads && typeof window.ads._devRewarded === "function" && window.ads._devRewarded());
 	if (!devR && !(window.chaochaoAuth && typeof window.chaochaoAuth.isSignedIn === "function" && window.chaochaoAuth.isSignedIn())) { return false; }
 	if (!(window.ads && typeof window.ads.isRewardedAvailable === "function" && window.ads.isRewardedAvailable())) { return false; }
 	return true;
 }
 
-// Start the rewarded flow (click / tap / gamepad Ⓐ). Shows the ad; on a CONFIRMED full watch
-// the server is asked to credit the doubled XP; on skip/error the button returns for a retry.
-function triggerRewardButton() {
-	if (!rewardButtonAvailable()) { return; }
+// Start the rewarded flow (from the lobby-edge prompt's "Watch" choice). Shows the ad; on a
+// CONFIRMED full watch the server is asked to credit the doubled XP and replies with `xpBonus`;
+// on skip/error nothing is credited (a soft toast on error).
+function triggerRewardWatch() {
+	if (!rewardClaimable()) { return; }
 	var matchId = currentMatchId;
-	rewardedClaimState = "watching"; // hide the button while the ad is up
+	rewardedClaimState = "watching";
 	window.ads.showRewarded({
 		placement: "xp_2x",
 		onReward: function () {
@@ -81,11 +78,11 @@ function triggerRewardButton() {
 			}
 		},
 		onSkip: function () {
-			// No-fill / closed before completing — leave the button up for a retry, no toast.
+			// No-fill / closed before completing — no toast, no credit.
 			if (rewardedClaimState === "watching") { rewardedClaimState = "idle"; }
 		},
 		onError: function () {
-			// SDK error / timeout — retry allowed + a soft toast.
+			// SDK error / timeout — soft toast.
 			if (rewardedClaimState === "watching") { rewardedClaimState = "idle"; }
 			if (typeof enqueueProgressionToasts === "function") {
 				enqueueProgressionToasts([{ type: "xp_bonus_error" }]);
@@ -94,16 +91,18 @@ function triggerRewardButton() {
 	});
 }
 
-// Hit-test a pointer (logical coords) against the results-screen reward button. On a hit,
-// kicks off the rewarded flow. Returns true if the tap was consumed. Mirrors handleMapRatingTap.
-function handleRewardButtonTap(lx, ly) {
-	if (!rewardButtonAvailable() || !rewardButtonHit) { return false; }
-	var h = rewardButtonHit;
-	if (lx >= h.x && lx <= h.x + h.w && ly >= h.y && ly <= h.y + h.h) {
-		triggerRewardButton();
-		return true;
-	}
-	return false;
+// Offer the 2× XP prompt at the gameOver -> lobby edge, if claimable. Returns true if the
+// prompt was shown (so the caller can skip the interstitial — never stack two ad surfaces).
+// The modal (gamepad.js) is mouse/touch/keyboard/gamepad navigable; "Watch" -> triggerRewardWatch,
+// "No thanks" -> just closes. Fail-open: if the modal helper is missing, no-op (returns false).
+function maybeOfferRewardedXp() {
+	if (!rewardClaimable()) { return false; }
+	if (typeof openRewardModal !== "function") { return false; }
+	openRewardModal({
+		onWatch: function () { triggerRewardWatch(); },
+		onDecline: function () { /* dismissed — nothing to do */ }
+	});
+	return true;
 }
 
 // The room's active playlist id for analytics, so rounds/matches can be segmented
@@ -789,7 +788,12 @@ function registerStateHandlers(server) {
 		if (cameFromGameOver && window.ads && typeof window.ads.onMatchEnded === "function") {
 			try {
 				window.ads.onMatchEnded();
-				if (window.ads.canShowInterstitial()) {
+				// One ad surface per match-end, max. Prefer the OPT-IN "2× your match XP"
+				// prompt (better for players AND for us — engaged, not forced) when it's
+				// claimable; only fall back to the forced interstitial when it isn't. Either
+				// way onMatchEnded already advanced the interstitial cadence so it isn't frozen.
+				var offered = (typeof maybeOfferRewardedXp === "function") && maybeOfferRewardedXp();
+				if (!offered && window.ads.canShowInterstitial()) {
 					window.ads.showInterstitial({ placement: "between_matches", onClose: function () {} });
 				}
 			} catch (e) { /* ads must never break the lobby transition */ }
@@ -817,6 +821,11 @@ function registerStateHandlers(server) {
 		// Same idea for celebration toasts: clear the queue so a long reward sequence doesn't
 		// keep popping over the race that's starting (toasts belong to the lobby).
 		if (typeof clearProgressionToasts === "function") { clearProgressionToasts(); }
+		// Tear down the "2× your match XP" prompt if it's still up — the next round is starting,
+		// so the offer window is over (it belongs to the lobby). Counts as a decline.
+		if (typeof closeRewardModal === "function" && typeof rewardModalIsOpen === "function" && rewardModalIsOpen()) {
+			try { closeRewardModal(true); } catch (e) { /* never block the gate */ }
+		}
 		setLobbySfxDampen(false); // restore full SFX before the game-start cue
 		stopSound(lobbyMusic);
 		playSound(gameStart);
@@ -1022,13 +1031,12 @@ function registerStateHandlers(server) {
 		myMapRating = 0;
 		ratingStarHits = [];
 		ratingPadCursor = 0;
-		// Rewarded "2× match XP" button: bind it to THIS match and reset its claim state so
-		// it can be earned once. matchId is server-stamped (absent from an older server -> the
-		// button simply never offers, since rewardButtonAvailable() requires it).
+		// Rewarded "2× match XP": bind to THIS match and reset its claim state so it can be
+		// earned once. matchId is server-stamped (absent from an older server -> the offer is
+		// never made, since rewardClaimable() requires it). The prompt fires at the next
+		// startLobby (gameOver -> lobby edge), not here on the results screen.
 		currentMatchId = (packet && packet.matchId != null) ? packet.matchId : null;
 		rewardedClaimState = "idle";
-		rewardButtonHit = null;
-		rewardPadFocused = false;
 		// Bump the medals-card reveal nonce so its entrance animation replays for
 		// this match — even when the same player wins back-to-back (playerWon
 		// unchanged). drawGameOverScreen watches this (see draw.js).

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -111,9 +111,11 @@ function triggerRewardWatch() {
 
 // Guard against the server never acking a claim (TTL rejection / transient DB failure / dropped
 // socket). Without this the player would be stuck in 'claiming' forever after watching an ad.
-// On timeout: unstick to 'idle', tell the player, and — if the match is still within its offer
-// window — re-offer so the watched-but-uncredited ad isn't wasted (the server reset its
-// single-claim flag on failure, so a retry can succeed).
+// On timeout: unstick to 'idle', tell the player, and re-offer for a genuine retry — but ONLY
+// while still in the lobby and within the offer window. A rewarded ad is deliberately allowed to
+// finish after the race has started; if the timeout fires mid-race we must NOT launch another
+// full-screen Watch prompt over live gameplay. We record the retry as pending and let the next
+// lobby arrival surface it (gated by rewardClaimable, so a stale/expired match never re-offers).
 function startRewardClaimAckTimeout() {
 	if (rewardClaimAckTimer) { clearTimeout(rewardClaimAckTimer); }
 	rewardClaimAckTimer = setTimeout(function () {
@@ -121,10 +123,12 @@ function startRewardClaimAckTimeout() {
 		if (rewardedClaimState !== "claiming") { return; } // already acked
 		rewardedClaimState = "idle";
 		if (typeof enqueueProgressionToasts === "function") { enqueueProgressionToasts([{ type: "xp_bonus_failed" }]); }
-		// Re-offer for a genuine retry while still in time.
-		if (rewardClaimable() && typeof flushRewardOffer === "function") {
+		var inLobby = (typeof config !== "undefined" && config && currentState === config.stateMap.lobby);
+		if (inLobby && rewardClaimable() && typeof flushRewardOffer === "function") {
 			rewardOfferPending = true;
-			flushRewardOffer();
+			flushRewardOffer();          // safe: still in the lobby
+		} else {
+			rewardOfferPending = true;   // surface on the next lobby entry, never over a live race
 		}
 	}, 12000);
 }
@@ -495,7 +499,10 @@ function clearProgressionToasts() {
 	rewardOfferToastEl = null;
 	rewardOfferPending = false;
 	if (rewardOfferFallbackTimer) { clearTimeout(rewardOfferFallbackTimer); rewardOfferFallbackTimer = null; }
-	if (rewardClaimAckTimer) { clearTimeout(rewardClaimAckTimer); rewardClaimAckTimer = null; }
+	// NOTE: do NOT clear rewardClaimAckTimer here. A rewarded ad is deliberately allowed to
+	// finish after startGated, so a claim may still be awaiting its xpBonus ack across the race
+	// transition — killing the watchdog would strand the player in 'claiming' if that ack never
+	// arrives. The watchdog self-clears on the ack (xpBonus) or fires its own recovery.
 	if (typeof document !== "undefined" && document.querySelectorAll) {
 		var open = document.querySelectorAll(".cc-progression-toast");
 		for (var i = 0; i < open.length; i++) {
@@ -541,6 +548,14 @@ function registerConnectionHandlers(server) {
 	// event. The server already pushed a fresh progressionUpdate for the lobby badge (writes-on);
 	// we only handle the celebration + analytics here so the funnel match_end -> ad_shown ->
 	// ad_complete -> reward_claimed closes.
+	// Server-authoritative eligibility for the rewarded 2× offer: arrives (targeted) only for
+	// players the server credited this match — raced + earned XP. Binds the offer to this match.
+	server.on('rewardedEligible', function (payload) {
+		if (!payload || payload.matchId == null) { return; }
+		currentMatchId = payload.matchId;
+		currentMatchOfferTs = Date.now();   // start of this match's offer window
+		rewardedClaimState = "idle";
+	});
 	server.on('xpBonus', function (payload) {
 		var bonus = (payload && typeof payload.bonus === "number") ? payload.bonus : 0;
 		// Ack arrived — the claim succeeded. Cancel the retry watchdog and lock it in.
@@ -1146,12 +1161,13 @@ function registerStateHandlers(server) {
 		myMapRating = 0;
 		ratingStarHits = [];
 		ratingPadCursor = 0;
-		// Rewarded "2× match XP": bind to THIS match and reset its claim state so it can be
-		// earned once. matchId is server-stamped (absent from an older server -> the offer is
-		// never made, since rewardClaimable() requires it). The prompt fires at the next
-		// startLobby (gameOver -> lobby edge), not here on the results screen.
-		currentMatchId = (packet && packet.matchId != null) ? packet.matchId : null;
-		currentMatchOfferTs = Date.now();   // start of this match's offer window
+		// Rewarded "2× match XP": clear last match's state. We do NOT take the matchId from this
+		// broadcast — the server sends a TARGETED `rewardedEligible` (right after this) only to
+		// players it actually credited (raced + earned XP), so spectators/guests are never offered
+		// an ad the claim handler would reject. currentMatchId is set by that handler; the prompt
+		// fires at the next startLobby (gameOver -> lobby edge), not here on the results screen.
+		currentMatchId = null;
+		currentMatchOfferTs = 0;
 		rewardedClaimState = "idle";
 		// Bump the medals-card reveal nonce so its entrance animation replays for
 		// this match — even when the same player wins back-to-back (playerWon

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -27,6 +27,71 @@ var ratingMapId = null,
 	ratingStarHits = [],
 	ratingPadCursor = 0;   // gamepad-highlighted star (1..5; 0 = uninitialised)
 
+// Rewarded "2× match XP" results-screen button state. currentMatchId: the server-stamped
+// id of the just-finished match (echoed back in claimXpMultiplier). rewardedClaimState:
+// 'idle' (button shown) | 'watching' (ad up — button hidden) | 'claimed' (done, button gone).
+// rewardButtonHit: the canvas hit-rect drawn by draw.js for input.js to test; rewardPadFocused:
+// the gamepad has the button highlighted (lets Ⓐ trigger it on the results screen).
+var currentMatchId = null,
+	rewardedClaimState = "idle",
+	rewardButtonHit = null,
+	rewardPadFocused = false;
+
+// True when the "📺 Watch ad to 2× your XP" button should render on the results screen:
+// signed-in (anonymous players have no server XP to multiply — hidden OUTRIGHT, never shown-
+// then-failed), a rewarded ad is loaded, we know which match to claim, and it isn't already
+// being watched / claimed.
+function rewardButtonAvailable() {
+	if (typeof config === "undefined" || config == null || currentState !== config.stateMap.gameOver) { return false; }
+	if (!currentMatchId || rewardedClaimState !== "idle") { return false; }
+	if (!(window.chaochaoAuth && typeof window.chaochaoAuth.isSignedIn === "function" && window.chaochaoAuth.isSignedIn())) { return false; }
+	if (!(window.ads && typeof window.ads.isRewardedAvailable === "function" && window.ads.isRewardedAvailable())) { return false; }
+	return true;
+}
+
+// Start the rewarded flow (click / tap / gamepad Ⓐ). Shows the ad; on a CONFIRMED full watch
+// the server is asked to credit the doubled XP; on skip/error the button returns for a retry.
+function triggerRewardButton() {
+	if (!rewardButtonAvailable()) { return; }
+	var matchId = currentMatchId;
+	rewardedClaimState = "watching"; // hide the button while the ad is up
+	window.ads.showRewarded({
+		placement: "xp_2x",
+		onReward: function () {
+			// Ad watched in full — ask the server to credit the bonus. The server validates
+			// matchId + TTL + single-claim and replies with `xpBonus` (multiplier is server-fixed;
+			// we send it only as a courtesy — the server ignores the client value).
+			rewardedClaimState = "claimed";
+			if (typeof server !== "undefined" && server) {
+				server.emit("claimXpMultiplier", { matchId: matchId, multiplier: 2 });
+			}
+		},
+		onSkip: function () {
+			// No-fill / closed before completing — leave the button up for a retry, no toast.
+			if (rewardedClaimState === "watching") { rewardedClaimState = "idle"; }
+		},
+		onError: function () {
+			// SDK error / timeout — retry allowed + a soft toast.
+			if (rewardedClaimState === "watching") { rewardedClaimState = "idle"; }
+			if (typeof enqueueProgressionToasts === "function") {
+				enqueueProgressionToasts([{ type: "xp_bonus_error" }]);
+			}
+		}
+	});
+}
+
+// Hit-test a pointer (logical coords) against the results-screen reward button. On a hit,
+// kicks off the rewarded flow. Returns true if the tap was consumed. Mirrors handleMapRatingTap.
+function handleRewardButtonTap(lx, ly) {
+	if (!rewardButtonAvailable() || !rewardButtonHit) { return false; }
+	var h = rewardButtonHit;
+	if (lx >= h.x && lx <= h.x + h.w && ly >= h.y && ly <= h.y + h.h) {
+		triggerRewardButton();
+		return true;
+	}
+	return false;
+}
+
 // The room's active playlist id for analytics, so rounds/matches can be segmented
 // by playlist (defaults to the configured default until a lobbyPlaylistChanged
 // arrives). Lets us tell whether wins/plays/skew concentrate in a given playlist.
@@ -240,6 +305,14 @@ function progressionToastText(ev) {
 	if (ev.type === "xp") {
 		return ev.amount > 0 ? ("+" + ev.amount + " XP") : null;
 	}
+	// Rewarded-video "2× match XP" claim feedback (results screen). The bonus is the EXTRA
+	// XP credited on top of what the match earned (2× total = +1× of the original).
+	if (ev.type === "xp_bonus") {
+		return ev.amount > 0 ? ("⭐ +" + ev.amount + " bonus XP — match XP doubled!") : "⭐ Match XP doubled!";
+	}
+	if (ev.type === "xp_bonus_error") {
+		return "Ad didn't finish — tap to try again for 2× XP.";
+	}
 	if (ev.type === "level") {
 		return "⬆️ Level up!  Lv " + ev.level;
 	}
@@ -333,6 +406,22 @@ function registerConnectionHandlers(server) {
 	server.on('progressionToasts', function (payload) {
 		var events = (payload && Array.isArray(payload.events)) ? payload.events : [];
 		if (events.length) { enqueueProgressionToasts(events); }
+	});
+	// Rewarded "2× match XP" claim acked by the server (after it validated + credited the
+	// bonus). Announce it immediately on the results screen and fire the reward_claimed GA
+	// event. The server already pushed a fresh progressionUpdate for the lobby badge (writes-on);
+	// we only handle the celebration + analytics here so the funnel match_end -> ad_shown ->
+	// ad_complete -> reward_claimed closes.
+	server.on('xpBonus', function (payload) {
+		var bonus = (payload && typeof payload.bonus === "number") ? payload.bonus : 0;
+		rewardedClaimState = "claimed";
+		if (typeof enqueueProgressionToasts === "function") {
+			enqueueProgressionToasts([{ type: "xp_bonus", amount: bonus }]);
+		}
+		trackEvent('reward_claimed', {
+			bonus: 'xp_2x',
+			match_id: (payload && payload.matchId) || currentMatchId || ''
+		});
 	});
 
 	// botGuard: the server confirmed this client actually drove a kart (not a pageview-only
@@ -919,6 +1008,13 @@ function registerStateHandlers(server) {
 		myMapRating = 0;
 		ratingStarHits = [];
 		ratingPadCursor = 0;
+		// Rewarded "2× match XP" button: bind it to THIS match and reset its claim state so
+		// it can be earned once. matchId is server-stamped (absent from an older server -> the
+		// button simply never offers, since rewardButtonAvailable() requires it).
+		currentMatchId = (packet && packet.matchId != null) ? packet.matchId : null;
+		rewardedClaimState = "idle";
+		rewardButtonHit = null;
+		rewardPadFocused = false;
 		// Bump the medals-card reveal nonce so its entrance animation replays for
 		// this match — even when the same player wins back-to-back (playerWon
 		// unchanged). drawGameOverScreen watches this (see draw.js).

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -41,12 +41,20 @@ var currentMatchId = null,
 var rewardOfferToastEl = null,
 	rewardOfferPending = false,
 	rewardOfferFallbackTimer = null;
+// Stop OFFERING / launching an ad once the match is this old, so a full watch always finishes
+// inside the server's claim TTL (180s) — never let a player burn an ad on a claim the server
+// will reject as expired. currentMatchOfferTs is stamped when the match id is set (startGameover).
+var REWARD_OFFER_WINDOW_MS = 120 * 1000,
+	currentMatchOfferTs = 0,
+	rewardClaimAckTimer = null;   // awaiting the server's xpBonus ack after a watch
 
 // True when the "2× your match XP" offer can be made: signed-in (anonymous players have no
 // server XP to multiply — never offered), a rewarded ad is loaded, we know which match to
 // claim, and it isn't already being watched / claimed.
 function rewardClaimable() {
 	if (!currentMatchId || rewardedClaimState !== "idle") { return false; }
+	// Expire the offer before launch: never start an ad we can't claim in time (server TTL).
+	if (Date.now() - currentMatchOfferTs > REWARD_OFFER_WINDOW_MS) { return false; }
 	// DEV-ONLY — STRIP BEFORE PR: the localhost ?testrewarded=1 override also offers it to
 	// guests (so it's testable without local Supabase auth); the reward is then simulated
 	// client-side in triggerRewardWatch (no server credit — guests have no XP).
@@ -66,20 +74,23 @@ function triggerRewardWatch() {
 	window.ads.showRewarded({
 		placement: "xp_2x",
 		onReward: function () {
-			// Ad watched in full — ask the server to credit the bonus. The server validates
-			// matchId + TTL + single-claim and replies with `xpBonus` (multiplier is server-fixed;
-			// we send it only as a courtesy — the server ignores the client value).
-			rewardedClaimState = "claimed";
+			// Ad watched in full — ask the server to credit the bonus.
 			// DEV-ONLY — STRIP BEFORE PR: under the localhost override a GUEST has no server
 			// progression to credit, so the server would reject the claim. Fake the ack locally
 			// so the toast/flow is visible. Signed-in players always take the real server path.
 			var signedIn = (window.chaochaoAuth && typeof window.chaochaoAuth.isSignedIn === "function" && window.chaochaoAuth.isSignedIn());
 			var devR = (window.ads && typeof window.ads._devRewarded === "function" && window.ads._devRewarded());
 			if (devR && !signedIn) {
+				rewardedClaimState = "claimed";
 				if (typeof enqueueProgressionToasts === "function") { enqueueProgressionToasts([{ type: "xp_bonus", amount: 0 }]); }
 				if (typeof trackEvent === "function") { trackEvent('reward_claimed', { bonus: 'xp_2x', match_id: matchId || '' }); }
 				return;
 			}
+			// Stay PENDING (not 'claimed') until the server's xpBonus ack — the server can still
+			// reject (TTL / transient DB failure), and marking 'claimed' now would consume the
+			// watched ad with no credit and no retry. The ack-timeout below re-offers on failure.
+			rewardedClaimState = "claiming";
+			startRewardClaimAckTimeout();
 			if (typeof server !== "undefined" && server) {
 				server.emit("claimXpMultiplier", { matchId: matchId, multiplier: 2 });
 			}
@@ -96,6 +107,26 @@ function triggerRewardWatch() {
 			}
 		}
 	});
+}
+
+// Guard against the server never acking a claim (TTL rejection / transient DB failure / dropped
+// socket). Without this the player would be stuck in 'claiming' forever after watching an ad.
+// On timeout: unstick to 'idle', tell the player, and — if the match is still within its offer
+// window — re-offer so the watched-but-uncredited ad isn't wasted (the server reset its
+// single-claim flag on failure, so a retry can succeed).
+function startRewardClaimAckTimeout() {
+	if (rewardClaimAckTimer) { clearTimeout(rewardClaimAckTimer); }
+	rewardClaimAckTimer = setTimeout(function () {
+		rewardClaimAckTimer = null;
+		if (rewardedClaimState !== "claiming") { return; } // already acked
+		rewardedClaimState = "idle";
+		if (typeof enqueueProgressionToasts === "function") { enqueueProgressionToasts([{ type: "xp_bonus_failed" }]); }
+		// Re-offer for a genuine retry while still in time.
+		if (rewardClaimable() && typeof flushRewardOffer === "function") {
+			rewardOfferPending = true;
+			flushRewardOffer();
+		}
+	}, 12000);
 }
 
 // Arm the 2× XP offer at the gameOver -> lobby edge, if claimable. Returns true if an offer
@@ -158,6 +189,12 @@ function rewardOfferToastOpen() { return !!rewardOfferToastEl; }
 function rewardOfferWatch() {
 	if (!rewardOfferToastEl) { return; }
 	removeRewardOfferToast();
+	// Guard a late tap on an offer that's aged out of the claim window — don't burn an ad on
+	// a claim the server will reject; tell the player instead of failing silently.
+	if (!rewardClaimable()) {
+		if (typeof enqueueProgressionToasts === "function") { enqueueProgressionToasts([{ type: "xp_bonus_error" }]); }
+		return;
+	}
 	triggerRewardWatch(); // shows the ad; onReward -> claim -> xpBonus toast
 }
 function rewardOfferDismiss() {
@@ -384,7 +421,10 @@ function progressionToastText(ev) {
 		return ev.amount > 0 ? ("⭐ +" + ev.amount + " bonus XP — match XP doubled!") : "⭐ Match XP doubled!";
 	}
 	if (ev.type === "xp_bonus_error") {
-		return "Ad didn't finish — tap to try again for 2× XP.";
+		return "Ad didn't finish — no bonus this time.";
+	}
+	if (ev.type === "xp_bonus_failed") {
+		return "Couldn't credit your bonus XP — try again.";
 	}
 	if (ev.type === "level") {
 		return "⬆️ Level up!  Lv " + ev.level;
@@ -455,6 +495,7 @@ function clearProgressionToasts() {
 	rewardOfferToastEl = null;
 	rewardOfferPending = false;
 	if (rewardOfferFallbackTimer) { clearTimeout(rewardOfferFallbackTimer); rewardOfferFallbackTimer = null; }
+	if (rewardClaimAckTimer) { clearTimeout(rewardClaimAckTimer); rewardClaimAckTimer = null; }
 	if (typeof document !== "undefined" && document.querySelectorAll) {
 		var open = document.querySelectorAll(".cc-progression-toast");
 		for (var i = 0; i < open.length; i++) {
@@ -502,6 +543,8 @@ function registerConnectionHandlers(server) {
 	// ad_complete -> reward_claimed closes.
 	server.on('xpBonus', function (payload) {
 		var bonus = (payload && typeof payload.bonus === "number") ? payload.bonus : 0;
+		// Ack arrived — the claim succeeded. Cancel the retry watchdog and lock it in.
+		if (rewardClaimAckTimer) { clearTimeout(rewardClaimAckTimer); rewardClaimAckTimer = null; }
 		rewardedClaimState = "claimed";
 		if (typeof enqueueProgressionToasts === "function") {
 			enqueueProgressionToasts([{ type: "xp_bonus", amount: bonus }]);
@@ -1108,6 +1151,7 @@ function registerStateHandlers(server) {
 		// never made, since rewardClaimable() requires it). The prompt fires at the next
 		// startLobby (gameOver -> lobby edge), not here on the results screen.
 		currentMatchId = (packet && packet.matchId != null) ? packet.matchId : null;
+		currentMatchOfferTs = Date.now();   // start of this match's offer window
 		rewardedClaimState = "idle";
 		// Bump the medals-card reveal nonce so its entrance animation replays for
 		// this match — even when the same player wins back-to-back (playerWon

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -45,8 +45,9 @@ var rewardOfferToastEl = null,
 // inside the server's claim TTL (180s) — never let a player burn an ad on a claim the server
 // will reject as expired. currentMatchOfferTs is stamped when the match id is set (startGameover).
 var REWARD_OFFER_WINDOW_MS = 120 * 1000,
-	currentMatchOfferTs = 0,
-	rewardClaimAckTimer = null;   // awaiting the server's xpBonus ack after a watch
+	currentMatchOfferTs = 0,       // anchored to the SERVER gameOver time (from rewardedEligible)
+	rewardClaimAckTimer = null,    // awaiting the server's xpBonus ack after a watch
+	pendingClaimMatchId = null;    // the matchId of the claim we're awaiting an ack for
 
 // True when the "2× your match XP" offer can be made: signed-in (anonymous players have no
 // server XP to multiply — never offered), a rewarded ad is loaded, we know which match to
@@ -74,21 +75,23 @@ function triggerRewardWatch() {
 	window.ads.showRewarded({
 		placement: "xp_2x",
 		onReward: function () {
-			// Ad watched in full — ask the server to credit the bonus.
-			// DEV-ONLY — STRIP BEFORE PR: under the localhost override a GUEST has no server
-			// progression to credit, so the server would reject the claim. Fake the ack locally
-			// so the toast/flow is visible. Signed-in players always take the real server path.
-			var signedIn = (window.chaochaoAuth && typeof window.chaochaoAuth.isSignedIn === "function" && window.chaochaoAuth.isSignedIn());
+			// DEV-ONLY — STRIP BEFORE PR: under the localhost ?testrewarded=1 override the ad is
+			// SIMULATED (no real network), so we must NEVER drive the real server claim — that
+			// would persist bonus XP without an actual ad watch. Keep it purely client-side
+			// (visual toast + GA only), regardless of sign-in, so the override can't credit XP.
 			var devR = (window.ads && typeof window.ads._devRewarded === "function" && window.ads._devRewarded());
-			if (devR && !signedIn) {
+			if (devR) {
 				rewardedClaimState = "claimed";
 				if (typeof enqueueProgressionToasts === "function") { enqueueProgressionToasts([{ type: "xp_bonus", amount: 0 }]); }
 				if (typeof trackEvent === "function") { trackEvent('reward_claimed', { bonus: 'xp_2x', match_id: matchId || '' }); }
 				return;
 			}
-			// Stay PENDING (not 'claimed') until the server's xpBonus ack — the server can still
-			// reject (TTL / transient DB failure), and marking 'claimed' now would consume the
-			// watched ad with no credit and no retry. The ack-timeout below re-offers on failure.
+			// Ad watched in full — ask the server to credit the bonus. Stay PENDING (not 'claimed')
+			// until the server's xpBonus ack — the server can still reject (TTL / transient DB
+			// failure), and marking 'claimed' now would consume the watched ad with no credit and
+			// no retry. The ack-timeout re-offers on failure. Remember WHICH match this claim is
+			// for, so a stale ack from a prior match can't mark a later one claimed.
+			pendingClaimMatchId = matchId;
 			rewardedClaimState = "claiming";
 			startRewardClaimAckTimeout();
 			if (typeof server !== "undefined" && server) {
@@ -121,6 +124,7 @@ function startRewardClaimAckTimeout() {
 	rewardClaimAckTimer = setTimeout(function () {
 		rewardClaimAckTimer = null;
 		if (rewardedClaimState !== "claiming") { return; } // already acked
+		pendingClaimMatchId = null; // give up waiting on this claim's ack
 		rewardedClaimState = "idle";
 		if (typeof enqueueProgressionToasts === "function") { enqueueProgressionToasts([{ type: "xp_bonus_failed" }]); }
 		var inLobby = (typeof config !== "undefined" && config && currentState === config.stateMap.lobby);
@@ -189,7 +193,6 @@ function removeRewardOfferToast() {
 		showNextProgressionToast(); // advance the (now usually empty) stream
 	}, 400);
 }
-function rewardOfferToastOpen() { return !!rewardOfferToastEl; }
 function rewardOfferWatch() {
 	if (!rewardOfferToastEl) { return; }
 	removeRewardOfferToast();
@@ -553,21 +556,31 @@ function registerConnectionHandlers(server) {
 	server.on('rewardedEligible', function (payload) {
 		if (!payload || payload.matchId == null) { return; }
 		currentMatchId = payload.matchId;
-		currentMatchOfferTs = Date.now();   // start of this match's offer window
+		// Anchor the offer window to the SERVER's gameOver timestamp (not client receipt time):
+		// if this event is delivered late (suspended/backgrounded tab), the window must still
+		// reflect how long the SERVER has had the claim open, so we don't offer an ad for a
+		// claim that has already expired against the server TTL. Fall back to local now if absent.
+		currentMatchOfferTs = (typeof payload.gameOverTs === "number") ? payload.gameOverTs : Date.now();
 		rewardedClaimState = "idle";
 	});
 	server.on('xpBonus', function (payload) {
-		var bonus = (payload && typeof payload.bonus === "number") ? payload.bonus : 0;
-		// Ack arrived — the claim succeeded. Cancel the retry watchdog and lock it in.
+		var ackMatchId = payload && payload.matchId;
+		// Validate the ack against the claim we're actually waiting on. A prior match's claim can
+		// resolve LATE (rewarded ads are allowed to finish during the next race), and an unguarded
+		// ack would mark a NEW match claimed + cancel its retry watchdog. Ignore anything that
+		// isn't our pending claim. (The bonus XP was still persisted server-side and the lobby
+		// badge is refreshed via progressionUpdate, so dropping a stale toast loses nothing.)
+		if (!ackMatchId || ackMatchId !== pendingClaimMatchId) { return; }
+		pendingClaimMatchId = null;
 		if (rewardClaimAckTimer) { clearTimeout(rewardClaimAckTimer); rewardClaimAckTimer = null; }
-		rewardedClaimState = "claimed";
+		// Only flip the live offer to 'claimed' if it's still the same match (a new match may
+		// already have armed a fresh offer — don't stomp it).
+		if (ackMatchId === currentMatchId) { rewardedClaimState = "claimed"; }
+		var bonus = (payload && typeof payload.bonus === "number") ? payload.bonus : 0;
 		if (typeof enqueueProgressionToasts === "function") {
 			enqueueProgressionToasts([{ type: "xp_bonus", amount: bonus }]);
 		}
-		trackEvent('reward_claimed', {
-			bonus: 'xp_2x',
-			match_id: (payload && payload.matchId) || currentMatchId || ''
-		});
+		trackEvent('reward_claimed', { bonus: 'xp_2x', match_id: ackMatchId });
 	});
 
 	// botGuard: the server confirmed this client actually drove a kart (not a pageview-only

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -4643,68 +4643,17 @@ function drawGameOverScreen(dt) {
         debugLog("recap draw error", e);
     }
 
-    // "Watch ad to 2× XP" reward button (signed-in + a rewarded ad loaded only), pinned
-    // just above the rating widget. Guarded like the rest — it must never take down the
-    // (load-bearing) game-over screen.
-    try {
-        drawRewardButton();
-    } catch (e) {
-        debugLog("reward button draw error", e);
-        rewardButtonHit = null;
-    }
-
     // "Rate this map" star widget, pinned bottom-centre. Guarded for the same
     // reason as the recap — it must never take down the game-over screen.
+    // (The rewarded "2× XP" offer is intentionally NOT here — it would compete with the
+    // recap/stats for the player's attention. It's a prompt at the gameOver -> lobby edge
+    // instead; see the startLobby handler in client.js.)
     try {
         drawMapRating();
     } catch (e) {
         debugLog("rating draw error", e);
     }
 
-}
-
-// The rewarded-video CTA on the results screen: "📺 Watch ad to 2× your XP". Rendered ONLY
-// when rewardButtonAvailable() (signed-in + a rewarded ad loaded + this match not yet claimed)
-// — anonymous players never see it. Records its logical hit-rect into rewardButtonHit for
-// input.js; highlights when the gamepad has it focused (rewardPadFocused). No DOM element, so
-// it stays outside the DOM button-compliance gates, exactly like the canvas rating widget.
-function drawRewardButton() {
-    rewardButtonHit = null;
-    if (typeof rewardButtonAvailable !== "function" || !rewardButtonAvailable()) {
-        return;
-    }
-    var label = "📺 Watch ad to 2× your XP";
-    var bw = 380, bh = 54;
-    var bx = LOGICAL_WIDTH / 2 - bw / 2;
-    // Sit just above the rating widget (pinned ~16px off the bottom, panel height 78).
-    var by = LOGICAL_HEIGHT - 78 - 16 - bh - 16;
-    var focused = (typeof activeInputMethod !== "undefined" && activeInputMethod === "pad" &&
-        typeof rewardPadFocused !== "undefined" && rewardPadFocused);
-
-    gameContext.save();
-    gameContext.globalAlpha = 0.96;
-    drawRoundRectPath(bx, by, bw, bh, 14);
-    gameContext.fillStyle = "rgba(20,24,32,0.92)";
-    gameContext.fill();
-    gameContext.globalAlpha = 1;
-    gameContext.lineWidth = focused ? 4 : 2.5;
-    gameContext.strokeStyle = "#FFCB30";
-    gameContext.stroke();
-
-    gameContext.fillStyle = "#FFE08A";
-    gameContext.font = "bold 22px sans-serif";
-    gameContext.textAlign = "center";
-    gameContext.textBaseline = "middle";
-    gameContext.fillText(label, LOGICAL_WIDTH / 2, by + bh / 2);
-
-    if (focused) {
-        gameContext.fillStyle = "rgba(255,255,255,0.7)";
-        gameContext.font = "13px sans-serif";
-        gameContext.fillText("Ⓐ to watch · ▼ to rate the map", LOGICAL_WIDTH / 2, by + bh + 14);
-    }
-    gameContext.restore();
-
-    rewardButtonHit = { x: bx, y: by, w: bw, h: bh };
 }
 
 // A 5-star "rate this map" strip pinned bottom-centre. Shown on the per-round

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -4643,6 +4643,16 @@ function drawGameOverScreen(dt) {
         debugLog("recap draw error", e);
     }
 
+    // "Watch ad to 2× XP" reward button (signed-in + a rewarded ad loaded only), pinned
+    // just above the rating widget. Guarded like the rest — it must never take down the
+    // (load-bearing) game-over screen.
+    try {
+        drawRewardButton();
+    } catch (e) {
+        debugLog("reward button draw error", e);
+        rewardButtonHit = null;
+    }
+
     // "Rate this map" star widget, pinned bottom-centre. Guarded for the same
     // reason as the recap — it must never take down the game-over screen.
     try {
@@ -4651,6 +4661,50 @@ function drawGameOverScreen(dt) {
         debugLog("rating draw error", e);
     }
 
+}
+
+// The rewarded-video CTA on the results screen: "📺 Watch ad to 2× your XP". Rendered ONLY
+// when rewardButtonAvailable() (signed-in + a rewarded ad loaded + this match not yet claimed)
+// — anonymous players never see it. Records its logical hit-rect into rewardButtonHit for
+// input.js; highlights when the gamepad has it focused (rewardPadFocused). No DOM element, so
+// it stays outside the DOM button-compliance gates, exactly like the canvas rating widget.
+function drawRewardButton() {
+    rewardButtonHit = null;
+    if (typeof rewardButtonAvailable !== "function" || !rewardButtonAvailable()) {
+        return;
+    }
+    var label = "📺 Watch ad to 2× your XP";
+    var bw = 380, bh = 54;
+    var bx = LOGICAL_WIDTH / 2 - bw / 2;
+    // Sit just above the rating widget (pinned ~16px off the bottom, panel height 78).
+    var by = LOGICAL_HEIGHT - 78 - 16 - bh - 16;
+    var focused = (typeof activeInputMethod !== "undefined" && activeInputMethod === "pad" &&
+        typeof rewardPadFocused !== "undefined" && rewardPadFocused);
+
+    gameContext.save();
+    gameContext.globalAlpha = 0.96;
+    drawRoundRectPath(bx, by, bw, bh, 14);
+    gameContext.fillStyle = "rgba(20,24,32,0.92)";
+    gameContext.fill();
+    gameContext.globalAlpha = 1;
+    gameContext.lineWidth = focused ? 4 : 2.5;
+    gameContext.strokeStyle = "#FFCB30";
+    gameContext.stroke();
+
+    gameContext.fillStyle = "#FFE08A";
+    gameContext.font = "bold 22px sans-serif";
+    gameContext.textAlign = "center";
+    gameContext.textBaseline = "middle";
+    gameContext.fillText(label, LOGICAL_WIDTH / 2, by + bh / 2);
+
+    if (focused) {
+        gameContext.fillStyle = "rgba(255,255,255,0.7)";
+        gameContext.font = "13px sans-serif";
+        gameContext.fillText("Ⓐ to watch · ▼ to rate the map", LOGICAL_WIDTH / 2, by + bh + 14);
+    }
+    gameContext.restore();
+
+    rewardButtonHit = { x: bx, y: by, w: bw, h: bh };
 }
 
 // A 5-star "rate this map" strip pinned bottom-centre. Shown on the per-round

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -529,8 +529,12 @@ function pollPadForSlot(pad, lp) {
     } else if (iOwnWheel) {
         pollEmojiWheel(pad, lp);
     } else if (lp.isPrimary && typeof config !== "undefined" && config &&
-        (currentState === config.stateMap.overview || currentState === config.stateMap.gameOver) &&
-        pollMapRatingPad(pad, lp)) {
+        currentState === config.stateMap.gameOver && pollGameOverPad(pad, lp)) {
+        // Results screen (primary pad only): the "Watch ad to 2× XP" reward button + the star
+        // rating share one focus model (D-pad ▲▼ switches, Ⓐ confirms). pollGameOverPad returns
+        // true only when it consumed an input, so B/Start/emoji still fall through.
+    } else if (lp.isPrimary && typeof config !== "undefined" && config &&
+        currentState === config.stateMap.overview && pollMapRatingPad(pad, lp)) {
         // Map-rating star strip (primary pad only — one shared widget). pollMapRatingPad
         // returns true only when it consumed a D-pad/A press this frame, so B/Start/emoji
         // still fall through to their branches at the overview.
@@ -861,6 +865,39 @@ function clearEmojiHighlight(items) {
 // stick, A confirms (dismisses — changes apply live as you step), B / emoji
 // closes. Per-slot, so two pads can configure two panels simultaneously. The
 // open/nav/confirm/close logic itself lives in lobbyHub.js (input-agnostic).
+// Results-screen focus model (primary pad). Two controls share the screen: the optional
+// "Watch ad to 2× XP" reward button (top) and the star-rating strip (bottom). Focus starts
+// on the reward button when it's offered; D-pad ▼ drops to the stars, ▲ returns. Ⓐ confirms
+// the focused control. Returns true ONLY when it consumed an input this frame (so B/Start/
+// emoji still fall through). Self-contained: reads the client globals rewardButtonAvailable /
+// rewardPadFocused / currentMatchId / triggerRewardButton.
+var goPadMatchId = null;
+function pollGameOverPad(pad, lp) {
+    var rewardAvail = (typeof rewardButtonAvailable === "function" && rewardButtonAvailable());
+    // Re-seed focus when a NEW match's results screen appears (currentMatchId changes): land on
+    // the reward button if it's offered, else the stars.
+    if (typeof currentMatchId !== "undefined" && currentMatchId !== goPadMatchId) {
+        goPadMatchId = (typeof currentMatchId !== "undefined") ? currentMatchId : null;
+        rewardPadFocused = rewardAvail;
+    }
+    if (!rewardAvail) {
+        // No reward button (anonymous / not loaded / already claimed) — just the star strip.
+        rewardPadFocused = false;
+        return pollMapRatingPad(pad, lp);
+    }
+    if (rewardPadFocused) {
+        if (buttonPressedThisFrame(pad, GP_DPAD_DOWN, lp)) { rewardPadFocused = false; return true; }
+        if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
+            if (typeof triggerRewardButton === "function") { triggerRewardButton(); }
+            return true;
+        }
+        return false; // leave B/emoji/Start to their own branches
+    }
+    // Stars focused: ▲ jumps back to the reward button; otherwise the normal star nav.
+    if (buttonPressedThisFrame(pad, GP_DPAD_UP, lp)) { rewardPadFocused = true; return true; }
+    return pollMapRatingPad(pad, lp);
+}
+
 // Drive the map-rating star strip with the pad: D-pad ◄ ► (or left stick) moves the
 // highlighted star, Ⓐ confirms the vote. Returns true ONLY when it consumed an input
 // this frame, so the caller's else-if chain still falls through to B/Start/emoji when

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -66,11 +66,6 @@ var leaveModalEl = null;
 var leaveFocusIdx = 1;   // 0 = Leave, 1 = Cancel (default to the safe choice)
 var gpLeaveStepAt = 0;
 
-// "2× your match XP" prompt (rewarded-video opt-in, shown at the gameOver -> lobby edge).
-var rewardModalEl = null;
-var rewardFocusIdx = 1;  // 0 = Watch, 1 = No thanks (default to the SAFE choice — never auto-launch an ad)
-var gpRewardStepAt = 0;
-var rewardOnWatch = null, rewardOnDecline = null;
 
 // --- in-game settings panel (primary/P1 only; same four toggles as the navbar) ---
 var settingsModalEl = null;
@@ -90,7 +85,6 @@ function initGamepad() {
     window.addEventListener("touchstart", markTouchUsed, false);
     buildHintBar();
     buildLeaveModalUI();
-    buildRewardModalUI();
     buildSettingsModalUI();
     buildTouchSettingsButton();
     buildPadPlayersUI();
@@ -154,23 +148,19 @@ function onGamepadKeyDown(e) {
         return;
     }
 
-    // The "2× your match XP" prompt (lobby edge) owns the keyboard while open: arrows / A-D
-    // move between Watch and No thanks, Enter/Space confirms, Esc declines. Top priority.
-    if (rewardModalIsOpen()) {
-        if (e.key === "Escape" || e.keyCode === 27) {
-            closeRewardModal(true); // decline
-        } else if (e.keyCode === 37 || e.keyCode === 65 || e.key === "ArrowLeft") {
-            setRewardFocus(0); // Watch
+    // The "2× your match XP" offer toast (lobby edge): Enter/Space watches, Esc dismisses.
+    // Non-blocking otherwise — it doesn't capture the keyboard, so other keys still work.
+    if (typeof rewardOfferToastOpen === "function" && rewardOfferToastOpen()) {
+        if (e.keyCode === 13 || e.keyCode === 32 || e.key === "Enter" || e.key === " ") {
+            if (typeof rewardOfferWatch === "function") { rewardOfferWatch(); }
             e.preventDefault();
-        } else if (e.keyCode === 39 || e.keyCode === 68 || e.key === "ArrowRight") {
-            setRewardFocus(1); // No thanks
-            e.preventDefault();
-        } else if (e.keyCode === 13 || e.keyCode === 32 || e.key === "Enter" || e.key === " ") {
-            var rbtns = rewardButtons();
-            if (rbtns[rewardFocusIdx]) { rbtns[rewardFocusIdx].click(); }
-            e.preventDefault();
+            return;
         }
-        return;
+        if (e.key === "Escape" || e.keyCode === 27) {
+            if (typeof rewardOfferDismiss === "function") { rewardOfferDismiss(); }
+            e.preventDefault();
+            return;
+        }
     }
 
     // The centre leave modal (used when solo, or when the primary has no inline
@@ -534,11 +524,16 @@ function pollPadForSlot(pad, lp) {
         setInputMethod("pad");
     }
 
-    if (lp.isPrimary && rewardModalIsOpen()) {
-        // P1 navigates the centre "2× your match XP" prompt (lobby edge). Top priority so
-        // Ⓐ/D-pad drive it before anything else; other local players keep idling in the lobby.
-        pollRewardModal(pad, lp);
-    } else if (lp.isPrimary && settingsModalIsOpen()) {
+    // "2× your match XP" offer toast (lobby edge): a NON-blocking actionable toast, so the
+    // player can still move in the lobby. We only divert the primary pad's Ⓐ (watch) / Ⓑ
+    // (dismiss) on the frame they're pressed — every other frame falls through to normal
+    // lobby control. (Mouse/touch tap the toast buttons; keyboard uses Enter/Esc.)
+    if (lp.isPrimary && typeof rewardOfferToastOpen === "function" && rewardOfferToastOpen()) {
+        if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) { if (typeof rewardOfferWatch === "function") { rewardOfferWatch(); } return; }
+        if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) { if (typeof rewardOfferDismiss === "function") { rewardOfferDismiss(); } return; }
+    }
+
+    if (lp.isPrimary && settingsModalIsOpen()) {
         // P1 navigates the shared settings panel. Other local players are NOT in
         // this branch (it's primary-only), so they keep racing while P1 adjusts
         // settings — the panel just diverts the primary pad.
@@ -1095,100 +1090,6 @@ function pollLeaveModal(pad, lp) {
         if (Math.abs(lx) > 0.5 && now - gpLeaveStepAt > 250) {
             setLeaveFocus(lx < 0 ? 0 : 1);
             gpLeaveStepAt = now;
-        }
-    }
-}
-
-// --- "2× your match XP" prompt (rewarded-video opt-in) ---
-// A centre confirm-modal shown ONCE at the gameOver -> lobby edge (see client.js
-// maybeOfferRewardedXp), reusing the leave modal's CSS + nav pattern. Kept OFF the results
-// screen so it never competes with the recap/stats. Two buttons: "📺 Watch" (the opt-in CTA)
-// and "No thanks". Default focus is the SAFE choice (No thanks) so a stray Ⓐ/Enter at lobby
-// entry can never auto-launch an ad. Hidden in the DOM by default, so — like the leave modal —
-// it's invisible to the button-compliance gate until opened.
-function buildRewardModalUI() {
-    if (rewardModalEl || typeof document === "undefined" || !document.body) {
-        return;
-    }
-    var el = document.createElement("div");
-    el.id = "rewardModal";
-    el.className = "confirm-modal hidden";
-    el.innerHTML =
-        '<div class="confirm-dialog">' +
-        '<div class="confirm-title">Double your match XP?</div>' +
-        '<div class="confirm-subtitle">Watch a short ad to 2× the XP you just earned.</div>' +
-        '<div class="confirm-buttons">' +
-        '<button type="button" class="confirm-btn confirm-watch">📺 Watch</button>' +
-        '<button type="button" class="confirm-btn confirm-decline">No thanks</button>' +
-        '</div></div>';
-    document.body.appendChild(el);
-    rewardModalEl = el;
-    // Mouse/touch users tap either button directly.
-    el.querySelector(".confirm-watch").addEventListener("click", function () { closeRewardModal(false); if (typeof rewardOnWatch === "function") { rewardOnWatch(); } });
-    el.querySelector(".confirm-decline").addEventListener("click", function () { closeRewardModal(true); });
-}
-
-function rewardModalIsOpen() {
-    return !!rewardModalEl && rewardModalEl.classList.contains("visible");
-}
-
-// Open the prompt. opts: { onWatch, onDecline }. No-op (and onDecline fires) if the UI can't
-// be built — fail-open so a missing modal never strands the offer.
-function openRewardModal(opts) {
-    opts = opts || {};
-    rewardOnWatch = (typeof opts.onWatch === "function") ? opts.onWatch : null;
-    rewardOnDecline = (typeof opts.onDecline === "function") ? opts.onDecline : null;
-    if (!rewardModalEl) { buildRewardModalUI(); }
-    if (!rewardModalEl) { if (rewardOnDecline) { rewardOnDecline(); } return; }
-    rewardModalEl.className = "confirm-modal visible";
-    setRewardFocus(1); // default to "No thanks" — never auto-launch an ad
-}
-
-// Close the prompt. If `declined`, fire onDecline. Always clears the stashed callbacks so a
-// later close can't double-fire them.
-function closeRewardModal(declined) {
-    if (rewardModalEl) { rewardModalEl.className = "confirm-modal hidden"; }
-    var d = rewardOnDecline;
-    rewardOnWatch = null;
-    rewardOnDecline = null;
-    if (declined && typeof d === "function") { d(); }
-}
-
-function rewardButtons() {
-    if (!rewardModalEl) { return []; }
-    return [rewardModalEl.querySelector(".confirm-watch"), rewardModalEl.querySelector(".confirm-decline")];
-}
-
-function setRewardFocus(idx) {
-    var btns = rewardButtons();
-    rewardFocusIdx = idx;
-    for (var i = 0; i < btns.length; i++) {
-        if (!btns[i]) { continue; }
-        if (i === idx) { btns[i].classList.add("gp-focus"); try { btns[i].focus(); } catch (e) {} }
-        else { btns[i].classList.remove("gp-focus"); }
-    }
-}
-
-function pollRewardModal(pad, lp) {
-    if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
-        closeRewardModal(true); // B = decline
-        return;
-    }
-    if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
-        var btns = rewardButtons();
-        if (btns[rewardFocusIdx]) { btns[rewardFocusIdx].click(); }
-        return;
-    }
-    if (buttonPressedThisFrame(pad, GP_DPAD_LEFT, lp)) {
-        setRewardFocus(0);
-    } else if (buttonPressedThisFrame(pad, GP_DPAD_RIGHT, lp)) {
-        setRewardFocus(1);
-    } else {
-        var lx = pad.axes[0] || 0;
-        var now = Date.now();
-        if (Math.abs(lx) > 0.5 && now - gpRewardStepAt > 250) {
-            setRewardFocus(lx < 0 ? 0 : 1);
-            gpRewardStepAt = now;
         }
     }
 }

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -148,20 +148,9 @@ function onGamepadKeyDown(e) {
         return;
     }
 
-    // The "2× your match XP" offer toast (lobby edge): Enter/Space watches, Esc dismisses.
-    // Non-blocking otherwise — it doesn't capture the keyboard, so other keys still work.
-    if (typeof rewardOfferToastOpen === "function" && rewardOfferToastOpen()) {
-        if (e.keyCode === 13 || e.keyCode === 32 || e.key === "Enter" || e.key === " ") {
-            if (typeof rewardOfferWatch === "function") { rewardOfferWatch(); }
-            e.preventDefault();
-            return;
-        }
-        if (e.key === "Escape" || e.keyCode === 27) {
-            if (typeof rewardOfferDismiss === "function") { rewardOfferDismiss(); }
-            e.preventDefault();
-            return;
-        }
-    }
+    // NOTE: the "2× your match XP" offer toast is intentionally NOT bound to the keyboard either.
+    // Space/Enter are gameplay/confirm keys, so binding them to "watch a full-screen ad" would
+    // launch an ad from ordinary input. Watching is an explicit pointer tap on the toast button.
 
     // The centre leave modal (used when solo, or when the primary has no inline
     // block) owns the keyboard while open, in any mode: arrows / A-D move between
@@ -524,14 +513,11 @@ function pollPadForSlot(pad, lp) {
         setInputMethod("pad");
     }
 
-    // "2× your match XP" offer toast (lobby edge): a NON-blocking actionable toast, so the
-    // player can still move in the lobby. We only divert the primary pad's Ⓐ (watch) / Ⓑ
-    // (dismiss) on the frame they're pressed — every other frame falls through to normal
-    // lobby control. (Mouse/touch tap the toast buttons; keyboard uses Enter/Esc.)
-    if (lp.isPrimary && typeof rewardOfferToastOpen === "function" && rewardOfferToastOpen()) {
-        if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) { if (typeof rewardOfferWatch === "function") { rewardOfferWatch(); } return; }
-        if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) { if (typeof rewardOfferDismiss === "function") { rewardOfferDismiss(); } return; }
-    }
+    // NOTE: the "2× your match XP" offer toast is intentionally NOT bound to any gamepad button.
+    // It's a non-blocking lobby toast and the primary pad's face buttons are live gameplay
+    // controls (Ⓐ = attack/station-interact, Ⓑ = leave) — reinterpreting a bare press as
+    // "watch a full-screen ad" would launch an ad from ordinary input. Watching must be an
+    // explicit pointer tap on the toast's button; the toast otherwise auto-clears at race start.
 
     if (lp.isPrimary && settingsModalIsOpen()) {
         // P1 navigates the shared settings panel. Other local players are NOT in

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -66,6 +66,12 @@ var leaveModalEl = null;
 var leaveFocusIdx = 1;   // 0 = Leave, 1 = Cancel (default to the safe choice)
 var gpLeaveStepAt = 0;
 
+// "2× your match XP" prompt (rewarded-video opt-in, shown at the gameOver -> lobby edge).
+var rewardModalEl = null;
+var rewardFocusIdx = 1;  // 0 = Watch, 1 = No thanks (default to the SAFE choice — never auto-launch an ad)
+var gpRewardStepAt = 0;
+var rewardOnWatch = null, rewardOnDecline = null;
+
 // --- in-game settings panel (primary/P1 only; same four toggles as the navbar) ---
 var settingsModalEl = null;
 var settingsFocusIdx = 0;   // which row the d-pad focus ring is on
@@ -84,6 +90,7 @@ function initGamepad() {
     window.addEventListener("touchstart", markTouchUsed, false);
     buildHintBar();
     buildLeaveModalUI();
+    buildRewardModalUI();
     buildSettingsModalUI();
     buildTouchSettingsButton();
     buildPadPlayersUI();
@@ -144,6 +151,25 @@ function onGamepadKeyDown(e) {
     // a fresh leave prompt; a leave modal already up still takes over below).
     var primaryHub = (typeof localPlayers !== "undefined") ? localPlayers[primarySlot] : null;
     if (((primaryHub && primaryHub.stationPanel) || e.defaultPrevented) && !leaveModalIsOpen()) {
+        return;
+    }
+
+    // The "2× your match XP" prompt (lobby edge) owns the keyboard while open: arrows / A-D
+    // move between Watch and No thanks, Enter/Space confirms, Esc declines. Top priority.
+    if (rewardModalIsOpen()) {
+        if (e.key === "Escape" || e.keyCode === 27) {
+            closeRewardModal(true); // decline
+        } else if (e.keyCode === 37 || e.keyCode === 65 || e.key === "ArrowLeft") {
+            setRewardFocus(0); // Watch
+            e.preventDefault();
+        } else if (e.keyCode === 39 || e.keyCode === 68 || e.key === "ArrowRight") {
+            setRewardFocus(1); // No thanks
+            e.preventDefault();
+        } else if (e.keyCode === 13 || e.keyCode === 32 || e.key === "Enter" || e.key === " ") {
+            var rbtns = rewardButtons();
+            if (rbtns[rewardFocusIdx]) { rbtns[rewardFocusIdx].click(); }
+            e.preventDefault();
+        }
         return;
     }
 
@@ -508,7 +534,11 @@ function pollPadForSlot(pad, lp) {
         setInputMethod("pad");
     }
 
-    if (lp.isPrimary && settingsModalIsOpen()) {
+    if (lp.isPrimary && rewardModalIsOpen()) {
+        // P1 navigates the centre "2× your match XP" prompt (lobby edge). Top priority so
+        // Ⓐ/D-pad drive it before anything else; other local players keep idling in the lobby.
+        pollRewardModal(pad, lp);
+    } else if (lp.isPrimary && settingsModalIsOpen()) {
         // P1 navigates the shared settings panel. Other local players are NOT in
         // this branch (it's primary-only), so they keep racing while P1 adjusts
         // settings — the panel just diverts the primary pad.
@@ -529,12 +559,8 @@ function pollPadForSlot(pad, lp) {
     } else if (iOwnWheel) {
         pollEmojiWheel(pad, lp);
     } else if (lp.isPrimary && typeof config !== "undefined" && config &&
-        currentState === config.stateMap.gameOver && pollGameOverPad(pad, lp)) {
-        // Results screen (primary pad only): the "Watch ad to 2× XP" reward button + the star
-        // rating share one focus model (D-pad ▲▼ switches, Ⓐ confirms). pollGameOverPad returns
-        // true only when it consumed an input, so B/Start/emoji still fall through.
-    } else if (lp.isPrimary && typeof config !== "undefined" && config &&
-        currentState === config.stateMap.overview && pollMapRatingPad(pad, lp)) {
+        (currentState === config.stateMap.overview || currentState === config.stateMap.gameOver) &&
+        pollMapRatingPad(pad, lp)) {
         // Map-rating star strip (primary pad only — one shared widget). pollMapRatingPad
         // returns true only when it consumed a D-pad/A press this frame, so B/Start/emoji
         // still fall through to their branches at the overview.
@@ -865,39 +891,6 @@ function clearEmojiHighlight(items) {
 // stick, A confirms (dismisses — changes apply live as you step), B / emoji
 // closes. Per-slot, so two pads can configure two panels simultaneously. The
 // open/nav/confirm/close logic itself lives in lobbyHub.js (input-agnostic).
-// Results-screen focus model (primary pad). Two controls share the screen: the optional
-// "Watch ad to 2× XP" reward button (top) and the star-rating strip (bottom). Focus starts
-// on the reward button when it's offered; D-pad ▼ drops to the stars, ▲ returns. Ⓐ confirms
-// the focused control. Returns true ONLY when it consumed an input this frame (so B/Start/
-// emoji still fall through). Self-contained: reads the client globals rewardButtonAvailable /
-// rewardPadFocused / currentMatchId / triggerRewardButton.
-var goPadMatchId = null;
-function pollGameOverPad(pad, lp) {
-    var rewardAvail = (typeof rewardButtonAvailable === "function" && rewardButtonAvailable());
-    // Re-seed focus when a NEW match's results screen appears (currentMatchId changes): land on
-    // the reward button if it's offered, else the stars.
-    if (typeof currentMatchId !== "undefined" && currentMatchId !== goPadMatchId) {
-        goPadMatchId = (typeof currentMatchId !== "undefined") ? currentMatchId : null;
-        rewardPadFocused = rewardAvail;
-    }
-    if (!rewardAvail) {
-        // No reward button (anonymous / not loaded / already claimed) — just the star strip.
-        rewardPadFocused = false;
-        return pollMapRatingPad(pad, lp);
-    }
-    if (rewardPadFocused) {
-        if (buttonPressedThisFrame(pad, GP_DPAD_DOWN, lp)) { rewardPadFocused = false; return true; }
-        if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
-            if (typeof triggerRewardButton === "function") { triggerRewardButton(); }
-            return true;
-        }
-        return false; // leave B/emoji/Start to their own branches
-    }
-    // Stars focused: ▲ jumps back to the reward button; otherwise the normal star nav.
-    if (buttonPressedThisFrame(pad, GP_DPAD_UP, lp)) { rewardPadFocused = true; return true; }
-    return pollMapRatingPad(pad, lp);
-}
-
 // Drive the map-rating star strip with the pad: D-pad ◄ ► (or left stick) moves the
 // highlighted star, Ⓐ confirms the vote. Returns true ONLY when it consumed an input
 // this frame, so the caller's else-if chain still falls through to B/Start/emoji when
@@ -1102,6 +1095,100 @@ function pollLeaveModal(pad, lp) {
         if (Math.abs(lx) > 0.5 && now - gpLeaveStepAt > 250) {
             setLeaveFocus(lx < 0 ? 0 : 1);
             gpLeaveStepAt = now;
+        }
+    }
+}
+
+// --- "2× your match XP" prompt (rewarded-video opt-in) ---
+// A centre confirm-modal shown ONCE at the gameOver -> lobby edge (see client.js
+// maybeOfferRewardedXp), reusing the leave modal's CSS + nav pattern. Kept OFF the results
+// screen so it never competes with the recap/stats. Two buttons: "📺 Watch" (the opt-in CTA)
+// and "No thanks". Default focus is the SAFE choice (No thanks) so a stray Ⓐ/Enter at lobby
+// entry can never auto-launch an ad. Hidden in the DOM by default, so — like the leave modal —
+// it's invisible to the button-compliance gate until opened.
+function buildRewardModalUI() {
+    if (rewardModalEl || typeof document === "undefined" || !document.body) {
+        return;
+    }
+    var el = document.createElement("div");
+    el.id = "rewardModal";
+    el.className = "confirm-modal hidden";
+    el.innerHTML =
+        '<div class="confirm-dialog">' +
+        '<div class="confirm-title">Double your match XP?</div>' +
+        '<div class="confirm-subtitle">Watch a short ad to 2× the XP you just earned.</div>' +
+        '<div class="confirm-buttons">' +
+        '<button type="button" class="confirm-btn confirm-watch">📺 Watch</button>' +
+        '<button type="button" class="confirm-btn confirm-decline">No thanks</button>' +
+        '</div></div>';
+    document.body.appendChild(el);
+    rewardModalEl = el;
+    // Mouse/touch users tap either button directly.
+    el.querySelector(".confirm-watch").addEventListener("click", function () { closeRewardModal(false); if (typeof rewardOnWatch === "function") { rewardOnWatch(); } });
+    el.querySelector(".confirm-decline").addEventListener("click", function () { closeRewardModal(true); });
+}
+
+function rewardModalIsOpen() {
+    return !!rewardModalEl && rewardModalEl.classList.contains("visible");
+}
+
+// Open the prompt. opts: { onWatch, onDecline }. No-op (and onDecline fires) if the UI can't
+// be built — fail-open so a missing modal never strands the offer.
+function openRewardModal(opts) {
+    opts = opts || {};
+    rewardOnWatch = (typeof opts.onWatch === "function") ? opts.onWatch : null;
+    rewardOnDecline = (typeof opts.onDecline === "function") ? opts.onDecline : null;
+    if (!rewardModalEl) { buildRewardModalUI(); }
+    if (!rewardModalEl) { if (rewardOnDecline) { rewardOnDecline(); } return; }
+    rewardModalEl.className = "confirm-modal visible";
+    setRewardFocus(1); // default to "No thanks" — never auto-launch an ad
+}
+
+// Close the prompt. If `declined`, fire onDecline. Always clears the stashed callbacks so a
+// later close can't double-fire them.
+function closeRewardModal(declined) {
+    if (rewardModalEl) { rewardModalEl.className = "confirm-modal hidden"; }
+    var d = rewardOnDecline;
+    rewardOnWatch = null;
+    rewardOnDecline = null;
+    if (declined && typeof d === "function") { d(); }
+}
+
+function rewardButtons() {
+    if (!rewardModalEl) { return []; }
+    return [rewardModalEl.querySelector(".confirm-watch"), rewardModalEl.querySelector(".confirm-decline")];
+}
+
+function setRewardFocus(idx) {
+    var btns = rewardButtons();
+    rewardFocusIdx = idx;
+    for (var i = 0; i < btns.length; i++) {
+        if (!btns[i]) { continue; }
+        if (i === idx) { btns[i].classList.add("gp-focus"); try { btns[i].focus(); } catch (e) {} }
+        else { btns[i].classList.remove("gp-focus"); }
+    }
+}
+
+function pollRewardModal(pad, lp) {
+    if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
+        closeRewardModal(true); // B = decline
+        return;
+    }
+    if (buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
+        var btns = rewardButtons();
+        if (btns[rewardFocusIdx]) { btns[rewardFocusIdx].click(); }
+        return;
+    }
+    if (buttonPressedThisFrame(pad, GP_DPAD_LEFT, lp)) {
+        setRewardFocus(0);
+    } else if (buttonPressedThisFrame(pad, GP_DPAD_RIGHT, lp)) {
+        setRewardFocus(1);
+    } else {
+        var lx = pad.axes[0] || 0;
+        var now = Date.now();
+        if (Math.abs(lx) > 0.5 && now - gpRewardStepAt > 250) {
+            setRewardFocus(lx < 0 ? 0 : 1);
+            gpRewardStepAt = now;
         }
     }
 }

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -148,10 +148,6 @@ function onGamepadKeyDown(e) {
         return;
     }
 
-    // NOTE: the "2× your match XP" offer toast is intentionally NOT bound to the keyboard either.
-    // Space/Enter are gameplay/confirm keys, so binding them to "watch a full-screen ad" would
-    // launch an ad from ordinary input. Watching is an explicit pointer tap on the toast button.
-
     // The centre leave modal (used when solo, or when the primary has no inline
     // block) owns the keyboard while open, in any mode: arrows / A-D move between
     // Leave and Cancel, Enter or Space confirms, Esc closes.
@@ -172,6 +168,27 @@ function onGamepadKeyDown(e) {
             e.preventDefault();
         }
         return;
+    }
+
+    // The "2× your match XP" offer toast (lobby): a deliberate two-step, mirroring the pad, so a
+    // bare gameplay key can't launch a full-screen ad. Enter FIRST focuses the toast, a second
+    // Enter watches; Esc declines. NOT Space (Space is a gameplay key). Only when no modal above
+    // owns the keyboard. Other keys fall through, so the toast stays non-blocking.
+    if (typeof rewardOfferToastOpen === "function" && rewardOfferToastOpen()) {
+        if (e.key === "Escape" || e.keyCode === 27) {
+            if (typeof rewardOfferDismiss === "function") { rewardOfferDismiss(); }
+            e.preventDefault();
+            return;
+        }
+        if (e.keyCode === 13 || e.key === "Enter") {
+            if (typeof rewardOfferIsFocused === "function" && rewardOfferIsFocused()) {
+                if (typeof rewardOfferWatch === "function") { rewardOfferWatch(); }
+            } else if (typeof rewardOfferFocus === "function") {
+                rewardOfferFocus();
+            }
+            e.preventDefault();
+            return;
+        }
     }
 
     var primary = localPlayers[primarySlot];
@@ -513,12 +530,6 @@ function pollPadForSlot(pad, lp) {
         setInputMethod("pad");
     }
 
-    // NOTE: the "2× your match XP" offer toast is intentionally NOT bound to any gamepad button.
-    // It's a non-blocking lobby toast and the primary pad's face buttons are live gameplay
-    // controls (Ⓐ = attack/station-interact, Ⓑ = leave) — reinterpreting a bare press as
-    // "watch a full-screen ad" would launch an ad from ordinary input. Watching must be an
-    // explicit pointer tap on the toast's button; the toast otherwise auto-clears at race start.
-
     if (lp.isPrimary && settingsModalIsOpen()) {
         // P1 navigates the shared settings panel. Other local players are NOT in
         // this branch (it's primary-only), so they keep racing while P1 adjusts
@@ -545,6 +556,13 @@ function pollPadForSlot(pad, lp) {
         // Map-rating star strip (primary pad only — one shared widget). pollMapRatingPad
         // returns true only when it consumed a D-pad/A press this frame, so B/Start/emoji
         // still fall through to their branches at the overview.
+    } else if (lp.isPrimary && typeof rewardOfferToastOpen === "function" && rewardOfferToastOpen() &&
+        pollRewardOffer(pad, lp)) {
+        // "2× your match XP" offer toast (primary pad, lobby). Two-step so a bare press can
+        // never launch an ad: Ⓐ first FOCUSES the toast, a second Ⓐ watches; Ⓑ declines.
+        // pollRewardOffer returns true only when it consumed A/B this frame; reached only in
+        // normal lobby (the station-panel / wheel / leave branches above take priority), and it
+        // yields Ⓐ to a station when parked on one (so station interaction isn't hijacked).
     } else if (!wheelOpen && buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
         if (blocks) {
             openLeaveConfirm(lp);  // inline confirm in this player's block
@@ -872,6 +890,27 @@ function clearEmojiHighlight(items) {
 // stick, A confirms (dismisses — changes apply live as you step), B / emoji
 // closes. Per-slot, so two pads can configure two panels simultaneously. The
 // open/nav/confirm/close logic itself lives in lobbyHub.js (input-agnostic).
+// Drive the "2× your match XP" offer toast with the primary pad. Ⓑ declines at any time (a
+// safe action — never launches an ad). Ⓐ is a deliberate two-step: the first press FOCUSES the
+// toast (highlights it; no ad), the second press WATCHES — so an ordinary gameplay Ⓐ can't
+// launch a full-screen ad. Ⓐ is yielded when parked on a station (station interaction wins).
+// Returns true ONLY when it consumed A/B this frame, so other buttons fall through.
+function pollRewardOffer(pad, lp) {
+    if (buttonPressedThisFrame(pad, GP_BTN_B, lp)) {
+        if (typeof rewardOfferDismiss === "function") { rewardOfferDismiss(); }
+        return true;
+    }
+    if (!lp.nearStation && buttonPressedThisFrame(pad, GP_BTN_A, lp)) {
+        if (typeof rewardOfferIsFocused === "function" && rewardOfferIsFocused()) {
+            if (typeof rewardOfferWatch === "function") { rewardOfferWatch(); }
+        } else if (typeof rewardOfferFocus === "function") {
+            rewardOfferFocus();
+        }
+        return true;
+    }
+    return false;
+}
+
 // Drive the map-rating star strip with the pad: D-pad ◄ ► (or left stick) moves the
 // highlighted star, Ⓐ confirms the vote. Returns true ONLY when it consumed an input
 // this frame, so the caller's else-if chain still falls through to B/Start/emoji when

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -186,6 +186,11 @@ function handleClick(event) {
             var rect = gameCanvas.getBoundingClientRect();
             var lx = ((event.clientX - rect.left) / newWidth) * LOGICAL_WIDTH;
             var ly = ((event.clientY - rect.top) / newHeight) * LOGICAL_HEIGHT;
+            // Game-over screen: a click on the "Watch ad to 2× XP" button starts the rewarded flow.
+            if (typeof handleRewardButtonTap === "function" && handleRewardButtonTap(lx, ly)) {
+                event.preventDefault();
+                break;
+            }
             // Overview / game-over screen: a click on the star widget rates the map.
             if (typeof handleMapRatingTap === "function" && handleMapRatingTap(lx, ly)) {
                 event.preventDefault();
@@ -588,6 +593,11 @@ function onTouchStart(evt) {
     // would offset hits once the lobby follow-camera zooms in on touch.
     if (typeof config !== "undefined" && config && currentState === config.stateMap.lobby &&
         typeof lobbyHubHandlePrimaryPointer === "function" && lobbyHubHandlePrimaryPointer(touchX, touchY)) {
+        evt.preventDefault();
+        return;
+    }
+    // Game-over screen: a tap on the "Watch ad to 2× XP" button starts the rewarded flow.
+    if (typeof handleRewardButtonTap === "function" && handleRewardButtonTap(touchX, touchY)) {
         evt.preventDefault();
         return;
     }

--- a/client/scripts/input.js
+++ b/client/scripts/input.js
@@ -186,11 +186,6 @@ function handleClick(event) {
             var rect = gameCanvas.getBoundingClientRect();
             var lx = ((event.clientX - rect.left) / newWidth) * LOGICAL_WIDTH;
             var ly = ((event.clientY - rect.top) / newHeight) * LOGICAL_HEIGHT;
-            // Game-over screen: a click on the "Watch ad to 2× XP" button starts the rewarded flow.
-            if (typeof handleRewardButtonTap === "function" && handleRewardButtonTap(lx, ly)) {
-                event.preventDefault();
-                break;
-            }
             // Overview / game-over screen: a click on the star widget rates the map.
             if (typeof handleMapRatingTap === "function" && handleMapRatingTap(lx, ly)) {
                 event.preventDefault();
@@ -593,11 +588,6 @@ function onTouchStart(evt) {
     // would offset hits once the lobby follow-camera zooms in on touch.
     if (typeof config !== "undefined" && config && currentState === config.stateMap.lobby &&
         typeof lobbyHubHandlePrimaryPointer === "function" && lobbyHubHandlePrimaryPointer(touchX, touchY)) {
-        evt.preventDefault();
-        return;
-    }
-    // Game-over screen: a tap on the "Watch ad to 2× XP" button starts the rewarded flow.
-    if (typeof handleRewardButtonTap === "function" && handleRewardButtonTap(touchX, touchY)) {
         evt.preventDefault();
         return;
     }

--- a/docs/ads-monetization-operator-checklist.md
+++ b/docs/ads-monetization-operator-checklist.md
@@ -25,31 +25,48 @@ and what only the operator can do.
 - CHANGELOG `## Unreleased` transparency bullet (occasional short ad between
   matches).
 
-## DEFERRED: rewarded-video "Watch to 2× XP" half
+## What shipped (rewarded-video "Watch to 2× XP" half)
 
-**Why:** it has a HARD dependency on the cosmetics progression engine
-(`server/progression.js` + `auth.addProgression`) being in `main`. As of this
-chunk that engine is NOT in `main` (it lives on `worktree-progression-system`).
-Per the plan's own fallback (plan §"Dependency"), only the interstitial half is
-built. The rewarded API surface exists in `ads.js` but is stubbed
-(`isRewardedAvailable()` returns `false`, `showRewarded()` fails open) and NO
-"Watch to 2× XP" button is rendered, NO `claimXpMultiplier` server handler is
-added, and NO 2× XP CHANGELOG bullet is written.
+The progression engine (`server/progression.js` + `auth.addProgression`, gated on
+`auth.writesEnabled`) is now in `main`, so the rewarded half is built:
 
-**To finish the rewarded half once progression lands in main:**
-1. Rebase this branch onto `origin/main`; confirm `server/progression.js` exports
-   `addProgression` (gated on `auth.writesEnabled`) with the expected signature.
-2. Implement `showRewarded()` / `isRewardedAvailable()` against the chosen
-   network's rewarded API in `ads.js`.
-3. Render the "📺 Watch ad to 2× your XP this match" button in
-   `drawGameOverScreen` (`client/scripts/draw.js`) — signed-in players only
-   (`window.chaochaoAuth.isSignedIn()`), only when `ads.isRewardedAvailable()`.
-4. Add the `claimXpMultiplier` handler in `server/messenger.js` (signed-in only,
-   match-id + TTL + single-claim guards, server-fixed multiplier, persistence via
-   `auth.addProgression` behind `writesEnabled`); put
-   `XP_MULTIPLIER_REWARDED = 2` in `server/progression.js`.
-5. Add `ad_skipped` + `reward_claimed` GA events and the `## Unreleased` 2× XP
-   CHANGELOG bullet from the plan.
+- `ads.js`: real `showRewarded({ placement, onReward, onSkip, onError })` +
+  `isRewardedAvailable()`. Same fail-open discipline as the interstitial half —
+  single settle authority, 8 s request timeout, exactly-once. `onReward` fires
+  ONLY on a CONFIRMED full watch (an ad actually started AND completed); a no-fill
+  or close-before-complete is `onSkip`; an SDK throw / timeout is `onError`. No
+  reward is credited on a mere attempt or a no-fill.
+  - **GameMonetize reality:** their HTML5 SDK exposes only `showBanner()` and the
+    `SDK_GAME_PAUSE`/`SDK_GAME_START` events — there is NO dedicated rewarded unit,
+    no "reward granted" event, and **no server-to-server completion postback**
+    (verified against their SDK source). So a rewarded ad reuses `showBanner()` and
+    a `PAUSE → START` (confirmed play) is the reward signal. The gold-standard S2S
+    postback is a documented **follow-up** if GameMonetize later exposes one; until
+    then the server's single-claim + TTL + server-fixed multiplier are the
+    anti-abuse guardrails.
+- Client UI: a canvas "📺 Watch ad to 2× your XP" button on the results screen
+  (`drawRewardButton` in `draw.js`), pinned above the rating widget. Rendered ONLY
+  for signed-in players (`window.chaochaoAuth.isSignedIn()`), only when
+  `ads.isRewardedAvailable()` AND the match's bonus hasn't been claimed. Anonymous
+  players never see it (hidden outright). Click/tap hit-tested in `input.js`;
+  gamepad-reachable on the results screen (D-pad ▲▼ toggles reward ↔ stars, Ⓐ
+  confirms — `pollGameOverPad` in `gamepad.js`). It's a canvas control (no DOM
+  element), so it sits outside the DOM button-compliance gates like the rating widget.
+- Server: `claimXpMultiplier` handler in `server/messenger.js` — signed-in only,
+  validates `matchId` == the room's most-recently-completed match, single-claim
+  flag, 90 s TTL (server-stamped `gameOverTs`), bonus computed server-side
+  (`originalXpDelta × (multiplier − 1)`, multiplier never from the client),
+  persisted via `auth.addProgression({ xpDelta, suppressToasts:true })` behind
+  `writesEnabled`, then emits `xpBonus` back. Per-match `{ userId → { xpDelta,
+  claimed } }` is stashed on the Room object when `startGameover` is emitted
+  (intercepted in `messenger.messageRoomBySig`, so **no `game.js` edit**) — avoids a
+  DB read per claim.
+- `XP_MULTIPLIER_REWARDED = 2` lives in `server/progression.js` (NOT `config.json`).
+- GA events: `ad_shown` / `ad_complete` / `ad_skipped` / `ad_error`
+  `{ type:'rewarded', placement:'xp_2x' }` from `ads.js`; `reward_claimed`
+  `{ bonus:'xp_2x', match_id }` from the client after the server `xpBonus` ack.
+  `type` / `placement` / `bonus` added to `analytics/ga-config.json`.
+- CHANGELOG `## Unreleased` 2× XP player-facing bullet.
 
 ## Chosen network: GameMonetize (decided 2026-05-30)
 
@@ -112,11 +129,14 @@ side against a real domain** before ads serve — there is no localhost path. St
    Leave unset locally → ads no-op (verified).
 3. **Accept GameMonetize's TOS / data terms** in the dashboard (their network
    handles consent; we build no custom CMP).
-4. To persist rewarded bonus XP later: `ALLOW_SUPABASE_WRITES=true` on Heroku
-   (local default OFF — see the Supabase writes-gate rule).
-5. Register the new GA event params (`type`, `placement`, later `bonus`) as
-   custom event-scoped dimensions, or add them to `analytics/ga-config.json` for
-   the GA-config-as-code workflow.
+4. The rewarded 2× bonus persists through the **same Supabase writes gate as all
+   progression** (`auth.writesEnabled`) — no new env var. With writes off the button +
+   ad + claim + `xpBonus` ack/toast all still work; only the DB persist no-ops. Sign-in
+   must be working too (anonymous players never see the button — there's no XP to
+   multiply).
+5. The new GA event params (`type`, `placement`, `bonus`) are already in
+   `analytics/ga-config.json`, so the GA-config-as-code workflow registers them as
+   custom event-scoped dimensions on deploy — no manual GA Admin step needed.
 
 ### Deploy → verify order (important)
 GameMonetize's "Verify Game" inspects the LIVE page, so the order is:
@@ -166,5 +186,20 @@ GameMonetize's "Verify Game" inspects the LIVE page, so the order is:
 - Fail-open: request timeout (8 s) / throw / 404 all fire `onClose`; gameplay
   proceeds. Genuine errors still log `ad_error` (failure telemetry, never an
   impression); deliberate dismiss logs nothing. ✅
-- `npm run build`, `npm run test:smoke`, `test:unit`, `test:lint-buttons`,
-  `test:button-gate` all pass. ✅
+### Rewarded "2× XP" verification (headless + manual)
+
+- Headless `test:ads` (`.github/scripts/ads-rewarded-test.js`) drives a REAL match
+  end-to-end and asserts: (a) the server-recomputed per-user match XP stash equals
+  the engine's own award (no drift in the duplicated breakdown); (b) a signed-in
+  claim credits exactly `+xpDelta` (2× total) via a fake `addProgression`; (c) a
+  second claim for the same match is rejected (single-claim); (d) a wrong/empty
+  `matchId` is rejected; (e) an expired claim (>90 s) is rejected; (f) an anonymous
+  (no `userId`) claim is rejected. ✅
+- Manual signed-in 2× credit (writes enabled, DEV Supabase): sign in, finish a match,
+  click "Watch ad to 2× your XP", confirm the `xp` row in Supabase jumped by
+  `2× xpDelta` (i.e. `+xpDelta` on top of the match award), then DELETE the test row
+  delta. (Persistence rides the existing progression writes gate — `auth.writesEnabled`.)
+- Manual anonymous: not signed in → the reward button never renders; a forged
+  `claimXpMultiplier` from a guest socket is rejected server-side.
+- `npm run build`, `npm run test:smoke`, `test:unit`, `test:ads`,
+  `test:lint-buttons`, `test:button-gate` all pass. ✅

--- a/docs/ads-monetization-operator-checklist.md
+++ b/docs/ads-monetization-operator-checklist.md
@@ -48,10 +48,12 @@ The progression engine (`server/progression.js` + `auth.addProgression`, gated o
   appended as the LAST item of the lobby-arrival progression-toast stream (after the
   XP/level/skin celebration toasts) so it never competes with the results/recap screen
   and never collides with those toasts. Non-blocking (the lobby stays interactive) and
-  persistent until acted / dismissed / next-race teardown. **Watching is a deliberate
-  pointer tap only** — it is intentionally NOT bound to any gamepad/keyboard button, since
-  those are live gameplay controls and a bare press must never launch a full-screen ad
-  (Codex P2). Offered ONLY to players the **server** confirmed eligible for this match
+  persistent until acted / dismissed / next-race teardown. **Input:** mouse/touch tap the
+  buttons directly; controller/keyboard use a deliberate **two-step focus** so a bare
+  gameplay press can never launch a full-screen ad (Codex P2) — the first Ⓐ/Enter FOCUSES
+  the toast (highlight + Ⓐ/Ⓑ hint), a second Ⓐ/Enter watches, and Ⓑ/Esc declines (Ⓐ is
+  yielded to a station when parked on one). Offered ONLY to players the **server** confirmed
+  eligible for this match
   (targeted `rewardedEligible` — raced + earned XP; matchId is NOT broadcast), and only
   when `ads.isRewardedAvailable()` and the bonus is unclaimed; spectators/guests are never
   offered. **Mutually exclusive with the interstitial** — at most one ad surface per

--- a/docs/ads-monetization-operator-checklist.md
+++ b/docs/ads-monetization-operator-checklist.md
@@ -44,17 +44,20 @@ The progression engine (`server/progression.js` + `auth.addProgression`, gated o
     postback is a documented **follow-up** if GameMonetize later exposes one; until
     then the server's single-claim + TTL + server-fixed multiplier are the
     anti-abuse guardrails.
-- Client UI: a canvas "📺 Watch ad to 2× your XP" button on the results screen
-  (`drawRewardButton` in `draw.js`), pinned above the rating widget. Rendered ONLY
-  for signed-in players (`window.chaochaoAuth.isSignedIn()`), only when
-  `ads.isRewardedAvailable()` AND the match's bonus hasn't been claimed. Anonymous
-  players never see it (hidden outright). Click/tap hit-tested in `input.js`;
-  gamepad-reachable on the results screen (D-pad ▲▼ toggles reward ↔ stars, Ⓐ
-  confirms — `pollGameOverPad` in `gamepad.js`). It's a canvas control (no DOM
-  element), so it sits outside the DOM button-compliance gates like the rating widget.
+- Client UX: a one-tap **"Double your match XP?"** prompt at the `gameOver -> lobby`
+  edge (NOT on the results screen — it would compete with the recap/stats). It's a
+  centre confirm-modal (reusing the leave-modal `confirm-modal` CSS + nav: mouse/touch
+  click, keyboard arrows/Enter/Esc, gamepad D-pad/Ⓐ/Ⓑ) with "📺 Watch" / "No thanks";
+  default focus is "No thanks" so a stray press never auto-launches an ad. Shown ONLY
+  for signed-in players when `ads.isRewardedAvailable()` and the match's bonus is
+  unclaimed; anonymous players are never offered it. **Mutually exclusive with the
+  interstitial** — at most one ad surface per match-end: the opt-in 2× prompt is
+  preferred, and the forced interstitial only fires when the prompt isn't offered (the
+  interstitial cadence still advances either way). The modal is hidden in the DOM until
+  opened, so — like the leave modal — it's invisible to the button-compliance gate.
 - Server: `claimXpMultiplier` handler in `server/messenger.js` — signed-in only,
   validates `matchId` == the room's most-recently-completed match, single-claim
-  flag, 90 s TTL (server-stamped `gameOverTs`), bonus computed server-side
+  flag, 120 s TTL (server-stamped `gameOverTs`), bonus computed server-side
   (`originalXpDelta × (multiplier − 1)`, multiplier never from the client),
   persisted via `auth.addProgression({ xpDelta, suppressToasts:true })` behind
   `writesEnabled`, then emits `xpBonus` back. Per-match `{ userId → { xpDelta,

--- a/docs/ads-monetization-operator-checklist.md
+++ b/docs/ads-monetization-operator-checklist.md
@@ -44,17 +44,21 @@ The progression engine (`server/progression.js` + `auth.addProgression`, gated o
     postback is a documented **follow-up** if GameMonetize later exposes one; until
     then the server's single-claim + TTL + server-fixed multiplier are the
     anti-abuse guardrails.
-- Client UX: a one-tap **"Double your match XP?"** prompt at the `gameOver -> lobby`
-  edge (NOT on the results screen — it would compete with the recap/stats). It's a
-  centre confirm-modal (reusing the leave-modal `confirm-modal` CSS + nav: mouse/touch
-  click, keyboard arrows/Enter/Esc, gamepad D-pad/Ⓐ/Ⓑ) with "📺 Watch" / "No thanks";
-  default focus is "No thanks" so a stray press never auto-launches an ad. Shown ONLY
-  for signed-in players when `ads.isRewardedAvailable()` and the match's bonus is
-  unclaimed; anonymous players are never offered it. **Mutually exclusive with the
-  interstitial** — at most one ad surface per match-end: the opt-in 2× prompt is
-  preferred, and the forced interstitial only fires when the prompt isn't offered (the
-  interstitial cadence still advances either way). The modal is hidden in the DOM until
-  opened, so — like the leave modal — it's invisible to the button-compliance gate.
+- Client UX: a **"⭐ Double the XP you just earned? [📺 Watch] [×]"** actionable toast,
+  appended as the LAST item of the lobby-arrival progression-toast stream (after the
+  XP/level/skin celebration toasts) so it never competes with the results/recap screen
+  and never collides with those toasts. Non-blocking (the lobby stays interactive) and
+  persistent until acted / dismissed / next-race teardown. **Watching is a deliberate
+  pointer tap only** — it is intentionally NOT bound to any gamepad/keyboard button, since
+  those are live gameplay controls and a bare press must never launch a full-screen ad
+  (Codex P2). Offered ONLY to players the **server** confirmed eligible for this match
+  (targeted `rewardedEligible` — raced + earned XP; matchId is NOT broadcast), and only
+  when `ads.isRewardedAvailable()` and the bonus is unclaimed; spectators/guests are never
+  offered. **Mutually exclusive with the interstitial** — at most one ad surface per
+  match-end: the opt-in 2× toast is preferred; the forced interstitial only fires when the
+  toast isn't offered (cadence still advances). The offer window is anchored to the server
+  gameOver timestamp (so a suspended tab can't resurrect an expired claim), and a watched-
+  but-unacked claim keeps a recovery watchdog across the race transition.
 - Server: `claimXpMultiplier` handler in `server/messenger.js` — signed-in only,
   validates `matchId` == the room's most-recently-completed match, single-claim
   flag, 120 s TTL (server-stamped `gameOverTs`), bonus computed server-side

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "test:unit": "node .github/scripts/unit-tests.js",
         "test:smoke": "node .github/scripts/smoke-test.js",
         "test:progression": "node .github/scripts/progression-test.js",
+        "test:ads": "node .github/scripts/ads-rewarded-test.js",
         "test:perf-tick": "node .github/scripts/perf-tick-budget.js",
         "test:perf-client": "node .github/scripts/perf-client.js",
         "test:lint-buttons": "node .github/scripts/lint-button-input.js",

--- a/server/auth.js
+++ b/server/auth.js
@@ -456,16 +456,20 @@ async function addProgression(userId, opts) {
             }
             // Build the celebration toasts for this match (shown on next lobby arrival, not
             // on the game-over screen). Appended to the durable pending_toasts queue.
-            // opts.suppressToasts skips this: the rewarded-XP claim path persists the bonus
-            // but announces it with its own immediate `xpBonus` toast on the results screen,
-            // so queuing a duplicate "+N XP" lobby toast would double-announce the same XP.
-            var newToasts = opts.suppressToasts ? [] : progression.buildToastEvents({
+            var builtToasts = progression.buildToastEvents({
                 xpDelta: opts.xpDelta || 0,
                 oldLevel: oldLevel,
                 newLevel: newLevel,
                 levelSkinsUnlocked: skinRegistry.levelSkinsUnlockedBetween,
                 freshAchievementSkins: freshAchievementSkins
             });
+            // opts.suppressXpToast: the rewarded-XP claim announces the bonus with its OWN
+            // `xpBonus` toast, so drop the duplicate "+N XP" event here — but KEEP any level-up
+            // and newly-unlocked level-skin toasts the bonus crosses (those aren't duplicated
+            // anywhere else and the player would otherwise gain them silently).
+            var newToasts = opts.suppressXpToast
+                ? builtToasts.filter(function (t) { return t.type !== 'xp'; })
+                : builtToasts;
             var existingToasts = (existingData && Array.isArray(existingData.pending_toasts))
                 ? existingData.pending_toasts : [];
             var mergedToasts = existingToasts.concat(newToasts);

--- a/server/auth.js
+++ b/server/auth.js
@@ -456,7 +456,10 @@ async function addProgression(userId, opts) {
             }
             // Build the celebration toasts for this match (shown on next lobby arrival, not
             // on the game-over screen). Appended to the durable pending_toasts queue.
-            var newToasts = progression.buildToastEvents({
+            // opts.suppressToasts skips this: the rewarded-XP claim path persists the bonus
+            // but announces it with its own immediate `xpBonus` toast on the results screen,
+            // so queuing a duplicate "+N XP" lobby toast would double-announce the same XP.
+            var newToasts = opts.suppressToasts ? [] : progression.buildToastEvents({
                 xpDelta: opts.xpDelta || 0,
                 oldLevel: oldLevel,
                 newLevel: newLevel,

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -82,7 +82,19 @@ function stampRewardedMatch(sig, payload) {
 			claims[p.verifiedUserId] = { xpDelta: xpDelta, claimed: false };
 		}
 	}
-	room.rewardedMatch = { matchId: matchId, gameOverTs: Date.now(), claims: claims };
+	// Keep per-match claim records keyed by matchId (not just the latest match): a rewarded ad
+	// is allowed to finish during the NEXT race, and a long ad / suspended tab can complete after
+	// that next match has ended — the still-in-TTL prior claim must remain claimable. Prune
+	// records past the TTL on each stamp so the map can't grow. room.rewardedMatch points at the
+	// latest record for convenience; the claim handler looks up by the claimed matchId.
+	var now = Date.now();
+	if (!room.rewardedMatches) { room.rewardedMatches = {}; }
+	for (var oldId in room.rewardedMatches) {
+		if (now - room.rewardedMatches[oldId].gameOverTs > REWARD_CLAIM_TTL_MS) { delete room.rewardedMatches[oldId]; }
+	}
+	var record = { matchId: matchId, gameOverTs: now, claims: claims };
+	room.rewardedMatches[matchId] = record;
+	room.rewardedMatch = record;   // latest (same object reference as the map entry)
 	return payload;
 }
 
@@ -96,14 +108,16 @@ function emitRewardedEligibility(sig) {
 	if (!room || !room.rewardedMatch || !room.game || !room.game.playerList) { return; }
 	var rm = room.rewardedMatch;
 	var pl = room.game.playerList;
+	// Send the REMAINING claim lifetime as a DURATION (not a server timestamp): the client adds
+	// it to its OWN Date.now() to get a deadline, so the whole comparison stays on one clock and
+	// a client/server clock skew can neither hide a valid offer nor launch an expired one.
+	var ttlMs = REWARD_CLAIM_TTL_MS - (Date.now() - rm.gameOverTs);
+	if (ttlMs < 0) { ttlMs = 0; }
 	for (var id in pl) {
 		var p = pl[id];
 		if (p == null || !p.verifiedUserId || !rm.claims[p.verifiedUserId]) { continue; }
 		var sock = mailBoxList[id];
-		// Send the server's gameOver timestamp so the client anchors its offer window to the
-		// SAME clock the claim TTL is validated against — a late-delivered event (suspended tab)
-		// then can't make the client think a long-expired claim is still fresh.
-		if (sock) { sock.emit('rewardedEligible', { matchId: rm.matchId, gameOverTs: rm.gameOverTs }); }
+		if (sock) { sock.emit('rewardedEligible', { matchId: rm.matchId, ttlMs: ttlMs }); }
 	}
 }
 
@@ -845,10 +859,11 @@ function checkForMail(client) {
 		var matchId = payload && payload.matchId;
 		if (!matchId) { return; }
 		var room = hostess.getRoomBySig(roomMailList[client.id]);
-		if (!room || !room.rewardedMatch) { return; }
-		var rm = room.rewardedMatch;
-		// 2. matchId must be THIS room's most-recently-completed match.
-		if (rm.matchId !== matchId) { return; }
+		if (!room || !room.rewardedMatches) { return; }
+		// 2. Look the claim up by its OWN matchId (records are kept per-match, not just the
+		//    latest), so a rewarded ad that finished after the next match started can still pay.
+		var rm = room.rewardedMatches[matchId];
+		if (!rm) { return; }
 		// 3. Within the TTL since gameOver (server-stamped).
 		if (Date.now() - rm.gameOverTs > REWARD_CLAIM_TTL_MS) { return; }
 		var entry = rm.claims[client.userId];

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -32,7 +32,10 @@ var mailBoxList = {},
 // XP the instant `startGameover` is emitted (at that point the playerList still holds this
 // match's notches; resetForRace hasn't run). The stash lives on the Room object, is
 // overwritten every match, and a matchId + TTL + single-claim flag guard against replay.
-var REWARD_CLAIM_TTL_MS = 90 * 1000;   // a claim is only valid within 90s of gameOver
+// A claim is only valid within this window of gameOver. The offer is now a prompt at the
+// gameOver->lobby edge (a few seconds after gameOver) with a deliberate watch step, so this
+// covers the results window + the lobby decision + the ad playback comfortably.
+var REWARD_CLAIM_TTL_MS = 120 * 1000;
 var rewardedMatchSeq = 0;              // monotonic — makes each matchId unique per process
 
 // Recompute one signed-in human's match XP the SAME way game.js awardProgression does

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -100,7 +100,10 @@ function emitRewardedEligibility(sig) {
 		var p = pl[id];
 		if (p == null || !p.verifiedUserId || !rm.claims[p.verifiedUserId]) { continue; }
 		var sock = mailBoxList[id];
-		if (sock) { sock.emit('rewardedEligible', { matchId: rm.matchId }); }
+		// Send the server's gameOver timestamp so the client anchors its offer window to the
+		// SAME clock the claim TTL is validated against — a late-delivered event (suspended tab)
+		// then can't make the client think a long-expired claim is still fresh.
+		if (sock) { sock.emit('rewardedEligible', { matchId: rm.matchId, gameOverTs: rm.gameOverTs }); }
 	}
 }
 

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -51,9 +51,11 @@ function matchXpForPlayer(p, isWinner, isRunnerUp) {
 	return total;
 }
 
-// Stamp a server-authoritative matchId onto the outgoing startGameover packet and stash this
-// match's per-user earned XP for later rewarded-bonus claims. Called from messageRoomBySig
-// (the single emit path game.js uses) so no game.js edit is needed. Mutates + returns payload.
+// Stash this match's per-user earned XP for later rewarded-bonus claims. Called from
+// messageRoomBySig (the single startGameover emit path) so no game.js edit is needed. The
+// matchId is NOT broadcast — it's delivered targeted, only to players the server actually
+// credited (see emitRewardedEligibility), so a spectator who never raced is never offered an ad
+// the server would then reject. Returns the payload unchanged.
 function stampRewardedMatch(sig, payload) {
 	var room = hostess.getRoomBySig(sig);
 	if (!room || !room.game || !room.game.playerList || !payload) {
@@ -81,8 +83,25 @@ function stampRewardedMatch(sig, payload) {
 		}
 	}
 	room.rewardedMatch = { matchId: matchId, gameOverTs: Date.now(), claims: claims };
-	payload.matchId = matchId;   // the client echoes this back in claimXpMultiplier
 	return payload;
+}
+
+// Tell ONLY the players the server actually credited that a rewarded 2× claim is available for
+// this match (server-authoritative eligibility — racedCurrentMap + earned XP). Sent AFTER the
+// broadcast startGameover (which the client uses to reset its rewarded state), so the targeted
+// `rewardedEligible` lands last and isn't clobbered by that reset. Ineligible players (spectators,
+// guests, bots) get nothing and so are never offered an ad the claim handler would reject.
+function emitRewardedEligibility(sig) {
+	var room = hostess.getRoomBySig(sig);
+	if (!room || !room.rewardedMatch || !room.game || !room.game.playerList) { return; }
+	var rm = room.rewardedMatch;
+	var pl = room.game.playerList;
+	for (var id in pl) {
+		var p = pl[id];
+		if (p == null || !p.verifiedUserId || !rm.claims[p.verifiedUserId]) { continue; }
+		var sock = mailBoxList[id];
+		if (sock) { sock.emit('rewardedEligible', { matchId: rm.matchId }); }
+	}
 }
 
 // Persist one cosmetic-slot equip for a signed-in player (best-effort, behind the
@@ -189,10 +208,16 @@ exports.getClient = function (id) {
 	return mailBoxList[id];
 }
 exports.messageRoomBySig = function (sig, header, payload) {
-	// Rewarded-XP: stamp a matchId + stash this match's per-user earned XP as the
-	// results screen goes up, so a later claimXpMultiplier can be validated without a
-	// DB read and without any game.js edit (this is the single startGameover emit path).
-	if (header === 'startGameover') { payload = stampRewardedMatch(sig, payload); }
+	// Rewarded-XP: stash this match's per-user earned XP as the results screen goes up, so a
+	// later claimXpMultiplier can be validated without a DB read and without any game.js edit
+	// (this is the single startGameover emit path). Then tell ONLY the credited players they're
+	// eligible — AFTER the broadcast, so the client's startGameover reset can't clobber it.
+	if (header === 'startGameover') {
+		payload = stampRewardedMatch(sig, payload);
+		messageRoomBySig(sig, header, payload);
+		emitRewardedEligibility(sig);
+		return;
+	}
 	messageRoomBySig(sig, header, payload);
 }
 exports.messageClientBySig = function (sig, header, payload) {

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -32,10 +32,11 @@ var mailBoxList = {},
 // XP the instant `startGameover` is emitted (at that point the playerList still holds this
 // match's notches; resetForRace hasn't run). The stash lives on the Room object, is
 // overwritten every match, and a matchId + TTL + single-claim flag guard against replay.
-// A claim is only valid within this window of gameOver. The offer is now a prompt at the
-// gameOver->lobby edge (a few seconds after gameOver) with a deliberate watch step, so this
-// covers the results window + the lobby decision + the ad playback comfortably.
-var REWARD_CLAIM_TTL_MS = 120 * 1000;
+// A claim is only valid within this window of gameOver. The offer is a lobby-edge toast (a few
+// seconds after gameOver) with a deliberate watch step. The CLIENT stops OFFERING well before
+// this (REWARD_OFFER_WINDOW_MS in client.js) so an ad is never started without enough headroom
+// to finish + claim inside this window; this server cap is the backstop + anti-replay bound.
+var REWARD_CLAIM_TTL_MS = 180 * 1000;
 var rewardedMatchSeq = 0;              // monotonic — makes each matchId unique per process
 
 // Recompute one signed-in human's match XP the SAME way game.js awardProgression does
@@ -830,30 +831,49 @@ function checkForMail(client) {
 		// 5/6. Bonus computed server-side from the stashed delta + the fixed multiplier.
 		var bonus = progression.rewardedBonusXp(entry.xpDelta);
 		if (bonus <= 0) { entry.claimed = false; return; }
-		// 7. Persist (writes-gated inside addProgression; a no-op locally). suppressToasts: the
-		//    client shows its own immediate xpBonus toast, so don't also queue a lobby "+N XP".
-		auth.addProgression(client.userId, { xpDelta: bonus, suppressToasts: true })
+		// 7. Persist (writes-gated inside addProgression). suppressXpToast: the client shows its
+		//    own xpBonus toast, so drop the duplicate lobby "+N XP" (but keep any level-up/skin).
+		auth.addProgression(client.userId, { xpDelta: bonus, suppressXpToast: true })
 			.then(function (row) {
 				var live = mailBoxList[client.id];
-				if (!live) { return; }
-				// Refresh the lobby Lv/XP badge with the new authoritative totals (writes-on only).
 				if (row) {
-					var pp = buildProgressionPayload(row);
-					if (pp) { live.emit('progressionUpdate', pp); }
+					// SUCCESS. Refresh the SERVER-side cached progression too (not just the
+					// browser) so a bonus that crosses a level threshold immediately gates
+					// setCosmetic equips for the newly-unlocked level skins — otherwise the
+					// server would keep rejecting them until the player rejoined.
+					var liveRoom = hostess.getRoomBySig(roomMailList[client.id]);
+					var rp = liveRoom && liveRoom.playerList ? liveRoom.playerList[client.id] : null;
+					if (rp) {
+						rp.progression = {
+							xp: row.xp, level: row.level,
+							unlocked_skins: row.unlocked_skins || [],
+							medal_counts: row.medal_counts || {},
+							wins: row.wins || 0
+						};
+						rp.progressionLoaded = true;
+					}
+					if (live) {
+						var pp = buildProgressionPayload(row);
+						if (pp) { live.emit('progressionUpdate', pp); }
+						// 8. Ack so the client toasts the bonus + fires reward_claimed.
+						live.emit('xpBonus', { matchId: matchId, bonus: bonus, multiplier: progression.XP_MULTIPLIER_REWARDED, xp: row.xp, level: row.level });
+					}
+				} else if (!auth.writesEnabled) {
+					// Writes DELIBERATELY off (local dev / no Supabase): the bonus was computed but
+					// not persisted. Ack anyway so the UX stays testable; xp/level are unknown.
+					if (live) {
+						live.emit('xpBonus', { matchId: matchId, bonus: bonus, multiplier: progression.XP_MULTIPLIER_REWARDED, xp: null, level: null });
+					}
+				} else {
+					// Writes ENABLED but the persist FAILED (CAS exhausted / DB error -> null row).
+					// Do NOT ack as success — that would consume a watched ad with no credit. Reset
+					// the single-claim flag so the player can retry; the client's ack-timeout re-offers.
+					entry.claimed = false;
+					console.log('[rewarded] claim persist returned null with writes enabled — retry allowed');
 				}
-				// 8. Ack so the client toasts the bonus + fires reward_claimed. Emitted even when
-				//    writes are gated (row null) so the UX stays testable locally — the bonus was
-				//    still computed, just not persisted.
-				live.emit('xpBonus', {
-					matchId: matchId,
-					bonus: bonus,
-					multiplier: progression.XP_MULTIPLIER_REWARDED,
-					xp: row ? row.xp : null,
-					level: row ? row.level : null
-				});
 			})
 			.catch(function (e) {
-				// Persist failed — let the player retry (they watched the ad in good faith).
+				// Persist threw — let the player retry (they watched the ad in good faith).
 				entry.claimed = false;
 				console.log('[rewarded] claim persist failed:', e && e.message);
 			});

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -25,6 +25,62 @@ var mailBoxList = {},
 	roomMailList = {},
 	io;
 
+// ---- Rewarded "2× match XP" claim state ------------------------------------------------
+// The rewarded-video reward (docs/ads-monetization-plan.md) tops up a signed-in player's
+// match XP when they watch an ad on the results screen. To validate a claim WITHOUT a DB
+// read per attempt — and without touching game.js — we stash each match's per-user earned
+// XP the instant `startGameover` is emitted (at that point the playerList still holds this
+// match's notches; resetForRace hasn't run). The stash lives on the Room object, is
+// overwritten every match, and a matchId + TTL + single-claim flag guard against replay.
+var REWARD_CLAIM_TTL_MS = 90 * 1000;   // a claim is only valid within 90s of gameOver
+var rewardedMatchSeq = 0;              // monotonic — makes each matchId unique per process
+
+// Recompute one signed-in human's match XP the SAME way game.js awardProgression does
+// (participation + per-notch + win + runner-up bonuses, all from config). Kept in lockstep
+// with that breakdown; the headless ads test asserts this equals the engine's own award so
+// the duplication can't silently drift.
+function matchXpForPlayer(p, isWinner, isRunnerUp) {
+	var total = c.xpParticipate;
+	total += c.xpPerNotch * (p.notches || 0);
+	if (isWinner) { total += c.xpWinBonus; }
+	if (isRunnerUp) { total += c.xpRunnerUpBonus; }
+	return total;
+}
+
+// Stamp a server-authoritative matchId onto the outgoing startGameover packet and stash this
+// match's per-user earned XP for later rewarded-bonus claims. Called from messageRoomBySig
+// (the single emit path game.js uses) so no game.js edit is needed. Mutates + returns payload.
+function stampRewardedMatch(sig, payload) {
+	var room = hostess.getRoomBySig(sig);
+	if (!room || !room.game || !room.game.playerList || !payload) {
+		return payload;
+	}
+	var pl = room.game.playerList;
+	var winnerId = (payload.winner != null) ? String(payload.winner) : null;
+	// Runner-up = highest-notch non-winner (mirrors awardProgression; first/secondPlaceSig are
+	// null on the match-ending tick, so derive from the durable notch score instead).
+	var runnerUpId = null, bestNotches = -1;
+	for (var rid in pl) {
+		if (rid === winnerId || pl[rid] == null) { continue; }
+		var rn = pl[rid].notches || 0;
+		if (rn > bestNotches) { bestNotches = rn; runnerUpId = rid; }
+	}
+	var matchId = 'm' + (++rewardedMatchSeq) + '-' + Date.now();
+	var claims = {};
+	for (var id in pl) {
+		var p = pl[id];
+		// Only signed-in humans who actually raced earn XP -> only they can claim a multiplier.
+		if (p == null || p.isAI || !p.verifiedUserId || !p.racedCurrentMap) { continue; }
+		var xpDelta = matchXpForPlayer(p, id === winnerId, id === runnerUpId);
+		if (xpDelta > 0) {
+			claims[p.verifiedUserId] = { xpDelta: xpDelta, claimed: false };
+		}
+	}
+	room.rewardedMatch = { matchId: matchId, gameOverTs: Date.now(), claims: claims };
+	payload.matchId = matchId;   // the client echoes this back in claimXpMultiplier
+	return payload;
+}
+
 // Persist one cosmetic-slot equip for a signed-in player (best-effort, behind the
 // global writes gate inside auth.saveCosmetic). Guests / writes-off are a no-op.
 function persistCosmetic(userId, slot, id) {
@@ -129,6 +185,10 @@ exports.getClient = function (id) {
 	return mailBoxList[id];
 }
 exports.messageRoomBySig = function (sig, header, payload) {
+	// Rewarded-XP: stamp a matchId + stash this match's per-user earned XP as the
+	// results screen goes up, so a later claimXpMultiplier can be validated without a
+	// DB read and without any game.js edit (this is the single startGameover emit path).
+	if (header === 'startGameover') { payload = stampRewardedMatch(sig, payload); }
 	messageRoomBySig(sig, header, payload);
 }
 exports.messageClientBySig = function (sig, header, payload) {
@@ -739,6 +799,61 @@ function checkForMail(client) {
 		if (player != null) {
 			player.wakeUp();
 		}
+	});
+
+	// Rewarded video: a signed-in player watched a "2× match XP" ad on the results screen.
+	// Validate + credit a one-time bonus = original match XP * (multiplier-1), all computed
+	// server-side (the multiplier is a server constant, NEVER trusted from the client). The
+	// client onReward is only a signal — these guards (signed-in + matchId + TTL + single-claim)
+	// are the anti-abuse. GameMonetize's HTML5 SDK exposes no rewarded-completion S2S postback,
+	// so the gold-standard server postback is a documented follow-up (ads-monetization-plan.md).
+	client.on('claimXpMultiplier', function (payload) {
+		// 1. Signed-in only — guests have no progression to multiply. Silently ignore.
+		if (!client.userId) { return; }
+		var matchId = payload && payload.matchId;
+		if (!matchId) { return; }
+		var room = hostess.getRoomBySig(roomMailList[client.id]);
+		if (!room || !room.rewardedMatch) { return; }
+		var rm = room.rewardedMatch;
+		// 2. matchId must be THIS room's most-recently-completed match.
+		if (rm.matchId !== matchId) { return; }
+		// 3. Within the TTL since gameOver (server-stamped).
+		if (Date.now() - rm.gameOverTs > REWARD_CLAIM_TTL_MS) { return; }
+		var entry = rm.claims[client.userId];
+		if (!entry) { return; }          // earned no XP this match (didn't race / wasn't signed in then)
+		// 4. Single-claim guard. Set BEFORE the async persist so a rapid double-emit can't double-credit.
+		if (entry.claimed) { return; }
+		entry.claimed = true;
+		// 5/6. Bonus computed server-side from the stashed delta + the fixed multiplier.
+		var bonus = progression.rewardedBonusXp(entry.xpDelta);
+		if (bonus <= 0) { entry.claimed = false; return; }
+		// 7. Persist (writes-gated inside addProgression; a no-op locally). suppressToasts: the
+		//    client shows its own immediate xpBonus toast, so don't also queue a lobby "+N XP".
+		auth.addProgression(client.userId, { xpDelta: bonus, suppressToasts: true })
+			.then(function (row) {
+				var live = mailBoxList[client.id];
+				if (!live) { return; }
+				// Refresh the lobby Lv/XP badge with the new authoritative totals (writes-on only).
+				if (row) {
+					var pp = buildProgressionPayload(row);
+					if (pp) { live.emit('progressionUpdate', pp); }
+				}
+				// 8. Ack so the client toasts the bonus + fires reward_claimed. Emitted even when
+				//    writes are gated (row null) so the UX stays testable locally — the bonus was
+				//    still computed, just not persisted.
+				live.emit('xpBonus', {
+					matchId: matchId,
+					bonus: bonus,
+					multiplier: progression.XP_MULTIPLIER_REWARDED,
+					xp: row ? row.xp : null,
+					level: row ? row.level : null
+				});
+			})
+			.catch(function (e) {
+				// Persist failed — let the player retry (they watched the ad in good faith).
+				entry.claimed = false;
+				console.log('[rewarded] claim persist failed:', e && e.message);
+			});
 	});
 
 	// Star-rate the map you just played. Allowed on the per-round OVERVIEW (rate it

--- a/server/progression.js
+++ b/server/progression.js
@@ -6,6 +6,21 @@
 // the startGameover packet). Kept server-authoritative: the client only ever
 // renders values the server computed.
 
+// Rewarded-video "Watch to 2× match XP" multiplier. Lives HERE (not config.json) so
+// tuning it stays off the gameplay-mechanic CHANGELOG path. The server credits a BONUS
+// of originalXpDelta * (XP_MULTIPLIER_REWARDED - 1) on a confirmed ad watch — i.e. a 2×
+// multiplier tops up the match XP by another 1× of what the match originally earned.
+var XP_MULTIPLIER_REWARDED = 2;
+
+// The extra XP granted for watching the rewarded ad: the match's original earned XP times
+// (multiplier - 1). At 2× that's exactly the original delta again (total = 2× original).
+// Pure + server-authoritative (multiplier never comes from the client) so the claim handler
+// and the headless test compute the bonus the same way.
+function rewardedBonusXp(originalXpDelta) {
+    var base = (typeof originalXpDelta === 'number' && originalXpDelta > 0) ? originalXpDelta : 0;
+    return base * (XP_MULTIPLIER_REWARDED - 1);
+}
+
 // XP needed to advance FROM level n-1 TO level n. Fast-early, slow-late:
 //   xpRequiredForLevel(2) ≈ 152, (5) ≈ 657, (13) ≈ 3084.
 // Tuned (with the config XP awards, ~150-250 XP/match) for ~4-5 unlocks in a
@@ -175,6 +190,8 @@ function buildToastEvents(opts) {
 }
 
 module.exports = {
+    XP_MULTIPLIER_REWARDED: XP_MULTIPLIER_REWARDED,
+    rewardedBonusXp: rewardedBonusXp,
     xpRequiredForLevel: xpRequiredForLevel,
     cumulativeXpForLevel: cumulativeXpForLevel,
     levelForXp: levelForXp,


### PR DESCRIPTION
## Rewarded video — "Watch to 2× match XP" (PR2 of ad monetization)

Fills in the previously-stubbed rewarded half of the ad layer (the interstitial half shipped in #245). Signed-in players can watch a short ad after a match to **double the XP they earned that match**, server-validated and credited once per match.

Implements the "Rewarded video" section of `docs/ads-monetization-plan.md`.

### What's in here
- **`ads.js`** — real `showRewarded({placement,onReward,onSkip,onError})` + `isRewardedAvailable()`, network-isolated. Same fail-open discipline as the interstitial half (single settle authority, 8s request timeout, exactly-once). `onReward` fires **only** on a confirmed full watch; no-fill → skip; SDK throw/timeout → error (and the request is torn down so a late ad can't sneak through).
  - **GameMonetize reality:** their HTML5 SDK exposes only `showBanner()` + `SDK_GAME_PAUSE`/`SDK_GAME_START` — no dedicated rewarded unit, no reward-granted event, no S2S postback (verified against their SDK source). So a rewarded ad reuses `showBanner()` and a confirmed `PAUSE→START` play is the reward signal; the server's single-claim + TTL + fixed-multiplier are the anti-abuse. A true rewarded unit / S2S postback is a documented follow-up.
- **Client UX** — a `"⭐ Double the XP you just earned? [📺 Watch] [×]"` actionable toast appended as the **last item of the lobby-arrival progression-toast stream** (after the XP/level/skin celebration), so it never competes with the results/recap screen and never collides with those toasts. Non-blocking; persistent until acted / dismissed / next-race teardown. Mouse/touch tap directly; controller/keyboard use a deliberate **two-step focus** (first Ⓐ/Enter focuses, second watches; Ⓑ/Esc declines) so a bare gameplay press can never launch an ad.
- **Server** — `claimXpMultiplier` handler in `messenger.js`: signed-in only, server-authoritative eligibility (only players who **raced + earned XP** are told they're eligible, delivered targeted — never broadcast), `matchId` validation, single-claim, 180s TTL, per-match claim records kept by `matchId` (so a long ad spanning the next match still pays out), bonus computed server-side (`xpDelta × (mult−1)`), persisted via `auth.addProgression` behind the existing writes gate. Per-match XP is stashed by intercepting `messenger.messageRoomBySig('startGameover')` — **no `game.js` edit**.
- **`XP_MULTIPLIER_REWARDED = 2`** lives in `progression.js` (not `config.json`).
- **GA** — `ad_shown` / `ad_complete` / `ad_skipped` / `ad_error` `{type:'rewarded',placement}` + `reward_claimed` `{bonus:'xp_2x',match_id}`; `type` / `placement` / `bonus` added to `analytics/ga-config.json`.
- **Mutually exclusive with the interstitial** — at most one ad surface per match-end: the opt-in 2× toast is preferred; the forced interstitial only fires when the toast isn't offered.
- **CHANGELOG** `## Unreleased` player-facing bullet.

### Constraints honored
- Does **not** touch `server/game.js`, `server/engine.js`, or `server/config.json`.
- Fail-open everywhere; gameplay is never blocked on the ad SDK. Embedded mode no-ops.
- Anti-abuse: single-claim + TTL + server-computed bonus (server-fixed multiplier); spectators/guests never offered.

### Tests
New headless `test:ads` (`.github/scripts/ads-rewarded-test.js`, wired into PR CI) covers the ad-layer settle discipline (reward/skip/error/no-fill/timeout-teardown), the server claim path (credit / single-claim / wrong-match / TTL / anonymous-rejected / write-failure-not-acked / prior-match-still-claimable), targeted eligibility (+ spectator exclusion), the interstitial-vs-rewarded dismiss isolation, and AdinPlay early-close=skip. A drift check asserts the server-recomputed match XP equals the engine's own award.

All green: `build`, `test:smoke`, `test:unit`, `test:ads`, `test:progression`, `test:lint-buttons`, `test:button-gate`.

### Reviewed
Ran `/codex:review` over four rounds; all findings (2 P1 + 13 P2 across rounds, incl. fail-open/credit-loss edges, clock-skew, stale-ack, cross-match claims, consent) fixed. The localhost-only dev playtest override used during review was stripped before this PR.

---

## Operator prerequisites (only you can do these)
1. **GameMonetize dashboard:** add the game at `https://www.chaochaogame.com/play.html`, then **Verify Game** → **Request Activation** (verify inspects the LIVE page, so deploy first).
2. **Heroku config vars:** `ADS_PROVIDER=gamemonetize`, `ADS_PUBLISHER_ID=elvluveq681cl5oop2bd54ls7oza2mxo`. Unset locally → ads no-op.
3. **Persistence:** the 2× bonus rides the existing Supabase writes gate (`auth.writesEnabled`) — no new env var. With writes off the button/ad/claim/toast still work; only the DB write no-ops.
4. **GA dims** (`type`/`placement`/`bonus`) auto-register from `analytics/ga-config.json` via the GA-config-as-code workflow on deploy.
5. Suggested release label: `release:minor` (player-facing feature).

See `docs/ads-monetization-operator-checklist.md` for the full deploy→verify order and verification scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
