### PR TITLE
fix(ads): don't show an ad before the first match (lazy-load GameMonetize SDK)

### DIFF
--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -53,11 +53,13 @@ function loadAds(adsConfig) {
         sdk: null
     };
     const createdScripts = [];
+    const byId = {};   // appended elements indexed by id, so getElementById (the idempotency guard) works
+    function register(el) { if (el && el.id) { byId[el.id] = el; } }
     const fakeDoc = {
         createElement: function () { const el = { setAttribute: function () {}, src: '', async: false, id: '', onload: null, onerror: null, style: {} }; createdScripts.push(el); return el; },
-        getElementById: function () { return null; },
-        head: { appendChild: function () {} },
-        documentElement: { appendChild: function () {} },
+        getElementById: function (id) { return byId[id] || null; },
+        head: { appendChild: function (el) { register(el); } },
+        documentElement: { appendChild: function (el) { register(el); } },
         body: null
     };
     let clock = 1000;
@@ -82,7 +84,11 @@ function loadAds(adsConfig) {
         fireScriptLoads: function () { createdScripts.forEach(function (s) { if (typeof s.onload === "function") { s.onload(); } }); },
         fireTimers: function () { const due = timers.splice(0, timers.length); due.forEach(function (t) { t.fn(); }); },
         setNow: function (v) { clock = v; },
-        hasEvent: function (name, type) { return tracked.some(function (e) { return e.name === name && (!type || e.params.type === type); }); }
+        hasEvent: function (name, type) { return tracked.some(function (e) { return e.name === name && (!type || e.params.type === type); }); },
+        // Lazy-load introspection: how many <script id="..."> with a given id have been injected.
+        scriptCount: function (id) { return createdScripts.filter(function (s) { return s.id === id; }).length; },
+        // Read the frequency-cap localStorage directly (to assert cadence isn't burned).
+        ls: function (k) { return (k in lsStore) ? lsStore[k] : null; }
     };
 }
 
@@ -215,6 +221,79 @@ function testDismissDoesNotKillRewarded() {
     h2.fireSdk('SDK_GAME_PAUSE');     // interstitial started (adInFlight = 'interstitial')
     h2.ads.dismissInterstitial();     // race starting — tears it down
     check(closed, 'an in-flight interstitial IS torn down at race start (onClose fires)');
+}
+
+// Acquisition-UX fix: the GameMonetize loader must NOT be injected at page init (its SDK can
+// auto-show a preroll the instant it initializes — that splashed an ad on the very first lobby,
+// before the player had played). It's lazy-loaded on the first real ad demand instead, the first
+// such demand fails open, and an active-gameplay guard refuses to cover a live round.
+function testLazyLoadAndGameplayGuard() {
+    console.log('ads.js — GameMonetize loader is lazy-loaded (no ad on first lobby) + active-gameplay guard:');
+
+    // (a) On init, the loader <script id="gamemonetize-sdk"> is NOT injected.
+    const h = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    check(h.scriptCount('gamemonetize-sdk') === 0, '(a) on init the gamemonetize-sdk script is NOT injected (lazy — no first-lobby preroll possible)');
+    check(h.ads._config().sdkReady === false, '(a) sdkReady is false on init (SDK not loaded yet)');
+
+    // (b) The loader IS injected on the first real ad demand (a match-end interstitial check).
+    const firstCheck = h.ads.canShowInterstitial();
+    check(firstCheck === false, '(b) first canShowInterstitial() is false (SDK not ready yet) — fails open, no ad');
+    check(h.scriptCount('gamemonetize-sdk') === 1, '(b) the gamemonetize-sdk script IS injected on the first ad demand');
+    // Idempotent: repeated demands never inject a second copy.
+    h.ads.canShowInterstitial();
+    h.ads.isRewardedAvailable();
+    check(h.scriptCount('gamemonetize-sdk') === 1, '(b) repeated demands never inject a second loader (idempotent by id)');
+
+    // (c) An ad requested before the SDK is ready fails open (onClose), and the frequency cadence
+    //     is NOT burned — the next match can still try once the SDK has loaded.
+    const h2 = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h2.setNow(1000000);          // clear the 90s cooldown
+    h2.ads.onMatchEnded();       // a match ended -> cadence is now eligible
+    const countBefore = h2.ls('ads_match_count_since_interstitial');
+    let closed = false;
+    h2.ads.showInterstitial({ placement: 'between_matches', onClose: function () { closed = true; } });
+    check(closed, '(c) an interstitial requested before SDK-ready fails open (onClose fires, gameplay never blocks)');
+    check(!h2.hasEvent('ad_shown'), '(c) no ad_shown for a pre-ready request (no impression)');
+    check(h2.ls('ads_match_count_since_interstitial') === countBefore, '(c) the match-cadence counter is NOT burned by a pre-ready no-fill');
+    // Rewarded mirrors this: not available before ready -> a clean skip.
+    let rSkipped = false, rRewarded = false;
+    h2.ads.showRewarded({ placement: 'xp_2x', onReward: function () { rRewarded = true; }, onSkip: function () { rSkipped = true; } });
+    check(rSkipped && !rRewarded, '(c) a rewarded ad requested before SDK-ready is a clean SKIP (no reward, no crash)');
+
+    // (d) The active-gameplay guard blocks a show during gated/racing/collapsing even when the
+    //     SDK is ready and the cadence is eligible — an ad can NEVER cover a live round.
+    const stateMap = JSON.parse(fs.readFileSync(path.join(repoRoot, 'server', 'config.json'), 'utf8')).stateMap;
+    [['gated', stateMap.gated], ['racing', stateMap.racing], ['collapsing', stateMap.collapsing]].forEach(function (pair) {
+        const h3 = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+        h3.fireSdk('SDK_READY');
+        let bannerCalls = 0;
+        h3.win.sdk = { showBanner: function () { bannerCalls++; } };
+        h3.win.config = { stateMap: stateMap };
+        h3.win.currentState = pair[1];        // the client is mid-round
+        h3.setNow(1000000);
+        h3.ads.onMatchEnded();                 // cadence eligible
+        check(h3.ads.canShowInterstitial() === true, '(d/' + pair[0] + ') sanity: cadence + SDK would otherwise allow an interstitial');
+        let iClosed = false;
+        h3.ads.showInterstitial({ placement: 'between_matches', onClose: function () { iClosed = true; } });
+        check(iClosed && bannerCalls === 0, '(d/' + pair[0] + ') interstitial is REFUSED during ' + pair[0] + ' (no showBanner), onClose still fires');
+        check(h3.hasEvent('ad_blocked', 'interstitial'), '(d/' + pair[0] + ') ad_blocked {type:interstitial} logged for the gameplay-state refusal');
+        // Rewarded is refused too -> a clean skip, no banner.
+        let rSkip = false;
+        h3.ads.showRewarded({ placement: 'xp_2x', onReward: function () {}, onSkip: function () { rSkip = true; } });
+        check(rSkip && bannerCalls === 0, '(d/' + pair[0] + ') rewarded ad is REFUSED during ' + pair[0] + ' (skip, no showBanner)');
+    });
+
+    // And the valid surfaces (lobby / gameOver) are NOT blocked by the guard.
+    const h4 = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h4.fireSdk('SDK_READY');
+    let banner4 = 0;
+    h4.win.sdk = { showBanner: function () { banner4++; } };
+    h4.win.config = { stateMap: stateMap };
+    h4.win.currentState = stateMap.lobby;     // the normal interstitial surface
+    h4.setNow(1000000);
+    h4.ads.onMatchEnded();
+    h4.ads.showInterstitial({ placement: 'between_matches', onClose: function () {} });
+    check(banner4 === 1, '(d) an interstitial at the lobby edge is NOT blocked (showBanner called)');
 }
 
 // ---------------------------------------------------------------------------
