### PR TITLE
perf(client): fix cosmetic render collapse with many skinned karts

### DIFF
--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -8864,9 +8864,39 @@ function drawStandingsPbTag(player, xRight, cy, isYou) {
 // transform-scaled icon). Border behind, then cart skin OR plain disc + pattern —
 // same cosmetic dispatch as the legacy drawPlayerIcon.
 function drawOverviewKart(player, cx, cy, radius) {
+    // Paint the cosmetic stack UNSHADOWED into a small scratch canvas, then blit it
+    // ONCE with the colored glow. Keeping shadowBlur=10 live across a procedural
+    // skin's dozens of path/gradient ops rendered an intermediate blurred surface
+    // per op — with a full board of skinned karts the overview paid that every frame.
+    var ext = radius * 2.2; // covers border rim (~1.4r) with glow headroom
+    var sx = (typeof canvasScaleX !== "undefined" && canvasScaleX) ? canvasScaleX : 1;
+    var sy = (typeof canvasScaleY !== "undefined" && canvasScaleY) ? canvasScaleY : 1;
+    var w = Math.ceil(ext * 2 * sx), h = Math.ceil(ext * 2 * sy);
+    if (_overviewKartScratch == null) { _overviewKartScratch = document.createElement("canvas"); }
+    var s = _overviewKartScratch;
+    if (s.width < w) { s.width = w; }
+    if (s.height < h) { s.height = h; }
+    var sctx = s.getContext("2d");
+    sctx.setTransform(1, 0, 0, 1, 0, 0);
+    sctx.clearRect(0, 0, w, h);
+    sctx.setTransform(sx, 0, 0, sy, 0, 0);
+    // The skin painters draw through the gameContext global, so point it at the
+    // scratch for the repaint and ALWAYS restore (try/finally) so a throwing
+    // painter can't hijack the rest of the frame.
+    var prevCtx = gameContext;
+    gameContext = sctx;
+    try { drawOverviewKartBody(player, ext, ext, radius); } finally { gameContext = prevCtx; }
     gameContext.save();
     gameContext.shadowColor = player.color;
     gameContext.shadowBlur = 10;
+    gameContext.drawImage(s, 0, 0, w, h, cx - ext, cy - ext, ext * 2, ext * 2);
+    gameContext.restore();
+}
+var _overviewKartScratch = null;
+// The actual cosmetic stack (border behind, then cart skin OR plain disc + pattern),
+// shadow-free — drawOverviewKart composites it with the glow in one blit.
+function drawOverviewKartBody(player, cx, cy, radius) {
+    gameContext.save();
     // border FIRST (behind the body)
     var bid = player.border;
     var bskin = (typeof getSkin === "function" && bid) ? getSkin(bid) : null;

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -401,13 +401,29 @@ function init() {
     initEventHandlers();
     initGamepad();
 }
+// animloop is started from TWO places — setupPage()'s init() (loading screen)
+// and the gameState handler's init() (gameplay). Both used to schedule their own
+// requestAnimFrame chain, and a frame where BOTH gameRunning and loading were true
+// scheduled twice — so any client whose gameState arrived before the asset preload
+// finished ran 2+ permanent gameLoop chains forever, drawing every frame 2+ times
+// (half the FPS for the whole session). Funnel all scheduling through ONE pending
+// flag so exactly one rAF chain survives no matter how init() is re-entered.
+var animFramePending = false;
+function scheduleAnimFrame() {
+    if (animFramePending) {
+        return;
+    }
+    animFramePending = true;
+    requestAnimFrame(animloop);
+}
 function animloop() {
+    animFramePending = false;
     if (gameRunning) {
         var now = Date.now();
         dt = now - then;
         gameLoop(dt);
         then = now;
-        requestAnimFrame(animloop);
+        scheduleAnimFrame();
     }
     if (loading == true) {
         var loadedCount = 0;
@@ -428,7 +444,7 @@ function animloop() {
             loadingTimeoutShown = true;
             progressContainer.html('Loading is taking longer than usual. <a href="#" onclick="location.reload();return false;">Refresh the page</a> to retry.');
         }
-        requestAnimFrame(animloop);
+        scheduleAnimFrame();
     }
 }
 function gameLoop(dt) {

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -397,7 +397,11 @@ function init() {
     if (loading == false) {
         timeOutChecker = setInterval(checkForTimeout, 1000);
     }
-    animloop();
+    // Schedule (never call animloop() synchronously): a direct call while a rAF
+    // callback is already queued would clear animFramePending without consuming
+    // that queued callback, forking a second permanent chain — the exact bug the
+    // pending flag exists to prevent. init() runs twice (setupPage + gameState).
+    scheduleAnimFrame();
     initEventHandlers();
     initGamepad();
 }

--- a/client/scripts/terrainfx.js
+++ b/client/scripts/terrainfx.js
@@ -324,18 +324,49 @@ function tfxDrawLavaConvection(t, camX, camY) {
     ctx.restore();
 }
 
+// Shared scratch for the glow-profile blurred reflection. The kart's appearance is
+// painted UNFILTERED at device resolution into this small offscreen canvas, and only
+// the single drawImage onto the main canvas goes through ctx.filter. Re-painting the
+// full procedural skin (dozens of path/gradient ops for some carts) per kart per
+// frame WITH the blur filter active pushed every op through a slow intermediate-
+// surface path — a populated room in cosmetics collapsed to 2-5 FPS from this alone.
+var _tfxReflScratch = null;
 function tfxDrawIceReflections(camX, camY) {
     var ice = terrainFX.ice;
     if (!ice.length || typeof playerList === "undefined" || playerList == null) { return; }
     var ctx = gameContext;
-    ctx.save();
-    tfxPathCells(ctx, ice, camX, camY);
-    ctx.clip();
+    var vr = tfxVisibleWorldRect(camX, camY);
+    var clipped = false;
     var useBlur = (typeof perfGlow === "function") ? perfGlow() : true;
     for (var id in playerList) {
         var p = playerList[id];
         if (p == null || p.alive === false) { continue; }
         var rad = p.radius || 16;
+        // Half-extent of the painted appearance: borders ring out to ~1.4r and the
+        // punch pop scales up to ~1.3x, so 2.2r covers every current cosmetic.
+        var ext = rad * 2.2;
+        // World bbox the reflection can touch (it casts BELOW the kart, see pivot
+        // math under the blit): x +- ext, y .. y + ~4r, plus the 2.5px blur bleed.
+        var rminX = p.x - ext - 4, rmaxX = p.x + ext + 4;
+        var rminY = p.y, rmaxY = p.y + rad * 4 + 4;
+        // Skip karts whose reflection is off-screen or can't overlap any ice cell —
+        // the clip would discard every pixel, but the painter ops would still run
+        // (previously EVERY alive kart paid the full filtered repaint each frame
+        // whenever the map had any ice at all, even nowhere near it).
+        if (vr != null && (rmaxX < vr.loX || rminX > vr.hiX || rmaxY < vr.loY || rminY > vr.hiY)) { continue; }
+        var near = false;
+        for (var ci = 0; ci < ice.length; ci++) {
+            var cb = ice[ci];
+            if (rmaxX >= cb.minX && rminX <= cb.maxX && rmaxY >= cb.minY && rminY <= cb.maxY) { near = true; break; }
+        }
+        if (!near) { continue; }
+        if (!clipped) {
+            // Defer the save+clip until a kart actually reflects (most frames none do).
+            ctx.save();
+            tfxPathCells(ctx, ice, camX, camY);
+            ctx.clip();
+            clipped = true;
+        }
         var x = p.x + camX, y = p.y + camY;
         // Cast the reflection fully BELOW the kart so its top sits at the kart's
         // base (not hidden behind the body). Flip + squash about that pivot, and
@@ -345,15 +376,44 @@ function tfxDrawIceReflections(camX, camY) {
         var pivot = y + rad * 1.95;
         ctx.save();
         ctx.globalAlpha = 0.38;
-        if (useBlur && "filter" in ctx) { ctx.filter = "blur(2.5px)"; }
-        ctx.translate(x, pivot);
-        ctx.scale(1.0, -0.85);
-        ctx.translate(-x, -pivot);
-        if (typeof drawKartAppearance === "function") {
-            drawKartAppearance(p, x, pivot);
+        if (useBlur && "filter" in ctx && typeof drawKartAppearance === "function") {
+            // Glow profiles: paint the appearance into the scratch (no filter), then
+            // blur only the one blit. Same transform state as the old direct path,
+            // so the blur and squash read identically.
+            var sx = (typeof canvasScaleX !== "undefined" && canvasScaleX) ? canvasScaleX : 1;
+            var sy = (typeof canvasScaleY !== "undefined" && canvasScaleY) ? canvasScaleY : 1;
+            var w = Math.ceil(ext * 2 * sx), h = Math.ceil(ext * 2 * sy);
+            if (_tfxReflScratch == null) { _tfxReflScratch = document.createElement("canvas"); }
+            var s = _tfxReflScratch;
+            if (s.width < w) { s.width = w; }
+            if (s.height < h) { s.height = h; }
+            var sctx = s.getContext("2d");
+            sctx.setTransform(1, 0, 0, 1, 0, 0);
+            sctx.clearRect(0, 0, w, h);
+            sctx.setTransform(sx, 0, 0, sy, 0, 0);
+            // The skin painters draw through the gameContext global, so point it at
+            // the scratch for the repaint and ALWAYS restore (try/finally) so a
+            // throwing painter can't hijack the rest of the frame.
+            var prevCtx = gameContext;
+            gameContext = sctx;
+            try { drawKartAppearance(p, ext, ext); } finally { gameContext = prevCtx; }
+            ctx.filter = "blur(2.5px)";
+            ctx.translate(x, pivot);
+            ctx.scale(1.0, -0.85);
+            ctx.drawImage(s, 0, 0, w, h, -ext, -ext, ext * 2, ext * 2);
+        } else {
+            // No-glow profiles never paid the filter, so keep the direct repaint.
+            ctx.translate(x, pivot);
+            ctx.scale(1.0, -0.85);
+            ctx.translate(-x, -pivot);
+            if (typeof drawKartAppearance === "function") {
+                drawKartAppearance(p, x, pivot);
+            }
         }
         ctx.restore();
     }
-    ctx.restore();
+    if (clipped) {
+        ctx.restore();
+    }
 }
 

--- a/client/scripts/trailEffects.js
+++ b/client/scripts/trailEffects.js
@@ -241,6 +241,55 @@ function tfxPuffGrad(ctx, color) {
   g.addColorStop(1, tfxRGBA(color, 0));
   _tfxPuff[color] = g; return g;
 }
+// Scratch-glow compositor for the shadowBlur-heavy trail painters. Painting dozens
+// of fills/strokes per trail per frame WITH ctx.shadowBlur set renders an
+// intermediate blurred surface per op — with several wearers on screen that alone
+// collapsed High-profile frame rate. Instead: paint the geometry UNSHADOWED into a
+// shared scratch sized to the verts' on-screen bbox (device resolution, clamped to
+// the viewport), then draw the scratch ONCE onto ctx with the colored shadow. One
+// shadowed composite replaces the per-op surfaces; the halo follows the union
+// silhouette, which reads the same. The viewport clamp also stops fully off-screen
+// trails from painting at all. Only called on glow profiles (tfxGlow()); the
+// no-glow path keeps painting straight to the main canvas.
+var _tfxGlowScratch = null;
+function tfxGlowBlit(ctx, verts, color, glowR, margin, composite, body) {
+  var n = verts.length;
+  var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (var i = 0; i < n; i++) {
+    var v = verts[i];
+    if (v.x < minX) minX = v.x;
+    if (v.x > maxX) maxX = v.x;
+    if (v.y < minY) minY = v.y;
+    if (v.y > maxY) maxY = v.y;
+  }
+  var pad = glowR + margin;
+  minX -= pad; minY -= pad; maxX += pad; maxY += pad;
+  var W = (typeof LOGICAL_WIDTH !== "undefined" && LOGICAL_WIDTH) ? LOGICAL_WIDTH : 1366;
+  var H = (typeof LOGICAL_HEIGHT !== "undefined" && LOGICAL_HEIGHT) ? LOGICAL_HEIGHT : 768;
+  if (minX < -pad) minX = -pad;
+  if (minY < -pad) minY = -pad;
+  if (maxX > W + pad) maxX = W + pad;
+  if (maxY > H + pad) maxY = H + pad;
+  if (maxX - minX < 1 || maxY - minY < 1) return;
+  var sx = (typeof canvasScaleX !== "undefined" && canvasScaleX) ? canvasScaleX : 1;
+  var sy = (typeof canvasScaleY !== "undefined" && canvasScaleY) ? canvasScaleY : 1;
+  var w = Math.ceil((maxX - minX) * sx), h = Math.ceil((maxY - minY) * sy);
+  if (_tfxGlowScratch == null) { _tfxGlowScratch = document.createElement("canvas"); }
+  var s = _tfxGlowScratch;
+  if (s.width < w) { s.width = w; }
+  if (s.height < h) { s.height = h; }
+  var sc = s.getContext("2d");
+  sc.setTransform(1, 0, 0, 1, 0, 0);
+  sc.clearRect(0, 0, w, h);
+  sc.setTransform(sx, 0, 0, sy, -minX * sx, -minY * sy);
+  body(sc);
+  ctx.save();
+  ctx.shadowColor = color;
+  ctx.shadowBlur = glowR;
+  if (composite) { ctx.globalCompositeOperation = composite; }
+  ctx.drawImage(s, 0, 0, w, h, minX, minY, maxX - minX, maxY - minY);
+  ctx.restore();
+}
 // unit glyph paths, filled by the caller
 function tfxHeartPath(ctx, sz) {
   ctx.beginPath();
@@ -389,23 +438,30 @@ function drawCometTrail(ctx, verts, color, now, fadeMs, anim) {
     nx[j] = -tan.y; ny[j] = tan.x;
   }
   ctx.save();
-  if (tfxGlow()) { ctx.shadowColor = color; ctx.shadowBlur = GLOW; }
   ctx.lineJoin = "round";
-  ctx.fillStyle = color;
-  for (var s = 1; s < m; s++) {
-    var alpha = af[s] * 0.5;
-    if (alpha <= 0.02) continue;
-    var p0 = verts[idx[s - 1]], p1 = verts[idx[s]];
-    tfxAlpha(ctx, alpha);
-    ctx.beginPath();
-    ctx.moveTo(p0.x + nx[s - 1] * hw[s - 1], p0.y + ny[s - 1] * hw[s - 1]);
-    ctx.lineTo(p1.x + nx[s] * hw[s],         p1.y + ny[s] * hw[s]);
-    ctx.lineTo(p1.x - nx[s] * hw[s],         p1.y - ny[s] * hw[s]);
-    ctx.lineTo(p0.x - nx[s - 1] * hw[s - 1], p0.y - ny[s - 1] * hw[s - 1]);
-    ctx.closePath();
-    ctx.fill();
-  }
-  if (tfxGlow()) ctx.shadowBlur = GLOW * 0.5;
+  // Ribbon body: ~50 alpha-faded quad fills. Per-op shadowBlur here was the comet's
+  // frame killer — route the glow through ONE shadowed scratch blit instead.
+  var cometRibbon = function (c) {
+    c.lineJoin = "round";
+    c.fillStyle = color;
+    for (var s = 1; s < m; s++) {
+      var alpha = af[s] * 0.5;
+      if (alpha <= 0.02) continue;
+      var p0 = verts[idx[s - 1]], p1 = verts[idx[s]];
+      tfxAlpha(c, alpha);
+      c.beginPath();
+      c.moveTo(p0.x + nx[s - 1] * hw[s - 1], p0.y + ny[s - 1] * hw[s - 1]);
+      c.lineTo(p1.x + nx[s] * hw[s],         p1.y + ny[s] * hw[s]);
+      c.lineTo(p1.x - nx[s] * hw[s],         p1.y - ny[s] * hw[s]);
+      c.lineTo(p0.x - nx[s - 1] * hw[s - 1], p0.y - ny[s - 1] * hw[s - 1]);
+      c.closePath();
+      c.fill();
+    }
+  };
+  if (tfxGlow()) { tfxGlowBlit(ctx, verts, color, GLOW, WIDTH, null, cometRibbon); }
+  else { cometRibbon(ctx); }
+  // Core stroke: a single op, so a direct shadow stays cheap.
+  if (tfxGlow()) { ctx.shadowColor = color; ctx.shadowBlur = GLOW * 0.5; }
   var coreStart = -1;
   for (var c = 0; c < m; c++) { if (af[c] > 0.35) { coreStart = c; break; } }
   if (coreStart >= 0 && coreStart < m - 1) {
@@ -482,25 +538,32 @@ function drawAuroraTrail(ctx, verts, color, now, fadeMs, anim) {
     bk[i] = (age >= fadeMs) ? TFX_BUCKETS : Math.floor(age / bucketMs);
   }
   ctx.save();
-  ctx.globalCompositeOperation = "lighter";
-  if (tfxGlow()) { ctx.shadowColor = color; ctx.shadowBlur = GLOW; }
-  ctx.lineCap = "round"; ctx.lineJoin = "round";
-  for (var L = 0; L < layers; L++) {
-    var inner = layers > 1 ? L / (layers - 1) : 1;
-    ctx.lineWidth = (5 + AMP * 0.55) * (1 - inner * 0.72);
-    ctx.strokeStyle = (L === layers - 1) ? tfxHot(color, 0.35, 1) : color;
-    var layerA = 0.12 + 0.20 * inner;
-    for (var b = 0; b < TFX_BUCKETS; b++) {
-      tfxAlpha(ctx, layerA * (1 - (b + 0.5) / TFX_BUCKETS));
-      var run = false;
-      for (var vv = 1; vv < n; vv++) {
-        if (bk[vv] !== b) { if (run) { ctx.stroke(); run = false; } continue; }
-        if (!run) { ctx.beginPath(); ctx.moveTo(wx[vv - 1], wy[vv - 1]); run = true; }
-        ctx.lineTo(wx[vv], wy[vv]);
+  // All the wavy layer strokes, additive between themselves. Per-stroke shadowBlur
+  // (GLOW 27, ~a dozen long strokes) was the cost — paint them unshadowed and let
+  // tfxGlowBlit add the glow on the single 'lighter' composite, which keeps the
+  // additive-vs-background look.
+  var auroraBody = function (c) {
+    c.globalCompositeOperation = "lighter";
+    c.lineCap = "round"; c.lineJoin = "round";
+    for (var L = 0; L < layers; L++) {
+      var inner = layers > 1 ? L / (layers - 1) : 1;
+      c.lineWidth = (5 + AMP * 0.55) * (1 - inner * 0.72);
+      c.strokeStyle = (L === layers - 1) ? tfxHot(color, 0.35, 1) : color;
+      var layerA = 0.12 + 0.20 * inner;
+      for (var b = 0; b < TFX_BUCKETS; b++) {
+        tfxAlpha(c, layerA * (1 - (b + 0.5) / TFX_BUCKETS));
+        var run = false;
+        for (var vv = 1; vv < n; vv++) {
+          if (bk[vv] !== b) { if (run) { c.stroke(); run = false; } continue; }
+          if (!run) { c.beginPath(); c.moveTo(wx[vv - 1], wy[vv - 1]); run = true; }
+          c.lineTo(wx[vv], wy[vv]);
+        }
+        if (run) c.stroke();
       }
-      if (run) ctx.stroke();
     }
-  }
+  };
+  if (tfxGlow()) { tfxGlowBlit(ctx, verts, color, GLOW, AMP + 12, "lighter", auroraBody); }
+  else { ctx.globalCompositeOperation = "lighter"; auroraBody(ctx); }
   ctx.restore();
 }
 
@@ -638,33 +701,41 @@ function drawBoltTrail(ctx, verts, color, now, fadeMs, anim) {
     px[j] = verts[ii].x - t.y * jit; py[j] = verts[ii].y + t.x * jit;
   }
   ctx.save(); ctx.lineCap = "round"; ctx.lineJoin = "round";
+  // Soft outer bolt: one polyline stroke, so a direct shadow stays cheap.
   if (tfxGlow()) { ctx.shadowColor = color; ctx.shadowBlur = GLOW; }
   ctx.strokeStyle = tfxRGBA(color, 0.5); ctx.lineWidth = 4; tfxAlpha(ctx, 0.55);
   ctx.beginPath(); ctx.moveTo(px[0], py[0]);
   for (var s = 1; s < m; s++) ctx.lineTo(px[s], py[s]);
   ctx.stroke();
-  if (tfxGlow()) ctx.shadowBlur = GLOW * 0.5;
-  ctx.strokeStyle = tfxHot(color, 0.65, 1); ctx.lineWidth = 1.6;
-  for (var c = 1; c < m; c++) {
-    if (af[c] <= 0.04) continue;
-    tfxAlpha(ctx, af[c]);
-    ctx.beginPath(); ctx.moveTo(px[c - 1], py[c - 1]); ctx.lineTo(px[c], py[c]); ctx.stroke();
-  }
-  var forks = Math.round(FORKS);
-  if (forks > 0) {
-    ctx.lineWidth = 1.1; ctx.strokeStyle = tfxRGBA(color, 0.8);
-    var gap = Math.max(2, Math.floor(m / (forks * 2 + 1)));
-    for (var s2 = 2; s2 < m - 1; s2 += gap) {
-      if (af[s2] < 0.3) continue;
-      var t2 = tfxTangent(verts, idx[s2]);
-      var dir = (tfxHash(verts[idx[s2]].t + fstep * 51) < 0.5) ? 1 : -1;
-      var fl = 8 + tfxHash(verts[idx[s2]].t + fstep) * 12;
-      tfxAlpha(ctx, af[s2] * 0.7);
-      ctx.beginPath(); ctx.moveTo(px[s2], py[s2]);
-      ctx.lineTo(px[s2] - t2.y * fl * dir + t2.x * fl * 0.4, py[s2] + t2.x * fl * dir + t2.y * fl * 0.4);
-      ctx.stroke();
+  ctx.shadowBlur = 0;
+  // Hot core + forks: ~40 tiny per-segment strokes; per-op shadow here was the
+  // bolt's frame cost — glow them via one scratch blit instead.
+  var boltCore = function (c2) {
+    c2.lineCap = "round"; c2.lineJoin = "round";
+    c2.strokeStyle = tfxHot(color, 0.65, 1); c2.lineWidth = 1.6;
+    for (var c = 1; c < m; c++) {
+      if (af[c] <= 0.04) continue;
+      tfxAlpha(c2, af[c]);
+      c2.beginPath(); c2.moveTo(px[c - 1], py[c - 1]); c2.lineTo(px[c], py[c]); c2.stroke();
     }
-  }
+    var forks = Math.round(FORKS);
+    if (forks > 0) {
+      c2.lineWidth = 1.1; c2.strokeStyle = tfxRGBA(color, 0.8);
+      var gap = Math.max(2, Math.floor(m / (forks * 2 + 1)));
+      for (var s2 = 2; s2 < m - 1; s2 += gap) {
+        if (af[s2] < 0.3) continue;
+        var t2 = tfxTangent(verts, idx[s2]);
+        var dir = (tfxHash(verts[idx[s2]].t + fstep * 51) < 0.5) ? 1 : -1;
+        var fl = 8 + tfxHash(verts[idx[s2]].t + fstep) * 12;
+        tfxAlpha(c2, af[s2] * 0.7);
+        c2.beginPath(); c2.moveTo(px[s2], py[s2]);
+        c2.lineTo(px[s2] - t2.y * fl * dir + t2.x * fl * 0.4, py[s2] + t2.x * fl * dir + t2.y * fl * 0.4);
+        c2.stroke();
+      }
+    }
+  };
+  if (tfxGlow()) { tfxGlowBlit(ctx, verts, color, GLOW * 0.5, AMP + 24, null, boltCore); }
+  else { boltCore(ctx); }
   ctx.restore();
 }
 
@@ -846,24 +917,31 @@ function drawNeonTrail(ctx, verts, color, now, fadeMs, anim) {
   var WIDTH = TP('neon','WIDTH',8), GLOW = TP('neon','GLOW',11);
   var bucketMs = fadeMs / TFX_BUCKETS;
   ctx.save(); ctx.lineCap = "round"; ctx.lineJoin = "round";
-  if (tfxGlow()) { ctx.shadowColor = color; ctx.shadowBlur = GLOW; }
-  function strokeBuckets(width, style) {
-    ctx.lineWidth = width; ctx.strokeStyle = style;
+  // Each pass is ~TFX_BUCKETS alpha-faded strokes; with per-op shadowBlur the two
+  // passes tanked with several wearers. Paint each pass unshadowed and glow it via
+  // one scratch blit per pass.
+  function strokeBuckets(c, width, style) {
+    c.lineCap = "round"; c.lineJoin = "round";
+    c.lineWidth = width; c.strokeStyle = style;
     for (var b = 0; b < TFX_BUCKETS; b++) {
-      tfxAlpha(ctx, (1 - (b + 0.5) / TFX_BUCKETS));
+      tfxAlpha(c, (1 - (b + 0.5) / TFX_BUCKETS));
       var run = false;
       for (var i = 1; i < n; i++) {
         var age = now - verts[i].t; var seg = (age >= fadeMs) ? TFX_BUCKETS : Math.floor(age / bucketMs);
-        if (seg !== b) { if (run) { ctx.stroke(); run = false; } continue; }
-        if (!run) { ctx.beginPath(); ctx.moveTo(verts[i - 1].x, verts[i - 1].y); run = true; }
-        ctx.lineTo(verts[i].x, verts[i].y);
+        if (seg !== b) { if (run) { c.stroke(); run = false; } continue; }
+        if (!run) { c.beginPath(); c.moveTo(verts[i - 1].x, verts[i - 1].y); run = true; }
+        c.lineTo(verts[i].x, verts[i].y);
       }
-      if (run) ctx.stroke();
+      if (run) c.stroke();
     }
   }
-  strokeBuckets(WIDTH, tfxRGBA(color, 0.32));
-  if (tfxGlow()) ctx.shadowBlur = GLOW * 0.4;
-  strokeBuckets(Math.max(1.5, WIDTH * 0.28), tfxHot(color, 0.7, 1));
+  if (tfxGlow()) {
+    tfxGlowBlit(ctx, verts, color, GLOW, WIDTH, null, function (c) { strokeBuckets(c, WIDTH, tfxRGBA(color, 0.32)); });
+    tfxGlowBlit(ctx, verts, color, GLOW * 0.4, WIDTH, null, function (c) { strokeBuckets(c, Math.max(1.5, WIDTH * 0.28), tfxHot(color, 0.7, 1)); });
+  } else {
+    strokeBuckets(ctx, WIDTH, tfxRGBA(color, 0.32));
+    strokeBuckets(ctx, Math.max(1.5, WIDTH * 0.28), tfxHot(color, 0.7, 1));
+  }
   ctx.restore();
 }
 
@@ -873,16 +951,23 @@ function drawRippleTrail(ctx, verts, color, now, fadeMs, anim) {
   var SPACING = TP('ripple','SPACING',21), GLOW = TP('ripple','GLOW',3);
   var interval = Math.max(20, fadeMs / SPACING);
   ctx.save();
-  if (tfxGlow()) { ctx.shadowColor = color; ctx.shadowBlur = GLOW; }
-  ctx.strokeStyle = color;
-  tfxForEachParticle(verts, now, fadeMs, interval, function (v, ts, age) {
-    var life = tfxClamp01(age / fadeMs);
-    var R = 4 + life * 46;
-    var alpha = tfxClamp01(1 - life) * 0.8; if (alpha <= 0.03) return;
-    tfxAlpha(ctx, alpha); ctx.lineWidth = Math.max(1, 2.5 * (1 - life));
-    ctx.beginPath(); ctx.arc(v.x, v.y, R, 0, TFX_TAU); ctx.stroke();
-  });
+  // ~20 expanding ring strokes per frame; even GLOW 3 per-op shadows added an
+  // intermediate surface per ring. One scratch blit carries the glow instead.
+  var rippleRings = function (c) {
+    c.strokeStyle = color;
+    tfxForEachParticle(verts, now, fadeMs, interval, function (v, ts, age) {
+      var life = tfxClamp01(age / fadeMs);
+      var R = 4 + life * 46;
+      var alpha = tfxClamp01(1 - life) * 0.8; if (alpha <= 0.03) return;
+      tfxAlpha(c, alpha); c.lineWidth = Math.max(1, 2.5 * (1 - life));
+      c.beginPath(); c.arc(v.x, v.y, R, 0, TFX_TAU); c.stroke();
+    });
+  };
+  if (tfxGlow()) { tfxGlowBlit(ctx, verts, color, GLOW, 54, null, rippleRings); }
+  else { rippleRings(ctx); }
   var head = verts[n - 1];
+  // Head ping: single op, direct shadow stays cheap.
+  if (tfxGlow()) { ctx.shadowColor = color; ctx.shadowBlur = GLOW; }
   tfxAlpha(ctx, 0.9); ctx.fillStyle = tfxHot(color, 0.5, 1);
   ctx.beginPath(); ctx.arc(head.x, head.y, 2.4, 0, TFX_TAU); ctx.fill();
   ctx.restore();
@@ -943,55 +1028,64 @@ function drawFoundersFlareTrail(ctx, verts, color, now, fadeMs, anim) {
     nx[j] = -tan.y; ny[j] = tan.x;
   }
   ctx.save();
-  if (tfxGlow()) { ctx.shadowColor = gold; ctx.shadowBlur = GLOW; }
   ctx.lineJoin = "round";
-  ctx.fillStyle = gold;
-  // Molten body ribbon.
-  for (var s = 1; s < m; s++) {
-    var alpha = af[s] * 0.55;
-    if (alpha <= 0.02) continue;
-    var p0 = verts[idx[s - 1]], p1 = verts[idx[s]];
-    tfxAlpha(ctx, alpha);
-    ctx.beginPath();
-    ctx.moveTo(p0.x + nx[s - 1] * hw[s - 1], p0.y + ny[s - 1] * hw[s - 1]);
-    ctx.lineTo(p1.x + nx[s] * hw[s], p1.y + ny[s] * hw[s]);
-    ctx.lineTo(p1.x - nx[s] * hw[s], p1.y - ny[s] * hw[s]);
-    ctx.lineTo(p0.x - nx[s - 1] * hw[s - 1], p0.y - ny[s - 1] * hw[s - 1]);
-    ctx.closePath();
-    ctx.fill();
-  }
-  // White-hot inner core.
-  if (tfxGlow()) ctx.shadowBlur = GLOW * 0.45;
-  var coreStart = -1;
-  for (var c = 0; c < m; c++) { if (af[c] > 0.3) { coreStart = c; break; } }
-  if (coreStart >= 0 && coreStart < m - 1) {
-    tfxAlpha(ctx, 0.9);
-    ctx.strokeStyle = FLARE_HOT;
-    ctx.lineCap = "round";
-    ctx.lineWidth = Math.max(0.9, WIDTH * 0.16);
-    ctx.beginPath();
-    ctx.moveTo(verts[idx[coreStart]].x, verts[idx[coreStart]].y);
-    for (var cc = coreStart + 1; cc < m; cc++) ctx.lineTo(verts[idx[cc]].x, verts[idx[cc]].y);
-    ctx.stroke();
-  }
-  // Drifting ember flecks — deterministic per vertex (tfxHash), rising as they age.
-  ctx.fillStyle = gold;
-  for (var e = 1; e < m; e += 1) {
-    var fe = af[e];
-    if (fe <= 0.05) continue;
-    var h1 = tfxHash(verts[idx[e]].t);
-    if (h1 < 0.45) continue; // sparse — only some segments spit an ember
-    var age = 1 - fe;
-    var ev = verts[idx[e]];
-    var perp = (h1 - 0.5) * WIDTH * 1.6;
-    var rise = age * WIDTH * 1.1;
-    var ex = ev.x + nx[e] * perp;
-    var ey = ev.y + ny[e] * perp - rise;
-    var twinkle = 0.5 + 0.5 * Math.sin(anim * 0.02 + h1 * 31.0);
-    tfxAlpha(ctx, fe * twinkle * 0.9);
-    var er = Math.max(0.6, (1.8 * fe) * (0.6 + 0.4 * h1));
-    ctx.beginPath(); ctx.arc(ex, ey, er, 0, TFX_TAU); ctx.fill();
-  }
+  // Molten body ribbon: ~50 alpha-faded quad fills — the per-op shadowBlur here made
+  // this the single most expensive trail. Glow it via ONE shadowed scratch blit.
+  var flareRibbon = function (c) {
+    c.lineJoin = "round";
+    c.fillStyle = gold;
+    for (var s = 1; s < m; s++) {
+      var alpha = af[s] * 0.55;
+      if (alpha <= 0.02) continue;
+      var p0 = verts[idx[s - 1]], p1 = verts[idx[s]];
+      tfxAlpha(c, alpha);
+      c.beginPath();
+      c.moveTo(p0.x + nx[s - 1] * hw[s - 1], p0.y + ny[s - 1] * hw[s - 1]);
+      c.lineTo(p1.x + nx[s] * hw[s], p1.y + ny[s] * hw[s]);
+      c.lineTo(p1.x - nx[s] * hw[s], p1.y - ny[s] * hw[s]);
+      c.lineTo(p0.x - nx[s - 1] * hw[s - 1], p0.y - ny[s - 1] * hw[s - 1]);
+      c.closePath();
+      c.fill();
+    }
+  };
+  if (tfxGlow()) { tfxGlowBlit(ctx, verts, gold, GLOW, WIDTH, null, flareRibbon); }
+  else { flareRibbon(ctx); }
+  // White-hot inner core + ember flecks, both glowing at the softer radius — the
+  // core is one stroke but the embers are ~20 small fills, so share a scratch blit.
+  var flareCoreEmbers = function (c2) {
+    var coreStart = -1;
+    for (var c = 0; c < m; c++) { if (af[c] > 0.3) { coreStart = c; break; } }
+    if (coreStart >= 0 && coreStart < m - 1) {
+      tfxAlpha(c2, 0.9);
+      c2.strokeStyle = FLARE_HOT;
+      c2.lineCap = "round";
+      c2.lineWidth = Math.max(0.9, WIDTH * 0.16);
+      c2.beginPath();
+      c2.moveTo(verts[idx[coreStart]].x, verts[idx[coreStart]].y);
+      for (var cc = coreStart + 1; cc < m; cc++) c2.lineTo(verts[idx[cc]].x, verts[idx[cc]].y);
+      c2.stroke();
+    }
+    // Drifting ember flecks — deterministic per vertex (tfxHash), rising as they age.
+    c2.fillStyle = gold;
+    for (var e = 1; e < m; e += 1) {
+      var fe = af[e];
+      if (fe <= 0.05) continue;
+      var h1 = tfxHash(verts[idx[e]].t);
+      if (h1 < 0.45) continue; // sparse — only some segments spit an ember
+      var age = 1 - fe;
+      var ev = verts[idx[e]];
+      var perp = (h1 - 0.5) * WIDTH * 1.6;
+      var rise = age * WIDTH * 1.1;
+      var ex = ev.x + nx[e] * perp;
+      var ey = ev.y + ny[e] * perp - rise;
+      var twinkle = 0.5 + 0.5 * Math.sin(anim * 0.02 + h1 * 31.0);
+      tfxAlpha(c2, fe * twinkle * 0.9);
+      var er = Math.max(0.6, (1.8 * fe) * (0.6 + 0.4 * h1));
+      c2.beginPath(); c2.arc(ex, ey, er, 0, TFX_TAU); c2.fill();
+    }
+  };
+  if (tfxGlow()) { tfxGlowBlit(ctx, verts, gold, GLOW * 0.45, WIDTH * 2, null, flareCoreEmbers); }
+  else { flareCoreEmbers(ctx); }
   // Radiant head — bright sun-like blob.
   var head = verts[n - 1];
   var R = WIDTH * 1.0;

--- a/client/scripts/trailEffects.js
+++ b/client/scripts/trailEffects.js
@@ -253,6 +253,9 @@ function tfxPuffGrad(ctx, color) {
 // no-glow path keeps painting straight to the main canvas.
 var _tfxGlowScratch = null;
 function tfxGlowBlit(ctx, verts, color, glowR, margin, composite, body) {
+  // Geometry bbox in the CALLER's coordinate space (+margin for overhang like
+  // ribbon half-widths / ember rise). The shadow is applied at blit time on the
+  // main canvas and bleeds outside the image freely, so it needs no scratch pad.
   var n = verts.length;
   var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
   for (var i = 0; i < n; i++) {
@@ -262,32 +265,76 @@ function tfxGlowBlit(ctx, verts, color, glowR, margin, composite, body) {
     if (v.y < minY) minY = v.y;
     if (v.y > maxY) maxY = v.y;
   }
-  var pad = glowR + margin;
-  minX -= pad; minY -= pad; maxX += pad; maxY += pad;
-  var W = (typeof LOGICAL_WIDTH !== "undefined" && LOGICAL_WIDTH) ? LOGICAL_WIDTH : 1366;
-  var H = (typeof LOGICAL_HEIGHT !== "undefined" && LOGICAL_HEIGHT) ? LOGICAL_HEIGHT : 768;
-  if (minX < -pad) minX = -pad;
-  if (minY < -pad) minY = -pad;
-  if (maxX > W + pad) maxX = W + pad;
-  if (maxY > H + pad) maxY = H + pad;
-  if (maxX - minX < 1 || maxY - minY < 1) return;
-  var sx = (typeof canvasScaleX !== "undefined" && canvasScaleX) ? canvasScaleX : 1;
-  var sy = (typeof canvasScaleY !== "undefined" && canvasScaleY) ? canvasScaleY : 1;
-  var w = Math.ceil((maxX - minX) * sx), h = Math.ceil((maxY - minY) * sy);
+  minX -= margin; minY -= margin; maxX += margin; maxY += margin;
+  // Map the bbox through the caller's CURRENT transform (board scale, world zoom,
+  // screen shake, or a preview's translate/scale all compose here) into device
+  // space, where the scratch renders 1:1 — so this works under ANY transform.
+  var t = ctx.getTransform();
+  var xs = [], ys = [];
+  var corners = [[minX, minY], [maxX, minY], [minX, maxY], [maxX, maxY]];
+  for (var ci = 0; ci < 4; ci++) {
+    xs.push(t.a * corners[ci][0] + t.c * corners[ci][1] + t.e);
+    ys.push(t.b * corners[ci][0] + t.d * corners[ci][1] + t.f);
+  }
+  var dMinX = Math.floor(Math.min.apply(null, xs)), dMaxX = Math.ceil(Math.max.apply(null, xs));
+  var dMinY = Math.floor(Math.min.apply(null, ys)), dMaxY = Math.ceil(Math.max.apply(null, ys));
+  // Clamp to the real canvas (+glow bleed) — off-screen geometry can't show, and
+  // the clamp bounds the scratch (and its per-frame texture upload) to canvas size.
+  var bleed = glowR + 4;
+  if (dMinX < -bleed) dMinX = -bleed;
+  if (dMinY < -bleed) dMinY = -bleed;
+  if (dMaxX > ctx.canvas.width + bleed) dMaxX = ctx.canvas.width + bleed;
+  if (dMaxY > ctx.canvas.height + bleed) dMaxY = ctx.canvas.height + bleed;
+  var w = dMaxX - dMinX, h = dMaxY - dMinY;
+  if (w < 1 || h < 1) return;
   if (_tfxGlowScratch == null) { _tfxGlowScratch = document.createElement("canvas"); }
   var s = _tfxGlowScratch;
   if (s.width < w) { s.width = w; }
   if (s.height < h) { s.height = h; }
   var sc = s.getContext("2d");
+  // The scratch CONTEXT is shared across effects and frames, so isolate each use:
+  // a body that flips composite mode (aurora's 'lighter') must not leak it into the
+  // next effect's scratch render. save/restore plus explicit defaults — the canvas
+  // is grow-only, so a resize reset can't be relied on.
+  sc.save();
   sc.setTransform(1, 0, 0, 1, 0, 0);
   sc.clearRect(0, 0, w, h);
-  sc.setTransform(sx, 0, 0, sy, -minX * sx, -minY * sy);
+  sc.globalCompositeOperation = "source-over";
+  sc.globalAlpha = 1;
+  sc.shadowBlur = 0;
+  if ("filter" in sc) { sc.filter = "none"; }
+  sc.setLineDash([]);
+  // Caller's full transform, shifted so the device bbox lands at the scratch origin.
+  sc.setTransform(t.a, t.b, t.c, t.d, t.e - dMinX, t.f - dMinY);
   body(sc);
+  sc.restore();
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);   // blit 1:1 in device space
+  ctx.globalAlpha = 1;                  // body alphas are baked into the scratch
+  ctx.shadowColor = color;
+  ctx.shadowBlur = glowR;               // shadowBlur ignores the CTM, same as per-op
+  if (composite) { ctx.globalCompositeOperation = composite; }
+  ctx.drawImage(s, 0, 0, w, h, dMinX, dMinY, w, h);
+  ctx.restore();
+}
+// Glow dispatch shared by the heavy painters: no glow -> draw straight to ctx;
+// glow -> scratch + single shadowed blit (transform-aware). The per-op shadow
+// fallback only remains for ancient contexts without getTransform().
+function tfxGlowPaint(ctx, verts, color, glowR, margin, composite, body) {
+  if (!tfxGlow()) {
+    if (composite) { ctx.save(); ctx.globalCompositeOperation = composite; body(ctx); ctx.restore(); }
+    else { body(ctx); }
+    return;
+  }
+  if (typeof ctx.getTransform === "function") {
+    tfxGlowBlit(ctx, verts, color, glowR, margin, composite, body);
+    return;
+  }
   ctx.save();
   ctx.shadowColor = color;
   ctx.shadowBlur = glowR;
   if (composite) { ctx.globalCompositeOperation = composite; }
-  ctx.drawImage(s, 0, 0, w, h, minX, minY, maxX - minX, maxY - minY);
+  body(ctx);
   ctx.restore();
 }
 // unit glyph paths, filled by the caller
@@ -458,8 +505,7 @@ function drawCometTrail(ctx, verts, color, now, fadeMs, anim) {
       c.fill();
     }
   };
-  if (tfxGlow()) { tfxGlowBlit(ctx, verts, color, GLOW, WIDTH, null, cometRibbon); }
-  else { cometRibbon(ctx); }
+  tfxGlowPaint(ctx, verts, color, GLOW, WIDTH, null, cometRibbon);
   // Core stroke: a single op, so a direct shadow stays cheap.
   if (tfxGlow()) { ctx.shadowColor = color; ctx.shadowBlur = GLOW * 0.5; }
   var coreStart = -1;
@@ -562,8 +608,7 @@ function drawAuroraTrail(ctx, verts, color, now, fadeMs, anim) {
       }
     }
   };
-  if (tfxGlow()) { tfxGlowBlit(ctx, verts, color, GLOW, AMP + 12, "lighter", auroraBody); }
-  else { ctx.globalCompositeOperation = "lighter"; auroraBody(ctx); }
+  tfxGlowPaint(ctx, verts, color, GLOW, AMP + 12, "lighter", auroraBody);
   ctx.restore();
 }
 
@@ -734,8 +779,7 @@ function drawBoltTrail(ctx, verts, color, now, fadeMs, anim) {
       }
     }
   };
-  if (tfxGlow()) { tfxGlowBlit(ctx, verts, color, GLOW * 0.5, AMP + 24, null, boltCore); }
-  else { boltCore(ctx); }
+  tfxGlowPaint(ctx, verts, color, GLOW * 0.5, AMP + 24, null, boltCore);
   ctx.restore();
 }
 
@@ -935,13 +979,8 @@ function drawNeonTrail(ctx, verts, color, now, fadeMs, anim) {
       if (run) c.stroke();
     }
   }
-  if (tfxGlow()) {
-    tfxGlowBlit(ctx, verts, color, GLOW, WIDTH, null, function (c) { strokeBuckets(c, WIDTH, tfxRGBA(color, 0.32)); });
-    tfxGlowBlit(ctx, verts, color, GLOW * 0.4, WIDTH, null, function (c) { strokeBuckets(c, Math.max(1.5, WIDTH * 0.28), tfxHot(color, 0.7, 1)); });
-  } else {
-    strokeBuckets(ctx, WIDTH, tfxRGBA(color, 0.32));
-    strokeBuckets(ctx, Math.max(1.5, WIDTH * 0.28), tfxHot(color, 0.7, 1));
-  }
+  tfxGlowPaint(ctx, verts, color, GLOW, WIDTH, null, function (c) { strokeBuckets(c, WIDTH, tfxRGBA(color, 0.32)); });
+  tfxGlowPaint(ctx, verts, color, GLOW * 0.4, WIDTH, null, function (c) { strokeBuckets(c, Math.max(1.5, WIDTH * 0.28), tfxHot(color, 0.7, 1)); });
   ctx.restore();
 }
 
@@ -963,8 +1002,7 @@ function drawRippleTrail(ctx, verts, color, now, fadeMs, anim) {
       c.beginPath(); c.arc(v.x, v.y, R, 0, TFX_TAU); c.stroke();
     });
   };
