### PR TITLE
Controlled prod deploys (nightly prod branch + emergency label) with graceful in-game shutdown warnings

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -122,17 +122,29 @@ jobs:
           echo "Drain announced (3 min heads-up; new races now paused)."
           sleep 180
           # Wait up to a further 10 min for in-flight races to finish.
+          races=unknown
           for i in $(seq 1 30); do
             races=$(curl -fsS -H "x-ops-secret: $OPS_SECRET" "$PROD_URL/ops/status" \
                     | jq -r '.activeRaces' 2>/dev/null || echo unknown)
             if [ "$races" = "0" ]; then
               echo "No active races — proceeding."
-              exit 0
+              break
             fi
             echo "Still $races active race(s) (poll $i/30) — waiting 20s."
             sleep 20
           done
-          echo "::warning::races still active after the 10 min bound — deploying anyway (SIGTERM countdown covers them)."
+          if [ "$races" != "0" ]; then
+            echo "::warning::races still active after the 10 min bound — deploying anyway (SIGTERM countdown covers them)."
+          fi
+          # Re-anchor the drain to push time: the server's 15-min auto-expiry
+          # started at the announcement above, and this step may have waited up
+          # to 13 min — a slow Heroku build after the push could otherwise
+          # outlive the grace and let races resume on the old dyno right
+          # before SIGTERM cuts them.
+          if ! curl -fsS -X POST -H "x-ops-secret: $OPS_SECRET" \
+               "$PROD_URL/ops/drain?seconds=0" > /dev/null; then
+            echo "::warning::re-drain failed — grace stays anchored to the original announcement."
+          fi
 
       - name: Fast-forward prod
         if: steps.resolve.outputs.changed == 'true'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,77 @@
+name: Deploy to prod (Heroku)
+
+# Prod deploy control. Heroku auto-deploys the `prod` branch (dashboard:
+# Deploy tab → GitHub → automatic deploys from `prod`, NOT main), so merging
+# a PR into main no longer restarts the live server. This workflow is the
+# only thing that advances `prod`:
+#
+#   nightly    — 09:00 UTC (~5am ET, lowest-traffic window for the mostly-US
+#                audience) fast-forwards prod to main. Pushing an unchanged
+#                SHA is a git no-op, so a quiet night produces no Heroku
+#                build and no dyno restart.
+#   emergency  — merge a PR carrying the `deploy:prod` label and prod is
+#                fast-forwarded to main immediately. (The release workflow's
+#                "Release vX.Y.Z" version-bump commit may land on main just
+#                after; prod picks it up at the next nightly — harmless.)
+#   manual     — Run workflow from the Actions tab, optionally with a
+#                specific ref, to ship main (or any commit on it) right now.
+#
+# prod only ever moves forward: a non-fast-forward push fails loudly rather
+# than silently rewriting deploy history. To roll back prod, use
+# `heroku rollback -a chaochaogame` (instant, no rebuild) or force-push prod
+# by hand if you really want Heroku to rebuild an older commit.
+#
+# NOTE: keep Heroku's "Wait for CI to pass before deploy" OFF — no CI runs on
+# pushes to prod (main is already validated by PR checks), so a CI wait would
+# hang every deploy.
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch/SHA to deploy (must be an ancestor-compatible advance of prod)
+        default: main
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+# Serialize deploys so a label-merge and the nightly can't race on prod.
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    # Nightly and manual runs always proceed; PR-close runs only when the PR
+    # actually merged AND was labeled deploy:prod.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'deploy:prod'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0          # need full history to fast-forward prod
+
+      - name: Fast-forward prod
+        env:
+          REF: ${{ github.event.inputs.ref || 'main' }}
+        run: |
+          target=$(git rev-parse --verify "origin/$REF" 2>/dev/null \
+                || git rev-parse --verify "$REF")
+          current=$(git rev-parse --verify origin/prod 2>/dev/null || echo none)
+          echo "prod: $current -> $target"
+          if [ "$target" = "$current" ]; then
+            echo "prod is already at $target — nothing to deploy."
+            exit 0
+          fi
+          # Plain (non-force) push: fails if $target would rewind prod.
+          git push origin "$target:refs/heads/prod"
+          echo "Pushed — Heroku auto-deploy of prod will pick this up."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,13 +8,26 @@ name: Deploy to prod (Heroku)
 #   nightly    — 09:00 UTC (~5am ET, lowest-traffic window for the mostly-US
 #                audience) fast-forwards prod to main. Pushing an unchanged
 #                SHA is a git no-op, so a quiet night produces no Heroku
-#                build and no dyno restart.
+#                build and no dyno restart. Before pushing, the drain step
+#                tells the live server maintenance is coming: players see a
+#                "new races are paused" banner, rooms stop starting races,
+#                and the workflow waits (bounded) for in-flight races to end.
 #   emergency  — merge a PR carrying the `deploy:prod` label and prod is
