### PR TITLE
docs(spikes): cosmetic perf verification results + device/profile perf follow-up prompts

### DIFF
--- a/docs/spikes/cosmetic-perf-verification.md
+++ b/docs/spikes/cosmetic-perf-verification.md
@@ -1,0 +1,44 @@
+# Per-id cosmetic FPS sweep — PR #259 verification round (2026-06-03)
+Conditions: 9 live karts same id, ice map, profile pinned High, 1440px viewport,
+display cap 120 (rAF), gl=1.0 gameLoop/frame on every sample, alive=9 gated at
+window start+end. state: 3=gated 4=racing. "dip→retest" = first sample landed in
+an environmentally slow round (concurrent __none__ baseline dipped identically);
+retest in a clean round.
+
+## Baselines (__none__, no cosmetics)
+120, 120, 120, 120, 120, 119.9, 111.8, 90.2*, 71.4* (*environmental dip rounds)
+
+## Carts (43 incl. warlord control) — all ≥90 clean
+warlord 120 | pizza 120.1 | golden_champion 120.6 | wheel_of_fortune 75.5→120 |
+firetruck 120 | compass 120 | coin 120 | dartboard 118.8 | clock 113 |
+disco_ball 120 | hypno 120 | cookie 120.1 | beach_ball 120 | sun 120.3 |
+shuriken 119.9 | turtle 120 | pumpkin 120 | moon 120 | ok_hand 120 | mouse 118.8 |
+dino 107.6 | hoverbike 114.7 | starfighter 120 | earth 120 | smiley 120 |
+eight_ball 120 | saw_blade 120 | donut 120 | vinyl 120 | eyeball 120.1 |
+soccer_ball 120 | basketball 120 | yin_yang 78.8→119.9 | ferris_wheel 97.2→120.1 |
+pinwheel 120 | watermelon 120 | tire 120 | gear 100.2→120 | galaxy 78.2→120 |
+flower 75.6→120 | helm 74.7→120 | aperture 72.6→120 | cheese 71.4→119.9 |
+citrus 66.1→120
+
+## Trails (12) — all 120 clean
+guardian 49.9→120/120.1 (twice, NOT slow — no optimization needed) | dashes 120 |
+sparkle 120 | bubbles 120 | survivor 120 | ribbon 120 | hearts 120 | smoke 120 |
+confetti 120 | snow 120 | tracks 120 | notes 120
+
+## Borders (17) — all ≥104
+border_ring 104.1 | border_double 109.4 | border_studs 119.9 |
+border_chevrons 119.9 | border_dashed 120 | border_ticks 120 |
+border_scales 119.9 | border_glow 117.6 | border_spikes 117.6 | border_gear 120 |
+border_sawblade 120 | border_flames 120 | border_electric 120 |
+border_orbit 120 | border_laurel 120 | border_crown 120 | border_plasma 119.9
+
+## Patterns (16) — all ≥102 clean
+stripes 119.9 | polka 120 | checkered 120 | flames 120 | executioner 120 |
+punching_bag 120 | carbon 120 | camo 120 | hazard 117.7 | circuit 118.8 |
+scales 111.8→120.1 | electric 46.8→120 | tiger 69.1→120 | waves 102.5 |
+honeycomb 117.1 | splatter 120
+
+## Verdict
+Zero ids <90 under clean conditions. The PR #259 fix holds across every cosmetic.
+Environmental dips (baseline 71-90) are round/map ambient cost, identical with
+cosmetics OFF — pre-existing, not cosmetic-related.

--- a/docs/spikes/cosmetic-perf-verification.md
+++ b/docs/spikes/cosmetic-perf-verification.md
@@ -1,15 +1,24 @@
 # Per-id cosmetic FPS sweep — PR #259 verification round (2026-06-03)
 Conditions: 9 live karts same id, ice map, profile pinned High, 1440px viewport,
-display cap 120 (rAF), gl=1.0 gameLoop/frame on every sample, alive=9 gated at
-window start+end. state: 3=gated 4=racing. "dip→retest" = first sample landed in
-an environmentally slow round (concurrent __none__ baseline dipped identically);
+display cap 120 (rAF; readings a few tenths above 120 are timer jitter, not
+real), gl=1.0 gameLoop/frame on every sample, alive=9 gated at window start+end.
+state: 3=gated 4=racing. "dip→retest" = first sample landed in an
+environmentally slow round (concurrent __none__ baseline dipped identically);
 retest in a clean round.
