### PR TITLE
feat(lobby): skin hub 🎲 Random button, Equipped preview, co-op panel docking

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Headless progression test (XP / levels / achievement unlocks)
         run: node .github/scripts/progression-test.js
 
-      - name: Headless rewarded-ads test (2x XP claim: credit / anti-abuse / ad layer)
+      - name: "Headless rewarded-ads test (2x XP claim: credit / anti-abuse / ad layer)"
         run: node .github/scripts/ads-rewarded-test.js
 
   perf-tick-budget:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- The Skins station has a new 🎲 Random button — one press dresses your kart in a random colour plus a random set of the carts, patterns, borders and trails you've unlocked. Works with touch, mouse, keyboard and controller.
 
 ## v0.28.2 — 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 ### General
 
 - The Skins station has a new 🎲 Random button — one press dresses your kart in a random colour plus a random set of the carts, patterns, borders and trails you've unlocked. Works with touch, mouse, keyboard and controller.
+- The Skins station now shows an "Equipped" preview beside the picker: a live in-game render of your kart with its trail flowing behind it, plus a row for each slot (colour, cart, pattern, border, trail) naming exactly what you're wearing.
+- Couch co-op: when two or more players open lobby station menus at the same time, the panels now spread out into their own corners of the screen (tagged P1/P2/…) instead of piling up on top of each other.
 
 ## v0.28.2 — 2026-06-02
 

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1218,7 +1218,11 @@ function drawEquippedPreview(lp, px0, py0, pw0, ph0, tint) {
     gameContext.fillStyle = "rgba(255,255,255,0.05)";
     lhRoundRect(gameContext, vx, vy, vw, vpH, 8);
     gameContext.fill();
+    // try/catch/finally so a thrown draw (a future skin painter / sprite path) can't leak
+    // the viewport clip onto the rest of the frame or kill the rAF loop — swallowed like
+    // the recap's montage draws: a broken preview must not take the lobby HUD down.
     gameContext.save();
+    try {
     lhRoundRect(gameContext, vx, vy, vw, vpH, 8);
     gameContext.clip();
     // Synthetic player wearing THIS kart's live cosmetic fields, at preview scale. Render
@@ -1278,7 +1282,8 @@ function drawEquippedPreview(lp, px0, py0, pw0, ph0, tint) {
             gameContext.stroke();
         }
     }
-    gameContext.restore(); // viewport clip
+    } catch (e) { /* keep the lobby HUD alive — see comment above */ }
+    finally { gameContext.restore(); } // viewport clip
     // --- slot rows --------------------------------------------------------------
     var ry = vy + vpH + 10;
     gameContext.textBaseline = "middle";

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -794,6 +794,20 @@ function drawLobbyHubHud() {
     drawSeasonalClaimBanner(); // top slot when active; AI + playlist drop a row below it
     drawLobbyAIStatus();
     drawLobbyPlaylistStatus();
+    // Couch co-op: when SEVERAL seats have a panel open at once, kart-anchored panels
+    // overlap and hide each other. Dock them to fixed non-overlapping screen cells
+    // instead (side-by-side for two, a 2×2 grid for three/four) so every open menu
+    // stays fully visible; a single open panel keeps the stick-to-your-kart anchor.
+    var openPanels = [];
+    for (var os = 0; os < localPlayers.length; os++) {
+        var olp = localPlayers[os];
+        if (olp) { olp._panelDock = null; }
+        if (olp && olp.stationPanel && olp.myID != null &&
+            typeof playerList !== "undefined" && playerList && playerList[olp.myID]) {
+            openPanels.push(olp);
+        }
+    }
+    if (openPanels.length >= 2) { assignPanelDocks(openPanels); }
     for (var slot = 0; slot < localPlayers.length; slot++) {
         var lp = localPlayers[slot];
         if (!lp) {
@@ -809,6 +823,37 @@ function drawLobbyHubHud() {
         } else if (lp.nearStation) {
             drawStationPrompt(lp, sp);
         }
+    }
+}
+
+// The drawn size of a slot's open panel (mirrors drawStationPanel's per-kind sizing) and
+// its full FOOTPRINT width — the skin picker carries the Equipped preview docked beside
+// it, so overlap layout must reserve that width too.
+function stationPanelSize(lp) {
+    var kind = lp.stationPanel.kind;
+    var w = 250, h = 132;
+    if (kind === "playlist") { w = 280; h = 150; }
+    if (kind === "skin") { w = 300; h = skinPanelHeight(); }
+    var fw = (kind === "skin") ? (w + 8 + EQUIP_PREVIEW_W) : w;
+    return { w: w, h: h, fw: fw };
+}
+// Dock 2+ open panels into fixed screen cells, in seat order: one row of two, or a 2×2
+// grid for three/four. Each panel's FOOTPRINT (panel + side preview) is centred in its
+// cell, so the skin picker's preview never crosses into a neighbour's cell.
+function assignPanelDocks(open) {
+    var cols = 2;
+    var rows = (open.length <= 2) ? 1 : 2;
+    var cw = LOGICAL_WIDTH / cols;
+    var chH = LOGICAL_HEIGHT / rows;
+    for (var i = 0; i < open.length; i++) {
+        var sz = stationPanelSize(open[i]);
+        var col = i % cols, row = Math.floor(i / cols);
+        var fx = col * cw + (cw - sz.fw) / 2;
+        var fy = row * chH + (chH - sz.h) / 2;
+        open[i]._panelDock = {
+            x: lhClamp(fx, 8, LOGICAL_WIDTH - sz.fw - 8),
+            y: lhClamp(fy, 8, LOGICAL_HEIGHT - sz.h - 8)
+        };
     }
 }
 
@@ -1028,20 +1073,19 @@ function drawStationPrompt(lp, sp) {
 
 function drawStationPanel(lp, sp) {
     var kind = lp.stationPanel.kind;
-    var w = 250;
-    var h = 132;
-    if (kind === "playlist") {
-        w = 280;
-        h = 150; // room for the playlist name + map count + one-line description
+    // Sizing lives in stationPanelSize (shared with the co-op dock layout).
+    var sz = stationPanelSize(lp);
+    var w = sz.w, h = sz.h;
+    // Anchored over the kart normally; when 2+ panels are open in couch co-op the dock
+    // layout (assignPanelDocks) pins each to its own screen cell so none overlap.
+    var x, y;
+    if (lp._panelDock) {
+        x = lp._panelDock.x;
+        y = lp._panelDock.y;
+    } else {
+        x = lhClamp(sp.x - w / 2, 8, LOGICAL_WIDTH - w - 8);
+        y = lhClamp(sp.y - h - 46, 8, LOGICAL_HEIGHT - h - 8);
     }
-    if (kind === "skin") {
-        w = 300;
-        // FIXED size (tabbed/paged picker) — independent of how many cosmetics exist, so
-        // several of these fit on screen at once in couch co-op. See skinPanelHeight().
-        h = skinPanelHeight();
-    }
-    var x = lhClamp(sp.x - w / 2, 8, LOGICAL_WIDTH - w - 8);
-    var y = lhClamp(sp.y - h - 46, 8, LOGICAL_HEIGHT - h - 8);
     var tint = (lp.myID != null && playerList && playerList[lp.myID]) ? playerList[lp.myID].color : "#fff";
     var hit = { prompt: null, options: [], close: null };
 
@@ -1068,7 +1112,21 @@ function drawStationPanel(lp, sp) {
     gameContext.textAlign = "left";
     gameContext.textBaseline = "middle";
     gameContext.font = "bold 18px sans-serif";
-    gameContext.fillText(stationGlyph(kind) + "  " + stationTitle(kind), x + 14, y + 22);
+    var titleStr = stationGlyph(kind) + "  " + stationTitle(kind);
+    gameContext.fillText(titleStr, x + 14, y + 22);
+    // Docked panels sit away from their kart, so tag whose panel it is: a "P<seat>" chip
+    // in the kart's colour right after the title (the border tint alone is easy to miss).
+    if (lp._panelDock) {
+        var chipX = x + 14 + gameContext.measureText(titleStr).width + 10;
+        gameContext.fillStyle = tint;
+        lhRoundRect(gameContext, chipX, y + 11, 30, 20, 6);
+        gameContext.fill();
+        gameContext.fillStyle = "#000";
+        gameContext.font = "bold 12px sans-serif";
+        gameContext.textAlign = "center";
+        gameContext.fillText("P" + (lp.slot + 1), chipX + 15, y + 21.5);
+        gameContext.textAlign = "left";
+    }
 
     // Close (✕) — top-right.
     var cl = { x: x + w - 30, y: y + 8, w: 24, h: 24 };
@@ -1102,11 +1160,159 @@ function drawStationPanel(lp, sp) {
         drawPlaylistPanelBody(x, y, w, h, hit);
     } else if (kind === "skin") {
         drawSkinPanelBody(lp, x, y, w, h, hit);
+        drawEquippedPreview(lp, x, y, w, h, tint);
     } else {
         drawStubPanelBody(x, y, w, h, "Coming soon");
     }
     gameContext.restore();
     stationHudHit[lp.slot] = hit;
+}
+
+// === Equipped-loadout side preview ===========================================
+// A display-only companion panel docked beside the open skin picker: a LIVE in-game
+// render of this seat's kart (the real drawKartAppearance chokepoint — border ring,
+// cart shape or plain disc + pattern, avatar composite — plus the real paintTrailFx
+// trail flowing behind it), and one row per cosmetic slot naming what's equipped.
+// Reads the same playerList fields the game renders from, so it updates the instant
+// a pick (or a 🎲 Random roll) lands. No hit rects / focus region — purely visual.
+var EQUIP_PREVIEW_W = 158;
+var EQUIP_SLOT_ROWS = [
+    { key: 'color', label: 'Color' },
+    { key: 'cart', label: 'Cart' },
+    { key: 'pattern', label: 'Pattern' },
+    { key: 'border', label: 'Border' },
+    { key: 'trail', label: 'Trail' }
+];
+function drawEquippedPreview(lp, px0, py0, pw0, ph0, tint) {
+    var p = (lp && lp.myID != null && typeof playerList !== "undefined" && playerList) ? playerList[lp.myID] : null;
+    if (!p) { return; }
+    var pad = 12, vpH = 84, rowH = 16;
+    var w = EQUIP_PREVIEW_W;
+    var h = 30 + vpH + 10 + EQUIP_SLOT_ROWS.length * rowH + pad;
+    // Dock to the right of the picker; flip to the left edge when it'd run off screen.
+    var x = px0 + pw0 + 8;
+    if (x + w > LOGICAL_WIDTH - 8) { x = px0 - w - 8; }
+    x = lhClamp(x, 8, LOGICAL_WIDTH - w - 8);
+    var y = lhClamp(py0, 8, LOGICAL_HEIGHT - h - 8);
+    // Same chrome as the station panels (shadowed near-opaque card, kart-tint border).
+    gameContext.save();
+    gameContext.shadowColor = "rgba(0,0,0,0.55)";
+    gameContext.shadowBlur = 18;
+    gameContext.shadowOffsetY = 5;
+    gameContext.fillStyle = "rgba(14,16,22,0.985)";
+    lhRoundRect(gameContext, x, y, w, h, 12);
+    gameContext.fill();
+    gameContext.shadowColor = "transparent";
+    gameContext.shadowBlur = 0;
+    gameContext.shadowOffsetY = 0;
+    gameContext.lineWidth = 2;
+    gameContext.strokeStyle = tint;
+    gameContext.stroke();
+    gameContext.fillStyle = "#fff";
+    gameContext.font = "bold 13px sans-serif";
+    gameContext.textAlign = "left";
+    gameContext.textBaseline = "middle";
+    gameContext.fillText("Equipped", x + pad, y + 17);
+    // --- live kart viewport ---------------------------------------------------
+    var vx = x + 9, vy = y + 30, vw = w - 18;
+    gameContext.fillStyle = "rgba(255,255,255,0.05)";
+    lhRoundRect(gameContext, vx, vy, vw, vpH, 8);
+    gameContext.fill();
+    gameContext.save();
+    lhRoundRect(gameContext, vx, vy, vw, vpH, 8);
+    gameContext.clip();
+    // Synthetic player wearing THIS kart's live cosmetic fields, at preview scale. Render
+    // goes through the game's own chokepoints, so it matches the racing look exactly.
+    var prev = {
+        color: p.color, cart: p.cart, pattern: p.pattern, border: p.border,
+        avatarUrl: p.avatarUrl, radius: 20, onFire: 0, punchAnimAt: null
+    };
+    var kx = vx + vw * 0.7, ky = vy + vpH * 0.52;
+    // Trail FIRST (it flows behind the kart): the real effect on a gentle arc sweeping in
+    // from the left, with live vertex timestamps so animated trails shimmer per-frame.
+    var trailId = p.trailFx || null;
+    var nowMs = Date.now();
+    var fadeMs = (typeof TRAIL_FADE_MS !== "undefined") ? TRAIL_FADE_MS : 1700;
+    var verts = [], STEPS = 24, span = vw * 0.62;
+    for (var ti = 0; ti <= STEPS; ti++) {
+        var u = ti / STEPS; // 0 = oldest (left), 1 = at the kart
+        verts.push({
+            x: kx - (1 - u) * span,
+            y: ky + Math.sin(u * Math.PI * 1.25 + nowMs / 600) * 7,
+            t: nowMs - fadeMs * (1 - u) * 0.85
+        });
+    }
+    var drewTrail = (trailId && typeof paintTrailFx === "function") &&
+        paintTrailFx(gameContext, trailId, verts, p.color, { fadeMs: fadeMs });
+    if (!drewTrail) {
+        // Default "Basic" trail (or unknown id): the plain stroke, like the picker default.
+        gameContext.strokeStyle = p.color; gameContext.lineWidth = 3; gameContext.lineCap = "round";
+        gameContext.globalAlpha = 0.6;
+        gameContext.beginPath();
+        gameContext.moveTo(verts[0].x, verts[0].y);
+        for (var vi = 1; vi < verts.length; vi++) { gameContext.lineTo(verts[vi].x, verts[vi].y); }
+        gameContext.stroke();
+        gameContext.globalAlpha = 1;
+    }
+    // The kart itself — the game's shared body chokepoint (border → cart/disc → pattern),
+    // pinned to heading 0 (facing right, like the overview scoreboard's static display).
+    if (typeof drawKartAppearance === "function") {
+        drawKartAppearance(prev, kx, ky, 0);
+    }
+    // Avatar skin composes over the plain disc in-game (skipped when a cart shape replaces
+    // the body) — mirror that treatment here: photo clipped to the kart circle + thin edge.
+    var hasCartShape = (typeof cartSkinPainter === "function") && cartSkinPainter(prev.cart) != null;
+    if (!hasCartShape && prev.avatarUrl && typeof preloadAvatarImage === "function") {
+        var av = preloadAvatarImage(prev.avatarUrl);
+        if (av && av.ready && !av.failed) {
+            gameContext.save();
+            gameContext.beginPath();
+            gameContext.arc(kx, ky, prev.radius, 0, 2 * Math.PI);
+            gameContext.clip();
+            try { gameContext.drawImage(av.img, kx - prev.radius, ky - prev.radius, prev.radius * 2, prev.radius * 2); } catch (e) { }
+            gameContext.restore();
+            gameContext.beginPath();
+            gameContext.arc(kx, ky, prev.radius, 0, 2 * Math.PI);
+            gameContext.lineWidth = 1.5;
+            gameContext.strokeStyle = "rgba(255,255,255,0.7)";
+            gameContext.stroke();
+        }
+    }
+    gameContext.restore(); // viewport clip
+    // --- slot rows --------------------------------------------------------------
+    var ry = vy + vpH + 10;
+    gameContext.textBaseline = "middle";
+    for (var r = 0; r < EQUIP_SLOT_ROWS.length; r++) {
+        var row = EQUIP_SLOT_ROWS[r];
+        var cy = ry + r * rowH + rowH / 2;
+        gameContext.fillStyle = "#9aa";
+        gameContext.font = "10px sans-serif";
+        gameContext.textAlign = "left";
+        gameContext.fillText(row.label, x + pad, cy);
+        if (row.key === 'color') {
+            // Swatch (the colour tints every cosmetic); flag the avatar photo when worn.
+            gameContext.fillStyle = p.color || "#ccc";
+            lhRoundRect(gameContext, x + pad + 48, cy - 5.5, 24, 11, 3);
+            gameContext.fill();
+            if (prev.avatarUrl) {
+                gameContext.fillStyle = "#f4c542";
+                gameContext.font = "10px sans-serif";
+                gameContext.fillText("+ Avatar", x + pad + 78, cy);
+            }
+            continue;
+        }
+        var id = currentCosmetic(lp, row.key);
+        var name = id
+            ? ((typeof skinDisplayName === "function") ? skinDisplayName(id) : id)
+            : ((typeof COSMETIC_SLOT_DEFAULT_NAME !== "undefined" && COSMETIC_SLOT_DEFAULT_NAME[row.key]) || "Default");
+        // A pattern stays equipped under a shaped cart but doesn't render — say so.
+        var hidden = (row.key === 'pattern' && id && hasCartShape);
+        gameContext.fillStyle = hidden ? "rgba(255,255,255,0.4)" : (id ? "#ffd34d" : "rgba(255,255,255,0.75)");
+        gameContext.font = (id ? "bold " : "") + "10px sans-serif";
+        gameContext.textAlign = "right";
+        gameContext.fillText(name + (hidden ? " (hidden)" : ""), x + w - pad, cy);
+    }
+    gameContext.restore();
 }
 
 // AI panel body: a ◄ value ► stepper plus the "applies next race" caption.

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -171,11 +171,12 @@ function stationPanelNav(lp, dx, dy) {
     }
 }
 
-// Keyboard/gamepad nav over the tabbed/paged skin picker. Three focus regions:
-//   'tabs' — the category row (◄► switch category, ▼ drops into the grid)
-//   'grid' — the current page's cells (▲ from the top row → tabs, ▼ from the last row →
-//            page arrows; ◄►/▲▼ move the cursor, crossing pages automatically)
-//   'page' — the ◄ ► page arrows (◄► flip pages, ▲ back to the grid)
+// Keyboard/gamepad nav over the tabbed/paged skin picker. Four focus regions:
+//   'tabs'   — the category row (◄► switch category, ▼ drops into the grid)
+//   'grid'   — the current page's cells (▲ from the top row → tabs, ▼ from the last row →
+//              the 🎲 Random button; ◄►/▲▼ move the cursor, crossing pages automatically)
+//   'random' — the full-width 🎲 Random button under the grid (▲ grid, ▼ page arrows)
+//   'page'   — the ◄ ► page arrows (◄► flip pages, ▲ back to the Random button)
 function skinPanelNav(lp, dx, dy) {
     var sp = lp.stationPanel;
     if (!sp) { return; }
@@ -203,7 +204,12 @@ function skinPanelNav(lp, dx, dy) {
             if (pg > pageCount - 1) { pg = pageCount - 1; }
             sp.cursor = Math.min(items.length - 1, pg * perPage);
         }
+        if (dy < 0) { sp.region = 'random'; }
+        return;
+    }
+    if (sp.region === 'random') {
         if (dy < 0) { sp.region = 'grid'; }
+        else if (dy > 0 && pageCount > 1) { sp.region = 'page'; }
         return;
     }
     // grid
@@ -214,7 +220,7 @@ function skinPanelNav(lp, dx, dy) {
     var lastRowInPage = Math.floor((Math.min(perPage, items.length - pageStart) - 1) / cols);
     if (dy < 0 && rowInPage === 0) { sp.region = 'tabs'; return; }
     if (dy > 0 && rowInPage === lastRowInPage) {
-        if (pageCount > 1) { sp.region = 'page'; }
+        sp.region = 'random';
         return;
     }
     var nc = cur;
@@ -225,12 +231,14 @@ function skinPanelNav(lp, dx, dy) {
     sp.cursor = nc;
 }
 
-// Commit the focused element: a tab switch, a page step, or the cell under the cursor.
+// Commit the focused element: a tab switch, the 🎲 Random re-roll, a page step, or the
+// cell under the cursor.
 function skinPanelConfirm(lp) {
     var sp = lp.stationPanel;
     if (!sp) { return; }
     skinValidateTab(lp);
     if (sp.region === 'tabs') { sp.region = 'grid'; sp.cursor = 0; return; }
+    if (sp.region === 'random') { stationRandomizeCosmetics(lp); return; }
     if (sp.region === 'page') { return; }
     var items = skinTabItems(lp, sp.tab);
     activateSkinItem(lp, items[sp.cursor || 0]);
@@ -276,6 +284,11 @@ function stationPanelAction(lp, action) {
         closeStationPanel(lp);
     } else if (action === "pickAvatar") {
         stationPickAvatar(lp);
+    } else if (action === "randomize") {
+        // Pointer tap on the 🎲 Random button — also move pad/keyboard focus onto it so a
+        // follow-up confirm re-rolls again without re-navigating.
+        if (lp.stationPanel) { lp.stationPanel.region = 'random'; }
+        stationRandomizeCosmetics(lp);
     } else if (action != null && action.indexOf("tab:") === 0) {
         // Switch the picker's active category (pointer tap on a tab).
         if (lp.stationPanel) { lp.stationPanel.tab = action.slice(4); lp.stationPanel.cursor = 0; lp.stationPanel.region = 'grid'; }
@@ -1240,9 +1253,10 @@ function cosmeticPickerCompare(lp, a, b) {
     if (la !== lb) { return la - lb; }                                     // unlocked before locked
     return cosmeticUnlockRank(a) - cosmeticUnlockRank(b);                  // then level asc, achievements last
 }
-// Full fixed panel height: title gap + tab row + grid + badge + page row.
+// Full fixed panel height: title gap + tab row + grid + 🎲 Random row + badge + page row.
+var SKIN_RANDOM_BTN_H = 24; // 🎲 Random button row height (full panel width — easy touch target)
 function skinPanelHeight() {
-    return 38 + 26 + 10 + SKIN_PICKER_ROWS * (SKIN_PICKER_CELLH + 6) + 20 + 24;
+    return 38 + 26 + 10 + SKIN_PICKER_ROWS * (SKIN_PICKER_CELLH + 6) + SKIN_RANDOM_BTN_H + 8 + 20 + 24;
 }
 
 function drawSkinPanelBody(lp, x, y, w, h, hit) {
@@ -1299,8 +1313,24 @@ function drawSkinPanelBody(lp, x, y, w, h, hit) {
         var cy = gridTop + Math.floor(k / cols) * (cellH + gap);
         drawSkinCell(lp, items[idx], cx, cy, cellW, cellH, (sp.region === 'grid' && idx === sp.cursor), currentColor, hit);
     }
+    // 🎲 Random — a full-width row between the grid and the badge. Tap it (touch/mouse),
+    // or ▼ off the grid's last row and confirm (pad/keyboard); each press re-rolls the
+    // whole look from this seat's unlocked cosmetics.
+    var rndY = gridTop + SKIN_PICKER_ROWS * (cellH + gap) + 2;
+    var rnd = { x: x + pad, y: rndY, w: w - pad * 2, h: SKIN_RANDOM_BTN_H };
+    var rndFocus = (sp.region === 'random');
+    gameContext.fillStyle = rndFocus ? "rgba(255,211,77,0.30)" : "rgba(255,211,77,0.12)";
+    lhRoundRect(gameContext, rnd.x, rnd.y, rnd.w, rnd.h, 7); gameContext.fill();
+    gameContext.lineWidth = rndFocus ? 2.5 : 1.5;
+    gameContext.strokeStyle = rndFocus ? "#fff" : HUB_ACCENT;
+    lhRoundRect(gameContext, rnd.x, rnd.y, rnd.w, rnd.h, 7); gameContext.stroke();
+    gameContext.fillStyle = "#ffd34d";
+    gameContext.font = "bold 12px sans-serif";
+    gameContext.textAlign = "center"; gameContext.textBaseline = "middle";
+    gameContext.fillText("🎲 Random", rnd.x + rnd.w / 2, rnd.y + rnd.h / 2 + 1);
+    hit.options.push({ rect: rnd, action: "randomize" });
     // Lv/XP badge (or sign-in nudge)
-    var badgeY = gridTop + SKIN_PICKER_ROWS * (cellH + gap) + 2;
+    var badgeY = rndY + SKIN_RANDOM_BTN_H + 6;
     drawProgressionBadge(lp, x + pad, badgeY, w - pad * 2);
     // page controls
     var pgY = y + h - 22;
@@ -1556,6 +1586,43 @@ function stationPickCosmetic(lp, opt) {
     if (p && field) {
         p[field] = id; // optimistic local update
     }
+}
+// 🎲 Random: equip a random loadout from what THIS seat has unlocked — a fresh colour
+// (never one another kart wears, never the current one, so a press always visibly changes
+// something) plus a random pick per cosmetic slot (the slot default counts as one candidate,
+// so plain looks stay in the pool). Patterns only render on the plain cart, so a shaped-cart
+// roll forces the pattern slot to None instead of burning the roll on an invisible pattern.
+// Every pick rides the existing commit paths (stationPickSkin / stationPickCosmetic), so
+// persistence, optimistic updates and server-side validation are identical to picking by hand.
+function stationRandomizeCosmetics(lp) {
+    if (!lp || !lp.socket) { return; }
+    noteHubActivity(lp);
+    var pal = skinPalette();
+    var taken = skinTakenColors(lp);
+    var cur = skinCurrentColor(lp);
+    var colors = [];
+    for (var i = 0; i < pal.length; i++) {
+        if (!taken[pal[i]] && pal[i] !== cur) { colors.push(pal[i]); }
+    }
+    if (colors.length) {
+        stationPickSkin(lp, colors[Math.floor(Math.random() * colors.length)]);
+    }
+    var cartId = randomUnlockedCosmetic(lp, 'cart');
+    stationPickCosmetic(lp, { slot: 'cart', id: cartId });
+    stationPickCosmetic(lp, { slot: 'pattern', id: (cartId != null) ? null : randomUnlockedCosmetic(lp, 'pattern') });
+    stationPickCosmetic(lp, { slot: 'border', id: randomUnlockedCosmetic(lp, 'border') });
+    stationPickCosmetic(lp, { slot: 'trail', id: randomUnlockedCosmetic(lp, 'trail') });
+}
+// One random candidate for a cosmetic slot: the slot default (null) + every id this seat
+// has UNLOCKED (couch seats gate at guest level — cartSkinUnlock handles that per-seat).
+function randomUnlockedCosmetic(lp, slot) {
+    var ids = [null];
+    for (var i = 0; i < COSMETIC_OPTIONS.length; i++) {
+        var opt = COSMETIC_OPTIONS[i];
+        if (opt.slot !== slot || opt.id == null) { continue; }
+        if (!cartSkinUnlock(opt.id, lp).locked) { ids.push(opt.id); }
+    }
+    return ids[Math.floor(Math.random() * ids.length)];
 }
 // Cosmetic-picker layout: positions each option in one of three labeled groups —
 // "Carts" / "Patterns" / "Trails" — each starting on a fresh row under a small header.

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1793,41 +1793,62 @@ function stationPickCosmetic(lp, opt) {
         p[field] = id; // optimistic local update
     }
 }
-// 🎲 Random: equip a random loadout from what THIS seat has unlocked — a fresh colour
-// (never one another kart wears, never the current one, so a press always visibly changes
-// something) plus a random pick per cosmetic slot (the slot default counts as one candidate,
-// so plain looks stay in the pool). Patterns only render on the plain cart, so a shaped-cart
-// roll forces the pattern slot to None instead of burning the roll on an invisible pattern.
-// Every pick rides the existing commit paths (stationPickSkin / stationPickCosmetic), so
-// persistence, optimistic updates and server-side validation are identical to picking by hand.
+// 🎲 Random: equip a random loadout from what THIS seat has unlocked. Every slot that has
+// an alternative re-rolls to something DIFFERENT (the current value is excluded from its
+// pool, with the slot default as one candidate); slots with nothing new to offer are left
+// untouched — no redundant emits. Two deliberate skips: the colour roll is skipped while
+// the avatar skin is worn (the server clears the avatar on ANY setSkin, and a random roll
+// must not silently destroy that explicit identity choice), and the pattern slot is skipped
+// while a shaped cart is equipped/rolled (patterns only render on the plain cart; manual
+// cart equips preserve the stored pattern hidden underneath, so a roll must too). If NOTHING
+// could change (a fresh guest with no unlocks in a colour-saturated lobby), flash the panel
+// toast instead of silently doing nothing. Picks ride the existing commit paths
+// (stationPickSkin / stationPickCosmetic): persistence + server validation match manual picks.
 function stationRandomizeCosmetics(lp) {
     if (!lp || !lp.socket) { return; }
     noteHubActivity(lp);
-    var pal = skinPalette();
-    var taken = skinTakenColors(lp);
-    var cur = skinCurrentColor(lp);
-    var colors = [];
-    for (var i = 0; i < pal.length; i++) {
-        if (!taken[pal[i]] && pal[i] !== cur) { colors.push(pal[i]); }
+    var changed = false;
+    if (!playerHasAvatarSkin(lp)) {
+        var pal = skinPalette();
+        var taken = skinTakenColors(lp);
+        var cur = skinCurrentColor(lp);
+        var colors = [];
+        for (var i = 0; i < pal.length; i++) {
+            if (!taken[pal[i]] && pal[i] !== cur) { colors.push(pal[i]); }
+        }
+        if (colors.length) {
+            stationPickSkin(lp, colors[Math.floor(Math.random() * colors.length)]);
+            changed = true;
+        }
     }
-    if (colors.length) {
-        stationPickSkin(lp, colors[Math.floor(Math.random() * colors.length)]);
+    // Cart first: the pattern skip below reads the (optimistically updated) cart slot.
+    var slots = ['cart', 'pattern', 'border', 'trail'];
+    for (var s = 0; s < slots.length; s++) {
+        var slot = slots[s];
+        if (slot === 'pattern' && currentCosmetic(lp, 'cart')) { continue; } // hidden under a shaped cart — preserve it
+        var id = randomUnlockedCosmetic(lp, slot);
+        if (id === undefined) { continue; } // nothing new this seat could equip here
+        stationPickCosmetic(lp, { slot: slot, id: id });
+        changed = true;
     }
-    var cartId = randomUnlockedCosmetic(lp, 'cart');
-    stationPickCosmetic(lp, { slot: 'cart', id: cartId });
-    stationPickCosmetic(lp, { slot: 'pattern', id: (cartId != null) ? null : randomUnlockedCosmetic(lp, 'pattern') });
-    stationPickCosmetic(lp, { slot: 'border', id: randomUnlockedCosmetic(lp, 'border') });
-    stationPickCosmetic(lp, { slot: 'trail', id: randomUnlockedCosmetic(lp, 'trail') });
+    if (!changed) {
+        lp._cartLockMsg = "Nothing new to roll — unlock more skins!";
+        lp._cartLockAt = Date.now();
+    }
 }
-// One random candidate for a cosmetic slot: the slot default (null) + every id this seat
-// has UNLOCKED (couch seats gate at guest level — cartSkinUnlock handles that per-seat).
+// One random NEW candidate for a cosmetic slot: the slot default (null) + every id this
+// seat has UNLOCKED (couch seats gate at guest level via cartSkinUnlock), minus whatever
+// is currently equipped — so a roll never re-deals the same hand. Returns undefined when
+// the slot has no alternative (e.g. a guest with no unlocks), so the caller skips the emit.
 function randomUnlockedCosmetic(lp, slot) {
-    var ids = [null];
+    var cur = currentCosmetic(lp, slot);
+    var ids = (cur !== null) ? [null] : [];
     for (var i = 0; i < COSMETIC_OPTIONS.length; i++) {
         var opt = COSMETIC_OPTIONS[i];
-        if (opt.slot !== slot || opt.id == null) { continue; }
+        if (opt.slot !== slot || opt.id == null || opt.id === cur) { continue; }
         if (!cartSkinUnlock(opt.id, lp).locked) { ids.push(opt.id); }
     }
+    if (!ids.length) { return undefined; }
     return ids[Math.floor(Math.random() * ids.length)];
 }
 // Cosmetic-picker layout: positions each option in one of three labeled groups —


### PR DESCRIPTION
## What

Three additions to the lobby **Skins station**, all in `client/scripts/lobbyHub.js`:

### 🎲 Random button
A full-width row in the skin picker (between the grid and the XP badge). One press equips a random loadout from what **that seat** has unlocked: a fresh colour (never taken, never current) plus a random pick per cosmetic slot. Works with **touch/mouse** (tap), **controller** (D-pad ▼ off the grid's last row → confirm; new `random` focus region in the existing tabs→grid→page nav model), and **keyboard** (arrows/WASD + Enter/E/Space).

- Every slot with an alternative always changes (current value excluded from its pool); slots with nothing new are skipped — no redundant emits.
- Colour roll is **skipped while the avatar skin is worn** (the server clears the avatar on any `setSkin` — a roll must not silently destroy that choice).
- Pattern slot is **skipped while a shaped cart is equipped/rolled** (matches manual behaviour: the stored pattern survives hidden underneath).
- If nothing could change (fresh guest, colour-saturated lobby) the panel flashes *"Nothing new to roll — unlock more skins!"* instead of doing nothing.
- All picks ride the existing `stationPickSkin`/`stationPickCosmetic` paths → persistence, optimistic updates and server-side validation identical to manual picks; couch seats gate at guest level.

### Equipped side preview
A display-only companion panel docked beside the open picker: a **live in-game render** of the kart through the game's own chokepoints (`drawKartAppearance` for border→cart/pattern, the in-game avatar circle composite, real `paintTrailFx` trail on an animated path), plus one row per slot (colour swatch, cart, pattern, border, trail) naming what's equipped. Patterns parked under a shaped cart show "(hidden)". Updates the instant any pick or 🎲 roll lands. The render is guarded with catch+restore (recap-montage style) so a future skin painter throw can't leak the clip or kill the rAF loop.

### Couch co-op panel docking
When 2+ seats have station panels open at once, `assignPanelDocks` pins each to its own screen cell (side-by-side for two, 2×2 grid for three/four; the skin picker's footprint reserves its preview's width) so no menu overlaps another and all stay fully on screen. Docked panels get a **P\<seat\> chip** in the kart's colour. A single open panel keeps the existing stick-to-kart anchor.

## Review

- **Codex review:** clean ("no clear functional regressions").
- **Deep review (7 finder angles + adversarial verification, 10 findings):** top 4 fixed in this branch — avatar-skin wipe on roll (CONFIRMED), permanent pattern clear on shaped-cart roll (CONFIRMED), silent no-op for guests (CONFIRMED), unguarded preview draw vs the rAF loop (PLAUSIBLE/latent). Remaining 6 are cleanup/altitude deferrals (chrome dedup, trail-preview builder sharing, avatar-composite helper extraction, dock-footprint consolidation, lobby-only perf micro-costs) — all zero-behavior-change refactors deliberately left out of a feature PR.

## Verification

- `npm run build` + full headless smoke test (52 maps) green, re-run after rebasing onto `origin/main`.
- Headless randomizer harness (real `skinRegistry` + `lobbyHub` in a VM): 400+ rolls × multiple progression levels — only unlocked ids emitted, colours never collide with taken/current, pattern preserved across 120 shaped-cart rolls, avatar wearers never emit `setSkin`, guests emit colour-only, saturated-guest case shows the toast.
- Headless HUD harness: 2-seat and 4-seat co-op dock layouts non-overlapping and fully on-screen; single panel stays kart-anchored.
- Playtested locally (incl. an `UNLOCK_ALL_COSMETICS=true` instance to roll across the full catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