-#                fast-forwarded to main immediately. (The release workflow's
-#                "Release vX.Y.Z" version-bump commit may land on main just
-#                after; prod picks it up at the next nightly — harmless.)
+#                fast-forwarded to main immediately, skipping the drain wait.
+#                (The release workflow's "Release vX.Y.Z" version-bump commit
+#                may land on main just after; prod picks it up at the next
+#                nightly — harmless.)
 #   manual     — Run workflow from the Actions tab, optionally with a
-#                specific ref, to ship main (or any commit on it) right now.
+#                specific ref and/or the nightly-style drain, to ship right now.
+#
+# Players ALWAYS get a final warning regardless of path: Heroku sends SIGTERM
+# 30s before SIGKILL on every restart, and index.js turns that into an
+# in-game "server restarting in 28s" countdown + race-start block.
+#
+# The drain endpoints are authenticated with the OPS_SECRET repo secret,
+# which must match the OPS_SECRET config var on the Heroku app. If either is
+# missing the drain is skipped (with a warning) and the deploy proceeds —
+# the SIGTERM countdown still covers the players.
 #
 # prod only ever moves forward: a non-fast-forward push fails loudly rather
 # than silently rewriting deploy history. To roll back prod, use
@@ -33,6 +46,10 @@ on:
       ref:
         description: Branch/SHA to deploy (must be an ancestor-compatible advance of prod)
         default: main
+      drain:
+        description: Announce + wait for in-flight races to finish before pushing (nightly-style)
+        type: boolean
+        default: false
   pull_request:
     types: [closed]
     branches: [main]
@@ -44,6 +61,9 @@ concurrency:
 
 permissions:
   contents: write
+
+env:
+  PROD_URL: https://www.chaochaogame.com
 
 jobs:
   deploy:
@@ -60,7 +80,8 @@ jobs:
         with:
           fetch-depth: 0          # need full history to fast-forward prod
 
-      - name: Fast-forward prod
+      - name: Resolve target
+        id: resolve
         env:
           REF: ${{ github.event.inputs.ref || 'main' }}
         run: |
@@ -70,8 +91,54 @@ jobs:
           echo "prod: $current -> $target"
           if [ "$target" = "$current" ]; then
             echo "prod is already at $target — nothing to deploy."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+
+      # Nightly (and drain-opted manual) runs give the live server a heads-up
+      # before the push: announce maintenance, stop new races, then wait for
+      # active races to finish — bounded, so a marathon room can never block a
+      # deploy forever. Emergencies (deploy:prod label, plain dispatch) skip
+      # straight to the push and rely on the 30s SIGTERM countdown.
+      - name: Drain prod (announce + wait for races)
+        if: >
+          steps.resolve.outputs.changed == 'true' &&
+          (github.event_name == 'schedule' ||
+           (github.event_name == 'workflow_dispatch' && inputs.drain))
+        env:
+          OPS_SECRET: ${{ secrets.OPS_SECRET }}
+        run: |
+          if [ -z "$OPS_SECRET" ]; then
+            echo "::warning::OPS_SECRET secret not set — skipping drain. Players still get the 30s SIGTERM countdown."
             exit 0
           fi
-          # Plain (non-force) push: fails if $target would rewind prod.
-          git push origin "$target:refs/heads/prod"
+          if ! curl -fsS -X POST -H "x-ops-secret: $OPS_SECRET" \
+               "$PROD_URL/ops/drain?seconds=180" > /dev/null; then
+            echo "::warning::drain call failed — deploying without the advance notice."
+            exit 0
+          fi
+          echo "Drain announced (3 min heads-up; new races now paused)."
+          sleep 180
+          # Wait up to a further 10 min for in-flight races to finish.
+          for i in $(seq 1 30); do
+            races=$(curl -fsS -H "x-ops-secret: $OPS_SECRET" "$PROD_URL/ops/status" \
+                    | jq -r '.activeRaces' 2>/dev/null || echo unknown)
+            if [ "$races" = "0" ]; then
+              echo "No active races — proceeding."
+              exit 0
+            fi
+            echo "Still $races active race(s) (poll $i/30) — waiting 20s."
+            sleep 20
+          done
+          echo "::warning::races still active after the 10 min bound — deploying anyway (SIGTERM countdown covers them)."
+
+      - name: Fast-forward prod
+        if: steps.resolve.outputs.changed == 'true'
+        env:
+          TARGET: ${{ steps.resolve.outputs.target }}
+        run: |
+          # Plain (non-force) push: fails if $TARGET would rewind prod.
+          git push origin "$TARGET:refs/heads/prod"
           echo "Pushed — Heroku auto-deploy of prod will pick this up."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- The game now warns you before the server goes down for an update: a banner counts down the final 30 seconds, new races stop starting while a restart is pending (races already underway get to finish), and you're brought back in automatically once the server is back.
 
 ## v0.28.3 — 2026-06-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run start:prod` — start with `NODE_ENV=production`, which makes `index.js` rewrite the `<!-- BUILD: bundle-start -->…<!-- BUILD: bundle-end -->` block in each served HTML page to point at the corresponding bundle in `client/scripts/dist/`. The bundles must already exist; run `npm run build` first.
 - `npm run heroku-postbuild` — invoked automatically by Heroku to build bundles during deploy.
 
