### PR TITLE
On-device render-perf harness + Balanced trail-glow fix (glowScale)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ changed_maps.txt
 
 # Local-only portal embed test (see docs/portal-submission-checklist.md)
 embed-test.html
+perf-harness-report.jsonl

--- a/build.js
+++ b/build.js
@@ -22,7 +22,8 @@ const bundles = {
         'client/scripts/audience.js',
         'client/scripts/recap.js',
         'client/scripts/joystick.js',
-        'client/scripts/utils.js'
+        'client/scripts/utils.js',
+        'client/scripts/perfharness.js'
     ],
     'create.bundle.min.js': [
         'client/scripts/rhill-voronoi-core.js',

--- a/client/play.html
+++ b/client/play.html
@@ -126,6 +126,7 @@
         <script src="scripts/recap.js"></script>
         <script src="scripts/joystick.js"></script>
         <script src="scripts/utils.js"></script>
+        <script src="scripts/perfharness.js"></script>
         <!-- BUILD: bundle-end -->
         <!-- Honeypot: invisible decoy control. A human never sees or tabs to it (off-screen,
              aria-hidden, removed from tab order); a DOM-scraping bot that auto-clicks

--- a/client/scripts/perf.js
+++ b/client/scripts/perf.js
@@ -26,6 +26,7 @@ var PERF_PROFILES = {
         cooldownMul: 1.0,        // multiplier on particle spawn cooldowns (>1 = rarer)
         maxEffects: 100000,      // cap on simultaneous transient effects (huge => unbounded)
         glow: true,              // per-frame shadowBlur glow passes (goal arrow, ability beam, trail, cut)
+        glowScale: 1,            // resolution of the trail-glow composite (1 = full-res blur, the pre-knob behavior; <1 routes the blur through a downsampled intermediate — gaussian cost drops to ~scale² of the pixels)
         embers: true,            // rising embers off burning karts
         explosionSparks: 10,     // debris sparks per explosion
         audience: true,          // letterbox crowd
@@ -41,6 +42,14 @@ var PERF_PROFILES = {
         cooldownMul: 1.4,
         maxEffects: 280,
         glow: true,
+        // Half-res trail-glow composite: the 2026-06-04 device sweep measured the
+        // glow-heaviest trails (founders_flare/aurora) at ~27 FPS on a phone-class
+        // GPU at this tier — the gaussian shadowBlur over trail-sized rects at
+        // dpr 2 × 9 karts is pure fill-rate cost. Quartering the blurred pixels
+        // keeps the halo (soft by nature, upscale is invisible on it) and restores
+        // the budget; HIGH stays at 1 so desktop rendering is byte-for-byte
+        // unchanged (the CHANGELOG promise).
+        glowScale: 0.5,
         embers: true,
         explosionSparks: 7,
         audience: true,
@@ -57,6 +66,7 @@ var PERF_PROFILES = {
         cooldownMul: 2.2,
         maxEffects: 120,
         glow: false,
+        glowScale: 0.5,          // unused while glow is off; set for consistency if a future knob re-enables glow here
         embers: false,
         explosionSparks: 4,
         audience: false,
@@ -232,6 +242,12 @@ function perfCooldown(ms) {
 // One-shot, cached (halo/sprite), lobby and HUD glows are intentionally left
 // alone — they're not in the per-frame racing budget the LOW tier targets.
 function perfGlow() { return !!PERF.glow; }
+// Resolution scale for the trail-glow composite (see tfxGlowBlit). 1 = the exact
+// pre-knob single-blit path; <1 runs the gaussian over a downsampled intermediate.
+function perfGlowScale() {
+    var s = PERF.glowScale;
+    return (typeof s === "number" && s > 0 && s < 1) ? s : 1;
+}
 function perfEmbers() { return !!PERF.embers; }
 // Gates ambient "extra" FX whose absence isn't visible at a glance: walking-speed
 // terrain flecks (sand/ice/dirt) and the multi-particle lava-death sinking corpse.

--- a/client/scripts/perfharness.js
+++ b/client/scripts/perfharness.js
@@ -10,10 +10,11 @@
 //      against prod even though the script ships in the bundle.
 //
 // What it does once active:
-//   - Driver (150ms): in lobby, requests 8 bots (setLobbyAI) + pins the ice
-//     playlist (setLobbyPlaylist 'ice' — the ice-reflection path is the known
-//     render hot spot), and steers onto the start button with a wander-escape
-//     when wedged; in rounds it jiggles (defeats the AFK kick; bots do the racing).
+//   - Driver (150ms): in lobby, requests 8 bots (setLobbyAI) and steers onto the
+//     start button with a wander-escape when wedged; in rounds it jiggles (defeats
+//     the AFK kick; bots do the racing) and, if a round drags past 90s (wedged
+//     bots — no global round failsafe exists), drives itself to the goal to force
+//     the next round.
 //   - Sampler (own rAF chain): walks a queue of scenarios (baseline / hot-spot
 //     cosmetic ids / worst-combo / random unknowns, per perf tier), forcing the
 //     scenario's cosmetics onto every kart EVERY frame, and records mean FPS +
@@ -68,7 +69,7 @@
 
     var hudEl = null, queue = [], results = [], doneSet = {}, glCalls = 0;
     var device = null, optTier = null, originalPref = null, finished = false;
-    var drv = { lastPos: null, stuckMs: 0, wanderUntil: 0, wanderMv: null, lastLobbyCfg: 0 };
+    var drv = { lastPos: null, stuckMs: 0, wanderUntil: 0, wanderMv: null, lastLobbyCfg: 0, lastState: null, stateSince: 0 };
     var S = { phase: "next", item: null, expectedLabel: null, t0: 0, frames: 0, sum: 0, worst: 0, gl0: 0, gate0: null, lastTs: 0, idx: 0 };
 
     // ---------- utilities ----------
@@ -398,53 +399,67 @@
         var SM = config.stateMap;
         var me = playerList[myID];
         var now = Date.now();
+        if (currentState !== drv.lastState) { drv.lastState = currentState; drv.stateSince = now; }
         var mv = { turnLeft: false, moveForward: false, turnRight: false, moveBackward: false, attack: false };
+        var target = null;
         if (currentState === SM.lobby) {
             if (now - drv.lastLobbyCfg > 2000) {
                 drv.lastLobbyCfg = now;
-                try {
-                    server.emit("setLobbyAI", { enabled: true, count: 8 });   // 8 bots + me = 9 karts
-                    server.emit("setLobbyPlaylist", { id: "ice" });           // every round on an icy map
-                } catch (e) { /* socket mid-reconnect */ }
+                // 8 bots + me = 9 karts. Default map rotation (no playlist pin):
+                // most rotation maps carry some ice for the ice gate, and the AI can
+                // actually FINISH them — pinning the all-ice playlist stalled rounds
+                // forever (bots wedge on ice; no global round failsafe exists).
+                try { server.emit("setLobbyAI", { enabled: true, count: 8 }); } catch (e) { /* socket mid-reconnect */ }
             }
-            var target = (typeof lobbyStartButton === "object" && lobbyStartButton) ? lobbyStartButton : null;
-            if (target) {
-                if (now < drv.wanderUntil && drv.wanderMv) {
+            target = (typeof lobbyStartButton === "object" && lobbyStartButton) ? lobbyStartButton : null;
+        } else if ((currentState === SM.racing || currentState === SM.collapsing) &&
+            now - drv.stateSince > 90000) {
+            // Round watchdog: bots can wedge on hostile maps and never reach the
+            // goal, and nothing else ends a racing round. After 90s of the same
+            // round, finish it ourselves — drive to the nearest goal.
+            var pts = (typeof worldGoalPoints === "function") ? worldGoalPoints() : [];
+            var bd = Infinity;
+            for (var i = 0; i < pts.length; i++) {
+                var d2 = (pts[i].x - me.x) * (pts[i].x - me.x) + (pts[i].y - me.y) * (pts[i].y - me.y);
+                if (d2 < bd) { bd = d2; target = pts[i]; }
+            }
+        }
+        if (target) {
+            if (now < drv.wanderUntil && drv.wanderMv) {
+                mv = drv.wanderMv;
+            } else {
+                // Movement is screen-relative omnidirectional: turnLeft = left,
+                // moveForward = up. Steer by dx/dy sign with a deadzone.
+                var dx = target.x - me.x, dy = target.y - me.y;
+                if (dx > 12) { mv.turnRight = true; } else if (dx < -12) { mv.turnLeft = true; }
+                if (dy > 12) { mv.moveBackward = true; } else if (dy < -12) { mv.moveForward = true; }
+            }
+            // Wedge escape: commanded movement but the kart hasn't budged for
+            // >1.2s (water pockets / walls wedge a straight-line driver) —
+            // wander in a random direction briefly, then resume seeking.
+            var wantsMove = mv.turnLeft || mv.turnRight || mv.moveForward || mv.moveBackward;
+            if (wantsMove && drv.lastPos) {
+                var moved = Math.abs(me.x - drv.lastPos.x) + Math.abs(me.y - drv.lastPos.y);
+                drv.stuckMs = (moved < 2) ? drv.stuckMs + 150 : 0;
+                if (drv.stuckMs > 1200) {
+                    drv.stuckMs = 0;
+                    drv.wanderUntil = now + 700;
+                    var dirs = [
+                        { turnLeft: true }, { turnRight: true }, { moveForward: true }, { moveBackward: true },
+                        { turnLeft: true, moveForward: true }, { turnRight: true, moveBackward: true },
+                        { turnRight: true, moveForward: true }, { turnLeft: true, moveBackward: true }
+                    ];
+                    var d = dirs[Math.floor(Math.random() * dirs.length)];
+                    drv.wanderMv = {
+                        turnLeft: !!d.turnLeft, moveForward: !!d.moveForward,
+                        turnRight: !!d.turnRight, moveBackward: !!d.moveBackward, attack: false
+                    };
                     mv = drv.wanderMv;
-                } else {
-                    // Movement is screen-relative omnidirectional: turnLeft = left,
-                    // moveForward = up. Steer by dx/dy sign with a deadzone.
-                    var dx = target.x - me.x, dy = target.y - me.y;
-                    if (dx > 12) { mv.turnRight = true; } else if (dx < -12) { mv.turnLeft = true; }
-                    if (dy > 12) { mv.moveBackward = true; } else if (dy < -12) { mv.moveForward = true; }
-                }
-                // Wedge escape: commanded movement but the kart hasn't budged for
-                // >1.2s (water pockets / walls wedge a straight-line driver) —
-                // wander in a random direction briefly, then resume seeking.
-                var wantsMove = mv.turnLeft || mv.turnRight || mv.moveForward || mv.moveBackward;
-                if (wantsMove && drv.lastPos) {
-                    var moved = Math.abs(me.x - drv.lastPos.x) + Math.abs(me.y - drv.lastPos.y);
-                    drv.stuckMs = (moved < 2) ? drv.stuckMs + 150 : 0;
-                    if (drv.stuckMs > 1200) {
-                        drv.stuckMs = 0;
-                        drv.wanderUntil = now + 700;
-                        var dirs = [
-                            { turnLeft: true }, { turnRight: true }, { moveForward: true }, { moveBackward: true },
-                            { turnLeft: true, moveForward: true }, { turnRight: true, moveBackward: true },
-                            { turnRight: true, moveForward: true }, { turnLeft: true, moveBackward: true }
-                        ];
-                        var d = dirs[Math.floor(Math.random() * dirs.length)];
-                        drv.wanderMv = {
-                            turnLeft: !!d.turnLeft, moveForward: !!d.moveForward,
-                            turnRight: !!d.turnRight, moveBackward: !!d.moveBackward, attack: false
-                        };
-                        mv = drv.wanderMv;
-                    }
                 }
             }
         } else {
-            // Jiggle through every non-lobby state: defeats the AFK kick and keeps
-            // rounds cycling forever (the bots race; we idle near the gate).
+            // Jiggle through every other state: defeats the AFK kick and keeps
+            // rounds cycling (the bots race; we idle near the gate).
             mv.moveForward = (Math.floor(now / 450) % 2) === 0;
             mv.moveBackward = !mv.moveForward;
         }

--- a/client/scripts/perfharness.js
+++ b/client/scripts/perfharness.js
@@ -68,7 +68,7 @@
     ];
 
     var hudEl = null, queue = [], results = [], doneSet = {}, glCalls = 0;
-    var device = null, optTier = null, originalPref = null, finished = false;
+    var device = null, optTier = null, originalPref = null, finished = false, filtered = false;
     var drv = { lastPos: null, stuckMs: 0, wanderUntil: 0, wanderMv: null, lastLobbyCfg: 0, lastState: null, stateSince: 0 };
     var S = { phase: "next", item: null, expectedLabel: null, t0: 0, frames: 0, sum: 0, worst: 0, gl0: 0, gate0: null, lastTs: 0, idx: 0 };
 
@@ -110,6 +110,7 @@
     }
 
     function saveState() {
+        if (filtered) { return; } // targeted verify runs are throwaway — never persist
         try {
             localStorage.setItem(STORAGE_KEY, JSON.stringify({
                 v: PH_VERSION, optTier: optTier, originalPref: originalPref, done: doneSet
@@ -530,8 +531,28 @@
             autoTier: optTier, storedPref: originalPref, resumed: !!saved
         };
         queue = buildQueue(optTier);
+        // Targeted verify mode: &phfilter=<substr>[,<substr>...] keeps only matching
+        // scenario labels (cap_probe always runs) and ignores/skips persistence, so a
+        // post-fix re-measure of a handful of ids takes minutes, not a full sweep.
+        // e.g. ?perfharness=1&phfilter=balanced  — every balanced-tier scenario.
+        var filt = null;
+        try {
+            var fm = (window.location.search || "").match(/[?&]phfilter=([^&]+)/);
+            if (fm) { filt = decodeURIComponent(fm[1]).split(","); }
+        } catch (e) { /* no location */ }
+        if (filt) {
+            filtered = true;
+            doneSet = {};
+            queue = queue.filter(function (it) {
+                if (it.label === "cap_probe") { return true; }
+                for (var fi = 0; fi < filt.length; fi++) {
+                    if (it.label.indexOf(filt[fi]) !== -1) { return true; }
+                }
+                return false;
+            });
+        }
         saveState();
-        report({ kind: "hello", device: device, queued: queue.length });
+        report({ kind: "hello", device: device, queued: queue.length, filter: filt });
         console.log("[perfHarness] installed — " + queue.length + " scenarios, optimal tier '" + optTier + "'" + (saved ? " (resumed)" : ""));
 
         // Wrap gameLoop to count calls per rAF frame — the duplicate-render-chain

--- a/client/scripts/perfharness.js
+++ b/client/scripts/perfharness.js
@@ -267,7 +267,11 @@
         if (!g.vis) { return "hidden"; }
         if (it.gate === "visible") { return null; }
         var SM = config.stateMap;
-        if (g.state !== SM.gated && g.state !== SM.racing && g.state !== SM.collapsing) { return "state:" + g.state; }
+        // Racing/collapsing ONLY — karts parked at the gate lay NO trail, so a
+        // gated-state window measures a phantom for every trail scenario (the
+        // 2026-06-04 phone runs proved it: same id, gated 60 fps vs racing 27).
+        // Uniform across scenario kinds so every row stays comparable.
+        if (g.state !== SM.racing && g.state !== SM.collapsing) { return "state:" + g.state; }
         if (g.alive !== 9) { return "alive:" + g.alive; }
         if (g.ice < 1) { return "no-ice"; }
         if (expectedLabel && g.label !== expectedLabel) { return "label:" + g.label; }

--- a/client/scripts/perfharness.js
+++ b/client/scripts/perfharness.js
@@ -1,0 +1,550 @@
+// On-device render-performance harness (dev-only). Ports the desktop live-perf
+// sweep methodology (autonomous in-page rAF sampler + bot driver + gated windows)
+// so render FPS per cosmetic id / perf tier can be measured on a REAL device
+// (iPad / Android) with zero operator involvement beyond opening the URL.
+//
+// Activation requires BOTH:
+//   1. ?perfharness=1 in the page URL, and
+//   2. config.perfHarness === true from the server (set only when the server was
+//      started with PERF_HARNESS=1 — see server/utils.js), so this can never run
+//      against prod even though the script ships in the bundle.
+//
+// What it does once active:
+//   - Driver (150ms): in lobby, requests 8 bots (setLobbyAI) + pins the ice
+//     playlist (setLobbyPlaylist 'ice' — the ice-reflection path is the known
+//     render hot spot), and steers onto the start button with a wander-escape
+//     when wedged; in rounds it jiggles (defeats the AFK kick; bots do the racing).
+//   - Sampler (own rAF chain): walks a queue of scenarios (baseline / hot-spot
+//     cosmetic ids / worst-combo / random unknowns, per perf tier), forcing the
+//     scenario's cosmetics onto every kart EVERY frame, and records mean FPS +
+//     worst single frame ms per window. Every window is gated at start AND end
+//     (tab visible, state in {gated,racing,collapsing}, 9 karts alive, ice on
+//     the map, pinned tier label in effect) and auto-requeued when a gate fails,
+//     so samples stay comparable.
+//   - Keep-awake: a muted inline looping <video> started on the first touch
+//     (NoSleep technique — the Screen Wake Lock API needs a secure context,
+//     which a plain-http LAN URL is not), plus the real Wake Lock API when
+//     available. Backgrounding/screen-off still poisons windows; the gates
+//     catch it and requeue.
+//   - Reporting: POSTs one JSON row per completed/skipped sample plus a final
+//     summary to /__perf/report (dev-only sink in index.js, written as JSONL).
+//   - Resume: completed scenario labels persist in localStorage, so a reload
+//     (e.g. a serverKick redirect) re-installs and skips finished work.
+(function () {
+    "use strict";
+
+    var urlOn = false;
+    try { urlOn = /[?&]perfharness=1\b/.test(window.location.search || ""); } catch (e) { /* no location */ }
+    if (!urlOn) { return; }
+
+    var PH_VERSION = "ph1";
+    var REPORT_URL = "/__perf/report";
+    var STORAGE_KEY = "perfHarnessState";
+    var SLOT_KEYS = ["cart", "pattern", "trailFx", "border"];
+    var SETTLE_MS = 350;
+    var SAMPLE_MS = 1700;
+    var BASELINE_MS = 3000;
+    var MAX_ATTEMPTS = 8;
+    // ~10s 2x2 black h264 mp4 (~1.8KB). Muted+playsinline+loop video playback is
+    // what keeps iOS Safari / Android Chrome from sleeping the screen over http.
+    var WAKE_VIDEO = "data:video/mp4;base64,AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAOzbW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAJxAAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAt10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAJxAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAIAAAACAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAACcQAACAAAABAAAAAAJVbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABAAAACgABVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAACAG1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAAcBzdGJsAAAAwHN0c2QAAAAAAAAAAQAAALBhdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAIAAgBIAAAASAAAAAAAAAABFUxhdmM2Mi4yOC4xMDEgbGlieDI2NAAAAAAAAAAAAAAAGP//AAAANmF2Y0MBZAAK/+EAGWdkAAqs2V+IiMBEAAADAAQAAAMACDxIllgBAAZo6+PLIsD9+PgAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAAApgAAAAAAAAAGHN0dHMAAAAAAAAAAQAAAAoAAEAAAAAAFHN0c3MAAAAAAAAAAQAAAAEAAABgY3R0cwAAAAAAAAAKAAAAAQAAgAAAAAABAAFAAAAAAAEAAIAAAAAAAQAAAAAAAAABAABAAAAAAAEAAUAAAAAAAQAAgAAAAAABAAAAAAAAAAEAAEAAAAAAAQAAgAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAoAAAABAAAAPHN0c3oAAAAAAAAAAAAAAAoAAALFAAAADAAAAAwAAAAMAAAADAAAABIAAAAOAAAADAAAAAwAAAASAAAAFHN0Y28AAAAAAAAAAQAAA+MAAABidWR0YQAAAFptZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAAC1pbHN0AAAAJal0b28AAAAdZGF0YQAAAAEAAAAATGF2ZjYyLjEyLjEwMQAAAAhmcmVlAAADR21kYXQAAAKtBgX//6ncRem95tlIt5Ys2CDZI+7veDI2NCAtIGNvcmUgMTY1IHIzMjIyIGIzNTYwNWEgLSBILjI2NC9NUEVHLTQgQVZDIGNvZGVjIC0gQ29weWxlZnQgMjAwMy0yMDI1IC0gaHR0cDovL3d3dy52aWRlb2xhbi5vcmcveDI2NC5odG1sIC0gb3B0aW9uczogY2FiYWM9MSByZWY9MyBkZWJsb2NrPTE6MDowIGFuYWx5c2U9MHgzOjB4MTEzIG1lPWhleCBzdWJtZT03IHBzeT0xIHBzeV9yZD0xLjAwOjAuMDAgbWl4ZWRfcmVmPTEgbWVfcmFuZ2U9MTYgY2hyb21hX21lPTEgdHJlbGxpcz0xIDh4OGRjdD0xIGNxbT0wIGRlYWR6b25lPTIxLDExIGZhc3RfcHNraXA9MSBjaHJvbWFfcXBfb2Zmc2V0PS0yIHRocmVhZHM9MSBsb29rYWhlYWRfdGhyZWFkcz0xIHNsaWNlZF90aHJlYWRzPTAgbnI9MCBkZWNpbWF0ZT0xIGludGVybGFjZWQ9MCBibHVyYXlfY29tcGF0PTAgY29uc3RyYWluZWRfaW50cmE9MCBiZnJhbWVzPTMgYl9weXJhbWlkPTIgYl9hZGFwdD0xIGJfYmlhcz0wIGRpcmVjdD0xIHdlaWdodGI9MSBvcGVuX2dvcD0wIHdlaWdodHA9MiBrZXlpbnQ9MjUwIGtleWludF9taW49MSBzY2VuZWN1dD00MCBpbnRyYV9yZWZyZXNoPTAgcmNfbG9va2FoZWFkPTQwIHJjPWNyZiBtYnRyZWU9MSBjcmY9MjMuMCBxY29tcD0wLjYwIHFwbWluPTAgcXBtYXg9NjkgcXBzdGVwPTQgaXBfcmF0aW89MS40MCBhcT0xOjEuMDAAgAAAABBliIQAF//+99S3zLLuByOBAAAACEGaJGxBf/7wAAAACEGeQniC34yBAAAACAGeYXRBX5KAAAAACAGeY2pBX5KBAAAADkGaaEmoQWiZTAgt//7xAAAACkGehkURLBb/jIEAAAAIAZ6ldEFfkoEAAAAIAZ6nakFfkoAAAAAOQZqpSahBbJlMCCv//vA=";
+
+    // The pre-fix collapse drivers / shadow-and-filter-heavy ids from the desktop
+    // rounds — all passed on desktop post-PR#259; the device sweep confirms the
+    // fixes hold on mobile GPUs at the tier Auto actually picks.
+    var HOT = {
+        cart: ["pizza", "golden_champion", "wheel_of_fortune", "firetruck", "compass", "coin", "dartboard", "clock"],
+        pattern: ["nebula"],
+        trailFx: ["comet", "founders_flare", "bolt", "aurora", "neon", "ripple", "guardian"],
+        border: ["border_runes"]
+    };
+    var WORST_COMBO = { cart: "warlord", pattern: "nebula", trailFx: "comet", border: "border_runes" };
+    // Shorter confirmation list for the non-optimal pinned tiers.
+    var SUBSET = [
+        ["cart", "pizza"], ["cart", "golden_champion"],
+        ["trailFx", "comet"], ["trailFx", "founders_flare"], ["trailFx", "aurora"],
+        ["pattern", "nebula"], ["border", "border_runes"]
+    ];
+
+    var hudEl = null, queue = [], results = [], doneSet = {}, glCalls = 0;
+    var device = null, optTier = null, originalPref = null, finished = false;
+    var drv = { lastPos: null, stuckMs: 0, wanderUntil: 0, wanderMv: null, lastLobbyCfg: 0 };
+    var S = { phase: "next", item: null, expectedLabel: null, t0: 0, frames: 0, sum: 0, worst: 0, gl0: 0, gate0: null, lastTs: 0, idx: 0 };
+
+    // ---------- utilities ----------
+
+    function report(row) {
+        row.t = Date.now();
+        row.v = PH_VERSION;
+        try {
+            fetch(REPORT_URL, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(row),
+                keepalive: true
+            }).catch(function () { /* dev sink unreachable — rows also live in `results` */ });
+        } catch (e) { /* fetch unavailable */ }
+    }
+
+    function hud(msg) {
+        if (!hudEl && document.body) {
+            hudEl = document.createElement("div");
+            hudEl.id = "perfHarnessHud";
+            hudEl.style.cssText = "position:fixed;bottom:6px;left:6px;z-index:99999;" +
+                "font:bold 11px monospace;background:rgba(0,0,0,.7);color:#7df;" +
+                "padding:4px 7px;border-radius:4px;pointer-events:none;white-space:pre;max-width:92vw;";
+            document.body.appendChild(hudEl);
+        }
+        if (hudEl) { hudEl.textContent = msg; }
+    }
+
+    // Deterministic PRNG so the "random unknowns" picks are reproducible run-to-run.
+    function mulberry32(a) {
+        return function () {
+            a |= 0; a = a + 0x6D2B79F5 | 0;
+            var t = Math.imul(a ^ a >>> 15, 1 | a);
+            t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+            return ((t ^ t >>> 14) >>> 0) / 4294967296;
+        };
+    }
+
+    function saveState() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify({
+                v: PH_VERSION, optTier: optTier, originalPref: originalPref, done: doneSet
+            }));
+        } catch (e) { /* storage disabled */ }
+    }
+
+    function loadState() {
+        try {
+            var s = JSON.parse(localStorage.getItem(STORAGE_KEY) || "null");
+            return (s && s.v === PH_VERSION) ? s : null;
+        } catch (e) { return null; }
+    }
+
+    // ---------- queue construction ----------
+
+    function ovFor(slot, id) {
+        var ov = { cart: null, pattern: null, trailFx: null, border: null };
+        ov[slot] = id;
+        return ov;
+    }
+
+    function item(label, tier, ov, dur, gate) {
+        return { label: label, tier: tier, ov: ov, dur: dur || SAMPLE_MS, gate: gate || "race", attempts: 0 };
+    }
+
+    function buildQueue(tier) {
+        var q = [], rand = mulberry32(1337), nBase = 0;
+        function baseline(t) { q.push(item(t + "|__none__#" + (++nBase), t, { cart: null, pattern: null, trailFx: null, border: null }, BASELINE_MS)); }
+
+        // Display-cap probe: visible-only gate so it completes immediately (in the
+        // lobby), calibrating the device's rAF ceiling before any gated work.
+        q.push(item("cap_probe", null, "server", BASELINE_MS, "visible"));
+
+        // Phase 1 — full hot-spot list on the device's OPTIMAL (Auto-resolved) tier.
+        baseline(tier);
+        var n = 0;
+        SLOT_KEYS.forEach(function (slot) {
+            (HOT[slot] || []).forEach(function (id) {
+                q.push(item(tier + "|" + slot + ":" + id, tier, ovFor(slot, id)));
+                if (++n % 5 === 0) { baseline(tier); }
+            });
+        });
+        q.push(item(tier + "|combo:worst", tier, WORST_COMBO));
+        q.push(item(tier + "|random_mix", tier, "server"));
+        baseline(tier);
+
+        // Phase 2 — confirmation subset on the other pinned tiers.
+        ["high", "balanced", "low"].forEach(function (t) {
+            if (t === tier) { return; }
+            baseline(t);
+            SUBSET.forEach(function (s) {
+                q.push(item(t + "|" + s[0] + ":" + s[1], t, ovFor(s[0], s[1])));
+            });
+            q.push(item(t + "|combo:worst", t, WORST_COMBO));
+        });
+
+        // Phase 3 — random unknowns on the optimal tier (device-specific surprises
+        // the desktop rounds couldn't catch), seeded so reruns pick the same ids.
+        baseline(tier);
+        var m = 0;
+        SLOT_KEYS.forEach(function (slot) {
+            var pool = SKINS.filter(function (s) {
+                var sslot = (s.slot === "trail") ? "trailFx" : s.slot;
+                return sslot === slot && (HOT[slot] || []).indexOf(s.id) === -1 && s.id !== WORST_COMBO[slot];
+            }).map(function (s) { return s.id; });
+            for (var i = pool.length - 1; i > 0; i--) {
+                var j = Math.floor(rand() * (i + 1)), tmp = pool[i]; pool[i] = pool[j]; pool[j] = tmp;
+            }
+            pool.slice(0, 4).forEach(function (id) {
+                q.push(item(tier + "|rnd|" + slot + ":" + id, tier, ovFor(slot, id)));
+                if (++m % 5 === 0) { baseline(tier); }
+            });
+        });
+        for (var k = 0; k < 2; k++) {
+            var combo = {};
+            SLOT_KEYS.forEach(function (slot) {
+                var pool = SKINS.filter(function (s) { return ((s.slot === "trail") ? "trailFx" : s.slot) === slot; });
+                combo[slot] = pool[Math.floor(rand() * pool.length)].id;
+            });
+            q.push(item(tier + "|rnd|combo#" + (k + 1), tier, combo));
+        }
+        baseline(tier);
+        return q;
+    }
+
+    // ---------- cosmetic override ----------
+
+    // Force the current scenario's cosmetics onto every kart every frame — beats
+    // any server packet reset, and only REAL playerList karts hit the ice-reflection
+    // path (synthetic karts lie; desktop round 1 lesson). The first value seen per
+    // slot (and any later server-side rewrite, detected as "differs from what we
+    // last forced") is remembered in __phOrig so the random-mix scenario can hand
+    // the kart back to its server-assigned (dev-patch random) outfit.
+    function applyOverride(it) {
+        if (!it || !it.ov || typeof playerList !== "object" || !playerList) { return; }
+        var serverMode = (it.ov === "server");
+        for (var id in playerList) {
+            var p = playerList[id];
+            if (!p || typeof p !== "object") { continue; }
+            if (!p.__phOrig) {
+                p.__phOrig = {};
+                for (var i = 0; i < SLOT_KEYS.length; i++) { p.__phOrig[SLOT_KEYS[i]] = p[SLOT_KEYS[i]]; }
+            }
+            if (serverMode) { continue; }
+            if (!p.__phForced) { p.__phForced = {}; }
+            for (var j = 0; j < SLOT_KEYS.length; j++) {
+                var k = SLOT_KEYS[j];
+                var want = (it.ov[k] !== undefined) ? it.ov[k] : null;
+                if (p[k] !== want) {
+                    if (p.__phForced[k] !== undefined && p[k] !== p.__phForced[k]) {
+                        p.__phOrig[k] = p[k]; // a server packet rewrote it since our last force
+                    }
+                    p[k] = want;
+                }
+                p.__phForced[k] = want;
+            }
+        }
+    }
+
+    function restoreServerCosmetics() {
+        if (typeof playerList !== "object" || !playerList) { return; }
+        for (var id in playerList) {
+            var p = playerList[id];
+            if (p && p.__phOrig) {
+                for (var i = 0; i < SLOT_KEYS.length; i++) { p[SLOT_KEYS[i]] = p.__phOrig[SLOT_KEYS[i]]; }
+                p.__phForced = null;
+            }
+        }
+    }
+
+    // ---------- gating ----------
+
+    function gateSnapshot() {
+        var alive = 0, karts = 0;
+        if (typeof playerList === "object" && playerList) {
+            for (var id in playerList) {
+                if (!playerList[id]) { continue; }
+                karts++;
+                if (playerList[id].alive !== false) { alive++; }
+            }
+        }
+        return {
+            vis: (typeof document !== "undefined") ? document.visibilityState === "visible" : true,
+            state: (typeof currentState === "number") ? currentState : -1,
+            alive: alive,
+            karts: karts,
+            ice: (typeof terrainFX === "object" && terrainFX && terrainFX.ice) ? terrainFX.ice.length : 0,
+            label: (typeof perfProfileLabel === "function") ? perfProfileLabel() : ""
+        };
+    }
+
+    function gateFail(g, it, expectedLabel) {
+        if (!g.vis) { return "hidden"; }
+        if (it.gate === "visible") { return null; }
+        var SM = config.stateMap;
+        if (g.state !== SM.gated && g.state !== SM.racing && g.state !== SM.collapsing) { return "state:" + g.state; }
+        if (g.alive !== 9) { return "alive:" + g.alive; }
+        if (g.ice < 1) { return "no-ice"; }
+        if (expectedLabel && g.label !== expectedLabel) { return "label:" + g.label; }
+        return null;
+    }
+
+    // ---------- sampler ----------
+
+    function nextItem() {
+        while (S.idx < queue.length && doneSet[queue[S.idx].label]) { S.idx++; }
+        if (S.idx >= queue.length) { finish(); return; }
+        S.item = queue[S.idx];
+        if (S.item.tier && typeof getPerfPref === "function" && getPerfPref() !== S.item.tier) {
+            setPerfPref(S.item.tier);
+            applyPerfProfile();
+        }
+        if (S.item.ov === "server") { restoreServerCosmetics(); }
+        S.expectedLabel = S.item.tier ? PERF_LABEL[S.item.tier] : null;
+        S.phase = "settle";
+        S.t0 = 0;
+        S.waitMs = 0;
+    }
+
+    function requeue(reason) {
+        var it = S.item;
+        it.attempts++;
+        if (it.attempts >= MAX_ATTEMPTS) {
+            doneSet[it.label] = 1;
+            saveState();
+            report({ kind: "skip", label: it.label, tier: it.tier, reason: reason, attempts: it.attempts, idx: S.idx, total: queue.length });
+            results.push({ label: it.label, skipped: reason });
+        } else {
+            queue.push(it); // retry later (likely a different round); keep the sweep moving now
+        }
+        S.idx++;
+        S.phase = "next";
+    }
+
+    function completeItem(g1) {
+        var it = S.item;
+        var fps = (S.sum > 0) ? 1000 * S.frames / S.sum : 0;
+        var row = {
+            kind: "sample", label: it.label, tier: it.tier,
+            tierLabel: g1.label, fps: Math.round(fps * 10) / 10,
+            worstMs: Math.round(S.worst * 10) / 10, frames: S.frames,
+            durMs: Math.round(S.sum), state0: S.gate0.state, state1: g1.state,
+            alive: g1.alive, ice: g1.ice,
+            gl: (S.frames > 0) ? Math.round((glCalls - S.gl0) / S.frames * 100) / 100 : 0,
+            attempt: it.attempts, idx: S.idx, total: queue.length
+        };
+        report(row);
+        results.push(row);
+        doneSet[it.label] = 1;
+        saveState();
+        S.idx++;
+        S.phase = "next";
+    }
+
+    function finish() {
+        if (finished) { return; }
+        finished = true;
+        restoreServerCosmetics();
+        if (originalPref && typeof setPerfPref === "function") {
+            setPerfPref(originalPref);
+            applyPerfProfile();
+        }
+        report({ kind: "summary", device: device, optTier: optTier, n: results.length, results: results });
+        hud("PERF HARNESS DONE — " + results.length + " rows. You can close this page.");
+    }
+
+    function samplerTick(ts) {
+        if (!finished) { requestAnimationFrame(samplerTick); }
+        var dt = S.lastTs ? ts - S.lastTs : 0;
+        S.lastTs = ts;
+        if (finished) { return; }
+        if (S.phase === "next") { nextItem(); return; }
+        if (!S.item) { return; }
+        applyOverride(S.item);
+        if (S.phase === "settle") {
+            if (!S.t0) { S.t0 = ts; }
+            if (ts - S.t0 >= SETTLE_MS) {
+                var g = gateSnapshot();
+                var bad = gateFail(g, S.item, S.expectedLabel);
+                if (bad) {
+                    // Pre-window failure = WAIT, don't burn an attempt — sitting out
+                    // the lobby/overview between rounds is normal, not a bad sample.
+                    // Attempts are only consumed by windows that started and then got
+                    // poisoned (state flip / stall / hidden), plus this wait budget so
+                    // one pathological scenario can't stall the sweep forever.
+                    S.waitMs += ts - S.t0;
+                    S.t0 = ts;
+                    hud("PERF " + (S.idx + 1) + "/" + queue.length + " " + S.item.label +
+                        " waiting (" + bad + ") " + Math.round(S.waitMs / 1000) + "s");
+                    if (S.waitMs > 180000) { S.waitMs = 0; requeue("wait-timeout:" + bad); }
+                    return;
+                }
+                S.gate0 = g;
+                S.phase = "window";
+                S.t0 = ts; S.frames = 0; S.sum = 0; S.worst = 0; S.gl0 = glCalls;
+            }
+            return;
+        }
+        if (S.phase === "window") {
+            if (dt > 0) {
+                S.frames++;
+                S.sum += dt;
+                if (dt > S.worst) { S.worst = dt; }
+            }
+            // A multi-second "frame" is a background/sleep stall, not rendering —
+            // the whole window is poisoned.
+            if (dt > 2000) { requeue("stall:" + Math.round(dt)); return; }
+            var liveFps = (S.sum > 0) ? Math.round(1000 * S.frames / S.sum) : 0;
+            hud("PERF " + (S.idx + 1) + "/" + queue.length + " " + S.item.label +
+                " try" + (S.item.attempts + 1) + "  " + liveFps + "fps worst " + Math.round(S.worst) + "ms");
+            if (ts - S.t0 >= S.item.dur) {
+                var g1 = gateSnapshot();
+                var bad1 = gateFail(g1, S.item, S.expectedLabel);
+                if (!bad1 && S.item.gate === "race" && g1.state !== S.gate0.state) { bad1 = "state-change:" + S.gate0.state + ">" + g1.state; }
+                if (bad1) { requeue(bad1); return; }
+                completeItem(g1);
+            }
+        }
+    }
+
+    // ---------- driver ----------
+
+    function driverTick() {
+        if (typeof server !== "object" || !server || !myID ||
+            typeof playerList !== "object" || !playerList || !playerList[myID]) { return; }
+        var SM = config.stateMap;
+        var me = playerList[myID];
+        var now = Date.now();
+        var mv = { turnLeft: false, moveForward: false, turnRight: false, moveBackward: false, attack: false };
+        if (currentState === SM.lobby) {
+            if (now - drv.lastLobbyCfg > 2000) {
+                drv.lastLobbyCfg = now;
+                try {
+                    server.emit("setLobbyAI", { enabled: true, count: 8 });   // 8 bots + me = 9 karts
+                    server.emit("setLobbyPlaylist", { id: "ice" });           // every round on an icy map
+                } catch (e) { /* socket mid-reconnect */ }
+            }
+            var target = (typeof lobbyStartButton === "object" && lobbyStartButton) ? lobbyStartButton : null;
+            if (target) {
+                if (now < drv.wanderUntil && drv.wanderMv) {
+                    mv = drv.wanderMv;
+                } else {
+                    // Movement is screen-relative omnidirectional: turnLeft = left,
+                    // moveForward = up. Steer by dx/dy sign with a deadzone.
+                    var dx = target.x - me.x, dy = target.y - me.y;
+                    if (dx > 12) { mv.turnRight = true; } else if (dx < -12) { mv.turnLeft = true; }
+                    if (dy > 12) { mv.moveBackward = true; } else if (dy < -12) { mv.moveForward = true; }
+                }
+                // Wedge escape: commanded movement but the kart hasn't budged for
+                // >1.2s (water pockets / walls wedge a straight-line driver) —
+                // wander in a random direction briefly, then resume seeking.
+                var wantsMove = mv.turnLeft || mv.turnRight || mv.moveForward || mv.moveBackward;
+                if (wantsMove && drv.lastPos) {
+                    var moved = Math.abs(me.x - drv.lastPos.x) + Math.abs(me.y - drv.lastPos.y);
+                    drv.stuckMs = (moved < 2) ? drv.stuckMs + 150 : 0;
+                    if (drv.stuckMs > 1200) {
+                        drv.stuckMs = 0;
+                        drv.wanderUntil = now + 700;
+                        var dirs = [
+                            { turnLeft: true }, { turnRight: true }, { moveForward: true }, { moveBackward: true },
+                            { turnLeft: true, moveForward: true }, { turnRight: true, moveBackward: true },
+                            { turnRight: true, moveForward: true }, { turnLeft: true, moveBackward: true }
+                        ];
+                        var d = dirs[Math.floor(Math.random() * dirs.length)];
+                        drv.wanderMv = {
+                            turnLeft: !!d.turnLeft, moveForward: !!d.moveForward,
+                            turnRight: !!d.turnRight, moveBackward: !!d.moveBackward, attack: false
+                        };
+                        mv = drv.wanderMv;
+                    }
+                }
+            }
+        } else {
+            // Jiggle through every non-lobby state: defeats the AFK kick and keeps
+            // rounds cycling forever (the bots race; we idle near the gate).
+            mv.moveForward = (Math.floor(now / 450) % 2) === 0;
+            mv.moveBackward = !mv.moveForward;
+        }
+        drv.lastPos = { x: me.x, y: me.y };
+        try { server.emit("movement", mv); } catch (e) { /* socket mid-reconnect */ }
+    }
+
+    // ---------- keep-awake ----------
+
+    function installKeepAwake() {
+        var v = document.createElement("video");
+        v.setAttribute("playsinline", "");
+        v.muted = true;
+        v.loop = true;
+        v.style.cssText = "position:fixed;left:-9999px;top:-9999px;width:2px;height:2px;";
+        v.src = WAKE_VIDEO;
+        document.body.appendChild(v);
+        var started = false;
+        function start() {
+            if (started) { return; }
+            var p = v.play();
+            if (p && p.then) {
+                p.then(function () { started = true; report({ kind: "note", note: "wake-video playing" }); })
+                    .catch(function () { /* needs another gesture */ });
+            }
+        }
+        // Gesture-gated: mobile browsers only allow play() from a user gesture.
+        ["touchstart", "pointerdown", "click", "keydown"].forEach(function (ev) {
+            document.addEventListener(ev, start, { passive: true });
+        });
+        // Belt and braces: some browsers stop tiny looping videos; restart it.
+        v.addEventListener("pause", function () { if (started) { try { v.play(); } catch (e) { } } });
+        // Real Wake Lock API too, for when the page is served over https.
+        function reqWakeLock() {
+            try {
+                if (navigator.wakeLock && navigator.wakeLock.request) {
+                    navigator.wakeLock.request("screen").catch(function () { /* insecure context */ });
+                }
+            } catch (e) { /* unsupported */ }
+        }
+        reqWakeLock();
+        document.addEventListener("visibilitychange", function () {
+            if (document.visibilityState === "visible") { reqWakeLock(); }
+        });
+    }
+
+    // ---------- install ----------
+
+    function install() {
+        var nav = navigator || {};
+        originalPref = (typeof getPerfPref === "function") ? getPerfPref() : "auto";
+        var saved = loadState();
+        if (saved) {
+            optTier = saved.optTier;
+            originalPref = saved.originalPref || originalPref;
+            doneSet = saved.done || {};
+        } else {
+            optTier = (typeof detectPerfTier === "function") ? detectPerfTier() : "high";
+        }
+        device = {
+            ua: (nav.userAgent || "").slice(0, 200),
+            platform: nav.platform || "",
+            dpr: window.devicePixelRatio || 1,
+            iw: window.innerWidth, ih: window.innerHeight,
+            sw: (screen && screen.width) || 0, sh: (screen && screen.height) || 0,
+            cores: nav.hardwareConcurrency || 0, mem: nav.deviceMemory || 0,
+            touch: (typeof isTouchScreen !== "undefined") ? isTouchScreen : null,
+            autoTier: optTier, storedPref: originalPref, resumed: !!saved
+        };
+        queue = buildQueue(optTier);
+        saveState();
+        report({ kind: "hello", device: device, queued: queue.length });
+        console.log("[perfHarness] installed — " + queue.length + " scenarios, optimal tier '" + optTier + "'" + (saved ? " (resumed)" : ""));
+
+        // Wrap gameLoop to count calls per rAF frame — the duplicate-render-chain
+        // detector (a healthy client reads 1.0).
+        var origGameLoop = gameLoop;
+        gameLoop = function (dt) { glCalls++; return origGameLoop(dt); };
+
+        installKeepAwake();
+        hud("PERF HARNESS armed — tap once to start keep-awake. " + queue.length + " scenarios.");
+        setInterval(driverTick, 150);
+        requestAnimationFrame(samplerTick);
+    }
+
+    // Socket globals (config/myID/playerList) arrive async after page load; poll
+    // until everything the harness touches exists. config.perfHarness===false
+    // (i.e. a server not started with PERF_HARNESS=1) refuses to activate.
+    var installTimer = setInterval(function () {
+        if (typeof config !== "object" || !config || !config.stateMap) { return; }
+        if (config.perfHarness !== true) {
+            clearInterval(installTimer);
+            console.warn("[perfHarness] ?perfharness=1 set but the server was not started with PERF_HARNESS=1 — not activating.");
+            return;
+        }
+        if (typeof playerList === "object" && playerList && myID &&
+            typeof server === "object" && server &&
+            typeof gameLoop === "function" && typeof SKINS !== "undefined") {
+            clearInterval(installTimer);
+            install();
+        }
+    }, 400);
+})();

--- a/client/scripts/trailEffects.js
+++ b/client/scripts/trailEffects.js
@@ -293,6 +293,7 @@ function tfxPuffGrad(ctx, color) {
 // trails from painting at all. Only called on glow profiles (tfxGlow()); the
 // no-glow path keeps painting straight to the main canvas.
 var _tfxGlowScratch = null;
+var _tfxGlowScratch2 = null; // small intermediate for the downsampled-glow path (glowScale < 1)
 function tfxGlowBlit(ctx, verts, color, glowR, margin, composite, body) {
   // Geometry bbox in the CALLER's coordinate space (+margin for overhang like
   // ribbon half-widths / ember rise). The shadow is applied at blit time on the
@@ -328,10 +329,21 @@ function tfxGlowBlit(ctx, verts, color, glowR, margin, composite, body) {
   if (dMaxY > ctx.canvas.height + bleed) dMaxY = ctx.canvas.height + bleed;
   var w = dMaxX - dMinX, h = dMaxY - dMinY;
   if (w < 1 || h < 1) return;
+  // Glow resolution (perf knob). The gaussian shadowBlur at blit time runs over the
+  // DESTINATION-sized rect, so at full res a long trail costs a near-screen-sized
+  // blur per blit — ×9 wearers ×(1-2 blits each) that is the fill-rate collapse the
+  // 2026-06-04 device sweep measured on phone-class GPUs (founders_flare/aurora
+  // ~27 FPS on Balanced). gs < 1 renders the body at gs scale, runs the blur over a
+  // small intermediate (gs² of the pixels), then does ONE plain smoothed upscale —
+  // the halo is soft by nature so the upscale doesn't read. gs === 1 keeps the
+  // original single-blit path bit-for-bit (HIGH's no-op promise).
+  var gs = (typeof perfGlowScale === "function") ? perfGlowScale() : 1;
+  var w1 = (gs < 1) ? Math.max(1, Math.ceil(w * gs)) : w;
+  var h1 = (gs < 1) ? Math.max(1, Math.ceil(h * gs)) : h;
   if (_tfxGlowScratch == null) { _tfxGlowScratch = document.createElement("canvas"); }
   var s = _tfxGlowScratch;
-  if (s.width < w) { s.width = w; }
-  if (s.height < h) { s.height = h; }
+  if (s.width < w1) { s.width = w1; }
+  if (s.height < h1) { s.height = h1; }
   var sc = s.getContext("2d");
   // The scratch CONTEXT is shared across effects and frames, so isolate each use:
   // a body that flips composite mode (aurora's 'lighter') must not leak it into the
@@ -339,23 +351,53 @@ function tfxGlowBlit(ctx, verts, color, glowR, margin, composite, body) {
   // is grow-only, so a resize reset can't be relied on.
   sc.save();
   sc.setTransform(1, 0, 0, 1, 0, 0);
-  sc.clearRect(0, 0, w, h);
+  sc.clearRect(0, 0, w1, h1);
   sc.globalCompositeOperation = "source-over";
   sc.globalAlpha = 1;
   sc.shadowBlur = 0;
   if ("filter" in sc) { sc.filter = "none"; }
   sc.setLineDash([]);
-  // Caller's full transform, shifted so the device bbox lands at the scratch origin.
-  sc.setTransform(t.a, t.b, t.c, t.d, t.e - dMinX, t.f - dMinY);
+  // Caller's full transform (scaled by the glow resolution), shifted so the device
+  // bbox lands at the scratch origin.
+  sc.setTransform(t.a * gs, t.b * gs, t.c * gs, t.d * gs, (t.e - dMinX) * gs, (t.f - dMinY) * gs);
   body(sc);
   sc.restore();
+  if (gs >= 1) {
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);   // blit 1:1 in device space
+    ctx.globalAlpha = 1;                  // body alphas are baked into the scratch
+    ctx.shadowColor = color;
+    ctx.shadowBlur = glowR;               // shadowBlur ignores the CTM, same as per-op
+    if (composite) { ctx.globalCompositeOperation = composite; }
+    ctx.drawImage(s, 0, 0, w, h, dMinX, dMinY, w, h);
+    ctx.restore();
+    return;
+  }
+  // Downsampled path: shadow-composite body+halo into a small second scratch (the
+  // blur runs HERE, over gs² of the pixels), then ONE plain upscale to the canvas.
+  var pad = Math.ceil(glowR * gs) + 4;    // room for the halo bleed at scratch scale
+  var w2 = w1 + pad * 2, h2 = h1 + pad * 2;
+  if (_tfxGlowScratch2 == null) { _tfxGlowScratch2 = document.createElement("canvas"); }
+  var s2 = _tfxGlowScratch2;
+  if (s2.width < w2) { s2.width = w2; }
+  if (s2.height < h2) { s2.height = h2; }
+  var sc2 = s2.getContext("2d");
+  sc2.save();                             // same shared-context isolation as above
+  sc2.setTransform(1, 0, 0, 1, 0, 0);
+  sc2.clearRect(0, 0, w2, h2);
+  sc2.globalCompositeOperation = "source-over";
+  sc2.globalAlpha = 1;
+  if ("filter" in sc2) { sc2.filter = "none"; }
+  sc2.shadowColor = color;
+  sc2.shadowBlur = glowR * gs;            // halo radius in scratch units = glowR on screen
+  sc2.drawImage(s, 0, 0, w1, h1, pad, pad, w1, h1);
+  sc2.restore();
   ctx.save();
-  ctx.setTransform(1, 0, 0, 1, 0, 0);   // blit 1:1 in device space
-  ctx.globalAlpha = 1;                  // body alphas are baked into the scratch
-  ctx.shadowColor = color;
-  ctx.shadowBlur = glowR;               // shadowBlur ignores the CTM, same as per-op
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.globalAlpha = 1;
   if (composite) { ctx.globalCompositeOperation = composite; }
-  ctx.drawImage(s, 0, 0, w, h, dMinX, dMinY, w, h);
+  // Map the padded scratch back to device space (pad/gs of halo bleed each side).
+  ctx.drawImage(s2, 0, 0, w2, h2, dMinX - pad / gs, dMinY - pad / gs, w2 / gs, h2 / gs);
   ctx.restore();
 }
 // Glow dispatch shared by the heavy painters: no glow -> draw straight to ctx;

--- a/docs/spikes/device-render-perf-sweep.md
+++ b/docs/spikes/device-render-perf-sweep.md
@@ -148,6 +148,31 @@ not chased.
 - Worst-frame stutter (>50ms) only ever accompanied the low-FPS rows or one-off
   ambient hitches — no silent texture-upload stutter at healthy FPS readings.
 
+## Fix shipped on this branch: downsampled trail-glow composite on Balanced
+
+Investigated post-sweep (operator-requested). Root cause of the Balanced
+founders_flare/aurora collapse: the trail-glow `shadowBlur` composite runs over the
+**destination-sized** rect — a trail's bbox spans much of the screen at dpr 2, and
+founders_flare issues TWO such blits per kart (ribbon + core/embers), aurora one with
+`'lighter'` — ×9 wearers ≈ 9-18 near-screen-sized gaussian passes per frame. Pure GPU
+fill-rate, invisible to JS profiling (the established pattern).
+
+Fix: new `glowScale` PERF knob (high 1 = bit-for-bit unchanged; balanced 0.5).
+`tfxGlowBlit` at scale <1 renders the body scratch at half device res, runs the
+shadowBlur over a small second scratch (¼ of the pixels), then does ONE plain smoothed
+upscale to the main canvas. The halo is soft by nature so the upscale doesn't read;
+geometry inside the glow image is half-res (Balanced-only, invisible at phone/tablet
+viewing sizes). Low keeps glow off; High keeps the original single-blit path.
+
+Desktop verification (targeted `&phfilter=` runs through the new path):
+founders_flare/aurora/comet on pinned Balanced all at the 120 fps display cap, gl 1.0,
+visuals spot-checked. Phone re-verification of the Balanced subset: pending (one
+~5-min targeted run).
+
+Also added for that verification: `&phfilter=<substr>[,<substr>]` harness URL param —
+filters the scenario queue (cap_probe always runs), skips persistence, so a post-fix
+re-measure takes minutes.
+
 ## Follow-up prompt (operator-injectable)
 
 > Glow-heavy trails (founders_flare, aurora — comet next) overwhelm mobile GPUs one

--- a/docs/spikes/device-render-perf-sweep.md
+++ b/docs/spikes/device-render-perf-sweep.md
@@ -51,7 +51,38 @@ _(pending on-device run)_
 
 ## Desktop validation (sanity check of the harness itself)
 
-_(filled in below during the build session)_
+Validated end-to-end on desktop Chrome (Mac, 120Hz rAF cap) against the dev server
+before the device run:
+
+- Install gate, hello row, 66-scenario queue build, JSONL streaming: ✔
+- Driver autonomously reaches the lobby start button, requests 8 bots, race starts,
+  bots spawn in random cosmetics (dev world.js patch): ✔
+- Race-gated samples complete with correct gates (state 3→3, alive 9, ice>0,
+  pinned-tier label, gl ratio 1.0) at the 120fps display cap, worst ~9ms: ✔
+- localStorage resume after reload skips completed labels: ✔
+- Requeue/wait on gate failure (lobby/overview between rounds): ✔ after a fix —
+  see "lessons" below.
+
+Lessons baked back into the harness during validation:
+
+1. **Don't pin the all-ice playlist.** The AI can't finish ice-heavy maps (the
+   ice-nav fix lives in unmerged PR #181) and NOTHING else ends a racing round —
+   the sweep stalled forever in round 1. The default (featured) rotation carries
+   enough ice for the `ice>0` gate, and bots actually finish those maps. A 90s
+   round watchdog was also added: the driver goal-seeks with its own kart to force
+   the round over if bots wedge anyway.
+2. **Pre-window gate failures must WAIT, not burn retry attempts** — sitting out
+   the lobby/overview between rounds is normal. Attempts are only consumed by
+   windows that started and then got poisoned (state flip / stall / hidden), plus
+   a 180s wait budget per visit.
+3. Desktop-only trap (irrelevant on-device, fatal in validation): another agent
+   session sharing Chrome steals tab focus; a hidden tab freezes rAF and
+   eventually trips the AFK kick via intensive timer throttling. Running the
+   harness in its own Chrome window (visibility is per-window occlusion, not app
+   focus) fixed it.
+4. The lobby floor's ice cells make the drive to the start button SLOW
+   (`ice.acel` = 15 vs 300) — patience, not a bug; the wedge-escape handles the
+   shoreline pockets.
 
 ## Follow-ups
 

--- a/docs/spikes/device-render-perf-sweep.md
+++ b/docs/spikes/device-render-perf-sweep.md
@@ -185,8 +185,35 @@ viewing sizes). Low keeps glow off; High keeps the original single-blit path.
 
 Desktop verification (targeted `&phfilter=` runs through the new path):
 founders_flare/aurora/comet on pinned Balanced all at the 120 fps display cap, gl 1.0,
-visuals spot-checked. Phone re-verification of the Balanced subset: pending (one
-~5-min targeted run).
+visuals spot-checked.
+
+### Final phone verification (corrected racing-only gate, rested device)
+
+| Row (run order) | FPS | Pre-fix racing |
+| --- | --- | --- |
+| carts pizza / golden_champion | 60.1 | 60.1 |
+| trailFx:comet | 31.8 | (no valid pre — old row was gated) |
+| **trailFx:founders_flare** | **36.8** | 26.6 (+38%) |
+| **trailFx:aurora** | **37.6** | 27.2 (+38%) |
+| pattern:nebula | 39.7 | 57.7 |
+| border:border_runes | 26.8 | 60.1 |
+| combo:worst | 15.8 | 45.5 |
+| `__none__` baseline (ran LAST) | **60.1 / 16.7ms** | 60.1 |
+
+The baseline at the cap immediately after combo's 15.8 is the decisive read: the
+device recovers instantly when cosmetics come off, so the low rows are the genuine
+sustained cost of 9 heavy-cosmetic karts racing at Balanced on a phone-class GPU —
+not a lingering thermal state. (nebula/border deltas vs pre-fix carry round/map
+variance; the same-position founders/aurora comparison is the controlled one.)
+
+**Conclusion:** the glowScale fix delivers a real +38% on the two worst trails and is
+kept. Beyond it, phone-class GPUs at Balanced are simply above budget under 9-wearer
+load (~27-45 fps; stacked combo 15.8) — while the SAME phone at Low (its actual
+Auto tier) runs everything at 60, and iPad-Balanced holds 59-60 racing. Further
+per-painter surgery can't close a ~2× hardware gap. If weak Android tablets
+(Auto→Balanced) ever report stutter in the field, the product lever is a one-line
+`namedDeviceTier` demotion of Android tablets to `low` — operator decision,
+deliberately NOT shipped in this branch.
 
 Also added for that verification: `&phfilter=<substr>[,<substr>]` harness URL param —
 filters the scenario queue (cap_probe always runs), skips persistence, so a post-fix

--- a/docs/spikes/device-render-perf-sweep.md
+++ b/docs/spikes/device-render-perf-sweep.md
@@ -1,6 +1,6 @@
 # On-device render-performance sweep (real iPad / Android hardware)
 
-**Status:** iPad run COMPLETE (66/66 scenarios, 0 skips). Android still pending a device.
+**Status:** COMPLETE — iPad run 66/66 and Android-phone run 66/66, both 0 skips.
 **Date:** 2026-06-04
 **Branch:** `worktree-perf-device-sweep`
 
@@ -95,17 +95,71 @@ real mobile hardware at every tier the device can Auto-resolve to.
 - Mid-run resume worked in production conditions: 16 banked rows survived the
   sleep, the remaining 50 completed after wake with no duplicates or skips.
 
+## Device results — Android phone (Android 10+, Chrome 148 Mobile, 8 cores, dpr 2.625, 412×915)
+
+Display cap: **60 fps** (probe 58.8). Auto tier resolved: **low** (as `namedDeviceTier`
+predicts for Android phones). 66/66 scenarios, 0 skips, gl 1.0 throughout. Early-run
+page reloads (Android pull-to-refresh) were absorbed by localStorage resume — 4 hellos,
+zero lost rows. Android Chrome's keep-awake video DID hold the screen (no sleep, unlike
+iPadOS).
+
+### Low — the tier phones actually ship with (Auto): ALL CLEAR
+
+All hot spots, worst-combo, random_mix, and random unknowns ≥54 fps, almost all at the
+60 cap with 17ms worsts. The two sub-58 rows carry ambient-hitch signatures (a
+`__none__` baseline itself read 55.8 with a 233ms one-off spike during the early reload
+churn; wheel_of_fortune 54.3/100ms in the same stretch).
+
+### Balanced — what ANDROID TABLETS Auto-resolve to: two glow-heavy trails collapse
+
+| Scenario (balanced) | FPS | Worst ms |
+| --- | --- | --- |
+| __none__ baseline / carts / border_runes | 60.1 | 17 |
+| pattern:nebula | 57.7 | 33 |
+| trailFx:comet | 60.1 | 17 |
+| **trailFx:founders_flare** | **26.6** | 50 |
+| **trailFx:aurora** | **27.2** | 50 |
+| combo:worst | 45.5 | 33 |
+
+Baseline-anchored (60.1 same phase). Balanced keeps `glow: true` at 0.6× particle
+volume — founders_flare/aurora's glow passes still overwhelm a phone-class GPU. This is
+the strongest finding of the device round: **an Android tablet (Auto→balanced) with
+multiple founders_flare/aurora wearers could see ~27 fps.** Mitigation context: 9
+same-trail wearers is the synthetic stress case; typical rooms have 1-2.
+
+### High (manual override only): combo collapse, trails individually OK
+
+Unlike the iPad (individual trails 24-42 on High), this phone runs each heavy trail at
+57-60 on High but **combo:worst collapses to 22.8 fps** — cumulative 4-layer cost, not
+any single effect. One more suggestive row: golden_champion 38.1 on the heaviest-ice
+round (89 sites) while a Low-tier row in the SAME round read 60.1 — plausibly the
+statue-skin × ice-reflection repaint interaction at High's full budget; single reading,
+not chased.
+
+## Cross-device picture
+
+- **Every tier Auto can actually pick is clean**: iPad→Balanced ✔, Android
+  phone→Low ✔ (and iPad Balanced runs even the heavy trails at cap — tablet iPad GPU
+  ≫ phone GPU at the same tier).
+- The trail-glow budget is the consistent offender once you step one tier above a
+  device's Auto resolution: founders_flare + aurora are the worst, comet next.
+- Worst-frame stutter (>50ms) only ever accompanied the low-FPS rows or one-off
+  ambient hitches — no silent texture-upload stutter at healthy FPS readings.
+
 ## Follow-up prompt (operator-injectable)
 
-> High graphics tier on tablets degrades on heavy trails (iPad: comet 38 fps,
-> founders_flare 24 fps, aurora 37 fps w/ 96 ms hitches at 9 wearers; Balanced and
-> Low hold 60). Auto never picks High on tablets, so this only affects manual
-> overrides. If we want it fixed anyway: scale the trail/glow particle budget by
-> device class even when pref=High (e.g. touch devices get particleCount 0.6 +
-> maxEffects 280 for trail FX only), or simply cap maxEffects on touch-High.
-> Verify with `PERF_HARNESS=1 UNLOCK_ALL_COSMETICS=true PORT=<free> node index.js`
-> + `http://<LAN-IP>:<port>/play.html?perfharness=1` on the device — the
-> harness's phase-2 High subset covers exactly these ids.
+> Glow-heavy trails (founders_flare, aurora — comet next) overwhelm mobile GPUs one
+> tier above the device's Auto resolution. Measured at 9 same-trail wearers:
+> Android phone on Balanced 26.6/27.2 fps (Balanced is what ANDROID TABLETS
+> Auto-resolve to — the real exposure); iPad on High 24-42 fps; phone on High
+> combo 22.8 fps. Every Auto-picked tier is clean on both devices. Recommended
+> shape of a fix: gate the trail glow pass (`perfGlow()`-style) or scale the trail
+> particle budget by device class (touch → Low's trail knobs) even when the
+> player pins a higher tier — or demote just founders_flare/aurora's glow on
+> touch devices. Verify on-device with
+> `PERF_HARNESS=1 UNLOCK_ALL_COSMETICS=true PORT=<free> node index.js` +
+> `http://<LAN-IP>:<port>/play.html?perfharness=1` — the phase-2 tier subsets
+> cover exactly these ids; compare against the committed tables in this doc.
 
 ## Raw data
 

--- a/docs/spikes/device-render-perf-sweep.md
+++ b/docs/spikes/device-render-perf-sweep.md
@@ -1,6 +1,6 @@
 # On-device render-performance sweep (real iPad / Android hardware)
 
-**Status:** in progress — harness built + desktop-validated; awaiting on-device run.
+**Status:** iPad run COMPLETE (66/66 scenarios, 0 skips). Android still pending a device.
 **Date:** 2026-06-04
 **Branch:** `worktree-perf-device-sweep`
 
@@ -42,12 +42,76 @@ mostly carry some ice; ice-only playlist deliberately NOT pinned — see lessons
 pinned tier label in effect; failures auto-requeue (max 8 attempts). Each row records mean FPS **and worst single-frame ms** (stutter
 hides in averages — GPU texture re-upload lesson).
 
-## Device results
+## Device results — iPad (iPadOS 26.5, Chrome/WebKit, 8 cores, dpr 2, 1180×688)
 
-_(pending on-device run)_
+Display cap (rAF ceiling): **60 fps** (cap_probe). Healthy = 60; flag <45.
+Auto tier resolved: **balanced** (matches `namedDeviceTier`). 66/66 scenarios, 0 skips,
+gl ratio 1.0 throughout (no duplicate render chain on the device).
 
-| Tier | Scenario | FPS | Worst ms | Notes |
-| ---- | -------- | --- | -------- | ----- |
+### Balanced — the tier iPads actually ship with (Auto): ALL CLEAR
+
+All 8 hot-spot carts, all 7 hot-spot trails (comet, founders_flare, bolt, aurora,
+neon, ripple, guardian), nebula, border_runes, the worst-combo
+(warlord+nebula+border_runes+comet), random_mix, and all 18 random unknowns +
+2 random combos read **60 fps at the display cap, worst frame 17-22ms** (17ms =
+no dropped frames at 60Hz). Three soft rows, all explained by ambient hitches —
+an interleaved `__none__` baseline itself read 56 fps / 86ms worst, so these are
+round-transition/GC/texture hitches, not cosmetics:
+
+| Scenario (balanced) | FPS | Worst ms | Verdict |
+| --- | --- | --- | --- |
+| border:border_runes | 54.9 | 130 | ambient hitch (same border reads 60/17 on High; combo carrying it reads 59/21) |
+| rnd|cart:eight_ball | 58.2 | 77 | ambient hitch (baseline #8 hitched 86ms with cosmetics OFF) |
+| __none__#8 (baseline) | 56.0 | 86 | the ambient hitch itself |
+
+### Low: ALL CLEAR — every subset row at 60 fps / 17ms worst.
+
+### High (manual override only on an iPad): heavy trails degrade
+
+| Scenario (high) | FPS | Worst ms |
+| --- | --- | --- |
+| __none__ baseline | 60 | 17 |
+| cart:pizza / cart:golden_champion | 60 | 17 |
+| pattern:nebula / border:border_runes | 60 | 17 |
+| **trailFx:comet** | **37.9** | 30 |
+| **trailFx:founders_flare** | **24.4** | 44 |
+| **trailFx:aurora** | **37.4** | **96** |
+| **combo:worst** (carries comet) | **42.1** | 26 |
+
+Reproducible and baseline-anchored (60-fps baseline in the same round). The delta
+vs Balanced is the High knob set: full particle volume (particleCount 1.0 vs 0.6),
+no effect cap (100000 vs 280), shorter spawn cooldowns — per-particle glow blits at
+full volume overwhelm the mobile GPU. **Not a ship blocker**: Auto never puts a
+tablet on High; a player must force it manually. Verdict: the PR #259 fixes hold on
+real mobile hardware at every tier the device can Auto-resolve to.
+
+### Run notes
+
+- The NoSleep-style muted looping video does NOT prevent screen sleep on
+  iPadOS 26 (Chrome or Safari — both WebKit). The device slept mid-run; gates
+  caught it, rows resumed cleanly after wake. **Operator must set
+  Settings → Display & Brightness → Auto-Lock → Never for the run.** The video
+  + visibility gates remain useful (re-arm on tap, poisoned-window requeue).
+- Mid-run resume worked in production conditions: 16 banked rows survived the
+  sleep, the remaining 50 completed after wake with no duplicates or skips.
+
+## Follow-up prompt (operator-injectable)
+
+> High graphics tier on tablets degrades on heavy trails (iPad: comet 38 fps,
+> founders_flare 24 fps, aurora 37 fps w/ 96 ms hitches at 9 wearers; Balanced and
+> Low hold 60). Auto never picks High on tablets, so this only affects manual
+> overrides. If we want it fixed anyway: scale the trail/glow particle budget by
+> device class even when pref=High (e.g. touch devices get particleCount 0.6 +
+> maxEffects 280 for trail FX only), or simply cap maxEffects on touch-High.
+> Verify with `PERF_HARNESS=1 UNLOCK_ALL_COSMETICS=true PORT=<free> node index.js`
+> + `http://<LAN-IP>:<port>/play.html?perfharness=1` on the device — the
+> harness's phase-2 High subset covers exactly these ids.
+
+## Raw data
+
+Full JSONL row sets archived in the session job dir during the run
+(`desktop-sweep.jsonl`, `ipad-sweep.jsonl`); regenerate any time by re-running the
+harness — rows stream to `perf-harness-report.jsonl`.
 
 ## Desktop validation (sanity check of the harness itself)
 
@@ -95,6 +159,3 @@ desktop methodology prescribes. Per-id desktop verdicts were already settled in
 `docs/spikes/cosmetic-perf-verification.md`; this run validates the harness, the
 device run is the new data.
 
-## Follow-ups
-
-_(pending)_

--- a/docs/spikes/device-render-perf-sweep.md
+++ b/docs/spikes/device-render-perf-sweep.md
@@ -1,0 +1,58 @@
+# On-device render-performance sweep (real iPad / Android hardware)
+
+**Status:** in progress — harness built + desktop-validated; awaiting on-device run.
+**Date:** 2026-06-04
+**Branch:** `worktree-perf-device-sweep`
+
+Port of the desktop live render-perf harness (see `docs/spikes/cosmetic-perf-verification.md`
+for the desktop round this follows up) to a self-installing, on-device variant: the page
+itself runs the sampler/driver/reporting autonomously so a real tablet/phone can be swept
+by just opening a URL.
+
+## How to run
+
+```bash
+npm install
+PERF_HARNESS=1 UNLOCK_ALL_COSMETICS=true PORT=<free> node index.js
+# (optional, dev-only, never commit: the world.js bot-cosmetics patch so the
+#  random_mix scenario dresses bots in random cosmetics)
+```
+
+Then open `http://<LAN-IP>:<port>/play.html?perfharness=1` on the device, tap once
+(arms the keep-awake video), and keep the page foregrounded. Rows stream to
+`perf-harness-report.jsonl` (override path with `PERF_HARNESS_LOG`).
+
+Activation requires BOTH the `?perfharness=1` URL param AND `config.perfHarness === true`
+(only set when the server booted with `PERF_HARNESS=1`), so the committed plumbing is
+inert in prod.
+
+## Scenario matrix
+
+1. `cap_probe` — display-cap calibration (visible-only gate, runs in lobby).
+2. Optimal (Auto-resolved) tier: `__none__` baselines + the desktop-round hot spots
+   (carts pizza, golden_champion, wheel_of_fortune, firetruck, compass, coin, dartboard,
+   clock; trails comet, founders_flare, bolt, aurora, neon, ripple, guardian;
+   border_runes; nebula) + worst-combo (warlord+nebula+border_runes+comet) + random_mix.
+3. Pinned non-optimal tiers (high/balanced/low): baseline + confirmation subset + combo.
+4. Random unknowns (seeded, 4 per slot + 2 combos) on the optimal tier.
+
+All race-gated samples require: tab visible, state ∈ {gated, racing, collapsing} and
+unchanged across the window, 9 karts alive, ice on the map (`setLobbyPlaylist 'ice'`
+pins the Slip & Slide playlist), pinned tier label in effect; failures auto-requeue
+(max 8 attempts). Each row records mean FPS **and worst single-frame ms** (stutter
+hides in averages — GPU texture re-upload lesson).
+
+## Device results
+
+_(pending on-device run)_
+
+| Tier | Scenario | FPS | Worst ms | Notes |
+| ---- | -------- | --- | -------- | ----- |
+
+## Desktop validation (sanity check of the harness itself)
+
+_(filled in below during the build session)_
+
+## Follow-ups
+
+_(pending)_

--- a/docs/spikes/device-render-perf-sweep.md
+++ b/docs/spikes/device-render-perf-sweep.md
@@ -100,8 +100,10 @@ real mobile hardware at every tier the device can Auto-resolve to.
 Display cap: **60 fps** (probe 58.8). Auto tier resolved: **low** (as `namedDeviceTier`
 predicts for Android phones). 66/66 scenarios, 0 skips, gl 1.0 throughout. Early-run
 page reloads (Android pull-to-refresh) were absorbed by localStorage resume — 4 hellos,
-zero lost rows. Android Chrome's keep-awake video DID hold the screen (no sleep, unlike
-iPadOS).
+zero lost rows. Operator-confirmed: the keep-awake video did NOT hold the screen on
+Android Chrome either — the phone slept at its own 10-minute timeout mid-run and the
+gates + resume absorbed it. **Treat screen-timeout/Auto-Lock override as the required
+keep-awake mechanism on BOTH platforms**; the video is best-effort only.
 
 ### Low — the tier phones actually ship with (Auto): ALL CLEAR
 

--- a/docs/spikes/device-render-perf-sweep.md
+++ b/docs/spikes/device-render-perf-sweep.md
@@ -148,6 +148,25 @@ not chased.
 - Worst-frame stutter (>50ms) only ever accompanied the low-FPS rows or one-off
   ambient hitches — no silent texture-upload stutter at healthy FPS readings.
 
+## CORRECTION (post-fix verification round): the gated-state confound
+
+The original gate accepted `gated` rounds — but gated karts are PARKED and lay no
+trail, so **every trail-scenario row that ran in state 3 is a phantom** (same id,
+same device: gated 60 fps vs racing 27). Re-reading the tables above with states:
+
+- Phone Balanced collapses (founders_flare 26.6 / aurora 27.2 / combo 45.5) were
+  RACING rows — real. Phone-High "trails individually fine" was gated — unmeasured.
+- iPad-High trail collapses were racing — real. iPad-Balanced per-id trail rows were
+  mostly gated, BUT its racing rows (combo:worst 59, guardian 60, random_mix 60)
+  show iPad-Balanced genuinely holds up.
+- Phone Low all-clear: mostly racing rows — real.
+
+The harness gate now requires racing/collapsing (gated excluded) for every scenario.
+Verification runs also surfaced **thermal throttling** as a third confound: the 3rd
+consecutive ~run on the phone read cap_probe 49 fps (vs 58 rested) with whole-frame
+degradation and 250-550ms ambient stalls — rest the device between runs and judge
+only against same-round baselines.
+
 ## Fix shipped on this branch: downsampled trail-glow composite on Balanced
 
 Investigated post-sweep (operator-requested). Root cause of the Balanced

--- a/docs/spikes/device-render-perf-sweep.md
+++ b/docs/spikes/device-render-perf-sweep.md
@@ -37,9 +37,9 @@ inert in prod.
 4. Random unknowns (seeded, 4 per slot + 2 combos) on the optimal tier.
 
 All race-gated samples require: tab visible, state ∈ {gated, racing, collapsing} and
-unchanged across the window, 9 karts alive, ice on the map (`setLobbyPlaylist 'ice'`
-pins the Slip & Slide playlist), pinned tier label in effect; failures auto-requeue
-(max 8 attempts). Each row records mean FPS **and worst single-frame ms** (stutter
+unchanged across the window, 9 karts alive, ice on the map (default rotation maps
+mostly carry some ice; ice-only playlist deliberately NOT pinned — see lessons),
+pinned tier label in effect; failures auto-requeue (max 8 attempts). Each row records mean FPS **and worst single-frame ms** (stutter
 hides in averages — GPU texture re-upload lesson).
 
 ## Device results
@@ -83,6 +83,17 @@ Lessons baked back into the harness during validation:
 4. The lobby floor's ice cells make the drive to the start button SLOW
    (`ice.acel` = 15 vs 300) — patience, not a bug; the wedge-escape handles the
    shoreline pockets.
+
+The full 66-scenario desktop run completed (66 samples, 0 skips, ~25 min,
+Chrome/Mac M-series, 120Hz cap): clean stretches read 120 fps across hot spots
+(pizza/golden_champion/comet/etc.) on High; Balanced ~89-104; Low ~96-104. A
+late-run stretch dipped to 49-77 fps — **including the interleaved `__none__`
+baselines (52-67)** — i.e. an environmental dip (the harness window was
+backgrounded/partially occluded; macOS Chrome throttles occluded windows), not a
+cosmetic regression. Judge ids relative to the nearest baseline, exactly as the
+desktop methodology prescribes. Per-id desktop verdicts were already settled in
+`docs/spikes/cosmetic-perf-verification.md`; this run validates the harness, the
+device run is the new data.
 
 ## Follow-ups
 

--- a/index.js
+++ b/index.js
@@ -369,6 +369,27 @@ app.get('/ops/status', function (req, res) {
     });
 });
 
+// Dev-only render-perf harness sink (client/scripts/perfharness.js). Registered ONLY
+// when PERF_HARNESS is set (c.perfHarness) so prod never exposes the route. The page
+// POSTs one JSON row per completed/skipped sample plus a final summary; rows append as
+// JSONL to PERF_HARNESS_LOG (default perf-harness-report.jsonl in the repo root) for
+// the operator/agent to tail. Same express.json body-cap pattern as /feedback above;
+// no rate limit — the route only exists on a local dev server.
+if (c.perfHarness) {
+    var perfHarnessLog = process.env.PERF_HARNESS_LOG || path.join(__dirname, 'perf-harness-report.jsonl');
+    console.log('[perfHarness] report sink ON -> ' + perfHarnessLog);
+    app.post('/__perf/report', express.json({ limit: '256kb' }), function (req, res) {
+        var row = req.body || {};
+        row.serverTime = Date.now();
+        try {
+            fs.appendFileSync(perfHarnessLog, JSON.stringify(row) + '\n');
+        } catch (e) {
+            console.log('[perfHarness] write failed: ' + e.message);
+        }
+        res.json({ status: true });
+    });
+}
+
 //Base Server vars
 var serverSleeping = true,
     pendingReboot = false,

--- a/index.js
+++ b/index.js
@@ -373,13 +373,50 @@ app.get('/ops/status', function (req, res) {
 // when PERF_HARNESS is set (c.perfHarness) so prod never exposes the route. The page
 // POSTs one JSON row per completed/skipped sample plus a final summary; rows append as
 // JSONL to PERF_HARNESS_LOG (default perf-harness-report.jsonl in the repo root) for
-// the operator/agent to tail. Same express.json body-cap pattern as /feedback above;
-// no rate limit — the route only exists on a local dev server.
+// the operator/agent to tail. Defense-in-depth even though the route only exists on a
+// local dev server: same express.json body cap as /feedback, a per-IP rate limit, and
+// the body is projected through a typed allowlist (numbers coerced, strings stripped
+// to printable ASCII and length-capped) so request data never flows raw to disk.
 if (c.perfHarness) {
     var perfHarnessLog = process.env.PERF_HARNESS_LOG || path.join(__dirname, 'perf-harness-report.jsonl');
     console.log('[perfHarness] report sink ON -> ' + perfHarnessLog);
+    var perfReportLimited = makeRateLimiter(60 * 1000, 600); // ~1 row/2s per device + bursts
+    var phNum = function (v) { var n = Number(v); return isFinite(n) ? n : null; };
+    var phStr = function (v) {
+        return (typeof v === 'string') ? v.replace(/[^\x20-\x7E]/g, '').slice(0, 300) : null;
+    };
+    // Allowlist projection of one report row. Nested summary `results` are dropped —
+    // every row was already streamed (and logged) individually as it completed.
+    function cleanPerfRow(b) {
+        var row = {};
+        ['kind', 'label', 'tier', 'tierLabel', 'reason', 'note', 'v'].forEach(function (k) {
+            if (b[k] != null) { row[k] = phStr(b[k]); }
+        });
+        ['fps', 'worstMs', 'frames', 'durMs', 'state0', 'state1', 'alive', 'ice', 'gl',
+            'attempt', 'idx', 'total', 't', 'queued', 'n'].forEach(function (k) {
+                if (b[k] != null) { row[k] = phNum(b[k]); }
+            });
+        if (Array.isArray(b.filter)) { row.filter = b.filter.slice(0, 16).map(phStr); }
+        if (b.device && typeof b.device === 'object') {
+            var d = {};
+            ['ua', 'platform', 'autoTier', 'storedPref'].forEach(function (k) {
+                if (b.device[k] != null) { d[k] = phStr(b.device[k]); }
+            });
+            ['dpr', 'iw', 'ih', 'sw', 'sh', 'cores', 'mem'].forEach(function (k) {
+                if (b.device[k] != null) { d[k] = phNum(b.device[k]); }
+            });
+            d.touch = !!b.device.touch;
+            d.resumed = !!b.device.resumed;
+            row.device = d;
+        }
+        return row;
+    }
     app.post('/__perf/report', express.json({ limit: '256kb' }), function (req, res) {
-        var row = req.body || {};
+        var ip = botGuard.resolveClientIp(req.headers['x-forwarded-for'], req.ip) || 'unknown';
+        if (perfReportLimited(ip)) {
+            return res.status(429).json({ status: false });
+        }
+        var row = cleanPerfRow(req.body || {});
         row.serverTime = Date.now();
         try {
             fs.appendFileSync(perfHarnessLog, JSON.stringify(row) + '\n');

--- a/server/utils.js
+++ b/server/utils.js
@@ -16,6 +16,12 @@ c.port = process.env.PORT || c.port;
 // gated — set UNLOCK_ALL_COSMETICS=true only on a local test server. Delivered to the
 // client in the config payload as `config.unlockAllCosmetics`.
 c.unlockAllCosmetics = (process.env.UNLOCK_ALL_COSMETICS === 'true');
+// Dev/testing seam: on-device render-perf harness (client/scripts/perfharness.js).
+// When PERF_HARNESS=1 (or true) the served config carries `perfHarness: true` — one of
+// the two activation conditions for the in-page sampler (the other is ?perfharness=1 in
+// the page URL) — and index.js registers the dev-only POST /__perf/report sink. Default
+// OFF so the harness can never activate in prod.
+c.perfHarness = (process.env.PERF_HARNESS === '1' || process.env.PERF_HARNESS === 'true');
 
 // Test-only config override seam (CI perf harness). When CHAO_PERF_OVERRIDE is a
 // JSON object, deep-merge it over the loaded config so a separate-process server


### PR DESCRIPTION
## What

Two things, born from the same on-device performance round:

### 1. Self-installing on-device render-perf harness (dev-only)

Ports the desktop live-perf methodology (autonomous rAF sampler + bot driver + gated sample windows) into a committed, self-installing harness so real iPad/Android hardware can be swept by just opening a URL:

- `client/scripts/perfharness.js` — sampler (per-scenario FPS + worst-frame ms, start/end gating on visible/racing/9-alive/ice/pinned-tier, auto-requeue, localStorage resume), driver (bots via `setLobbyAI`, start-button seeking with wedge-escape, 90s goal-seek round watchdog), keep-awake video, JSONL reporting, `&phfilter=` targeted-verify mode
- `POST /__perf/report` JSONL sink in `index.js` (mirrors the `/feedback` pattern)
- `c.perfHarness` env gate in `server/utils.js`

**Activation requires BOTH `?perfharness=1` in the URL AND `PERF_HARNESS=1` on the server** (delivered via the config payload), so the committed plumbing is inert in prod. The script ships in the play bundle (~8KB minified) but no-ops without both gates.

### 2. `perf(client)`: downsampled trail-glow composite on Balanced

The device sweep measured founders_flare/aurora trails at ~27 FPS (racing, 9 wearers) on a phone-class GPU at Balanced. Root cause: the trail-glow `shadowBlur` composite runs over **destination-sized** rects (near-screen per trail at dpr 2) — 1-2 blits × 9 wearers per frame of pure GPU fill, invisible to JS profiling.

Fix: new `glowScale` PERF knob — **High stays 1 = bit-for-bit the existing path** (the tier's no-op promise); Balanced 0.5 routes the glow through a downsampled intermediate (body at half res, gaussian over ¼ the pixels, one plain smoothed upscale). The soft halo reads the same.

**On-device verified: founders_flare 26.6→36.8 FPS, aurora 27.2→37.6 (+38%)**, controlled same-round comparisons, reproduced twice.

## Findings (full tables in `docs/spikes/device-render-perf-sweep.md`)

- iPad (Auto→Balanced) and Android phone (Auto→Low): **every Auto-picked tier clean at the 60fps cap** in real racing windows — the PR #259 fixes hold on mobile GPUs
- Residual after the fix: phone-class GPUs are **hardware-bound at Balanced** under 9-heavy-wearer load (~27-45 FPS; instant-recovery baseline proved real load, not thermal). Phones never ship Balanced; the only exposure is weak Android tablets — the documented lever (deliberately NOT shipped here) is a one-line `namedDeviceTier` demotion of Android tablets to `low`
- Methodology corrections baked into the harness + doc: gated-state windows are phantoms for trails (parked karts), thermal throttling on consecutive phone runs, keep-awake video doesn't hold screens on either mobile platform (Auto-Lock override required)

## Verification

- `npm run build` + headless smoke test green (re-run post-rebase onto main)
- Codex review: working-tree, branch-diff, and post-fix branch-diff passes — all clean
- Desktop: High path unchanged (gs=1 short-circuit), Balanced trails at the 120 cap through the new path, visuals spot-checked
- CHANGELOG: exempt (perf work; no config/game/engine changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)