+
+Scope: this round covers every registry id NOT already measured during PR #259
+development itself. Verified back then (see PR #259 / its review thread), so
+deliberately excluded from the table below: cart snowflake, pattern nebula,
+border border_runes, trails comet / aurora / bolt / neon / ripple /
+founders_flare. Combined, the two rounds cover the full registry:
+45/45 carts, 18/18 borders, 17/17 patterns, 18/18 trails.
 
 ## Baselines (__none__, no cosmetics)
 120, 120, 120, 120, 120, 119.9, 111.8, 90.2*, 71.4* (*environmental dip rounds)
 
-## Carts (43 incl. warlord control) — all ≥90 clean
-warlord 120 | pizza 120.1 | golden_champion 120.6 | wheel_of_fortune 75.5→120 |
+## Carts (44 of 45; snowflake verified in the #259 round) — all ≥90 clean
+warlord 120 (control; also verified in #259) | pizza 120.1 |
+golden_champion 120.6 | wheel_of_fortune 75.5→120 |
 firetruck 120 | compass 120 | coin 120 | dartboard 118.8 | clock 113 |
 disco_ball 120 | hypno 120 | cookie 120.1 | beach_ball 120 | sun 120.3 |
 shuriken 119.9 | turtle 120 | pumpkin 120 | moon 120 | ok_hand 120 | mouse 118.8 |
@@ -20,25 +29,29 @@ pinwheel 120 | watermelon 120 | tire 120 | gear 100.2→120 | galaxy 78.2→120 
 flower 75.6→120 | helm 74.7→120 | aperture 72.6→120 | cheese 71.4→119.9 |
 citrus 66.1→120
 
-## Trails (12) — all 120 clean
+## Trails (12 of 18; the 6 shadow-heavy outliers verified in the #259 round) — all 120 clean
 guardian 49.9→120/120.1 (twice, NOT slow — no optimization needed) | dashes 120 |
 sparkle 120 | bubbles 120 | survivor 120 | ribbon 120 | hearts 120 | smoke 120 |
 confetti 120 | snow 120 | tracks 120 | notes 120
 
-## Borders (17) — all ≥104
+## Borders (17 of 18; border_runes verified in the #259 round) — all ≥104
 border_ring 104.1 | border_double 109.4 | border_studs 119.9 |
 border_chevrons 119.9 | border_dashed 120 | border_ticks 120 |
 border_scales 119.9 | border_glow 117.6 | border_spikes 117.6 | border_gear 120 |
 border_sawblade 120 | border_flames 120 | border_electric 120 |
 border_orbit 120 | border_laurel 120 | border_crown 120 | border_plasma 119.9
 
-## Patterns (16) — all ≥102 clean
+## Patterns (16 of 17; nebula verified in the #259 round) — all ≥102 clean
 stripes 119.9 | polka 120 | checkered 120 | flames 120 | executioner 120 |
 punching_bag 120 | carbon 120 | camo 120 | hazard 117.7 | circuit 118.8 |
 scales 111.8→120.1 | electric 46.8→120 | tiger 69.1→120 | waves 102.5 |
 honeycomb 117.1 | splatter 120
 
+## Camera-zoom mini-sweep (dynamic world zoom ON, re-spot-checks of #259-round ids)
+__none__ 120 | comet 120 | aurora 120 | warlord 120 | neon 91.9
+(The main sweep above also ran with the dynamic-camera default enabled.)
+
 ## Verdict
-Zero ids <90 under clean conditions. The PR #259 fix holds across every cosmetic.
+Zero ids <90 under clean conditions across both rounds — full registry covered.
 Environmental dips (baseline 71-90) are round/map ambient cost, identical with
-cosmetics OFF — pre-existing, not cosmetic-related.
+cosmetics OFF — pre-existing (brutal-round overlays), not cosmetic-related.

--- a/docs/spikes/graphics-profile-perf-prompt.md
+++ b/docs/spikes/graphics-profile-perf-prompt.md
@@ -7,8 +7,12 @@
 ---
 
 Run a per-graphics-profile render-performance sweep of the chaochao client,
-using the live in-page harness methodology from memory `live-render-perf-harness.md`
-(read it first — it has the full architecture and the sample-poisoning pitfalls).
+using the live in-page harness methodology from the agent-session memory note
+`live-render-perf-harness.md` (NOT a repo file — it lives in the Claude memory
+directory and is auto-recalled; it has the full architecture and the
+sample-poisoning pitfalls). Measurement is rAF-delta sampling in the page —
+DevTools flamechart tracing is NOT part of this method (use it ad hoc only if
+a specific regression needs root-causing).
 
 ## Goal
 

--- a/docs/spikes/graphics-profile-perf-prompt.md
+++ b/docs/spikes/graphics-profile-perf-prompt.md
@@ -48,6 +48,14 @@ judge RELATIVE to the nearest control; requeue suspect clusters for a clean roun
   silently disappear entirely (e.g. a trail id that draws NOTHING on Low is a bug).
 - Auto: confirm the resolved tier at 1440px and at <900px window widths.
 
+## Run discipline (operator working agreement)
+
+- **Hard time cap: 3 hours wall-clock** for the whole run. When the cap nears,
+  stop all monitors/waits, finalize with collected data, report coverage
+  honestly (measured vs skipped).
+- **Operator messages preempt monitoring**: answer immediately, pause watch
+  loops while a question is pending, stop entirely if asked.
+
 ## Deliverable
 
 Per-profile × per-scenario FPS table + visual contract screenshots + any fixes

--- a/docs/spikes/graphics-profile-perf-prompt.md
+++ b/docs/spikes/graphics-profile-perf-prompt.md
@@ -1,0 +1,57 @@
+# Follow-up prompt: per-graphics-profile render-perf sweep
+
+> Operator: inject this as a fresh prompt once the cosmetic-perf verification round
+> (PR #259 follow-up) is merged/PR'd. It reuses the live-measurement methodology
+> documented in memory `live-render-perf-harness.md`.
+
+---
+
+Run a per-graphics-profile render-performance sweep of the chaochao client,
+using the live in-page harness methodology from memory `live-render-perf-harness.md`
+(read it first — it has the full architecture and the sample-poisoning pitfalls).
+
+## Goal
+
+Quantify client FPS for EACH perf profile — `high`, `balanced`, `low`, and `auto`
+(report what auto resolves to at common window sizes: <900px wide → balanced gotcha) —
+under identical, worst-realistic load, and confirm each profile's visual contract
+(High = full glow/ambient FX; Balanced = reduced; Low = direct paints, no glow,
+no audience, flat terrain ambient).
+
+## Setup
+
+- Fresh worktree off origin/main (or the cosmetic-perf verify branch if not yet merged).
+- `UNLOCK_ALL_COSMETICS=true PORT=<free> node index.js` + the world.js dev
+  bot-cosmetics patch (in the old cosmetic-perf-collapse worktree, uncommitted —
+  `git -C <old-worktree> diff -- server/entities/world.js | git apply`). NEVER commit it.
+- Chrome MCP tab, VISIBLE, window ≥1280 wide. Do not touch other sessions' dev servers.
+
+## Matrix (per profile × scenario, ~2s gated samples, alive==9, ice map, state recorded)
+
+Scenarios, all 9 karts dressed identically via the client-side override:
+1. `__none__` baseline (no cosmetics)
+2. Worst-cart combo: cart `warlord` + pattern `nebula` + border `border_runes` + trail `comet`
+3. Heavy trails: all 9 wearing `comet` (then `aurora`, `founders_flare`)
+4. Random-mix (dev-patch cosmetics as-served)
+
+For each profile: pin via `setPerfPref('<tier>'); applyPerfProfile()`, gate every
+sample on `perfProfileLabel()` matching the pinned tier, and interleave `__none__`
+controls (environmental dips: brutal rounds — blackout/cloudy — drag the baseline;
+judge RELATIVE to the nearest control; requeue suspect clusters for a clean round).
+
+## Visual contract checks (screenshot each profile)
+
+- High: trail glow present, ice reflections present, audience present.
+- Balanced: reduced FX per PERF_PROFILES knobs (read perf.js for the expected set).
+- Low: trails render via the DIRECT no-glow path (still visible, no shadowBlur),
+  no ice reflections, no audience, terrain ambient flat. None of these should
+  silently disappear entirely (e.g. a trail id that draws NOTHING on Low is a bug).
+- Auto: confirm the resolved tier at 1440px and at <900px window widths.
+
+## Deliverable
+
+Per-profile × per-scenario FPS table + visual contract screenshots + any fixes
+(committed on the worktree branch; never push/PR without operator go-ahead),
+smoke+build green, dev server hosted with localhost AND LAN-IP URLs printed,
+memory updated (`live-render-perf-harness.md` + a new finding memory if anything
+actionable surfaces).

--- a/docs/spikes/mobile-device-perf-prompt.md
+++ b/docs/spikes/mobile-device-perf-prompt.md
@@ -44,9 +44,14 @@ sample-poisoning pitfalls all carry over).
   Some iPads are 120Hz ProMotion; calibrate with `__none__` baselines first and
   report the cap. Flag <45 (≈ the 90-of-120 line scaled), investigate <30.
 - **Foreground/awake**: backgrounding or screen-sleep freezes rAF + socket
-  heartbeats (this killed two desktop sessions — on mobile it's harsher). Have
-  the operator disable auto-lock (or use Guided Access) for the run; detect
-  visibility loss in the harness and auto-requeue poisoned samples as before.
+  heartbeats (this killed two desktop sessions — on mobile it's harsher).
+  KEEP-AWAKE IS THE HARNESS'S JOB, not the operator's: the Screen Wake Lock API
+  is NOT available over plain http:// LAN (secure-context only), so use the
+  NoSleep.js technique — a tiny muted inline looping <video> element started on
+  the first touch (gesture-gated; works on iOS Safari + Android Chrome over
+  http). Ask the operator to disable auto-lock only as a belt-and-braces
+  fallback. Still detect visibility loss / rAF stalls in the harness and
+  auto-requeue poisoned samples as before.
 - **Scenario matrix** (keep it smaller than the desktop 87-id sweep — the goal
   is device headroom, not per-id regression): `__none__` baseline, worst-cart
   combo (warlord+nebula+border_runes+comet), all-9-comet, all-9-guardian,
@@ -55,6 +60,16 @@ sample-poisoning pitfalls all carry over).
 - **Watch for**: GPU texture re-upload stutter that dt-FPS misses (memory
   `device-perf-profiles-feature`) — also report worst-frame ms (max rAF delta
   per window), not just the mean, since stutter hides in averages.
+
+## Run discipline (operator working agreement)
+
+- **Hard time cap: 3 hours wall-clock** for the whole run (setup + sweep +
+  fixes). Track start time; when the cap nears, stop all monitors/waits,
+  finalize with whatever data is collected, and report coverage honestly
+  (measured vs skipped) rather than running on.
+- **Operator messages preempt monitoring**: answer immediately and pause any
+  watch loops while a question is pending; resume only after replying (and
+  stop entirely if asked). Never let a babysitting loop delay a status answer.
 
 ## Deliverable
 

--- a/docs/spikes/mobile-device-perf-prompt.md
+++ b/docs/spikes/mobile-device-perf-prompt.md
@@ -8,9 +8,10 @@
 ---
 
 Build and run an on-device render-performance sweep of the chaochao client for
-real iPad/Android hardware, porting the live harness methodology from memory
-`live-render-perf-harness.md` (read it first — sampler design, gating rules,
-sample-poisoning pitfalls all carry over).
+real iPad/Android hardware, porting the live harness methodology from the
+agent-session memory note `live-render-perf-harness.md` (NOT a repo file — it
+lives in the Claude memory directory and is auto-recalled; read it first —
+sampler design, gating rules, sample-poisoning pitfalls all carry over).
 
 ## Architecture (verified feasible — follow existing repo precedents)
 
@@ -62,8 +63,11 @@ sample-poisoning pitfalls all carry over).
      border_runes; pattern nebula; plus the worst-combo
      (warlord+nebula+border_runes+comet) and the ice-reflection stressor
      (any cart, ice-heavy map — the scratch+blit path PR #259 added).
-     These all passed at desktop-High; the point is confirming the fix holds
-     on mobile GPUs at the tier Auto actually picks for the device.
+     These all passed on desktop (carts/guardian in the verification round —
+     see docs/spikes/cosmetic-perf-verification.md; the shadow-heavy trail
+     outliers, border_runes and nebula during PR #259 development itself);
+     the point is confirming the fixes hold on mobile GPUs at the tier Auto
+     actually picks for the device.
   3. Random unknowns: 3-5 random same-id picks per slot (seeded from the
      full registry, ids not in the hot-spot list) + the random-mix dev-patch
      dressing — catches anything device-specific the desktop round couldn't.

--- a/docs/spikes/mobile-device-perf-prompt.md
+++ b/docs/spikes/mobile-device-perf-prompt.md
@@ -52,11 +52,23 @@ sample-poisoning pitfalls all carry over).
   http). Ask the operator to disable auto-lock only as a belt-and-braces
   fallback. Still detect visibility loss / rAF stalls in the harness and
   auto-requeue poisoned samples as before.
-- **Scenario matrix** (keep it smaller than the desktop 87-id sweep — the goal
-  is device headroom, not per-id regression): `__none__` baseline, worst-cart
-  combo (warlord+nebula+border_runes+comet), all-9-comet, all-9-guardian,
-  random-mix; × each pinned tier; on an ice map. 9 karts via
-  `setLobbyAI {enabled:true, count:8}`.
+- **Scenario matrix — validate the KNOWN hot spots on the device's OPTIMAL
+  (Auto-resolved) tier first**, then pinned tiers, then random unknowns:
+  1. `__none__` baseline (calibrates the device's display cap + headroom).
+  2. The identified hot spots from the desktop rounds — the ids that were
+     pre-fix collapse drivers or shadow/filter-heavy: carts pizza,
+     golden_champion, wheel_of_fortune, firetruck, compass, coin, dartboard,
+     clock; trails comet, founders_flare, bolt, aurora, neon, ripple, guardian;
+     border_runes; pattern nebula; plus the worst-combo
+     (warlord+nebula+border_runes+comet) and the ice-reflection stressor
+     (any cart, ice-heavy map — the scratch+blit path PR #259 added).
+     These all passed at desktop-High; the point is confirming the fix holds
+     on mobile GPUs at the tier Auto actually picks for the device.
+  3. Random unknowns: 3-5 random same-id picks per slot (seeded from the
+     full registry, ids not in the hot-spot list) + the random-mix dev-patch
+     dressing — catches anything device-specific the desktop round couldn't.
+  All on an ice map, 9 karts via `setLobbyAI {enabled:true, count:8}`,
+  interleaved `__none__` controls as always.
 - **Watch for**: GPU texture re-upload stutter that dt-FPS misses (memory
   `device-perf-profiles-feature`) — also report worst-frame ms (max rAF delta
   per window), not just the mean, since stutter hides in averages.

--- a/docs/spikes/mobile-device-perf-prompt.md
+++ b/docs/spikes/mobile-device-perf-prompt.md
@@ -1,0 +1,67 @@
+# Follow-up prompt: on-device (iPad / Android) render-perf sweep
+
+> Operator: inject this as a fresh prompt. Feasibility was verified 2026-06-04:
+> the live harness (memory `live-render-perf-harness.md`) is pure page JS and
+> ports to mobile by self-installing via a URL flag instead of browser-automation
+> injection. No adb / Web Inspector / cables needed — the device just opens a URL.
+
+---
+
+Build and run an on-device render-performance sweep of the chaochao client for
+real iPad/Android hardware, porting the live harness methodology from memory
+`live-render-perf-harness.md` (read it first — sampler design, gating rules,
+sample-poisoning pitfalls all carry over).
+
+## Architecture (verified feasible — follow existing repo precedents)
+
+1. **Self-installing harness**: add a dev-only client script (or block) gated by
+   `?perfharness=1` in the URL — same opt-in pattern as `?debugtouch=1`
+   (client/scripts/input.js:85) and `?fps=1` (perf.js:258). When present, the
+   page installs the rAF sampler + cosmetic override + driver (drive to
+   lobbyStartButton, jiggle/goal-seek during rounds, wander-escape when wedged
+   >1.2s — water pockets WILL wedge a naive straight-line driver) and runs the
+   queue autonomously. Also gate on a server env var (e.g. PERF_HARNESS=1
+   delivered via the config payload) so this can never activate in prod.
+2. **Result reporting**: the page POSTs each completed sample (and a final
+   summary) to a dev-only `POST /__perf/report` endpoint — mirror the existing
+   `app.post('/feedback', express.json(...))` in index.js:293, gated behind the
+   same env var, writing JSONL to a file the agent tails. (Alternative: a
+   dev-gated socket message mirroring the TOUCH_DEBUG server-log pattern.)
+3. **Agent loop**: agent starts `PERF_HARNESS=1 UNLOCK_ALL_COSMETICS=true
+   PORT=<free> node index.js` (+ the world.js bot-cosmetics dev patch from the
+   old cosmetic-perf-collapse worktree — never commit it), prints
+   `http://<LAN-IP>:<port>/play.html?perfharness=1`, asks the operator to open
+   it on the device, then tails the report file and narrates progress. The
+   operator's only job: open the URL and keep the screen awake/foregrounded.
+
+## Mobile-specific methodology (differences from the desktop round)
+
+- **Auto tier**: `namedDeviceTier` maps iPad→balanced, Android-phone→low,
+  Android-tablet→balanced. Record what Auto resolves to on the device, then run
+  the sweep per pinned tier (high/balanced/low) via `setPerfPref`. Gate every
+  sample on `perfProfileLabel()` as before.
+- **Display cap**: most tablets/phones are 60Hz — healthy baseline ≈60, not 120.
+  Some iPads are 120Hz ProMotion; calibrate with `__none__` baselines first and
+  report the cap. Flag <45 (≈ the 90-of-120 line scaled), investigate <30.
+- **Foreground/awake**: backgrounding or screen-sleep freezes rAF + socket
+  heartbeats (this killed two desktop sessions — on mobile it's harsher). Have
+  the operator disable auto-lock (or use Guided Access) for the run; detect
+  visibility loss in the harness and auto-requeue poisoned samples as before.
+- **Scenario matrix** (keep it smaller than the desktop 87-id sweep — the goal
+  is device headroom, not per-id regression): `__none__` baseline, worst-cart
+  combo (warlord+nebula+border_runes+comet), all-9-comet, all-9-guardian,
+  random-mix; × each pinned tier; on an ice map. 9 karts via
+  `setLobbyAI {enabled:true, count:8}`.
+- **Watch for**: GPU texture re-upload stutter that dt-FPS misses (memory
+  `device-perf-profiles-feature`) — also report worst-frame ms (max rAF delta
+  per window), not just the mean, since stutter hides in averages.
+
+## Deliverable
+
+Per-tier × per-scenario FPS (+ worst-frame ms) table from the real device,
+device model + resolved Auto tier noted; any fixes committed on a worktree
+branch (never push/PR without operator go-ahead; strip dev patches);
+smoke+build green; memory updated (`live-render-perf-harness.md` gains the
+on-device variant; new finding memory if anything actionable). The
+`?perfharness=1` + `/__perf/report` plumbing may be committed if cleanly
+env-gated — call it out in the PR description either way.


### PR DESCRIPTION
## Summary

Follow-up to #259 (merged): the per-id cosmetic render-perf **verification round** results, plus two operator-injectable follow-up prompts for the next perf rounds.

- **`docs/spikes/cosmetic-perf-verification.md`** — full per-id live FPS table (9 karts same id, ice maps, pinned High, camera zoom on, gated rAF sampling with interleaved no-cosmetic baselines). Combined with the ids measured during #259 development itself, the **full registry is covered: 45/45 carts, 18/18 borders, 17/17 patterns, 18/18 trails — zero ids <90 FPS in clean rounds, no fixes needed** (guardian, the un-optimized watch item, reads 120). Key finding: every scary low read was a brutal-round overlay dragging the whole frame (baselines dipped identically with cosmetics off).
- **`docs/spikes/graphics-profile-perf-prompt.md`** — ready-to-inject prompt for a per-graphics-profile (High/Balanced/Low/Auto) sweep.
- **`docs/spikes/mobile-device-perf-prompt.md`** — ready-to-inject prompt for on-device iPad/Android sweeps: dev-gated `?perfharness=1` self-installing harness + `POST /__perf/report`, NoSleep keep-awake (Wake Lock unavailable over plain-http LAN), hot-spot validation on the device's Auto-resolved tier + random unknowns, 60Hz baseline + worst-frame-ms.

Both prompts carry the run-discipline rules (hard 3h cap; operator messages preempt monitoring).

Docs-only — no gameplay/code changes (release-notes exempt). Codex-reviewed; all findings addressed in `18b5820`.

## Test plan

- [x] `npm run build` green
- [x] smoke test green (52 maps ticked headlessly)
- [x] Diff verified docs-only vs main (dev bot-cosmetics patch kept out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)