@@ -472,6 +551,7 @@ function testMultiplierConstant() {
     testAdsGameMonetizeRewarded();
     testAdsAdinPlayEarlyCloseIsSkip();
     testDismissDoesNotKillRewarded();
+    testLazyLoadAndGameplayGuard();
     // Part B
     testMultiplierConstant();
     await testStashMatchesEngineAward();

--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -389,6 +389,31 @@ function testProviderAutostartAdoption() {
     check(h5.tracked.filter(function (e) { return e.name === 'ad_shown'; }).length === shownBefore, 'no duplicate ad_shown for the abandoned request');
 }
 
+// Review finding: a SOLICITED interstitial whose request times out must be TORN DOWN (mirroring
+// the rewarded path), so a slow fill that arrives after the 8s watchdog can't re-fire a phantom
+// impression / burn the cap after onClose already ran, nor cover the next round untracked.
+function testInterstitialTimeoutTeardown() {
+    console.log('ads.js — a timed-out solicited interstitial is torn down (no phantom late impression):');
+    const h = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h.fireSdk('SDK_READY');
+    h.win.sdk = { showBanner: function () {} };   // never fires PAUSE/START -> the request times out
+    h.setNow(1000000);                             // clear the 90s cooldown
+    h.ads.onMatchEnded();                          // cadence eligible
+    let closed = false;
+    h.ads.showInterstitial({ placement: 'between_matches', onClose: function () { closed = true; } });
+    h.fireTimers();                                // 8s watchdog -> settle('timeout') -> adapter.dismiss()
+    check(closed, 'onClose fires on the interstitial timeout (fail-open, gameplay proceeds)');
+    check(h.ads._config().adInFlight == null, 'nothing in flight after the timeout');
+    check(h.ls('ads_last_interstitial_ts') == null, 'a timed-out request does NOT burn the cooldown (no impression occurred)');
+    const shownBefore = h.tracked.filter(function (e) { return e.name === 'ad_shown'; }).length;
+    // A slow provider that serves the ad AFTER the timeout must not sneak through.
+    h.fireSdk('SDK_GAME_PAUSE');
+    h.fireSdk('SDK_GAME_START');
+    check(h.tracked.filter(function (e) { return e.name === 'ad_shown'; }).length === shownBefore, 'a late fill after the interstitial timeout fires NO ad_shown (no phantom impression after onClose)');
+    check(!h.hasEventWith('ad_shown', 'placement', 'provider_auto'), 'the late PAUSE is NOT mis-adopted as a provider_auto autostart (one-shot suppression)');
+    check(h.ads._config().adInFlight == null, 'the late PAUSE leaves nothing in flight (cannot cover the next round)');
+}
+
 // Codex P2: with pure lazy-loading the SDK would be invisible to GameMonetize's activation
 // verifier (which visits play.html without playing a match). An INERT, source/DOM-detectable
 // marker is injected at init: a <script type="text/plain"> carrying the sdk.js URL — never
@@ -661,6 +686,7 @@ function testMultiplierConstant() {
     testDismissDoesNotKillRewarded();
     testLazyLoadAndGameplayGuard();
     testProviderAutostartAdoption();
+    testInterstitialTimeoutTeardown();
     testVerificationMarker();
     // Part B
     testMultiplierConstant();

--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -298,6 +298,19 @@ function testLazyLoadAndGameplayGuard() {
     h4.ads.onMatchEnded();
     h4.ads.showInterstitial({ placement: 'between_matches', onClose: function () {} });
     check(banner4 === 1, '(d) an interstitial at the lobby edge is NOT blocked (showBanner called)');
+
+    // (e) preloadSdk() loads the SDK EARLY (gameOver/results edge) to widen the lead time before
+    //     the race, but is a no-op during active gameplay so a slow autostart can't be kicked
+    //     into a live round (Codex P1: delayed init covering gameplay).
+    const hp = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    hp.win.config = { stateMap: stateMap };
+    check(hp.scriptCount('gamemonetize-sdk') === 0, '(e) no executable loader before preloadSdk()');
+    hp.win.currentState = stateMap.racing;
+    hp.ads.preloadSdk();                       // mid-round -> refused
+    check(hp.scriptCount('gamemonetize-sdk') === 0, '(e) preloadSdk() is a no-op during active gameplay (no load kicked into a live round)');
+    hp.win.currentState = stateMap.gameOver;   // results screen -> valid surface
+    hp.ads.preloadSdk();
+    check(hp.scriptCount('gamemonetize-sdk') === 1, '(e) preloadSdk() at the gameOver edge injects the executable loader early (more lead time before the race)');
 }
 
 // Codex P1: a GameMonetize preroll the SDK autostarts on init bypasses our showBanner() flow,
@@ -313,12 +326,18 @@ function testProviderAutostartAdoption() {
     h.fireSdk('SDK_READY');
     h.win.sdk = { showBanner: function () {} };
     check(h.ads._config().adInFlight == null, 'no ad in flight before the autostart');
+    h.setNow(50000);               // a real clock so markInterstitialShown stamps a cooldown ts
     h.fireSdk('SDK_GAME_PAUSE');   // the SDK started a preroll we never requested
     check(h.ads._config().adInFlight === 'interstitial', 'an unsolicited autostart is adopted as an in-flight interstitial (so the dismiss net covers it)');
     check(h.hasEventWith('ad_shown', 'placement', 'provider_auto'), 'ad_shown {placement:provider_auto} emitted for the autostart (not invisible)');
+    // P1b: an adopted preroll IS an impression, so it burns the frequency cap like a solicited one.
+    check(h.ls('ads_last_interstitial_ts') === '50000', 'adopted autostart stamps the cooldown ts (frequency cap applied)');
+    check(h.ls('ads_match_count_since_interstitial') === '0', 'adopted autostart resets the match cadence counter (no back-to-back ad next match)');
     // The race-start dismiss safety net can now reclaim it.
     h.ads.dismissInterstitial();
     check(h.ads._config().adInFlight == null, 'dismissInterstitial() tears down the adopted autostart at the gate');
+    // P2: a deliberate teardown (cancelled) records NO completion.
+    check(!h.hasEventWith('ad_complete', 'placement', 'provider_auto'), 'a dismissed autostart records no ad_complete (cancelled, not completed)');
     // A trailing SDK_GAME_START for the dismissed ad is a harmless no-op (already settled).
     h.fireSdk('SDK_GAME_START');
     check(h.ads._config().adInFlight == null, 'a late SDK_GAME_START after dismiss is a no-op');
@@ -331,6 +350,8 @@ function testProviderAutostartAdoption() {
     check(h2.ads._config().adInFlight === 'interstitial', 'autostart adopted');
     h2.fireSdk('SDK_GAME_START');
     check(h2.ads._config().adInFlight == null, 'the adopted autostart resolves on its own SDK_GAME_START');
+    // P2: a normally-completed autostart records ad_complete (symmetric funnel, not "abandoned").
+    check(h2.hasEventWith('ad_complete', 'placement', 'provider_auto'), 'a completed autostart records ad_complete {placement:provider_auto}');
 
     // Autostart that races into a LIVE round is flagged (ad_blocked) but still tracked so the
     // gate dismiss can attempt teardown — never silent.

--- a/.github/scripts/ads-rewarded-test.js
+++ b/.github/scripts/ads-rewarded-test.js
@@ -87,6 +87,10 @@ function loadAds(adsConfig) {
         hasEvent: function (name, type) { return tracked.some(function (e) { return e.name === name && (!type || e.params.type === type); }); },
         // Lazy-load introspection: how many <script id="..."> with a given id have been injected.
         scriptCount: function (id) { return createdScripts.filter(function (s) { return s.id === id; }).length; },
+        // The most-recently-created element with a given id (to assert its type/src).
+        getScript: function (id) { for (let i = createdScripts.length - 1; i >= 0; i--) { if (createdScripts[i].id === id) { return createdScripts[i]; } } return null; },
+        // True if an event with the given name + a matching params field was tracked.
+        hasEventWith: function (name, key, val) { return tracked.some(function (e) { return e.name === name && e.params[key] === val; }); },
         // Read the frequency-cap localStorage directly (to assert cadence isn't burned).
         ls: function (k) { return (k in lsStore) ? lsStore[k] : null; }
     };
@@ -294,6 +298,89 @@ function testLazyLoadAndGameplayGuard() {
     h4.ads.onMatchEnded();
     h4.ads.showInterstitial({ placement: 'between_matches', onClose: function () {} });
     check(banner4 === 1, '(d) an interstitial at the lobby edge is NOT blocked (showBanner called)');
+}
+
+// Codex P1: a GameMonetize preroll the SDK autostarts on init bypasses our showBanner() flow,
+// so it must still be ADOPTED into the interstitial bookkeeping — tracked, telemetered, and
+// torn down by the startGated/startRace dismiss safety net — instead of being invisible. And a
+// request we deliberately tore down must NOT have its late stray PAUSE misread as a fresh
+// autostart (one-shot suppression).
+function testProviderAutostartAdoption() {
+    console.log('ads.js — an SDK-autostarted (unsolicited) preroll is adopted + dismissable:');
+
+    // Unsolicited PAUSE with no prior showInterstitial() -> adopted as an in-flight interstitial.
+    const h = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h.fireSdk('SDK_READY');
+    h.win.sdk = { showBanner: function () {} };
+    check(h.ads._config().adInFlight == null, 'no ad in flight before the autostart');
+    h.fireSdk('SDK_GAME_PAUSE');   // the SDK started a preroll we never requested
+    check(h.ads._config().adInFlight === 'interstitial', 'an unsolicited autostart is adopted as an in-flight interstitial (so the dismiss net covers it)');
+    check(h.hasEventWith('ad_shown', 'placement', 'provider_auto'), 'ad_shown {placement:provider_auto} emitted for the autostart (not invisible)');
+    // The race-start dismiss safety net can now reclaim it.
+    h.ads.dismissInterstitial();
+    check(h.ads._config().adInFlight == null, 'dismissInterstitial() tears down the adopted autostart at the gate');
+    // A trailing SDK_GAME_START for the dismissed ad is a harmless no-op (already settled).
+    h.fireSdk('SDK_GAME_START');
+    check(h.ads._config().adInFlight == null, 'a late SDK_GAME_START after dismiss is a no-op');
+
+    // An autostart that completes on its own (PAUSE -> START, never dismissed) resolves cleanly.
+    const h2 = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h2.fireSdk('SDK_READY');
+    h2.win.sdk = { showBanner: function () {} };
+    h2.fireSdk('SDK_GAME_PAUSE');
+    check(h2.ads._config().adInFlight === 'interstitial', 'autostart adopted');
+    h2.fireSdk('SDK_GAME_START');
+    check(h2.ads._config().adInFlight == null, 'the adopted autostart resolves on its own SDK_GAME_START');
+
+    // Autostart that races into a LIVE round is flagged (ad_blocked) but still tracked so the
+    // gate dismiss can attempt teardown — never silent.
+    const h3 = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h3.fireSdk('SDK_READY');
+    h3.win.sdk = { showBanner: function () {} };
+    const stateMap = JSON.parse(fs.readFileSync(path.join(repoRoot, 'server', 'config.json'), 'utf8')).stateMap;
+    h3.win.config = { stateMap: stateMap };
+    h3.win.currentState = stateMap.racing;
+    h3.fireSdk('SDK_GAME_PAUSE');
+    check(h3.hasEventWith('ad_blocked', 'reason', 'provider_auto_in_gameplay'), 'an autostart over a live round is flagged ad_blocked {reason:provider_auto_in_gameplay}');
+    check(h3.ads._config().adInFlight === 'interstitial', 'still tracked (so the gate dismiss can attempt teardown)');
+
+    // Regression: a SOLICITED interstitial PAUSE is NOT re-adopted as provider_auto.
+    const h4 = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h4.fireSdk('SDK_READY');
+    h4.win.sdk = { showBanner: function () {} };
+    h4.setNow(1000000);
+    h4.ads.onMatchEnded();
+    h4.ads.showInterstitial({ placement: 'between_matches', onClose: function () {} });
+    h4.fireSdk('SDK_GAME_PAUSE');   // solicited -> fires our onStart, not the adopt path
+    check(!h4.hasEventWith('ad_shown', 'placement', 'provider_auto'), 'a solicited interstitial PAUSE is NOT mislabeled provider_auto');
+    check(h4.hasEventWith('ad_shown', 'placement', 'between_matches'), 'the solicited interstitial impression is recorded normally');
+
+    // One-shot suppression: after a torn-down request, a late stray PAUSE is NOT adopted (no
+    // duplicate impression). Mirrors the rewarded-timeout teardown.
+    const h5 = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    h5.fireSdk('SDK_READY');
+    h5.win.sdk = { showBanner: function () {} };
+    h5.ads.showRewarded({ placement: 'xp_2x', onReward: function () {}, onSkip: function () {} });
+    h5.fireTimers();                 // request times out -> dismiss() sets the suppress flag
+    const shownBefore = h5.tracked.filter(function (e) { return e.name === 'ad_shown'; }).length;
+    h5.fireSdk('SDK_GAME_PAUSE');    // late stray PAUSE for the torn-down request
+    check(h5.ads._config().adInFlight == null, 'a stray PAUSE after a teardown is NOT adopted (one-shot suppression)');
+    check(h5.tracked.filter(function (e) { return e.name === 'ad_shown'; }).length === shownBefore, 'no duplicate ad_shown for the abandoned request');
+}
+
+// Codex P2: with pure lazy-loading the SDK would be invisible to GameMonetize's activation
+// verifier (which visits play.html without playing a match). An INERT, source/DOM-detectable
+// marker is injected at init: a <script type="text/plain"> carrying the sdk.js URL — never
+// fetched/executed (so no autostart), while the executable loader stays lazy under a different id.
+function testVerificationMarker() {
+    console.log('ads.js — an inert SDK marker is detectable at init (no preroll), executable loader stays lazy:');
+    const h = loadAds({ provider: 'gamemonetize', publisherId: 'g' });
+    check(h.scriptCount('gamemonetize-sdk-marker') === 1, 'an inert gamemonetize-sdk-marker is injected at init (detectable for verification)');
+    const marker = h.getScript('gamemonetize-sdk-marker');
+    check(marker && marker.type === 'text/plain', 'the marker is type="text/plain" — inert: never fetched or executed (no autostart possible)');
+    check(marker && marker.src === 'https://api.gamemonetize.com/sdk.js', 'the marker carries the canonical sdk.js URL (source-detectable)');
+    check(h.scriptCount('gamemonetize-sdk') === 0, 'the EXECUTABLE loader is still NOT injected at init (stays lazy until a match ends)');
+    check(!!h.win.SDK_OPTIONS && h.win.SDK_OPTIONS.gameId === 'g', 'window.SDK_OPTIONS is set at init (gameId present) — detectable by an executing verifier too');
 }
 
 // ---------------------------------------------------------------------------
@@ -552,6 +639,8 @@ function testMultiplierConstant() {
     testAdsAdinPlayEarlyCloseIsSkip();
     testDismissDoesNotKillRewarded();
     testLazyLoadAndGameplayGuard();
+    testProviderAutostartAdoption();
+    testVerificationMarker();
     // Part B
     testMultiplierConstant();
     await testStashMatchesEngineAward();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- Ads no longer appear before you've played — they only show between matches now, never on the first lobby when you open the game.
 
 ## v0.28.1 — 2026-06-02
 

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -293,6 +293,13 @@
     var gmPendingComplete = null; // fires on SDK_GAME_START (ad done / no-fill)
     function initGameMonetize() {
         sdkReady = false;
+        // One-shot guard: set whenever we deliberately TEAR DOWN a request we initiated (a
+        // rewarded/interstitial timeout or a race-start dismiss). After a teardown the provider
+        // can still fire a late SDK_GAME_PAUSE for that abandoned request; without this we'd
+        // misread that stray PAUSE as a fresh unsolicited autostart and adopt it (double
+        // impression). The flag makes the very next stray PAUSE be ignored once — a genuine
+        // init-autostart (no preceding teardown) is still adopted. See the PAUSE handler.
+        var gmSuppressUnsolicited = false;
         // LAZY LOAD (acquisition-UX fix): we set up SDK_OPTIONS here but DELIBERATELY do
         // NOT inject https://api.gamemonetize.com/sdk.js yet. Their loader can auto-show a
         // preroll the instant it initializes, so pulling it in at page load splashed an ad
@@ -316,7 +323,25 @@
                     // This is the impression signal — commit the cap / emit ad_shown.
                     var sb = gmPendingStart;
                     gmPendingStart = null;
-                    if (typeof sb === "function") { sb(); }
+                    if (typeof sb === "function") {
+                        sb();   // our solicited ad's impression
+                    } else if (gmSuppressUnsolicited) {
+                        // A request we initiated was just torn down (timeout / dismiss); this
+                        // stray PAUSE belongs to it, not a fresh autostart. Ignore it once.
+                        gmSuppressUnsolicited = false;
+                    } else if (adInFlight === null) {
+                        // UNSOLICITED preroll: GameMonetize's SDK can autostart an ad on init,
+                        // OUTSIDE our showBanner() flow. It never passed through showInterstitial(),
+                        // so without this it's invisible — no impression telemetry, and the
+                        // startGated/startRace dismiss safety net (which keys off adInFlight) can't
+                        // reclaim the screen if the ad lingers into the next race. Adopt it as an
+                        // in-flight interstitial (sets adInFlight + activeSettle) and bridge its
+                        // completion (the next SDK_GAME_START) to the adopted settle so it resolves
+                        // cleanly. The dismiss is still best-effort (GM exposes no hard close — see
+                        // adapter.dismiss), but now the autostart is tracked, muted, and torn down
+                        // at the gate exactly like a solicited interstitial.
+                        gmPendingComplete = trackProviderInterstitial();
+                    }
                 } else if (name === "SDK_GAME_START") {
                     // Ad finished (or no fill) — resolve the in-flight interstitial.
                     var cb = gmPendingComplete;
@@ -326,6 +351,30 @@
                 }
             }
         };
+        // VERIFICATION DETECTABILITY (P2): GameMonetize's activation check visits play.html
+        // WITHOUT completing a match and expects to find the SDK integrated. Pure lazy-loading
+        // would make us invisible to that scan. So at init we add an INERT, detectable marker:
+        // a <script type="text/plain"> carrying the canonical sdk.js URL. A text/plain script is
+        // NOT fetched and NOT executed by the browser, so it CANNOT autostart a preroll (the very
+        // thing we're suppressing), yet it leaves a DOM/source-detectable reference to the SDK
+        // (script[src*="gamemonetize"] + window.SDK_OPTIONS, both present pre-match). The
+        // EXECUTABLE loader is still injected lazily by gmEnsureLoaded() under a DIFFERENT id,
+        // only after a match. NOTE: if GM's verifier instead requires the SDK to have actually
+        // executed (window.sdk live), that can't be satisfied without re-introducing the preroll
+        // — the operator must then either verify once with autostart on, or (preferred) ask GM to
+        // disable dashboard autostart so the real SDK can load eagerly with no preroll. Network
+        // specifics stay in this file (ads.js).
+        try {
+            if (!document.getElementById("gamemonetize-sdk-marker")) {
+                var marker = document.createElement("script");
+                marker.id = "gamemonetize-sdk-marker";
+                marker.type = "text/plain";   // inert: never fetched, never executed -> no autostart
+                marker.setAttribute("data-gamemonetize-sdk", "1");
+                marker.src = "https://api.gamemonetize.com/sdk.js";
+                (document.head || document.documentElement).appendChild(marker);
+            }
+        } catch (e) { /* the marker is best-effort; never block init */ }
+
         // Lazy loader: inject the GameMonetize loader exactly as their README specifies, but
         // ONLY when first asked (ensureSdkLoaded -> adapter.ensureLoaded). Idempotent by id —
         // the gamemonetize-sdk guard means the <script> is appended at most once no matter how
@@ -386,6 +435,9 @@
             dismiss: function () {
                 gmPendingStart = null;
                 gmPendingComplete = null;
+                // The provider may emit a late PAUSE for this torn-down request — suppress
+                // adopting that stray event as a fresh unsolicited autostart (one-shot).
+                gmSuppressUnsolicited = true;
             }
         };
     }
@@ -531,6 +583,36 @@
         if (typeof activeSettle === "function") { activeSettle("cancelled"); }
     }
 