-  if (tfxGlow()) { tfxGlowBlit(ctx, verts, color, GLOW, 54, null, rippleRings); }
-  else { rippleRings(ctx); }
+  tfxGlowPaint(ctx, verts, color, GLOW, 54, null, rippleRings);
   var head = verts[n - 1];
   // Head ping: single op, direct shadow stays cheap.
   if (tfxGlow()) { ctx.shadowColor = color; ctx.shadowBlur = GLOW; }
@@ -1048,8 +1086,7 @@ function drawFoundersFlareTrail(ctx, verts, color, now, fadeMs, anim) {
       c.fill();
     }
   };
-  if (tfxGlow()) { tfxGlowBlit(ctx, verts, gold, GLOW, WIDTH, null, flareRibbon); }
-  else { flareRibbon(ctx); }
+  tfxGlowPaint(ctx, verts, gold, GLOW, WIDTH, null, flareRibbon);
   // White-hot inner core + ember flecks, both glowing at the softer radius — the
   // core is one stroke but the embers are ~20 small fills, so share a scratch blit.
   var flareCoreEmbers = function (c2) {
@@ -1084,8 +1121,7 @@ function drawFoundersFlareTrail(ctx, verts, color, now, fadeMs, anim) {
       c2.beginPath(); c2.arc(ex, ey, er, 0, TFX_TAU); c2.fill();
     }
   };