+Prod (Heroku app `chaochaogame`) auto-deploys the **`prod` branch, not `main`** — merging a PR does not restart the live server. `.github/workflows/deploy-prod.yml` fast-forwards prod→main nightly at 09:00 UTC, immediately when a merged PR carries the `deploy:prod` label (emergencies), or via manual workflow dispatch.
+
 There is no unit-test framework, linter, or formatter configured. `client/scripts/dist/` is ignored by `.gitignore` (the `dist` rule), so bundles are produced at deploy time, not committed.
 
 ### Testing gameplay (headless)

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -642,14 +642,40 @@ function registerConnectionHandlers(server) {
 		serverMaintenance = data;
 	});
 
-	// When an announced restart actually cuts the socket, bring the player back
-	// automatically: the new dyno boots in parallel with the old one's 28s
-	// countdown, so a short pause + reload lands them on the fresh server. Any
-	// other disconnect keeps today's behavior (socket.io auto-reconnect).
+	// When a maintenance restart cuts the socket, bring the player back
+	// automatically. Any active maintenance state counts — not just 'restart':
+	// during a nightly the final SIGTERM broadcast can be lost in the dyno
+	// cutover, leaving the client holding 'drain' when the socket drops, and a
+	// bare auto-reconnect would strand them roomless (nothing re-sends
+	// enterGame on the primary socket). Rather than guessing how long the new
+	// dyno takes to boot, poll until the server actually answers, then reload.
 	server.on("disconnect", function () {
-		if (serverMaintenance == null || serverMaintenance.reason !== "restart") { return; }
-		debugLog("socket dropped during maintenance restart -- reloading shortly");
-		setTimeout(function () { window.location.reload(); }, 6000);
+		if (serverMaintenance == null) { return; }
+		// Stale state guard: a hidden tab's draw loop never runs, so the
+		// banner's own expiry can't clear serverMaintenance — don't treat a
+		// long-expired drain as a live restart hours later.
+		if (serverMaintenance.expiresAt != null && Date.now() > serverMaintenance.expiresAt) {
+			serverMaintenance = null;
+			return;
+		}
+		debugLog("socket dropped during maintenance -- waiting for server, then reloading");
+		var attempts = 0;
+		var waitForServer = setInterval(function () {
+			attempts++;
+			if (attempts > 30) { // ~60s: stop probing and just try the reload
+				clearInterval(waitForServer);
+				window.location.reload();
+				return;
+			}
+			fetch(window.location.pathname, { method: "HEAD", cache: "no-store" })
+				.then(function (res) {
+					if (res.ok) {
+						clearInterval(waitForServer);
+						window.location.reload();
+					}
+				})
+				.catch(function () { /* server not up yet — keep polling */ });
+		}, 2000);
 	});
 
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -633,6 +633,25 @@ function registerConnectionHandlers(server) {
 		dropLocalPlayer(primarySlot);
 	});
 