+    // Adopt a PROVIDER-INITIATED ad (one the network's SDK started on its own — e.g. a
+    // GameMonetize preroll fired on init, outside our showBanner() flow) into the same
+    // interstitial bookkeeping a solicited ad uses, so it's never invisible: registers
+    // adInFlight = "interstitial" + an activeSettle, so dismissInterstitial() reclaims the slot
+    // at race start (best-effort — the provider may expose no hard close), and emits the
+    // impression. If the autostart somehow began over a live round it's flagged (ad_blocked),
+    // never silent. Returns the one-shot settle the adapter bridges to the provider's completion
+    // event (SDK_GAME_START) so the adopted ad resolves and clears adInFlight cleanly. No-op-safe
+    // to call again: a second adoption while one is in flight is prevented by the caller's
+    // adInFlight === null guard.
+    function trackProviderInterstitial() {
+        var settled = false;
+        function settle() {
+            if (settled) { return; }
+            settled = true;
+            if (activeSettle === settle) { activeSettle = null; }
+            if (adInFlight === "interstitial") { adInFlight = null; }
+        }
+        activeSettle = settle;     // dismissInterstitial() calls activeSettle("cancelled") -> settle()
+        adInFlight = "interstitial";
+        track("ad_shown", { type: "interstitial", placement: "provider_auto" });
+        if (inActiveGameplay()) {
+            // The autostart raced into a live round. We can't force-close the provider's overlay
+            // (no API — same limitation as a solicited ad), but flag it so it's never silent;
+            // dismissInterstitial() at the next gate will still attempt the best-effort teardown.
+            track("ad_blocked", { type: "interstitial", reason: "provider_auto_in_gameplay" });
+        }
+        return settle;
+    }
+
     // ---- Rewarded video — "Watch to 2× match XP" ------------------------------
     // True once a real network's SDK is ready (and we're allowed to show ads at all:
     // not embedded, provider != 'none'). The UI gates the results-screen reward button