-  if (tfxGlow()) { tfxGlowBlit(ctx, verts, gold, GLOW * 0.45, WIDTH * 2, null, flareCoreEmbers); }
-  else { flareCoreEmbers(ctx); }
+  tfxGlowPaint(ctx, verts, gold, GLOW * 0.45, WIDTH * 2, null, flareCoreEmbers);
   // Radiant head — bright sun-like blob.
   var head = verts[n - 1];
   var R = WIDTH * 1.0;


### PR DESCRIPTION
## Problem

A populated room with cosmetics equipped (1 human + 8 bots, random skins — the marketing-GIF capture scenario, but any populated room hits it) collapsed to **2-5 FPS on the High profile** on a capable laptop.

## Diagnosis (measured, not guessed)

rAF frame polling + live A/B no-op toggles in the running game. Key counter-intuitive finding: the procedural skin painters themselves are cheap (9 karts × the heaviest painter ≈ 120 FPS drawn directly; total JS draw time ~3ms/frame even mid-collapse). The cost was GPU-side per-op filter/shadow intermediate surfaces — invisible to CPU profiling. Four compounding causes:

1. **Ice reflections** (`terrainfx.js`): `tfxDrawIceReflections` re-painted **every alive kart's full procedural skin through `ctx.filter='blur(2.5px)'` every frame** whenever the map had *any* ice — even for karts nowhere near it. 9 warlord karts: 2.4 FPS → 99 FPS with this alone disabled.
2. **Six trail painters** (`trailEffects.js`): comet/founders_flare/bolt/aurora/neon/ripple filled/stroked dozens of segments per frame with `shadowBlur` live (8-47 FPS at 9 wearers).
3. **Overview scoreboard** (`draw.js`): `drawOverviewKart` held `shadowBlur=10` across the whole procedural skin paint.
4. **Double render loop** (`game.js`): `animloop` self-scheduled from both its `gameRunning` and `loading` branches and `init()` runs twice (setupPage + gameState) — any client whose `gameState` arrived before the asset preload finished ran 2+ permanent `gameLoop` chains forever, drawing every frame ≥2×.