+	// Deploy heads-up: the server is restarting soon ('restart' carries a
+	// wall-clock deadline ~28s out) or draining ahead of a nightly deploy
+	// ('drain': new races are paused, restart follows in a few minutes).
+	// draw.js renders the banner from this global; it self-expires there.
+	server.on("serverMaintenance", function (data) {
+		debugLog("serverMaintenance received", data);
+		serverMaintenance = data;
+	});
+
+	// When an announced restart actually cuts the socket, bring the player back
+	// automatically: the new dyno boots in parallel with the old one's 28s
+	// countdown, so a short pause + reload lands them on the fresh server. Any
+	// other disconnect keeps today's behavior (socket.io auto-reconnect).
+	server.on("disconnect", function () {
+		if (serverMaintenance == null || serverMaintenance.reason !== "restart") { return; }
+		debugLog("socket dropped during maintenance restart -- reloading shortly");
+		setTimeout(function () { window.location.reload(); }, 6000);
+	});
+
 
 	server.on("gameState", function (gameState) {
 		debugLog("gameState received, gameID=", gameState.gameID, "myID=", gameState.myID, "players=", Object.keys(gameState.clientList || {}).length);

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -7624,9 +7624,58 @@ function drawHUD() {
     drawBrutalBadges();
     drawSpectatorLeaderboard();
     drawWorldRecordBanner();
+    drawMaintenanceBanner();
     drawVirtualButtons();
     drawTouchControls();
     drawTitle();
+}
+
+// Deploy heads-up banner (top-center, every state — drawHUD runs in both the
+// main loop and the overview pass). A 'restart' shows a live countdown to the
+// server-sent deadline ("back in a moment" — client.js auto-reloads after the
+// drop); a 'drain' shows a static "new races paused" notice until the restart
+// that always follows it takes over. Self-expires past expiresAt so a
+// canceled deploy clears the banner without a server round-trip.
+function drawMaintenanceBanner() {
+    if (serverMaintenance == null) { return; }
+    var now = Date.now();
+    if (serverMaintenance.expiresAt != null && now > serverMaintenance.expiresAt) {
+        serverMaintenance = null;
+        return;
+    }
+    var line1, line2;
+    if (serverMaintenance.reason === "restart") {
+        var secsLeft = Math.max(0, Math.ceil((serverMaintenance.deadline - now) / 1000));
+        line1 = secsLeft > 0 ? ("Server restarting in " + secsLeft + "s") : "Server restarting…";
+        line2 = "Game update — you'll be back in the action in a moment";
+    } else {
+        line1 = "Server update coming up";
+        line2 = "New races are paused — a quick restart follows shortly";
+    }
+    var cx = LOGICAL_WIDTH / 2;
+    var by = 28;
+    // Urgency pulse on the headline once a restart countdown is live, same
+    // accelerating-sine trick as the gate line.
+    var alpha = 1;
+    if (serverMaintenance.reason === "restart") {
+        alpha = 0.75 + 0.25 * Math.sin(now / 180);
+    }
+    gameContext.save();
+    gameContext.textAlign = "center";
+    gameContext.textBaseline = "alphabetic";
+    gameContext.font = "bold 20px Arial";
+    gameContext.lineWidth = 3;
+    gameContext.strokeStyle = "rgba(0,0,0,0.85)";
+    gameContext.globalAlpha = alpha;
+    gameContext.strokeText(line1, cx, by);
+    gameContext.fillStyle = "#ffb347";
+    gameContext.fillText(line1, cx, by);
+    gameContext.globalAlpha = 1;
+    gameContext.font = "14px Arial";
+    gameContext.strokeText(line2, cx, by + 19);
+    gameContext.fillStyle = "white";
+    gameContext.fillText(line2, cx, by + 19);
+    gameContext.restore();
 }
 
 // Persistent top-right badge (just under the race timer) showing one icon per active

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -88,6 +88,10 @@ var server = null,
     // startedAt }. Single slot — a fresh WR replaces the active banner so the
     // most recent wins (rare enough that queueing isn't worth the code).
     worldRecordBanner = null,
+    // Server-pushed maintenance notice: { reason: 'drain'|'restart', deadline,
+    // expiresAt } (ms timestamps). 'restart' renders a live countdown banner,
+    // 'drain' a static "new races paused" notice; null = no banner.
+    serverMaintenance = null,
     round = 0,
     timeOutChecker = null,
     currentState = null,

--- a/index.js
+++ b/index.js
@@ -255,6 +255,8 @@ var utils = require('./server/utils.js');
 var messenger = require('./server/messenger.js');
 var hostess = require('./server/hostess.js');
 var botGuard = require('./server/botGuard.js');
+var maintenance = require('./server/maintenance.js');
+var crypto = require('crypto');
 var c = utils.loadConfig();
 
 // In-browser feedback / bug-report endpoint. The widget (client/scripts/feedback.js)
@@ -316,6 +318,38 @@ app.post('/feedback', express.json({ limit: '16kb' }), function (req, res) {
     }).catch(function (e) {
         console.log(e);
         res.json({ status: false, message: "Couldn't send your feedback right now. Please try again in a moment." });
+    });
+});
+
+// Deploy-time ops endpoints, live only when OPS_SECRET is set (a Heroku config
+// var). The deploy workflow POSTs /ops/drain minutes before pushing the prod
+// branch — players get a "races paused" banner and rooms stop starting new
+// races — then polls /ops/status until active races finish. Without the secret
+// (local dev) or without the right header both endpoints 404, so probes can't
+// even tell they exist.
+var OPS_SECRET = process.env.OPS_SECRET || null;
+function opsAuthorized(req) {
+    if (!OPS_SECRET) { return false; }
+    var given = req.headers['x-ops-secret'];
+    if (typeof given !== 'string') { return false; }
+    var a = Buffer.from(given), b = Buffer.from(OPS_SECRET);
+    return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+app.post('/ops/drain', function (req, res) {
+    if (!opsAuthorized(req)) { return res.status(404).end(); }
+    // Bound the heads-up window: 0 (announce only) to 15 min, default 3 min.
+    var seconds = parseInt(req.query.seconds, 10);
+    if (isNaN(seconds)) { seconds = 180; }
+    seconds = Math.max(0, Math.min(15 * 60, seconds));
+    maintenance.begin(seconds, 'drain');
+    res.json({ status: true, seconds: seconds });
+});
+app.get('/ops/status', function (req, res) {
+    if (!opsAuthorized(req)) { return res.status(404).end(); }
+    res.json({
+        clients: clientCount,
+        activeRaces: hostess.countActiveRaces(),
+        maintenance: maintenance.getState()
     });
 });
 
@@ -420,6 +454,11 @@ io.on('connection', (client) => {
     }
     messenger.addMailBox(client.id, client, { userId: client.userId, deviceId: client.deviceId });
 
+    // A client connecting mid-maintenance missed the broadcast — replay the
+    // banner state so they see the countdown/drain notice too.
+    var maint = maintenance.getState();
+    if (maint != null) { client.emit('serverMaintenance', maint); }
+
     client.on('disconnect', () => {
       botGuard.unregister(client.id);
       hostess.kickFromRoom(client.id);
@@ -433,6 +472,23 @@ process.on( 'SIGINT', function() {
     console.log( "\nServer shutting down from (Ctrl-C)" );
     //io.sockets.emit("serverShutdown","Server terminated");
     process.exit();
+});
+
+// Heroku sends SIGTERM at every restart/deploy and SIGKILLs the dyno 30s
+// later. Use that fixed grace window: announce a restart countdown to every
+// connected player (and block new races via the maintenance gate), keep
+// ticking so in-flight races play on, then exit just inside the window. The
+// new dyno boots in parallel, so clients reconnect to it right after the
+// drop (client.js auto-reloads when a maintenance restart cuts the socket).
+// With nobody connected there's no one to warn — exit immediately.
+process.on('SIGTERM', function () {
+    if (clientCount === 0) {
+        console.log('Server shutting down (SIGTERM, idle)');
+        process.exit(0);
+    }
+    console.log('Server shutting down (SIGTERM) — announcing 28s restart countdown to ' + clientCount + ' client(s)');
+    maintenance.begin(28, 'restart');
+    setTimeout(function () { process.exit(0); }, 28 * 1000);
 });
 
 

--- a/index.js
+++ b/index.js
@@ -259,39 +259,43 @@ var maintenance = require('./server/maintenance.js');
 var crypto = require('crypto');
 var c = utils.loadConfig();
 
+// Tiny per-IP sliding-window rate limiter, shared by the public endpoints
+// below. Keyed by client IP. A Map (not a plain object) so a hostile IP string
+// can never be a special property name (__proto__, constructor, …) — there's
+// no prototype to pollute and key lookups stay O(1) on arbitrary strings.
+// Each limiter sweeps its expired keys once per window so an endpoint hit by
+// many distinct IPs can't grow the map without bound (entries are otherwise
+// only pruned when that same IP calls again). Cheap (runs once per window)
+// and harmless while the server sleeps.
+function makeRateLimiter(windowMs, maxPerWindow) {
+    var hitsByIp = new Map(); // ip -> [timestamps] within the window
+    setInterval(function () {
+        var now = Date.now();
+        hitsByIp.forEach(function (timestamps, ip) {
+            var hits = timestamps.filter(function (t) { return now - t < windowMs; });
+            if (hits.length === 0) { hitsByIp.delete(ip); }
+            else { hitsByIp.set(ip, hits); }
+        });
+    }, windowMs).unref();
+    return function rateLimited(ip) {
+        var now = Date.now();
+        var hits = (hitsByIp.get(ip) || []).filter(function (t) { return now - t < windowMs; });
+        if (hits.length >= maxPerWindow) {
+            hitsByIp.set(ip, hits);
+            return true;
+        }
+        hits.push(now);
+        hitsByIp.set(ip, hits);
+        return false;
+    };
+}
+
 // In-browser feedback / bug-report endpoint. The widget (client/scripts/feedback.js)
 // POSTs here and utils.submitIssue files it as a GitHub issue using the server's
 // GITHUB_AUTH token (same credential map-submit uses). Because it's unauthenticated
 // and writes to GitHub, it's guarded by: a tight JSON body cap, a hidden honeypot
 // field (any value = a bot, silently accepted-and-dropped), and a per-IP rate limit.
-// Keyed by client IP. A Map (not a plain object) so a hostile IP string can never
-// be a special property name (__proto__, constructor, …) — there's no prototype to
-// pollute and key lookups stay O(1) on arbitrary strings.
-var feedbackHits = new Map(); // ip -> [timestamps] within the window
-var FEEDBACK_WINDOW_MS = 10 * 60 * 1000;
-var FEEDBACK_MAX_PER_WINDOW = 5;
-function feedbackRateLimited(ip) {
-    var now = Date.now();
-    var hits = (feedbackHits.get(ip) || []).filter(function (t) { return now - t < FEEDBACK_WINDOW_MS; });
-    if (hits.length >= FEEDBACK_MAX_PER_WINDOW) {
-        feedbackHits.set(ip, hits);
-        return true;
-    }
-    hits.push(now);
-    feedbackHits.set(ip, hits);
-    return false;
-}
-// Sweep expired keys so a public endpoint hit by many distinct IPs can't grow
-// feedbackHits without bound (entries are otherwise only pruned when that same IP
-// submits again). Cheap (runs once per window) and harmless while the server sleeps.
-setInterval(function () {
-    var now = Date.now();
-    feedbackHits.forEach(function (timestamps, ip) {
-        var hits = timestamps.filter(function (t) { return now - t < FEEDBACK_WINDOW_MS; });
-        if (hits.length === 0) { feedbackHits.delete(ip); }
-        else { feedbackHits.set(ip, hits); }
-    });
-}, FEEDBACK_WINDOW_MS).unref();
+var feedbackRateLimited = makeRateLimiter(10 * 60 * 1000, 5);
 app.post('/feedback', express.json({ limit: '16kb' }), function (req, res) {
     var body = req.body || {};
     // Honeypot: a real form leaves `website` empty (it's hidden off-screen). Any
@@ -335,8 +339,20 @@ function opsAuthorized(req) {
     var a = Buffer.from(given), b = Buffer.from(OPS_SECRET);
     return a.length === b.length && crypto.timingSafeEqual(a, b);
 }
+// Per-IP limiter shared by both ops endpoints, checked BEFORE the secret so
+// brute-forcing OPS_SECRET is throttled too. The nightly workflow makes at
+// most ~35 calls per run from one runner IP, so 120/10min is generous for
+// legitimate use. A limited caller gets the same 404 the cloak uses — it
+// can't even tell the endpoints exist. Same trusted-proxy IP resolution as
+// /feedback (left-most x-forwarded-for entries are caller-forgeable).
+var opsRateLimited = makeRateLimiter(10 * 60 * 1000, 120);
+function opsGate(req) {
+    var ip = botGuard.resolveClientIp(req.headers['x-forwarded-for'], req.ip) || 'unknown';
+    if (opsRateLimited(ip)) { return false; }
+    return opsAuthorized(req);
+}
 app.post('/ops/drain', function (req, res) {
-    if (!opsAuthorized(req)) { return res.status(404).end(); }
+    if (!opsGate(req)) { return res.status(404).end(); }
     // Bound the heads-up window: 0 (announce only) to 15 min, default 3 min.
     var seconds = parseInt(req.query.seconds, 10);
     if (isNaN(seconds)) { seconds = 180; }
@@ -345,7 +361,7 @@ app.post('/ops/drain', function (req, res) {
     res.json({ status: true, seconds: seconds });
 });
 app.get('/ops/status', function (req, res) {
-    if (!opsAuthorized(req)) { return res.status(404).end(); }
+    if (!opsGate(req)) { return res.status(404).end(); }
     res.json({
         clients: clientCount,
         activeRaces: hostess.countActiveRaces(),

--- a/server/game.js
+++ b/server/game.js
@@ -303,18 +303,23 @@ class Game {
 			this.resetLobbyTimer();
 			return;
 		}
+		//Preview play-test: the solo creator has no one to rally on the lobby
+		//start button, so skip the lobby and head straight to the race gate.
+		//Checked BEFORE the maintenance drain: previews never hold up a deploy
+		//(countActiveRaces skips them), so a drain shouldn't freeze a creator's
+		//solo test either.
+		if (this.gameBoard.isPreview) {
+			this.startGated();
+			return;
+		}
 		//Maintenance drain: a restart is pending, so hold the room in the lobby —
 		//no new race may start (one already underway elsewhere is left to finish).
 		//Reset the start-button timer so the race doesn't fire the instant the
-		//block lifts; players re-rally on the button instead.
+		//block lifts; players re-rally on the button instead. (startGated() has
+		//its own backstop gate; this earlier check just keeps the button timer
+		//from spinning pointlessly.)
 		if (maintenance.isRaceBlocked()) {
 			this.resetLobbyTimer();
-			return;
-		}
-		//Preview play-test: the solo creator has no one to rally on the lobby
-		//start button, so skip the lobby and head straight to the race gate.
-		if (this.gameBoard.isPreview) {
-			this.startGated();
 			return;
 		}
 		//If majority of players stand on the gamestart button start the timer
@@ -338,9 +343,13 @@ class Game {
 		this.gatedTimer = Date.now();
 	}
 	checkNewRaceTimer() {
-		//Maintenance drain: freeze the between-rounds countdown — the next race
-		//of the series doesn't start while a server restart is pending.
+		//Maintenance drain: the next race of the series doesn't start while a
+		//server restart is pending. Null the timer (don't just early-return) so
+		//wall-clock elapsed during the block is discarded and the room gets a
+		//fresh full countdown when the block lifts — mirrors resetLobbyTimer()
+		//in checkGatedStart.
 		if (maintenance.isRaceBlocked()) {
+			this.newRaceTimer = null;
 			return;
 		}
 		if (this.newRaceTimer != null) {
@@ -737,6 +746,14 @@ class Game {
 		messenger.deliverRoomToasts(this.playerList);
 	}
 	startGated() {
+		//Structural maintenance gate at the single choke point every race start
+		//flows through, so a future caller can't bypass the drain. Callers are
+		//tick-driven check* functions that re-arm and retry, so a silent no-op
+		//just holds the room until the block lifts. Previews are exempt: they
+		//never delay a deploy and the restart cuts them regardless.
+		if (!this.gameBoard.isPreview && maintenance.isRaceBlocked()) {
+			return;
+		}
 		console.log("Start Gated");
 		this.locked = true;
 		// Leaving the lobby tutorial (this is the lobby->race transition; later rounds

--- a/server/game.js
+++ b/server/game.js
@@ -3,6 +3,7 @@ var utils = require('./utils.js');
 var c = utils.loadConfig();
 var messenger = require('./messenger.js');
 var hostess = require('./hostess.js');
+var maintenance = require('./maintenance.js');
 var _engine = require('./engine.js');
 var compressor = require('./compressor.js');
 var debug = require('./debug.js');
@@ -302,6 +303,14 @@ class Game {
 			this.resetLobbyTimer();
 			return;
 		}
+		//Maintenance drain: a restart is pending, so hold the room in the lobby —
+		//no new race may start (one already underway elsewhere is left to finish).
+		//Reset the start-button timer so the race doesn't fire the instant the
+		//block lifts; players re-rally on the button instead.
+		if (maintenance.isRaceBlocked()) {
+			this.resetLobbyTimer();
+			return;
+		}
 		//Preview play-test: the solo creator has no one to rally on the lobby
 		//start button, so skip the lobby and head straight to the race gate.
 		if (this.gameBoard.isPreview) {
@@ -329,6 +338,11 @@ class Game {
 		this.gatedTimer = Date.now();
 	}
 	checkNewRaceTimer() {
+		//Maintenance drain: freeze the between-rounds countdown — the next race
+		//of the series doesn't start while a server restart is pending.
+		if (maintenance.isRaceBlocked()) {
+			return;
+		}
 		if (this.newRaceTimer != null) {
 			this.newRaceTimeLeft = ((this.newRaceWaitTime * 1000 - (Date.now() - this.newRaceTimer)) / (1000)).toFixed(1);
 			if (this.newRaceTimeLeft > 0) {

--- a/server/hostess.js
+++ b/server/hostess.js
@@ -65,6 +65,22 @@ exports.getRooms = function () {
 	}
 	return rooms;
 }
+// Rooms currently mid-race (gate raised through collapse). The deploy
+// workflow polls this via /ops/status after a drain to wait for in-flight
+// races to finish before pushing a new build. Preview play-tests and tarpit
+// rooms never hold up a deploy.
+exports.countActiveRaces = function () {
+	var count = 0;
+	for (var sig in roomList) {
+		var room = roomList[sig];
+		if (room.isPreview || room.isTarpit) { continue; }
+		var state = room.game.currentState;
+		if (state == c.stateMap.gated || state == c.stateMap.racing || state == c.stateMap.collapsing) {
+			count++;
+		}
+	}
+	return count;
+}
 exports.findARoom = function (clientID) {
 	if (getRoomCount() == 0) {
 		var sig = generateNewRoom();

--- a/server/maintenance.js
+++ b/server/maintenance.js
@@ -1,0 +1,45 @@
+// Maintenance mode: announce an impending server restart to every connected
+// client and stop NEW races from starting (a race already underway is left to
+// finish). Two things turn it on:
+//   - POST /ops/drain (index.js) — the deploy workflow calls it minutes ahead
+//     of pushing the prod branch, so players get a heads-up and rooms drain.
+//   - the SIGTERM handler in index.js — Heroku sends SIGTERM at every restart
+//     and SIGKILLs 30s later, so this is the universal "30 seconds to go"
+//     announcement, deploys and manual restarts alike.
+// State auto-expires past `expiresAt` so a drained-but-never-restarted server
+// (failed build, canceled run) resumes races on its own — no operator action.
+
+// A drain's deadline marks the deploy *push*; the actual restart follows it by
+// a Heroku build (minutes). The long grace keeps races blocked across that
+// build window. A restart's deadline is the process exit itself — the small
+// grace only matters if the exit somehow fails.
+var DRAIN_GRACE_MS = 15 * 60 * 1000;
+var RESTART_GRACE_MS = 2 * 60 * 1000;
+
+var state = null; // { reason: 'drain'|'restart', deadline: ms, expiresAt: ms }
+
+exports.begin = function (seconds, reason) {
+	var now = Date.now();
+	state = {
+		reason: reason,
+		deadline: now + seconds * 1000,
+		expiresAt: now + seconds * 1000 + (reason === 'restart' ? RESTART_GRACE_MS : DRAIN_GRACE_MS),
+	};
+	// Lazy require: messenger -> hostess -> game must finish loading before
+	// this module touches it (game.js requires us at its top).
+	require('./messenger.js').broadcastAll('serverMaintenance', exports.getState());
+	console.log('[maintenance] ' + reason + ' announced, deadline in ' + seconds + 's');
+};
+
+// null when inactive or expired. Broadcast on begin(); index.js also replays
+// it to clients that connect mid-maintenance.
+exports.getState = function () {
+	if (state == null || Date.now() > state.expiresAt) { return null; }
+	return state;
+};
+
+// Race-start gate, checked by game.js before the lobby->gated and
+// overview->gated transitions.
+exports.isRaceBlocked = function () {
+	return exports.getState() != null;
+};


### PR DESCRIPTION
## What

Take prod deploys off the every-merge treadmill and make every restart graceful.

### Deploy control (`.github/workflows/deploy-prod.yml`)

Heroku will auto-deploy a new **`prod` branch instead of `main`** (one-time dashboard retarget, see rollout below). This workflow is then the only thing that advances `prod`:

- **Nightly** at 09:00 UTC (~5am ET): fast-forwards prod→main. Unchanged SHA = git no-op → no build, no dyno restart on quiet nights. Before pushing it **drains** the live server (players see a "new races are paused" banner, in-flight races get up to 13 min to finish), then re-anchors the drain right before the push so a slow Heroku build can't outlive the server-side grace.
- **Emergency**: merge a PR with the `deploy:prod` label → prod fast-forwards immediately, skipping the drain wait.
- **Manual**: workflow_dispatch with optional ref + optional nightly-style drain.

`prod` only moves forward (non-FF pushes fail loudly); rollback = `heroku rollback`.

### Graceful shutdown (every restart, deploys or otherwise)

Heroku sends SIGTERM 30s before SIGKILL. `index.js` turns that into:

- an in-game **"Server restarting in 28s"** countdown banner broadcast to every player (idle server exits immediately instead),
- a **race-start block** while the restart is pending — gated structurally inside `startGated()` (the single choke point), with editor previews exempt; races already underway play out during the countdown,
- **auto-recovery**: when the announced restart cuts the socket, the client polls until the server answers and reloads, instead of leaving the player on a dead socket.

New `OPS_SECRET`-gated `/ops/drain` + `/ops/status` endpoints (404-cloaked, timing-safe compare; absent in dev) let the workflow announce ahead of time and wait for races. Maintenance state auto-expires, so a canceled/failed deploy resumes races on its own.

## Testing

- `npm run build` + the full CI smoke test pass.
- New 19-assertion headless test against the real engine (drain broadcast shape, lobby held, direct `startGated()` refused at the choke point, between-rounds timer discarded for a fresh countdown, auto-expiry resumes races, `countActiveRaces`, restart deadline).
- Live E2E on a real server instance: endpoint auth (404/404/200), SIGTERM idle = instant exit, SIGTERM with a connected client = announced + held 28s + clean timed exit.
- 7-angle code review with adversarial verification; all 5 accepted findings fixed (reload-guard robustness, push-time drain re-anchor, choke-point gate, fresh countdown after unblock, preview exemption).
- `actionlint` clean.

## Rollout (after merge, in order)

1. `gh label create deploy:prod` (emergency-deploy label).
2. `git push origin origin/main:refs/heads/prod` (bootstrap the branch).
3. Set the ops secret both sides: `heroku config:set OPS_SECRET=<random> -a chaochaogame` + repo secret `OPS_SECRET` (drain degrades gracefully if unset).
4. **Heroku dashboard** → chaochaogame → Deploy → switch automatic deploys from `main` to `prod`; keep "Wait for CI" **off** (no CI runs on prod pushes).

Until step 4 happens, merging this PR changes nothing about how prod deploys today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