@@ -650,7 +732,7 @@
         isRewardedAvailable: isRewardedAvailable,
         showRewarded: showRewarded,
         // Exposed for headless tests / debugging.
-        _config: function () { return { provider: provider, sdkReady: sdkReady }; }
+        _config: function () { return { provider: provider, sdkReady: sdkReady, adInFlight: adInFlight }; }
     };
 
     // Auto-init from server-injected config. window.__ADS__ is set by the

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -108,6 +108,10 @@
     // Idempotent + fail-open: a missing ensureLoaded or a load failure just keeps us a no-op.
     function ensureSdkLoaded() {
         if (!shouldShow()) { return; }   // provider 'none' / embedded -> never load a network
+        // Never KICK a load during a live round: an SDK that autostarts a preroll on init could
+        // then splash it over gameplay. Loads are kicked from gameOver/lobby edges (preloadSdk /
+        // the availability gates), so this is belt-and-suspenders against a stray gameplay call.
+        if (inActiveGameplay()) { return; }
         try {
             if (adapter && typeof adapter.ensureLoaded === "function") { adapter.ensureLoaded(); }
         } catch (e) { /* fail-open: load failure just leaves the SDK absent (no-op) */ }
@@ -340,7 +344,10 @@
                         // cleanly. The dismiss is still best-effort (GM exposes no hard close — see
                         // adapter.dismiss), but now the autostart is tracked, muted, and torn down
                         // at the gate exactly like a solicited interstitial.
-                        gmPendingComplete = trackProviderInterstitial();
+                        var adoptedSettle = trackProviderInterstitial();
+                        // SDK_GAME_START for this autostart resolves it as a real completion
+                        // (records ad_complete); dismissInterstitial settles it "cancelled".
+                        gmPendingComplete = function () { adoptedSettle("complete"); };
                     }
                 } else if (name === "SDK_GAME_START") {
                     // Ad finished (or no fill) — resolve the in-flight interstitial.
@@ -595,15 +602,25 @@
     // adInFlight === null guard.
     function trackProviderInterstitial() {
         var settled = false;
-        function settle() {
+        // status: "complete" (provider's SDK_GAME_START) or "cancelled" (dismissInterstitial at
+        // the gate). Mirrors showInterstitial's settle so the funnel stays symmetric: an adopted
+        // preroll that finishes records ad_complete; a deliberate teardown records nothing.
+        function settle(status) {
             if (settled) { return; }
             settled = true;
             if (activeSettle === settle) { activeSettle = null; }
             if (adInFlight === "interstitial") { adInFlight = null; }
+            if (status === "complete") {
+                track("ad_complete", { type: "interstitial", placement: "provider_auto" });
+            }
         }
-        activeSettle = settle;     // dismissInterstitial() calls activeSettle("cancelled") -> settle()
+        activeSettle = settle;     // dismissInterstitial() calls activeSettle("cancelled") -> settle("cancelled")
         adInFlight = "interstitial";
         track("ad_shown", { type: "interstitial", placement: "provider_auto" });
+        // An autostarted preroll IS a real impression, so it must burn the frequency cap exactly
+        // like a solicited interstitial — otherwise the seeded cadence stays eligible and the
+        // very next match could request another ad, breaking the 2-match / 90s cap.
+        markInterstitialShown();
         if (inActiveGameplay()) {
             // The autostart raced into a live round. We can't force-close the provider's overlay
             // (no API — same limitation as a solicited ad), but flag it so it's never silent;
@@ -722,9 +739,19 @@
         }
     }
 
+    // Start loading the network SDK as EARLY as possible in the post-match break (called from
+    // the gameOver/results edge), so a GameMonetize-style loader that autostarts a preroll on
+    // init does so over the results screen — a valid ad surface — with the whole lobby countdown
+    // of lead time before the next race, instead of racing into gated/racing. Idempotent + a
+    // no-op while in active gameplay / for provider 'none' / embedded; never blocks anything.
+    function preloadSdk() {
+        try { ensureSdkLoaded(); } catch (e) { /* fail-open */ }
+    }
+
     window.ads = {
         init: init,
         onMatchEnded: onMatchEnded,
+        preloadSdk: preloadSdk,
         canShowInterstitial: canShowInterstitial,
         showInterstitial: showInterstitial,
         dismissInterstitial: dismissInterstitial,

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -99,6 +99,35 @@
         return true;
     }
 
+    // Lazy-load kick. The network SDK is NOT injected at page init (some loaders, e.g.
+    // GameMonetize, auto-show a preroll the moment they initialize — that splashed an ad on
+    // the first lobby, before the player had played). Instead each adapter exposes an optional
+    // ensureLoaded() that injects its <script> once, and we call this from the demand paths
+    // (canShowInterstitial / isRewardedAvailable / the show* entry points). Those are only
+    // reached AFTER a match ends, so the SDK is pulled in lazily — never on the first lobby.
+    // Idempotent + fail-open: a missing ensureLoaded or a load failure just keeps us a no-op.
+    function ensureSdkLoaded() {
+        if (!shouldShow()) { return; }   // provider 'none' / embedded -> never load a network
+        try {
+            if (adapter && typeof adapter.ensureLoaded === "function") { adapter.ensureLoaded(); }
+        } catch (e) { /* fail-open: load failure just leaves the SDK absent (no-op) */ }
+    }
+
+    // Hard guard: an ad must NEVER cover live gameplay. Returns true when the client is in an
+    // active-gameplay state (gated / racing / collapsing) — the waiting / lobby / overview /
+    // gameOver edges are the only valid ad surfaces. Reads the shared `currentState` /
+    // `config.stateMap` globals from the play bundle. If they're absent (load-order, or this
+    // file on a non-play page) we return false so a missing global can't suppress a legitimate
+    // ad — the cadence/availability gates upstream already constrain WHEN we get here.
+    function inActiveGameplay() {
+        try {
+            var cs = window.currentState;
+            var sm = window.config && window.config.stateMap;
+            if (typeof cs !== "number" || !sm) { return false; }
+            return cs === sm.gated || cs === sm.racing || cs === sm.collapsing;
+        } catch (e) { return false; }
+    }
+
     // ---- Frequency cap --------------------------------------------------------
     // Called once per FINISHED match (from the gameOver hook), regardless of
     // whether an ad ends up showing — it advances the per-match counter.
@@ -119,6 +148,10 @@
 
     function canShowInterstitial() {
         if (!shouldShow()) { return false; }
+        // First demand for an ad after a match end — kick the lazy SDK load (no-op once
+        // loaded). The first request races the SDK becoming ready, so this returns false
+        // now (treated as no-fill, gameplay proceeds) and the SDK is ready for next time.
+        ensureSdkLoaded();
         if (!sdkReady) { return false; } // nothing loaded => nothing to show
         var count = parseInt(lsGet(LS_MATCH_COUNT) || "0", 10);
         if (isNaN(count)) { count = 0; }
@@ -260,6 +293,13 @@
     var gmPendingComplete = null; // fires on SDK_GAME_START (ad done / no-fill)
     function initGameMonetize() {
         sdkReady = false;
+        // LAZY LOAD (acquisition-UX fix): we set up SDK_OPTIONS here but DELIBERATELY do
+        // NOT inject https://api.gamemonetize.com/sdk.js yet. Their loader can auto-show a
+        // preroll the instant it initializes, so pulling it in at page load splashed an ad
+        // on the very FIRST lobby — before the player had played a single match. The loader
+        // is now injected on demand by gmEnsureLoaded() (wired to adapter.ensureLoaded and
+        // kicked from the show / availability paths), and the first such demand can only
+        // happen AFTER a match ends. See ensureSdkLoaded() below.
         window.SDK_OPTIONS = {
             gameId: publisherId || "",
             onEvent: function (a) {
@@ -286,16 +326,20 @@
                 }
             }
         };
-        // Inject the loader exactly as their README specifies (idempotent by id).
-        try {
-            if (!document.getElementById("gamemonetize-sdk")) {
+        // Lazy loader: inject the GameMonetize loader exactly as their README specifies, but
+        // ONLY when first asked (ensureSdkLoaded -> adapter.ensureLoaded). Idempotent by id —
+        // the gamemonetize-sdk guard means the <script> is appended at most once no matter how
+        // many demands arrive. Fail-open: a 404/blocked load just leaves sdkReady false (no-op).
+        function gmEnsureLoaded() {
+            try {
+                if (document.getElementById("gamemonetize-sdk")) { return; }
                 var s = document.createElement("script");
                 s.id = "gamemonetize-sdk";
                 s.src = "https://api.gamemonetize.com/sdk.js";
                 s.onerror = function () { sdkReady = false; }; // 404/blocked -> no-op
                 (document.head || document.documentElement).appendChild(s);
-            }
-        } catch (e) { sdkReady = false; }
+            } catch (e) { sdkReady = false; }
+        }
 
         // One ad-show routine for BOTH interstitial and rewarded. GameMonetize's HTML5 SDK
         // exposes only showBanner() and the SDK_GAME_PAUSE/START events — there is NO dedicated
@@ -332,6 +376,7 @@
         adapter = {
             showInterstitial: gmShowAd,
             showRewarded: gmShowAd,
+            ensureLoaded: gmEnsureLoaded,   // lazy-injects sdk.js on first real ad demand
             // Best-effort teardown for race-start cancellation. NOTE: the GameMonetize
             // preroll SDK exposes no documented programmatic close, so we can only
             // drop our pending callbacks here — visually dismissing an already-playing
@@ -388,6 +433,15 @@
         args = args || {};
         var placement = args.placement || "gameover";
         var onClose = (typeof args.onClose === "function") ? args.onClose : function () {};
+        // Belt-and-suspenders: an ad must never cover live gameplay. The normal trigger is the
+        // gameOver->lobby edge, but refuse outright if somehow called while a round is live
+        // (gated/racing/collapsing). Fail-open: just fire onClose so nothing is gated on it.
+        if (inActiveGameplay()) {
+            try { console.warn("[ads] refused interstitial during active gameplay"); } catch (e) {}
+            track("ad_blocked", { type: "interstitial", reason: "active_gameplay" });
+            onClose();
+            return;
+        }
         if (!canShowInterstitial()) { onClose(); return; }
 
         // Impression/cadence are committed ONLY when the ad actually starts (onStart),
@@ -485,6 +539,11 @@
     // signal, so readiness == SDK ready.
     function isRewardedAvailable() {
         if (!shouldShow()) { return false; }  // provider 'none' or embedded -> not available
+        // Kick the lazy SDK load (no-op once loaded). This is reached at the gameOver->lobby
+        // edge when deciding whether to offer the 2× prompt — i.e. only AFTER a match — so the
+        // SDK never loads on the first lobby. First call returns false (not yet ready); the
+        // offer simply isn't made that match and the SDK is ready for the next one.
+        ensureSdkLoaded();
         return !!sdkReady;
     }
 
@@ -500,6 +559,16 @@
         var onReward = (typeof args.onReward === "function") ? args.onReward : function () {};
         var onSkip = (typeof args.onSkip === "function") ? args.onSkip : function () {};
         var onError = (typeof args.onError === "function") ? args.onError : function () {};
+
+        // Belt-and-suspenders: never play a rewarded ad over live gameplay. The offer toast is a
+        // lobby surface, but refuse outright if somehow triggered mid-round (gated/racing/
+        // collapsing) and fail open as a SKIP so the player can retry from the lobby.
+        if (inActiveGameplay()) {
+            try { console.warn("[ads] refused rewarded ad during active gameplay"); } catch (e) {}
+            track("ad_blocked", { type: "rewarded", reason: "active_gameplay" });
+            onSkip();
+            return;
+        }
 
         // No real, ready network (local 'none' / embedded / SDK not loaded) — fail open as a
         // skip so the caller leaves the button up for a retry and never credits a reward.

--- a/client/scripts/ads.js
+++ b/client/scripts/ads.js
@@ -534,6 +534,17 @@
             clearTimeout(timer);
             activeSettle = null;
             adInFlight = null;
+            if (status === "timeout") {
+                // The request is still pending in the provider (no ad started in time). Tear it
+                // down — mirroring the rewarded path — so a SLOW fill can't appear AFTER we've
+                // given up: otherwise the still-set gmPendingStart would re-fire onStart on a
+                // late SDK_GAME_PAUSE (a phantom impression + cap burn AFTER onClose already ran),
+                // and because adInFlight is now null neither the gameplay guard nor
+                // dismissInterstitial could reclaim it if it landed over the next round. dismiss()
+                // clears GameMonetize's pending callbacks and arms its one-shot stray-PAUSE
+                // suppression (and destroys AdinPlay's player).
+                try { if (adapter && typeof adapter.dismiss === "function") { adapter.dismiss(); } } catch (e) {}
+            }
             if (status === "complete") {
                 // Completion is only an impression if the ad actually started.
                 // A "complete" with no start is a NO-FILL (GameMonetize signals it

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -1239,6 +1239,15 @@ function registerStateHandlers(server) {
 		// required because the server emits startWaiting (currentState -> waiting)
 		// between this and the next startLobby, so a state-compare there is always false.
 		adPendingMatchEnd = true;
+		// Start loading the ad SDK NOW, at the results screen — the earliest valid ad surface —
+		// rather than waiting for the lobby edge. A network whose SDK autostarts a preroll on
+		// init (GameMonetize) then shows it over the results screen with the full lobby countdown
+		// of lead time before the next race, instead of risking a slow load whose autostart lands
+		// mid-race. Idempotent + fail-open: no-op once loaded, while embedded, or for provider
+		// 'none'. The lobby-edge availability gates still kick the load if this didn't run.
+		if (window.ads && typeof window.ads.preloadSdk === "function") {
+			try { window.ads.preloadSdk(); } catch (e) { /* ads must never break the results screen */ }
+		}
 	});
 	server.on("startCollapse", function (info) {
 		currentState = config.stateMap.collapsing;


### PR DESCRIPTION
## Why

Ads were showing on **lobby load — including the very first lobby on a fresh page open, before the player had played a single match**. That's bad acquisition UX (an ad before you've even played). This fixes the already-shipped GameMonetize integration (interstitial PR #245 + rewarded "2× XP" PR #254).

## Root cause

Our placement logic was already correct (the interstitial is gated on `cameFromGameOver`, which can't fire on the first lobby). The premature ad came from **when** the SDK loaded: `ads.js` injected `api.gamemonetize.com/sdk.js` at **page init**, and GameMonetize's SDK can auto-show a preroll the instant it initializes.

## What changed (all in `client/scripts/ads.js`, the only file that knows the network)

- **Lazy-load the SDK.** `initGameMonetize()` sets up `SDK_OPTIONS` but no longer injects `sdk.js`. The loader is injected on demand (`adapter.ensureLoaded` / `ensureSdkLoaded`), kicked only from the post-match paths (`canShowInterstitial` / `isRewardedAvailable` / `preloadSdk`). The first demand races the SDK becoming ready → fails open (no ad), SDK ready for next time. The 8s watchdog, exactly-once settle, and no-fill cadence preservation are intact.
- **Active-gameplay guard.** An ad is refused at the show entry points if `currentState` is `gated`/`racing`/`collapsing` (logs `ad_blocked`); only the waiting/lobby/overview/gameOver edges are valid surfaces.

### Hardening from review rounds (2× Codex + 1× /code-review)

- **Adopt SDK-autostarted prerolls.** An unsolicited `SDK_GAME_PAUSE` (the SDK autostarting outside our flow) is now adopted into the interstitial bookkeeping — tracked (`adInFlight`), telemetered (`ad_shown {placement:provider_auto}` + `ad_complete`), frequency-capped (`markInterstitialShown`), and torn down by `dismissInterstitial()` at the gate. A one-shot suppression flag stops a stray late PAUSE from a torn-down request being mis-adopted.
- **Earlier load + gameplay guard on load.** `ads.preloadSdk()` (called from `client.js` `startGameover`, the earliest valid surface) widens the lead time before the next race; `ensureSdkLoaded()` refuses to kick a load during active gameplay.
- **Verification marker.** An inert `<script type="text/plain">` carrying the canonical `sdk.js` URL is injected at init (never fetched/executed → no preroll) so GameMonetize's activation verifier can detect the integration without a match.
- **Timed-out interstitial teardown.** `settle("timeout")` now calls `adapter.dismiss()` (symmetric with the rewarded path) so a slow late fill can't fire a phantom impression, burn the cap, or cover gameplay untracked.

## Tests

- `.github/scripts/ads-rewarded-test.js` extended: lazy-load (no SDK on init, injected on first demand, idempotent), pre-ready fail-open with cadence preserved, active-gameplay guard, provider-autostart adoption (adopt/dismiss/complete/cancel/cap-burn/one-shot-suppression/solicited-not-mislabeled), `preloadSdk` early-load + no-op-in-gameplay, the inert marker, and the interstitial-timeout teardown (proven to fail without the fix).
- Verified locally: `npm run build`, `test:ads`, `test:smoke`, `test:unit`, `test:lint-buttons`, `test:button-gate` all pass.
- **Live** (`npm start` with `ADS_PROVIDER=gamemonetize`): fresh first lobby has zero GameMonetize iframes, `window.sdk` undefined, executable loader absent — only the inert `text/plain` marker present.

## Operator follow-up (out of scope for this PR)

Recommend replying to the GameMonetize self-hosted approval thread to **disable dashboard automatic/preroll ads** so only our explicit `showBanner()` placements serve. The lazy-load + adoption fix the UX regardless, but disabling autostart is the clean root-cause fix on their side and fully removes the residual (their SDK exposes no programmatic overlay close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