## Fix — one shared technique, visuals unchanged

Paint geometry unfiltered/unshadowed into a scratch canvas at device resolution, then **one** filtered/shadowed `drawImage`:

- `tfxGlowBlit`/`tfxGlowPaint` (trailEffects.js) — transform-aware (maps the geometry bbox through `ctx.getTransform()` into device space, renders the scratch under the caller's full CTM, blits 1:1 at identity), so it stays on the fast path under world zoom / screen shake and is correct for transformed callers like the lobby trail preview. Scratch context state is isolated per use (aurora's `'lighter'` can't leak). Viewport clamping also stops fully off-screen trails from painting at all.
- Reflection scratch + ice-proximity skip (terrainfx.js) — karts whose reflection can't touch visible ice skip entirely; glow profiles pay one blurred blit per reflecting kart instead of a filtered repaint of the whole painter.
- `drawOverviewKartBody` split (draw.js) — skin painted shadow-free into a scratch, one shadowed blit carries the glow.
- Single rAF chain (game.js) — all scheduling funnels through one pending flag; `init()` schedules instead of calling `animloop()` synchronously.

Low/Balanced (no-glow) profiles keep their existing direct paths.

## Verification

Exact 9-kart random-cosmetics repro on High, 120 Hz display:

| condition | before | after |
|---|---|---|
| random cosmetics ×9 | **7.3 FPS** | **120 FPS** (display cap) |
| all 9 = warlord (worst cart) | 2.4 | 120 |
| all 9 = comet / founders_flare / aurora / bolt / ripple / neon | 8 / 7 / 16 / 14 / 36 / 47 | 120 / 120 / 120 / 113 / 110 / 120 |
| aurora+comet alternating (composite-leak case) | — | 120 |
| kitchen sink (cart+pattern+trail+border ×9) | — | 115 |

- `node .github/scripts/smoke-test.js` ✅, `npm run build` ✅
- Visuals spot-checked in-browser: racing trails (glow/head/embers), dino ice reflection, overview scoreboard skin glow, overview tail FX.
- Codex adversarial review run; all three findings (init re-entry chain fork, scratch composite leak, transformed-caller clamping) fixed in the second commit and re-verified.

Note: per CLAUDE.md, perf/render-only work is CHANGELOG-exempt (no `server/config.json` / `game.js` / `engine.js` changes). The `client-perf` CI gate is advisory/noisy — verified with direct frame polling instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)