### PR TITLE
feat(progression): unlock celebrations, capped-hook XP curve, achievement profile tab + pacing analytics

### DIFF
--- a/.github/scripts/progression-test.js
+++ b/.github/scripts/progression-test.js
@@ -189,10 +189,13 @@ function testLevelUp() {
     // The runner-up sits JUST past the L2 floor: under the capped-hook curve (50+22n,
     // tuned so a fresh player levels off their very first decent match) a 0-XP start
     // would cross L2 too — park them where one runner-up match can't reach L3.
+    // notches: 0 keeps a comfortable margin below the L3 floor (earns 90 vs the 115
+    // needed) so a small future bump to any XP award doesn't trip this assertion for
+    // reasons unrelated to what it guards.
     const r = runMatch({
         sig: 'prog-lvl',
         p1: { id: 'prog-lvl-1', notches: 5, totalKills: 0, progression: { xp: startXp, level: 1, unlocked_skins: [], medal_counts: {}, wins: 0 } },
-        p2: { id: 'prog-lvl-2', notches: 1, totalKills: 0, progression: { xp: progression.cumulativeXpForLevel(2), level: 2, unlocked_skins: [], medal_counts: {}, wins: 0 } }
+        p2: { id: 'prog-lvl-2', notches: 0, totalKills: 0, progression: { xp: progression.cumulativeXpForLevel(2), level: 2, unlocked_skins: [], medal_counts: {}, wins: 0 } }
     });
     check(r.p1.progression.level >= 2, 'winner cache level advanced past 1 (-> ' + r.p1.progression.level + ')');
     check(r.p2.progression.level === 2, 'low-XP runner-up stayed level 2');
@@ -413,8 +416,29 @@ function testSpectatorEarnsNothing() {
     check((r.p1.progression.wins || 0) === 0, '1 racer + 1 spectator is not "2 humans" — solo win does not count');
 }
 
+// MIGRATION-SAFETY GUARD: the live curve must stay at-or-below the ORIGINAL launch
+// curve (50·n^1.6) at every cumulative floor, forever. Level is derived from xp on
+// read, so any curve whose floors exceed a previous curve's would DEMOTE existing
+// players and revoke equipped level skins. If a retune trips this, make it cheaper —
+// never steeper than this pinned reference.
+function testCurveNeverDemotes() {
+    console.log('Curve migration safety (no demotion vs original 50·n^1.6 curve):');
+    function origReq(n) { return n <= 1 ? 0 : Math.round(50 * Math.pow(n, 1.6)); }
+    var origCum = 0, ok = true;
+    for (var n = 2; n <= 120; n++) {
+        origCum += origReq(n);
+        if (progression.cumulativeXpForLevel(n) > origCum) {
+            ok = false;
+            check(false, 'cumulative floor of Lv' + n + ' exceeds the original curve (' +
+                progression.cumulativeXpForLevel(n) + ' > ' + origCum + ') — this curve would demote players');
+        }
+    }
+    if (ok) { check(true, 'every cumulative floor Lv2-120 is <= the original launch curve'); }
+}
+
 (async function run() {
     testPureHelpers();
+    testCurveNeverDemotes();
     testXpBreakdown();
     testWinnerFromGameOverArg();
     testLevelUp();

--- a/.github/scripts/progression-test.js
+++ b/.github/scripts/progression-test.js
@@ -186,13 +186,16 @@ function testLevelUp() {
     // crosses it. The Racing Stripes pattern (id 'stripes') unlocks at Lv2, so crossing
     // into Lv2 should also queue a "skin" toast.
     const startXp = progression.cumulativeXpForLevel(2) - 12;
+    // The runner-up sits JUST past the L2 floor: under the capped-hook curve (50+22n,
+    // tuned so a fresh player levels off their very first decent match) a 0-XP start
+    // would cross L2 too — park them where one runner-up match can't reach L3.
     const r = runMatch({
         sig: 'prog-lvl',
         p1: { id: 'prog-lvl-1', notches: 5, totalKills: 0, progression: { xp: startXp, level: 1, unlocked_skins: [], medal_counts: {}, wins: 0 } },
-        p2: { id: 'prog-lvl-2', notches: 1, totalKills: 0, progression: progression.defaultProgression() }
+        p2: { id: 'prog-lvl-2', notches: 1, totalKills: 0, progression: { xp: progression.cumulativeXpForLevel(2), level: 2, unlocked_skins: [], medal_counts: {}, wins: 0 } }
     });
     check(r.p1.progression.level >= 2, 'winner cache level advanced past 1 (-> ' + r.p1.progression.level + ')');
-    check(r.p2.progression.level === 1, 'low-XP runner-up stayed level 1');
+    check(r.p2.progression.level === 2, 'low-XP runner-up stayed level 2');
     const t1 = drainMem('prog-lvl-1');
     check(t1.some(e => e.type === 'level' && e.level >= 2), 'winner queued a level-up toast');
     check(t1.some(e => e.type === 'skin' && e.id === 'stripes'), 'winner queued a Racing Stripes (stripes, Lv2) new-cosmetic toast');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- Leveling up is way faster now — and unlocking something new feels like it! XP needed per level has been massively reduced (no level ever costs more than ~10 matches' worth, and nobody loses progress — most players will jump several levels and find new cosmetics waiting). Unlocks now land every few matches instead of dozens.
+- New celebration screens: earning XP fills an animated level bar, leveling up gets a proper fanfare, and unlocking a cosmetic shows the actual item spinning in your color with confetti and a crowd cheer — plus a peek at the next skin you're closing in on.
 
 ## v0.28.5 — 2026-06-04
 

--- a/analytics/ga-config.json
+++ b/analytics/ga-config.json
@@ -24,7 +24,7 @@
       "parameterName": "playlist",
       "displayName": "Playlist",
       "scope": "EVENT",
-      "description": "Active map playlist on round_start/round_complete/match_end (featured | hardcore | pure | all | …). Lets gameplay be segmented by playlist and surfaces per-playlist skew."
+      "description": "Active map playlist on round_start/round_complete/match_end (featured | hardcore | pure | all | \u2026). Lets gameplay be segmented by playlist and surfaces per-playlist skew."
     },
     {
       "parameterName": "trap_source",
@@ -49,6 +49,24 @@
       "displayName": "Reward Bonus",
       "scope": "EVENT",
       "description": "Which rewarded bonus a player claimed on reward_claimed: xp_2x (double match XP). Extensible to future rewarded options."
+    },
+    {
+      "parameterName": "cosmetic_id",
+      "displayName": "Cosmetic Id",
+      "scope": "EVENT",
+      "description": "Which cosmetic was unlocked on cosmetic_unlocked (registry id, e.g. pizza, comet, border_ring)."
+    },
+    {
+      "parameterName": "cosmetic_slot",
+      "displayName": "Cosmetic Slot",
+      "scope": "EVENT",
+      "description": "Slot of the unlocked cosmetic on cosmetic_unlocked: cart | pattern | trail | border."
+    },
+    {
+      "parameterName": "unlock_kind",
+      "displayName": "Unlock Kind",
+      "scope": "EVENT",
+      "description": "How the cosmetic was earned on cosmetic_unlocked: skin (level ladder) | achievement | seasonal."
     }
   ],
   "customMetrics": [
@@ -65,6 +83,20 @@
       "scope": "EVENT",
       "measurementUnit": "STANDARD",
       "description": "Bots present in a match (used to separate humans-only metrics)."
+    },
+    {
+      "parameterName": "xp",
+      "displayName": "XP Earned",
+      "scope": "EVENT",
+      "measurementUnit": "STANDARD",
+      "description": "XP credited on xp_earned (per-match award; also fired for the rewarded 2x bonus). averageXp drives the pacing retune."
+    },
+    {
+      "parameterName": "level",
+      "displayName": "Player Level",
+      "scope": "EVENT",
+      "measurementUnit": "STANDARD",
+      "description": "Player level on level_up (level reached) and xp_earned (level after the award). Distribution over time shows curve pacing."
     }
   ],
   "keyEvents": [
@@ -74,6 +106,10 @@
     },
     {
       "eventName": "verified_human",
+      "countingMethod": "ONCE_PER_EVENT"
+    },
+    {
+      "eventName": "cosmetic_unlocked",
       "countingMethod": "ONCE_PER_EVENT"
     }
   ]

--- a/build.js
+++ b/build.js
@@ -17,6 +17,7 @@ const bundles = {
         'client/scripts/borderEffects.js',
         'client/scripts/terrainfx.js',
         'client/scripts/skinRegistry.js',
+        'client/scripts/celebrations.js',
         'client/scripts/gameboard.js',
         'client/scripts/lobbyHub.js',
         'client/scripts/audience.js',

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -2009,6 +2009,25 @@ html.cc-embedded .cc-toast {
     letter-spacing: 2px;
 }
 .cc-unlock-hint { font-size: 11px; opacity: 0.45; margin-top: 14px; }
+/* bulk-unlock summary card: grid of mini previews instead of N sequential reveals */
+.cc-unlock-grid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px;
+    margin: 14px 0 6px;
+    max-width: 340px;
+}
+.cc-unlock-grid-item { width: 72px; text-align: center; }
+.cc-unlock-grid-canvas { position: static; width: 64px; height: 64px; } /* beat the global canvas{position:absolute} */
+.cc-unlock-grid-name { font-size: 10px; opacity: 0.85; margin-top: 2px; }
+.cc-unlock-grid-more {
+    align-self: center;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--cc-accent, #ffd34d);
+    padding: 0 6px;
+}
 
 /* --- Confetti --------------------------------------------------------------- */
 .cc-confetti {

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1801,3 +1801,237 @@ html.cc-embedded #authLogin,
 html.cc-embedded .cc-toast {
     display: none !important;
 }
+
+/* === Progression celebrations (celebrations.js) ============================
+   Three tiers: XP card (non-blocking, top-center), level burst, and the
+   full-screen cosmetic-unlock reveal. --cc-accent is set per-card from the
+   cosmetic's rarity. z-index sits above the cc-toast family (2000) — the two
+   never show simultaneously (toasts defer while celebrations play). */
+.cc-celebrate {
+    position: fixed;
+    inset: 0;
+    z-index: 2050;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s;
+    overflow: hidden;
+}
+.cc-celebrate.visible { opacity: 1; }
+.cc-celebrate-level { background: rgba(0, 0, 0, 0.35); }
+.cc-celebrate-unlock {
+    pointer-events: auto;
+    cursor: pointer;
+    background: radial-gradient(ellipse at center, rgba(8, 10, 18, 0.55) 0%, rgba(8, 10, 18, 0.82) 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* --- Tier 1: XP card ------------------------------------------------------ */
+.cc-xp-card {
+    position: absolute;
+    left: 50%;
+    top: 76px;
+    transform: translate(-50%, -16px);
+    transition: transform 0.35s;
+    min-width: 300px;
+    max-width: 92vw;
+    padding: 14px 18px;
+    border-radius: 12px;
+    background: var(--navbar-bg);
+    color: var(--navbar-text);
+    border: 1px solid rgba(255, 211, 77, 0.85);
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 211, 77, 0.25);
+    text-align: center;
+}
+.cc-celebrate.visible .cc-xp-card { transform: translate(-50%, 0); }
+.cc-xp-amount {
+    font-size: 24px;
+    font-weight: 800;
+    color: #ffd34d;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+.cc-xp-sub { font-size: 13px; opacity: 0.85; margin-top: 2px; }
+.cc-xp-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+.cc-xp-level {
+    font-size: 13px;
+    font-weight: 700;
+    color: #ffd34d;
+    min-width: 42px;
+    text-align: left;
+}
+.cc-xp-level-pop { animation: ccXpLevelPop 0.5s ease-out; }
+@keyframes ccXpLevelPop {
+    0% { transform: scale(1); }
+    40% { transform: scale(1.6); }
+    100% { transform: scale(1); }
+}
+.cc-xp-bar {
+    flex: 1;
+    height: 10px;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.15);
+    overflow: hidden;
+}
+.cc-xp-fill {
+    height: 100%;
+    border-radius: 5px;
+    background: linear-gradient(90deg, #ffb02e, #ffd34d);
+    box-shadow: 0 0 8px rgba(255, 211, 77, 0.7);
+}
+.cc-xp-frac { font-size: 11px; opacity: 0.7; min-width: 64px; text-align: right; }
+.cc-xp-teaser {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    opacity: 0;
+    transition: opacity 0.4s;
+}
+.cc-xp-teaser.visible { opacity: 1; }
+.cc-xp-teaser-canvas { position: static; width: 30px; height: 30px; } /* beat the global canvas{position:absolute} */
+.cc-xp-teaser-text { font-size: 12.5px; opacity: 0.9; }
+
+/* --- Tier 2: level burst --------------------------------------------------- */
+.cc-level-burst {
+    position: absolute;
+    left: 50%;
+    top: 46%; /* below the lobby's stacked status banners */
+    transform: translate(-50%, -50%) scale(0.6);
+    transition: transform 0.45s cubic-bezier(0.2, 1.6, 0.4, 1);
+    text-align: center;
+}
+.cc-celebrate.visible .cc-level-burst { transform: translate(-50%, -50%) scale(1); }
+.cc-level-ring {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 30px;
+    height: 30px;
+    margin: -15px 0 0 -15px;
+    border: 3px solid rgba(255, 211, 77, 0.9);
+    border-radius: 50%;
+    animation: ccLevelRing 0.9s ease-out forwards;
+}
+@keyframes ccLevelRing {
+    0% { transform: scale(1); opacity: 1; }
+    100% { transform: scale(9); opacity: 0; }
+}
+/* shared by the standalone burst AND the pop inside the XP card */
+.cc-level-pop { margin-top: 10px; animation: ccCardPop 0.45s cubic-bezier(0.2, 1.6, 0.4, 1); }
+@keyframes ccCardPop {
+    0% { transform: scale(0.4); opacity: 0; }
+    100% { transform: scale(1); opacity: 1; }
+}
+.cc-level-pop-kicker {
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: 4px;
+    color: #ffd34d;
+}
+.cc-level-pop-num {
+    font-size: 64px;
+    font-weight: 900;
+    line-height: 1.05;
+    color: #fff;
+    text-shadow: 0 0 24px rgba(255, 211, 77, 0.8), 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+.cc-xp-card .cc-level-pop-num { font-size: 40px; }
+
+/* --- Tier 3: unlock reveal -------------------------------------------------- */
+.cc-unlock-rays {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 160vmax;
+    height: 160vmax;
+    margin: -80vmax 0 0 -80vmax;
+    background: repeating-conic-gradient(
+        from 0deg,
+        var(--cc-accent, #ffd34d) 0deg 9deg,
+        transparent 9deg 24deg
+    );
+    opacity: 0.12;
+    -webkit-mask-image: radial-gradient(circle, black 0%, transparent 62%);
+    mask-image: radial-gradient(circle, black 0%, transparent 62%);
+    animation: ccRays 18s linear infinite;
+}
+@keyframes ccRays {
+    to { transform: rotate(360deg); }
+}
+.cc-unlock-card {
+    position: relative;
+    max-width: min(420px, 92vw);
+    padding: 24px 34px 20px;
+    border-radius: 16px;
+    background: rgba(16, 19, 30, 0.96);
+    border: 2px solid var(--cc-accent, #ffd34d);
+    box-shadow: 0 0 48px rgba(0, 0, 0, 0.7), 0 0 28px var(--cc-accent, #ffd34d);
+    text-align: center;
+    color: #fff;
+    transform: scale(0.55);
+    transition: transform 0.5s cubic-bezier(0.2, 1.6, 0.4, 1);
+}
+.cc-celebrate.visible .cc-unlock-card { transform: scale(1); }
+.cc-unlock-kicker {
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: 3px;
+    color: var(--cc-accent, #ffd34d);
+}
+.cc-unlock-canvas {
+    position: static; /* beat the global canvas{position:absolute} */
+    display: block;
+    width: 200px;
+    height: 200px;
+    margin: 12px auto 6px;
+}
+.cc-unlock-name { font-size: 27px; font-weight: 800; }
+.cc-unlock-sub { font-size: 14px; opacity: 0.78; margin-top: 4px; }
+.cc-unlock-rarity {
+    display: inline-block;
+    margin-top: 10px;
+    padding: 2px 12px;
+    border: 1px solid var(--cc-accent, #ffd34d);
+    border-radius: 999px;
+    color: var(--cc-accent, #ffd34d);
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+.cc-unlock-hint { font-size: 11px; opacity: 0.45; margin-top: 14px; }
+
+/* --- Confetti --------------------------------------------------------------- */
+.cc-confetti {
+    position: absolute;
+    top: -14px;
+    width: 8px;
+    height: 13px;
+    animation: ccConfettiFall linear forwards;
+}
+@keyframes ccConfettiFall {
+    0% { transform: translate3d(0, 0, 0) rotate(0deg); opacity: 1; }
+    85% { opacity: 1; }
+    100% { transform: translate3d(var(--dx, 0px), 104vh, 0) rotate(var(--rot, 360deg)); opacity: 0; }
+}
+
+@media (max-width: 600px) {
+    .cc-unlock-canvas { width: 150px; height: 150px; }
+    .cc-unlock-name { font-size: 22px; }
+    .cc-xp-card { min-width: 260px; top: 64px; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .cc-unlock-rays { animation: none; }
+    .cc-confetti { display: none; }
+    .cc-level-ring { animation: none; opacity: 0; }
+}
+html.cc-embedded .cc-celebrate { display: none !important; }

--- a/client/play.html
+++ b/client/play.html
@@ -120,6 +120,7 @@
         <script src="scripts/borderEffects.js"></script>
         <script src="scripts/terrainfx.js"></script>
         <script src="scripts/skinRegistry.js"></script>
+        <script src="scripts/celebrations.js"></script>
         <script src="scripts/gameboard.js"></script>
         <script src="scripts/lobbyHub.js"></script>
         <script src="scripts/audience.js"></script>

--- a/client/scripts/audio.js
+++ b/client/scripts/audio.js
@@ -306,6 +306,12 @@ var musicTrackEndedHandler = null;
 
 // --- Sound descriptors (replaces the old `new Audio(...)` globals) ----------
 var playerJoinSound = makeSound("./assets/sounds/pleasing-bell.mp3");
+// Progression-celebration cues (celebrations.js): XP bar tick-up, level-up chime, and the
+// cosmetic-unlock crowd cheer. Distinct descriptors (not the in-game SFX) so their volume
+// can skip the lobby dampen — celebrations only ever play in the lobby.
+var celebrationXpTick = makeSound("./assets/sounds/collectitem.mp3");
+var celebrationLevelUp = makeSound("./assets/sounds/pleasing-bell.mp3", { duck: true });
+var celebrationCheer = makeSound("./assets/sounds/crowd-cheer-big.mp3", { duck: true });
 var playerDiedSound = makeSound("./assets/sounds/TailWhip.mp3");
 var countDownA = makeSound("./assets/sounds/countdown-a.mp3");
 var countDownB = makeSound("./assets/sounds/countdown-b.mp3");
@@ -428,6 +434,11 @@ function volumeChange() {
     // levels — they were tuned against a per-file loudness measurement.
     var sfx = masterVolume * sfxVolumeScalar;
     playerJoinSound.volume = .6 * sfx;   // join chime — must scale with the slider (historically it didn't)
+    // Celebration cues fold in the master toggle but NOT the lobby dampen scalar —
+    // they only fire in the lobby, where sfxVolumeScalar is 0.1 and would gut them.
+    celebrationXpTick.volume = .5 * masterVolume;
+    celebrationLevelUp.volume = .55 * masterVolume;
+    celebrationCheer.volume = .22 * masterVolume;  // crowd-cheer-big is mastered hot (in-game sits at .125)
     blackoutSound.volume = .35 * sfx;
     bumperSound.volume = .25 * sfx;
     cutSound.volume = .15 * sfx;

--- a/client/scripts/celebrations.js
+++ b/client/scripts/celebrations.js
@@ -51,6 +51,12 @@ function celebrationsActive() {
 // rewarded-bonus path, which suppresses its xp event) still get their own burst.
 function celebrationsEnqueue(events) {
 	if (!events || !events.length || !document.body) { return events || []; }
+	// Celebrations are a lobby-only flourish. A rewarded-ad xpBonus ack is explicitly
+	// allowed to resolve DURING the next race (see the xpBonus handler in client.js) —
+	// don't pop a celebration card + sound over live gameplay; returning the events
+	// unhandled drops them to the legacy quiet text toast instead.
+	if (typeof currentState !== "undefined" && typeof config !== "undefined" && config && config.stateMap
+		&& currentState !== config.stateMap.lobby) { return events; }
 	var leftover = [];
 	var mapped = [];
 	for (var i = 0; i < events.length; i++) {
@@ -78,6 +84,16 @@ function celebrationsEnqueue(events) {
 		} else {
 			leftover.push(ev); // xp_bonus_error / xp_bonus_failed / future types
 		}
+	}
+	// A pile of unlocks (multi-level vault from a 2× bonus, merged offline queues, a
+	// future curve retune) must not become minutes of sequential full-screen reveals —
+	// and a race start would silently destroy the unseen tail (the server's
+	// pending_toasts queue is already drained). Past 3, collapse every unlock into ONE
+	// summary reveal; up to 3 keep their individual full cards.
+	var unlocks = mapped.filter(function (m) { return m.kind === "unlock"; });
+	if (unlocks.length > 3) {
+		mapped = mapped.filter(function (m) { return m.kind !== "unlock"; });
+		mapped.push({ kind: "unlockBatch", items: unlocks });
 	}
 	if (mapped.length) {
 		celebrationQueue = celebrationQueue.concat(mapped);
@@ -124,6 +140,7 @@ function celebrationShowNext() {
 	var item = celebrationQueue.shift();
 	if (item.kind === "xp") { celebrationShowXp(item); }
 	else if (item.kind === "level") { celebrationShowLevel(item); }
+	else if (item.kind === "unlockBatch") { celebrationShowUnlockBatch(item); }
 	else { celebrationShowUnlock(item); }
 }
 
@@ -306,6 +323,17 @@ function celebrationShowXp(item) {
 	var dingedLevels = 0;
 
 	function step(ts) {
+		// Same never-strand contract as the unlock paintLoop: a throw here would kill
+		// the rAF chain with celebrationShowing stuck true, jamming the queue (and the
+		// deferred 2× XP offer behind it) for the rest of the lobby.
+		try {
+			stepBody(ts);
+		} catch (e) {
+			celebrationRafId = null;
+			celebrationShowNext();
+		}
+	}
+	function stepBody(ts) {
 		if (start == null) { start = ts; }
 		var u = Math.min(1, (ts - start) / fillDur);
 		var e = ease(u);
@@ -322,7 +350,12 @@ function celebrationShowXp(item) {
 				levelEl.classList.remove("cc-xp-level-pop");
 				void levelEl.offsetWidth; // restart the pop animation
 				levelEl.classList.add("cc-xp-level-pop");
-				celebrationPlay(typeof celebrationLevelUp !== "undefined" ? celebrationLevelUp : null);
+				// Big jumps cross several levels within a few frames; one chime per level
+				// just blats against the audio engine's 6-voice cap. Past 3 levels, save
+				// the chime for the final one (the visual pop still fires per level).
+				if (levelsCrossed <= 3 || dingedLevels === levelsCrossed) {
+					celebrationPlay(typeof celebrationLevelUp !== "undefined" ? celebrationLevelUp : null);
+				}
 			}
 			fillEl.style.width = (100 * Math.min(1, frac)).toFixed(1) + "%";
 			if (dingedLevels === levelsCrossed) {
@@ -452,6 +485,52 @@ function celebrationShowUnlock(item) {
 	}
 	overlay.addEventListener("pointerdown", finish);
 	celebrationTimer(finish, CELEBRATION_UNLOCK_MS);
+}
+
+// Summary reveal for a BULK unlock (4+ items in one batch): one full-screen card with
+// a grid of mini previews instead of minutes of sequential reveals. Static paint (no
+// per-thumb rAF loop — up to a dozen live painters at once isn't worth the GPU).
+function celebrationShowUnlockBatch(item) {
+	var items = item.items || [];
+	var overlay = celebrationEl("div", "cc-celebrate cc-celebrate-unlock", document.body);
+	celebrationRoot = overlay;
+	overlay.style.setProperty("--cc-accent", "#ffd34d");
+	celebrationEl("div", "cc-unlock-rays", overlay);
+	celebrationConfetti(overlay, 44, "#ffd34d");
+
+	var card = celebrationEl("div", "cc-unlock-card", overlay);
+	celebrationEl("div", "cc-unlock-kicker", card, items.length + " NEW ITEMS UNLOCKED");
+	var grid = celebrationEl("div", "cc-unlock-grid", card);
+	var color = celebrationPlayerColor();
+	var SHOWN = 8;
+	for (var i = 0; i < Math.min(items.length, SHOWN); i++) {
+		var cell = celebrationEl("div", "cc-unlock-grid-item", grid);
+		var cv = celebrationEl("canvas", "cc-unlock-grid-canvas", cell);
+		cv.width = 96; cv.height = 96;
+		try {
+			celebrationPaintCosmetic(cv.getContext("2d"), 96, 96, items[i].id, color, 0);
+		} catch (e) { /* a painter throw must never strand the overlay */ }
+		var nm = (typeof skinDisplayName === "function") ? skinDisplayName(items[i].id) : items[i].id;
+		celebrationEl("div", "cc-unlock-grid-name", cell, nm);
+	}
+	if (items.length > SHOWN) {
+		celebrationEl("div", "cc-unlock-grid-more", grid, "+" + (items.length - SHOWN) + " more");
+	}
+	celebrationEl("div", "cc-unlock-sub", card, "Find them all in the Skins station");
+	celebrationEl("div", "cc-unlock-hint", card, "tap to continue");
+
+	requestAnimationFrame(function () { overlay.classList.add("visible"); });
+	celebrationPlay(typeof celebrationCheer !== "undefined" ? celebrationCheer : null);
+
+	var done = false;
+	function finish() {
+		if (done) { return; }
+		done = true;
+		overlay.classList.remove("visible");
+		celebrationTimer(celebrationAdvance, 380);
+	}
+	overlay.addEventListener("pointerdown", finish);
+	celebrationTimer(finish, CELEBRATION_UNLOCK_MS + 1500); // a grid takes longer to read than one item
 }
 
 // ---------------------------------------------------------------------------

--- a/client/scripts/celebrations.js
+++ b/client/scripts/celebrations.js
@@ -1,0 +1,471 @@
+// celebrations.js — the progression reward sequence shown on lobby arrival.
+//
+// Replaces the old one-line text toasts with a three-tier celebration, sized to the
+// moment so a +80 XP drip and a 25-win Galaxy cart no longer get the same treatment:
+//   1. XP        — compact top-center card: count-up + an ANIMATED level-bar fill that
+//                  rolls over on level-up, ending in a "next unlock" teaser.
+//   2. Level up  — center burst: LEVEL N pop + ring shockwave (absorbed into the XP
+//                  card's rollover when the two arrive together).
+//   3. Unlock    — full-screen reveal: vignette + rotating rays + the ACTUAL cosmetic
+//                  painted live on a canvas in the player's color + confetti + cheer.
+//
+// Driven by the same server event batch as before (progressionToasts). client.js calls
+// celebrationsEnqueue(events) which consumes what it understands and RETURNS the rest
+// (error toasts, unknown ids, old-format queue entries) for the legacy text path. The
+// legacy queue (incl. the 2× XP reward offer) defers while celebrationsActive() and is
+// resumed by this file when the sequence drains, so the offer still lands last.
+//
+// Celebrations only ever show in the lobby: the batch is delivered on lobby arrival and
+// clearProgressionToasts() (startGated) calls celebrationsClear() before a race begins.
+// All cross-file references (skin registry painters, audio descriptors, playerList) are
+// typeof-guarded so this file is safe in any bundle order and in headless contexts.
+
+var celebrationQueue = [];           // mapped celebration items, one shown at a time
+var celebrationShowing = false;
+var celebrationRoot = null;          // the overlay element for the CURRENT item
+var celebrationRafId = null;         // canvas/bar animation loop for the current item
+var celebrationTimers = [];          // every pending timeout for the current item
+
+var CELEBRATION_UNLOCK_MS = 4500;    // unlock reveal auto-advance (click skips sooner)
+var CELEBRATION_LEVEL_MS = 2600;     // standalone level burst
+var CELEBRATION_XP_HOLD_MS = 1900;   // XP card hold after the bar finishes filling
+
+// Rarity accent colors (card border / kicker glow on the unlock reveal).
+var CELEBRATION_RARITY_COLORS = {
+	common: "#b8c0c8", uncommon: "#5fd97a", rare: "#4aa8ff",
+	epic: "#c77dff", legendary: "#ffa940", seasonal: "#ffd34d"
+};
+
+// ---------------------------------------------------------------------------
+// Queue plumbing
+// ---------------------------------------------------------------------------
+
+function celebrationsActive() {
+	return celebrationShowing || celebrationQueue.length > 0;
+}
+
+// Map a server toast batch into celebration items. Consumes what this system can
+// present and returns the LEFTOVER events for the legacy text-toast path. A 'level'
+// event directly after an 'xp' event whose bar already rolls past it is absorbed into
+// that card (the rollover IS the level-up moment); standalone 'level' events (e.g. the
+// rewarded-bonus path, which suppresses its xp event) still get their own burst.
+function celebrationsEnqueue(events) {
+	if (!events || !events.length || !document.body) { return events || []; }
+	var leftover = [];
+	var mapped = [];
+	for (var i = 0; i < events.length; i++) {
+		var ev = events[i];
+		if (!ev || !ev.type) { continue; }
+		if (ev.type === "xp" || ev.type === "xp_bonus") {
+			if (!(ev.amount > 0) && ev.type === "xp") { continue; }
+			mapped.push({ kind: "xp", amount: ev.amount || 0, from: ev.from || null, to: ev.to || null, bonus: ev.type === "xp_bonus" });
+		} else if (ev.type === "level") {
+			var prev = mapped[mapped.length - 1];
+			if (prev && prev.kind === "xp" && prev.to && prev.to.level >= ev.level) {
+				prev.levelBurst = ev.level; // rollover handles it
+			} else {
+				mapped.push({ kind: "level", level: ev.level });
+			}
+		} else if (ev.type === "skin" || ev.type === "achievement" || ev.type === "seasonal") {
+			// Only take ids the local registry can actually paint; anything unknown
+			// (older client vs newer server) falls back to the text toast.
+			var sk = (typeof getSkin === "function") ? getSkin(ev.id) : null;
+			if (sk) {
+				mapped.push({ kind: "unlock", id: ev.id, unlockType: ev.type });
+			} else {
+				leftover.push(ev);
+			}
+		} else {
+			leftover.push(ev); // xp_bonus_error / xp_bonus_failed / future types
+		}
+	}
+	if (mapped.length) {
+		celebrationQueue = celebrationQueue.concat(mapped);
+		if (!celebrationShowing) { celebrationShowNext(); }
+	}
+	return leftover;
+}
+
+// Tear down the live celebration + queue. Called from clearProgressionToasts() when
+// the lobby ends so nothing can linger over (or block input to) a live race.
+function celebrationsClear() {
+	celebrationQueue.length = 0;
+	celebrationShowing = false;
+	celebrationStopAnims();
+	if (celebrationRoot && celebrationRoot.parentNode) { celebrationRoot.parentNode.removeChild(celebrationRoot); }
+	celebrationRoot = null;
+}
+
+function celebrationStopAnims() {
+	if (celebrationRafId != null) { cancelAnimationFrame(celebrationRafId); celebrationRafId = null; }
+	for (var i = 0; i < celebrationTimers.length; i++) { clearTimeout(celebrationTimers[i]); }
+	celebrationTimers.length = 0;
+}
+
+function celebrationTimer(fn, ms) {
+	var id = setTimeout(fn, ms);
+	celebrationTimers.push(id);
+	return id;
+}
+
+function celebrationShowNext() {
+	celebrationStopAnims();
+	if (celebrationRoot && celebrationRoot.parentNode) { celebrationRoot.parentNode.removeChild(celebrationRoot); }
+	celebrationRoot = null;
+	if (!celebrationQueue.length || !document.body) {
+		celebrationShowing = false;
+		// Sequence done — release the legacy toast queue (the 2× XP offer waits there).
+		if (typeof showNextProgressionToast === "function" && typeof progressionToastShowing !== "undefined" && !progressionToastShowing) {
+			showNextProgressionToast();
+		}
+		return;
+	}
+	celebrationShowing = true;
+	var item = celebrationQueue.shift();
+	if (item.kind === "xp") { celebrationShowXp(item); }
+	else if (item.kind === "level") { celebrationShowLevel(item); }
+	else { celebrationShowUnlock(item); }
+}
+
+function celebrationAdvance() {
+	celebrationShowNext();
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function celebrationPlayerColor() {
+	var p = (typeof myID !== "undefined" && typeof playerList !== "undefined" && playerList) ? playerList[myID] : null;
+	return (p && p.color) || "#ffd34d";
+}
+
+function celebrationPlay(sound) {
+	if (typeof playSound === "function" && typeof sound !== "undefined" && sound) { playSound(sound); }
+}
+
+function celebrationEl(tag, className, parent, text) {
+	var el = document.createElement(tag);
+	if (className) { el.className = className; }
+	if (text != null) { el.textContent = text; } // textContent: never inject
+	if (parent) { parent.appendChild(el); }
+	return el;
+}
+
+// Spawn n confetti pieces inside `parent` (CSS does the falling/tumbling). Colors mix
+// the player color with the celebration palette so it reads as "yours".
+function celebrationConfetti(parent, n, accent) {
+	var colors = [celebrationPlayerColor(), accent || "#ffd34d", "#ff6b6b", "#4aa8ff", "#5fd97a", "#ffffff"];
+	for (var i = 0; i < n; i++) {
+		var piece = celebrationEl("div", "cc-confetti", parent);
+		piece.style.left = (Math.random() * 100) + "%";
+		piece.style.background = colors[i % colors.length];
+		piece.style.setProperty("--dx", ((Math.random() * 2 - 1) * 120).toFixed(0) + "px");
+		piece.style.setProperty("--rot", ((Math.random() * 2 - 1) * 720).toFixed(0) + "deg");
+		piece.style.animationDuration = (1.6 + Math.random() * 1.8).toFixed(2) + "s";
+		piece.style.animationDelay = (Math.random() * 0.7).toFixed(2) + "s";
+		if (Math.random() < 0.4) { piece.style.borderRadius = "50%"; }
+	}
+}
+
+// Paint one cosmetic onto an arbitrary canvas ctx, centered, in `color`. A port of the
+// lobby locker's drawCosmeticPreview (lobbyHub.js) generalized off gameContext, with a
+// LIVE anim time so animated carts spin and trail particles flow on the reveal card.
+function celebrationPaintCosmetic(ctx, w, h, id, color, animMs) {
+	var slot = (typeof getSkinSlot === "function") ? getSkinSlot(id) : null;
+	var skin = (typeof getSkin === "function") ? getSkin(id) : null;
+	var cx = w / 2, cy = h / 2, r = Math.min(w, h) * 0.30;
+	ctx.clearRect(0, 0, w, h);
+	ctx.save();
+	if (slot === "trail") {
+		// Trails are motion effects: render the real effect on a synthetic arc with the
+		// newest vertex at the kart head, like the locker preview — but with a live clock
+		// so the particles actually flow while the card is up.
+		var nowMs = Date.now();
+		var fadeMs = (typeof TRAIL_FADE_MS !== "undefined") ? TRAIL_FADE_MS : 1700;
+		var verts = [], STEPS = 26;
+		for (var ti = 0; ti <= STEPS; ti++) {
+			var u = ti / STEPS;
+			verts.push({
+				x: (u * 2 - 1) * 40,
+				y: Math.sin(u * Math.PI) * -14 + 6,
+				t: nowMs - fadeMs * (1 - u)
+			});
+		}
+		if (typeof paintTrailFx === "function") {
+			ctx.translate(cx, cy);
+			ctx.scale(r / 34, r / 34);
+			var drew = paintTrailFx(ctx, id, verts, color, { fadeMs: fadeMs, anim: animMs / 1000 });
+			if (drew) {
+				var head = verts[verts.length - 1];
+				ctx.fillStyle = color;
+				ctx.beginPath(); ctx.arc(head.x, head.y, 9, 0, Math.PI * 2); ctx.fill();
+				ctx.restore();
+				return;
+			}
+		}
+		ctx.restore();
+		// Fallback: plain stroke.
+		ctx.save();
+		ctx.strokeStyle = color; ctx.lineCap = "round"; ctx.lineWidth = 3;
+		ctx.beginPath(); ctx.moveTo(cx - r, cy + r * 0.3); ctx.quadraticCurveTo(cx, cy - r * 0.6, cx + r, cy + r * 0.3); ctx.stroke();
+		ctx.restore();
+		return;
+	}
+	var painter = (typeof getSkinPainter === "function") ? getSkinPainter(id) : null;
+	if (!painter) {
+		ctx.fillStyle = color;
+		ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI * 2); ctx.fill();
+		ctx.restore();
+		return;
+	}
+	ctx.translate(cx, cy);
+	// Match in-game orientation: statue carts draw upright natively; everything else
+	// faces +X, so rotate −90° to read as "up" (same rule as the locker preview).
+	var statue = !!(slot === "cart" && skin && skin.statue);
+	if (!statue) { ctx.rotate(-Math.PI / 2); }
+	var anim = animMs / 1000;
+	if (slot === "border") {
+		// Borders ring the rim (~1.0..1.4 normalized) over any cart: tinted disc stand-in,
+		// then the border painter unclipped, scaled tighter so the rim stays on-canvas.
+		ctx.scale(r, r);
+		ctx.fillStyle = color;
+		ctx.beginPath(); ctx.arc(0, 0, 0.7, 0, Math.PI * 2); ctx.fill();
+		painter(ctx, anim, color);
+	} else if (slot === "pattern") {
+		ctx.scale(r * 1.45, r * 1.45);
+		ctx.fillStyle = color;
+		ctx.beginPath(); ctx.arc(0, 0, 0.95, 0, Math.PI * 2); ctx.fill();
+		ctx.save();
+		ctx.beginPath(); ctx.arc(0, 0, 0.95, 0, Math.PI * 2); ctx.clip();
+		painter(ctx, anim, color);
+		ctx.restore();
+	} else {
+		ctx.scale(r * 1.45, r * 1.45);
+		painter(ctx, anim, color);
+	}
+	ctx.restore();
+}
+
+// "how you earned it" line for an unlock card.
+function celebrationUnlockSubtitle(item, skin) {
+	if (item.unlockType === "achievement") {
+		var defs = (typeof config !== "undefined" && config && config.achievementDefs) ? config.achievementDefs : null;
+		if (defs) {
+			for (var i = 0; i < defs.length; i++) {
+				if (defs[i].id === item.id) { return defs[i].desc; }
+			}
+		}
+		return "Achievement unlocked";
+	}
+	if (item.unlockType === "seasonal") {
+		var label = (skin && skin.unlock && skin.unlock.label) ? skin.unlock.label : "Limited";
+		return label + " — yours forever";
+	}
+	if (skin && skin.unlock && skin.unlock.kind === "level") { return "Reached Level " + skin.unlock.level; }
+	return "Unlocked";
+}
+
+function celebrationSlotWord(slot) {
+	return slot === "cart" ? "cart" : slot === "pattern" ? "pattern" : slot === "trail" ? "trail" : slot === "border" ? "border" : "cosmetic";
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1 — XP card (count-up + animated level bar + next-unlock teaser)
+// ---------------------------------------------------------------------------
+
+function celebrationShowXp(item) {
+	var overlay = celebrationEl("div", "cc-celebrate cc-celebrate-xp", document.body);
+	celebrationRoot = overlay;
+	var card = celebrationEl("div", "cc-xp-card", overlay);
+	var amountEl = celebrationEl("div", "cc-xp-amount", card, (item.bonus ? "⭐ +0 bonus XP" : "+0 XP"));
+	var hasBar = !!(item.from && item.to && item.to.xpForNextLevel);
+	var levelEl = null, fillEl = null, fracEl = null;
+	if (hasBar) {
+		var row = celebrationEl("div", "cc-xp-row", card);
+		levelEl = celebrationEl("span", "cc-xp-level", row, "Lv " + item.from.level);
+		var bar = celebrationEl("div", "cc-xp-bar", row);
+		fillEl = celebrationEl("div", "cc-xp-fill", bar);
+		fracEl = celebrationEl("span", "cc-xp-frac", row, "");
+		fillEl.style.width = (100 * Math.min(1, (item.from.xpThisLevel || 0) / (item.from.xpForNextLevel || 1))).toFixed(1) + "%";
+	} else if (item.bonus) {
+		celebrationEl("div", "cc-xp-sub", card, "Match XP doubled!");
+	}
+	requestAnimationFrame(function () { overlay.classList.add("visible"); });
+	celebrationPlay(typeof celebrationXpTick !== "undefined" ? celebrationXpTick : null);
+
+	var levelsCrossed = hasBar ? Math.max(0, item.to.level - item.from.level) : 0;
+	var fillDur = 1300 + Math.min(3, levelsCrossed) * 320;
+	var start = null;
+	function ease(u) { return 1 - Math.pow(1 - u, 3); } // easeOutCubic
+	// The bar's journey, in "level segments": fromFrac→1 for each crossed level (visual
+	// sweep — intermediate level costs live server-side only), then 0→toFrac.
+	var fromFrac = hasBar ? Math.min(1, (item.from.xpThisLevel || 0) / (item.from.xpForNextLevel || 1)) : 0;
+	var toFrac = hasBar ? Math.min(1, (item.to.xpThisLevel || 0) / (item.to.xpForNextLevel || 1)) : 0;
+	var totalSpan = levelsCrossed > 0 ? (1 - fromFrac) + (levelsCrossed - 1) + toFrac : (toFrac - fromFrac);
+	var dingedLevels = 0;
+
+	function step(ts) {
+		if (start == null) { start = ts; }
+		var u = Math.min(1, (ts - start) / fillDur);
+		var e = ease(u);
+		amountEl.textContent = (item.bonus ? "⭐ +" : "+") + Math.round(e * item.amount) + (item.bonus ? " bonus XP" : " XP");
+		if (hasBar) {
+			var traveled = fromFrac + e * totalSpan; // continuous position incl. rollovers
+			var wholeLevels = Math.floor(traveled);
+			var frac = traveled - wholeLevels;
+			if (wholeLevels > levelsCrossed) { wholeLevels = levelsCrossed; frac = toFrac; }
+			if (wholeLevels === levelsCrossed && frac > toFrac && levelsCrossed > 0) { frac = toFrac; }
+			while (dingedLevels < wholeLevels) {
+				dingedLevels++;
+				levelEl.textContent = "Lv " + (item.from.level + dingedLevels);
+				levelEl.classList.remove("cc-xp-level-pop");
+				void levelEl.offsetWidth; // restart the pop animation
+				levelEl.classList.add("cc-xp-level-pop");
+				celebrationPlay(typeof celebrationLevelUp !== "undefined" ? celebrationLevelUp : null);
+			}
+			fillEl.style.width = (100 * Math.min(1, frac)).toFixed(1) + "%";
+			if (dingedLevels === levelsCrossed) {
+				fracEl.textContent = item.to.xpThisLevel + " / " + item.to.xpForNextLevel;
+			}
+		}
+		if (u < 1) {
+			celebrationRafId = requestAnimationFrame(step);
+		} else {
+			celebrationRafId = null;
+			celebrationXpFinish(item, overlay, card);
+		}
+	}
+	celebrationRafId = requestAnimationFrame(step);
+}
+
+// Bar's done filling: optionally pop the absorbed LEVEL N burst, then the next-unlock
+// teaser, then hold + dismiss.
+function celebrationXpFinish(item, overlay, card) {
+	var hold = CELEBRATION_XP_HOLD_MS;
+	if (item.levelBurst) {
+		var burst = celebrationEl("div", "cc-level-pop", card);
+		celebrationEl("div", "cc-level-pop-kicker", burst, "LEVEL UP");
+		celebrationEl("div", "cc-level-pop-num", burst, "" + item.levelBurst);
+		celebrationConfetti(overlay, 26, "#ffd34d");
+		hold += 900;
+	}
+	// Teaser: what's next on the ladder (server-computed on the freshest progression).
+	var prog = (typeof myProgression !== "undefined") ? myProgression : null;
+	if (prog && prog.nextUnlock && prog.nextUnlock.id && typeof getSkin === "function" && getSkin(prog.nextUnlock.id)) {
+		var teaser = celebrationEl("div", "cc-xp-teaser", card);
+		var tCanvas = celebrationEl("canvas", "cc-xp-teaser-canvas", teaser);
+		tCanvas.width = 44; tCanvas.height = 44;
+		var nm = (typeof skinDisplayName === "function") ? skinDisplayName(prog.nextUnlock.id) : prog.nextUnlock.id;
+		// ~matches-to-go from the typical per-match XP (participation + a couple notches).
+		var perMatch = 90;
+		if (typeof config !== "undefined" && config && config.xpParticipate) {
+			perMatch = config.xpParticipate + 2 * (config.xpPerNotch || 0);
+		}
+		var matches = Math.max(1, Math.ceil((prog.nextUnlock.xpToGo || 0) / perMatch));
+		celebrationEl("div", "cc-xp-teaser-text", teaser,
+			"Next: " + nm + " · Lv " + prog.nextUnlock.level + " · ~" + matches + (matches === 1 ? " match away" : " matches away"));
+		try {
+			celebrationPaintCosmetic(tCanvas.getContext("2d"), 44, 44, prog.nextUnlock.id, celebrationPlayerColor(), 0);
+		} catch (e) { /* teaser thumb is decoration — never let it break the sequence */ }
+		requestAnimationFrame(function () { teaser.classList.add("visible"); });
+		hold += 600;
+	}
+	celebrationTimer(function () {
+		overlay.classList.remove("visible");
+		celebrationTimer(celebrationAdvance, 380);
+	}, hold);
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 — standalone level burst (xp-suppressed paths, old-format queues)
+// ---------------------------------------------------------------------------
+
+function celebrationShowLevel(item) {
+	var overlay = celebrationEl("div", "cc-celebrate cc-celebrate-level", document.body);
+	celebrationRoot = overlay;
+	var wrap = celebrationEl("div", "cc-level-burst", overlay);
+	celebrationEl("div", "cc-level-ring", wrap);
+	celebrationEl("div", "cc-level-pop-kicker", wrap, "LEVEL UP");
+	celebrationEl("div", "cc-level-pop-num", wrap, "" + item.level);
+	celebrationConfetti(overlay, 26, "#ffd34d");
+	requestAnimationFrame(function () { overlay.classList.add("visible"); });
+	celebrationPlay(typeof celebrationLevelUp !== "undefined" ? celebrationLevelUp : null);
+	celebrationTimer(function () {
+		overlay.classList.remove("visible");
+		celebrationTimer(celebrationAdvance, 380);
+	}, CELEBRATION_LEVEL_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Tier 3 — full-screen unlock reveal
+// ---------------------------------------------------------------------------
+
+function celebrationShowUnlock(item) {
+	var skin = (typeof getSkin === "function") ? getSkin(item.id) : null;
+	var slot = (typeof getSkinSlot === "function") ? getSkinSlot(item.id) : null;
+	var accent = CELEBRATION_RARITY_COLORS[(skin && skin.rarity) || "common"] || CELEBRATION_RARITY_COLORS.common;
+
+	var overlay = celebrationEl("div", "cc-celebrate cc-celebrate-unlock", document.body);
+	celebrationRoot = overlay;
+	overlay.style.setProperty("--cc-accent", accent);
+	celebrationEl("div", "cc-unlock-rays", overlay);
+	celebrationConfetti(overlay, 44, accent);
+
+	var card = celebrationEl("div", "cc-unlock-card", overlay);
+	var kicker = item.unlockType === "achievement" ? "ACHIEVEMENT UNLOCKED"
+		: item.unlockType === "seasonal" ? "LIMITED EDITION CLAIMED"
+		: ("NEW " + celebrationSlotWord(slot).toUpperCase() + " UNLOCKED");
+	celebrationEl("div", "cc-unlock-kicker", card, kicker);
+	var canvas = celebrationEl("canvas", "cc-unlock-canvas", card);
+	canvas.width = 220; canvas.height = 220;
+	var nm = (typeof skinDisplayName === "function") ? skinDisplayName(item.id) : item.id;
+	celebrationEl("div", "cc-unlock-name", card, nm);
+	celebrationEl("div", "cc-unlock-sub", card, celebrationUnlockSubtitle(item, skin));
+	if (skin && skin.rarity && skin.rarity !== "common") {
+		celebrationEl("div", "cc-unlock-rarity", card, skin.rarity);
+	}
+	celebrationEl("div", "cc-unlock-hint", card, "tap to continue");
+
+	requestAnimationFrame(function () { overlay.classList.add("visible"); });
+	celebrationPlay(typeof celebrationCheer !== "undefined" ? celebrationCheer : null);
+
+	// Live preview loop — animated carts spin, trails flow, in the player's color.
+	var ctx = canvas.getContext("2d");
+	var color = celebrationPlayerColor();
+	var t0 = null;
+	function paintLoop(ts) {
+		if (t0 == null) { t0 = ts; }
+		try {
+			celebrationPaintCosmetic(ctx, canvas.width, canvas.height, item.id, color, ts - t0);
+		} catch (e) { /* a painter throw must never strand the overlay */ }
+		celebrationRafId = requestAnimationFrame(paintLoop);
+	}
+	celebrationRafId = requestAnimationFrame(paintLoop);
+
+	var done = false;
+	function finish() {
+		if (done) { return; }
+		done = true;
+		overlay.classList.remove("visible");
+		celebrationTimer(celebrationAdvance, 380);
+	}
+	overlay.addEventListener("pointerdown", finish);
+	celebrationTimer(finish, CELEBRATION_UNLOCK_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Dev/tuning hook: window.__celebratePreview() replays a sample sequence (or pass your
+// own events array). Client-side only — renders fake toasts, grants nothing.
+// ---------------------------------------------------------------------------
+if (typeof window !== "undefined") {
+	window.__celebratePreview = function (events) {
+		celebrationsEnqueue(events || [
+			{ type: "xp", amount: 195, from: { level: 3, xpThisLevel: 100, xpForNextLevel: 138 }, to: { level: 4, xpThisLevel: 157, xpForNextLevel: 160 } },
+			{ type: "level", level: 4 },
+			{ type: "skin", id: "pizza" },
+			{ type: "achievement", id: "comet" },
+			{ type: "achievement", id: "galaxy" }
+		]);
+	};
+}

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -576,6 +576,29 @@ function registerConnectionHandlers(server) {
 	// {type:'skin',id} | {type:'achievement',id}.
 	server.on('progressionToasts', function (payload) {
 		var events = (payload && Array.isArray(payload.events)) ? payload.events : [];
+		// Progression pacing analytics — fired HERE (toast arrival) so it's independent
+		// of how the celebration is presented (full card vs text fallback vs cleared by
+		// a race start). The durable pending_toasts queue is drained exactly once, so
+		// these can't double-fire on reconnect. Only signed-in humans ever receive
+		// progression toasts, so no bots param is needed (always human traffic).
+		for (var ti = 0; ti < events.length; ti++) {
+			var tev = events[ti];
+			if (!tev || !tev.type) { continue; }
+			if (tev.type === "xp" && tev.amount > 0) {
+				trackEvent('xp_earned', {
+					xp: tev.amount,
+					level: (tev.to && tev.to.level) || (myProgression && myProgression.level) || 0
+				});
+			} else if (tev.type === "level") {
+				trackEvent('level_up', { level: tev.level }); // GA4 recommended games event
+			} else if (tev.type === "skin" || tev.type === "achievement" || tev.type === "seasonal") {
+				trackEvent('cosmetic_unlocked', {
+					cosmetic_id: tev.id,
+					cosmetic_slot: (typeof getSkinSlot === "function" && getSkinSlot(tev.id)) || 'unknown',
+					unlock_kind: tev.type
+				});
+			}
+		}
 		if (events.length) { enqueueProgressionToasts(events); }
 		// If a 2× offer is armed for this match, append it now so it lands right AFTER these
 		// celebration toasts (the natural "here's your XP → want to double it?" beat).
@@ -617,6 +640,11 @@ function registerConnectionHandlers(server) {
 			enqueueProgressionToasts([{ type: "xp_bonus", amount: bonus }]);
 		}
 		trackEvent('reward_claimed', { bonus: 'xp_2x', match_id: ackMatchId });
+		// Count the bonus toward XP-pacing totals too (its normal xp toast is suppressed
+		// server-side to avoid a duplicate "+N XP" celebration).
+		if (bonus > 0) {
+			trackEvent('xp_earned', { xp: bonus, level: (payload && payload.level) || (myProgression && myProgression.level) || 0 });
+		}
 	});
 
 	// botGuard: the server confirmed this client actually drove a kart (not a pageview-only

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -476,6 +476,12 @@ function progressionToastText(ev) {
 	return null;
 }
 function enqueueProgressionToasts(events) {
+	// The celebration system (celebrations.js) takes every event it can present —
+	// XP bar fills, level bursts, full-screen unlock reveals — and returns whatever
+	// it can't (error toasts, unknown skin ids) for this legacy text path.
+	if (typeof celebrationsEnqueue === "function") {
+		events = celebrationsEnqueue(events) || [];
+	}
 	for (var i = 0; i < events.length; i++) {
 		var txt = progressionToastText(events[i]);
 		if (txt) { progressionToastQueue.push(txt); }
@@ -485,6 +491,13 @@ function enqueueProgressionToasts(events) {
 function showNextProgressionToast() {
 	if (progressionToastQueue.length === 0) { progressionToastShowing = false; return; }
 	if (!document.body) { progressionToastShowing = false; return; }
+	// Defer while a celebration sequence is on screen — celebrations.js calls back
+	// into showNextProgressionToast() when it drains, so the queued items (notably
+	// the 2× XP reward offer) land right AFTER the celebration beat, never over it.
+	if (typeof celebrationsActive === "function" && celebrationsActive()) {
+		progressionToastShowing = false;
+		return;
+	}
 	progressionToastShowing = true;
 	var txt = progressionToastQueue.shift();
 	// The 2× XP offer is a special queue item: a persistent actionable toast that waits for
@@ -516,6 +529,9 @@ function showNextProgressionToast() {
 function clearProgressionToasts() {
 	progressionToastQueue.length = 0;
 	progressionToastShowing = false;
+	// Tear down any live/queued celebration overlays too (same race-start rationale —
+	// a full-screen unlock reveal must never sit over, or eat input from, live gameplay).
+	if (typeof celebrationsClear === "function") { celebrationsClear(); }
 	// Tear down the 2× offer too (its DOM node carries .cc-progression-toast, so it's removed
 	// below) and drop any armed/pending offer so it can't pop after the race has started.
 	rewardOfferToastEl = null;

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1602,6 +1602,10 @@ var SKIN_PICKER_ROWS = 3;
 var SKIN_PICKER_CELLH = 54;
 var SKIN_PICKER_PER_PAGE = SKIN_PICKER_COLS * SKIN_PICKER_ROWS;
 
+// Cache for the 🏆 profile tab's built item list (see skinTabItems) — rebuilt only when
+// the progression object or the achievement defs are replaced.
+var profileItemsCache = { prog: undefined, defs: undefined, items: null };
+
 function skinTabs(lp) {
     var tabs = [
         { key: 'color', label: 'Color' },
@@ -1651,6 +1655,14 @@ function skinTabItems(lp, tabKey) {
         // "almost there" ones are the hook; earned ones trail as the trophy shelf.
         var defs = (typeof config !== "undefined" && config && config.achievementDefs) ? config.achievementDefs : [];
         var prog = (lp && !lp.isPrimary) ? null : ((typeof myProgression !== "undefined") ? myProgression : null);
+        // Memoized: this runs EVERY frame the panel is open (draw + nav + hit paths) and
+        // rebuilding+sorting ~47 cells per frame is pure GC churn. myProgression is
+        // replaced wholesale on progressionUpdate, so reference identity is a sufficient
+        // key. (Single-entry cache: two seats with different progression both open on
+        // the 🏆 tab at once would thrash it — rare, and merely loses the memo.)
+        if (profileItemsCache.prog === prog && profileItemsCache.defs === defs && profileItemsCache.items) {
+            return profileItemsCache.items;
+        }
         var owned = (prog && prog.unlocked_skins) || [];
         var mc = (prog && prog.medal_counts) || {};
         var wins = (prog && prog.wins) || 0;
@@ -1671,6 +1683,9 @@ function skinTabItems(lp, tabKey) {
             return p.def.threshold - q.def.threshold;
         });
         for (var ix = 0; ix < out.length; ix++) { out[ix].idx = ix; } // for tap-to-focus hits
+        profileItemsCache.prog = prog;
+        profileItemsCache.defs = defs;
+        profileItemsCache.items = out;
         return out;
     }
     var cosmetics = [];

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -338,6 +338,13 @@ function stationPanelAction(lp, action) {
             lp.stationPanel.cursor = Math.min(items.length - 1, pg * perPage);
             lp.stationPanel.region = 'grid';
         }
+    } else if (action != null && action.indexOf("achv:") === 0) {
+        // Profile tab: tapping an achievement cell focuses it (read-only — focusing
+        // shows its "how to earn it" line under the grid).
+        if (lp.stationPanel) {
+            lp.stationPanel.cursor = parseInt(action.slice(5), 10) || 0;
+            lp.stationPanel.region = 'grid';
+        }
     } else if (action != null && action.indexOf("cosmetic:") === 0) {
         // "cosmetic:<slot>:<id>" (id may be empty for the slot default).
         var rest = action.slice("cosmetic:".length);
@@ -1609,6 +1616,10 @@ function skinTabs(lp) {
         tabs.push({ key: 'border', label: 'Borders' });
     }
     tabs.push({ key: 'trail', label: 'Trails' });
+    // Profile/achievements: every achievement cosmetic as a silhouette + "?" with a
+    // progress bar and (focused) its "how to earn it" line. Glyph label — six text
+    // labels don't fit the 300px tab row.
+    tabs.push({ key: 'profile', label: '🏆' });
     return tabs;
 }
 // Reset the active tab to a valid one if the current tab was just hidden (e.g. Patterns
@@ -1632,6 +1643,34 @@ function skinTabItems(lp, tabKey) {
         var pal = skinPalette();
         for (var i = 0; i < pal.length; i++) { out.push({ kind: 'color', color: pal[i] }); }
         if (avatarSkinProfile(lp)) { out.push({ kind: 'avatar' }); }
+        return out;
+    }
+    if (tabKey === 'profile') {
+        // One cell per achievement cosmetic (defs ship in the config payload, built from
+        // server/progression.js). In-progress first, closest-to-unlock leading — the
+        // "almost there" ones are the hook; earned ones trail as the trophy shelf.
+        var defs = (typeof config !== "undefined" && config && config.achievementDefs) ? config.achievementDefs : [];
+        var prog = (lp && !lp.isPrimary) ? null : ((typeof myProgression !== "undefined") ? myProgression : null);
+        var owned = (prog && prog.unlocked_skins) || [];
+        var mc = (prog && prog.medal_counts) || {};
+        var wins = (prog && prog.wins) || 0;
+        for (var a = 0; a < defs.length; a++) {
+            var def = defs[a];
+            var val = (def.stat === 'wins') ? wins : (mc[def.stat] || 0);
+            out.push({
+                kind: 'achv',
+                def: def,
+                value: Math.min(val, def.threshold),
+                done: owned.indexOf(def.id) !== -1
+            });
+        }
+        out.sort(function (p, q) {
+            if (p.done !== q.done) { return p.done ? 1 : -1; }
+            var fp = p.value / p.def.threshold, fq = q.value / q.def.threshold;
+            if (fp !== fq) { return fq - fp; }
+            return p.def.threshold - q.def.threshold;
+        });
+        for (var ix = 0; ix < out.length; ix++) { out[ix].idx = ix; } // for tap-to-focus hits
         return out;
     }
     var cosmetics = [];
@@ -1740,9 +1779,20 @@ function drawSkinPanelBody(lp, x, y, w, h, hit, S) {
     gameContext.textAlign = "center"; gameContext.textBaseline = "middle";
     gameContext.fillText("🎲 Random", rnd.x + rnd.w / 2, rnd.y + rnd.h / 2 + 1);
     hit.options.push({ rect: rnd, action: "randomize" });
-    // Lv/XP badge (or sign-in nudge)
+    // Lv/XP badge (or sign-in nudge). On the Profile tab the focused achievement's
+    // "how to earn it" line takes this slot instead — that's the tab's whole point —
+    // unless there's no progression (guest/couch seat), where the sign-in nudge matters more.
     var badgeY = rndY + (SKIN_RANDOM_BTN_H + 6) * S;
-    drawProgressionBadge(lp, x + pad, badgeY, w - pad * 2, S);
+    var profProg = (lp && !lp.isPrimary) ? null : ((typeof myProgression !== "undefined") ? myProgression : null);
+    var focusedAchv = (sp.tab === 'profile' && profProg) ? items[sp.cursor || 0] : null;
+    if (focusedAchv && focusedAchv.kind === 'achv') {
+        gameContext.fillStyle = "#fff"; gameContext.textAlign = "center"; gameContext.textBaseline = "middle";
+        gameContext.font = hubFont(S, 11);
+        var achLine = focusedAchv.def.desc + " · " + (focusedAchv.done ? "Done!" : (focusedAchv.value + "/" + focusedAchv.def.threshold));
+        gameContext.fillText(achLine, x + w / 2, badgeY + 9 * S, w - pad * 2);
+    } else {
+        drawProgressionBadge(lp, x + pad, badgeY, w - pad * 2, S);
+    }
     // page controls
     var pgY = y + h - 22 * S;
     if (pageCount > 1) {
@@ -1823,6 +1873,46 @@ function drawSkinCell(lp, item, cx, cy, cw, ch, focused, currentColor, hit, S) {
         hit.options.push({ rect: { x: cx, y: cy, w: cw, h: ch }, action: "pickAvatar" });
         return;
     }
+    if (item.kind === 'achv') {
+        // Profile tab: a not-yet-earned achievement cosmetic is a MYSTERY — dark
+        // silhouette + "?" + progress bar; earned ones show the real item + a ✓.
+        var d = item.def;
+        gameContext.fillStyle = "rgba(255,255,255,0.06)";
+        lhRoundRect(gameContext, cx, cy, cw, ch, 6 * S); gameContext.fill();
+        gameContext.lineWidth = 1;
+        gameContext.strokeStyle = item.done ? "rgba(95,217,122,0.55)" : "rgba(255,255,255,0.12)";
+        lhRoundRect(gameContext, cx, cy, cw, ch, 6 * S); gameContext.stroke();
+        if (focused) { gameContext.strokeStyle = "#fff"; gameContext.lineWidth = 2.5; lhRoundRect(gameContext, cx - 1, cy - 1, cw + 2, ch + 2, 7 * S); gameContext.stroke(); }
+        var pcx = cx + cw / 2, pcy = cy + ch * 0.34, pr = ch * 0.22;
+        if (item.done) {
+            drawCosmeticPreview({ slot: d.slot, id: d.id }, pcx, pcy, pr, currentColor, false, { x: cx, y: cy, w: cw, h: ch });
+            gameContext.beginPath(); gameContext.arc(cx + cw - 8 * S, cy + 8 * S, 7 * S, 0, 2 * Math.PI);
+            gameContext.fillStyle = "rgba(0,0,0,0.7)"; gameContext.fill();
+            gameContext.fillStyle = "#5fd97a"; gameContext.textAlign = "center"; gameContext.textBaseline = "middle";
+            gameContext.font = hubFont(S, 10, true); gameContext.fillText("✓", cx + cw - 8 * S, cy + 8.5 * S);
+        } else {
+            if (!drawAchievementSilhouette(d.id, pcx, pcy, pr)) {
+                gameContext.fillStyle = "#2a3140";
+                gameContext.beginPath(); gameContext.arc(pcx, pcy, pr, 0, Math.PI * 2); gameContext.fill();
+            }
+            gameContext.fillStyle = "#ffd34d"; gameContext.textAlign = "center"; gameContext.textBaseline = "middle";
+            gameContext.font = hubFont(S, 14, true); gameContext.fillText("?", pcx, pcy + 1);
+        }
+        // progress bar + count (earned = full green "Done")
+        var bx = cx + 5 * S, bw = cw - 10 * S, by = cy + ch * 0.66, bh = 5 * S;
+        var frac = item.done ? 1 : Math.min(1, item.value / d.threshold);
+        gameContext.fillStyle = "rgba(255,255,255,0.12)";
+        lhRoundRect(gameContext, bx, by, bw, bh, 2.5 * S); gameContext.fill();
+        if (frac > 0) {
+            gameContext.fillStyle = item.done ? "#5fd97a" : "#ffd34d";
+            lhRoundRect(gameContext, bx, by, Math.max(3 * S, bw * frac), bh, 2.5 * S); gameContext.fill();
+        }
+        gameContext.fillStyle = item.done ? "#5fd97a" : "rgba(255,255,255,0.6)";
+        gameContext.font = hubFont(S, 8); gameContext.textAlign = "center"; gameContext.textBaseline = "middle";
+        gameContext.fillText(item.done ? "Done" : (item.value + "/" + d.threshold), cx + cw / 2, cy + ch * 0.87);
+        hit.options.push({ rect: { x: cx, y: cy, w: cw, h: ch }, action: "achv:" + item.idx });
+        return;
+    }
     var opt = item.opt;
     var sel = currentCosmetic(lp, opt.slot) === opt.id;
     var lock = cartSkinUnlock(opt.id, lp);
@@ -1839,10 +1929,24 @@ function drawSkinCell(lp, item, cx, cy, cw, ch, focused, currentColor, hit, S) {
         lhRoundRect(gameContext, cx, cy, cw, ch, 6 * S); gameContext.stroke();
     }
     if (focused) { gameContext.strokeStyle = "#fff"; gameContext.lineWidth = 2.5; lhRoundRect(gameContext, cx - 1, cy - 1, cw + 2, ch + 2, 7 * S); gameContext.stroke(); }
-    drawCosmeticPreview(opt, cx + cw / 2, cy + ch * 0.34, ch * 0.22, currentColor, lock.locked, { x: cx, y: cy, w: cw, h: ch });
+    // Locked ACHIEVEMENT cosmetics stay a mystery in the picker too: silhouette + "?",
+    // name hidden — the 🏆 lock badge points at the Profile tab for the requirement, and
+    // the unlock celebration does the reveal. Level/seasonal locks keep the real preview
+    // (seeing the item you're leveling toward IS the carrot).
+    var mystery = lock.locked && raritySkin && raritySkin.unlock && raritySkin.unlock.kind === "achievement";
+    if (mystery) {
+        if (!drawAchievementSilhouette(opt.id, cx + cw / 2, cy + ch * 0.34, ch * 0.22)) {
+            gameContext.fillStyle = "#2a3140";
+            gameContext.beginPath(); gameContext.arc(cx + cw / 2, cy + ch * 0.34, ch * 0.22, 0, Math.PI * 2); gameContext.fill();
+        }
+        gameContext.fillStyle = "#ffd34d"; gameContext.textAlign = "center"; gameContext.textBaseline = "middle";
+        gameContext.font = hubFont(S, 14, true); gameContext.fillText("?", cx + cw / 2, cy + ch * 0.34 + 1);
+    } else {
+        drawCosmeticPreview(opt, cx + cw / 2, cy + ch * 0.34, ch * 0.22, currentColor, lock.locked, { x: cx, y: cy, w: cw, h: ch });
+    }
     gameContext.fillStyle = lock.locked ? "rgba(255,255,255,0.5)" : "#fff";
     gameContext.font = hubFont(S, 8.5); gameContext.textAlign = "center"; gameContext.textBaseline = "middle";
-    gameContext.fillText(opt.label, cx + cw / 2, cy + ch * 0.74);
+    gameContext.fillText(mystery ? "???" : opt.label, cx + cw / 2, cy + ch * 0.74);
     if (lock.locked && lock.text) {
         gameContext.fillStyle = "#ffd34d"; gameContext.font = hubFont(S, 8.5, true);
         gameContext.fillText("🔒 " + lock.text, cx + cw / 2, cy + ch * 0.93);
@@ -1856,6 +1960,35 @@ function activateSkinItem(lp, item) {
     if (item.kind === 'color') { stationPickSkin(lp, item.color); }
     else if (item.kind === 'avatar') { stationPickAvatar(lp); }
     else if (item.kind === 'cosmetic') { stationPickCosmetic(lp, item.opt); }
+    // 'achv' cells are read-only — focusing one already shows its requirement line.
+}
+
+// Cached dark-silhouette thumbnails for not-yet-earned achievement cosmetics: the real
+// painter's SHAPE with all detail flattened to one dark fill (mystery teaser — the unlock
+// celebration is the reveal). Painters are procedural (no image decode race), so a
+// render-once cache per id+size is safe; ~47 ids × one small canvas.
+var achvSilhouetteCache = {};
+function drawAchievementSilhouette(id, cx, cy, r) {
+    var size = Math.max(12, Math.ceil(r * 3.2));
+    var key = id + ":" + size;
+    var cv = achvSilhouetteCache[key];
+    if (cv === undefined) {
+        cv = null;
+        if (typeof celebrationPaintCosmetic === "function" && typeof document !== "undefined") {
+            try {
+                cv = document.createElement("canvas");
+                cv.width = size; cv.height = size;
+                var c2 = cv.getContext("2d");
+                celebrationPaintCosmetic(c2, size, size, id, "#ffffff", 0);
+                c2.globalCompositeOperation = "source-in"; // keep the shape, drop the detail
+                c2.fillStyle = "#2a3140";
+                c2.fillRect(0, 0, size, size);
+            } catch (e) { cv = null; }
+        }
+        achvSilhouetteCache[key] = cv;
+    }
+    if (cv) { gameContext.drawImage(cv, cx - size / 2, cy - size / 2); return true; }
+    return false;
 }
 
 

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1963,6 +1963,23 @@ function activateSkinItem(lp, item) {
     // 'achv' cells are read-only — focusing one already shows its requirement line.
 }
 
+// The "how to earn it" line for an achievement cosmetic id, with the player's live
+// progress when available: "Win 25 matches · 12/25". null for non-achievement ids
+// (level/seasonal locks keep their own wording). Same config.achievementDefs data the
+// 🏆 tab renders, so the picker and the profile always agree.
+function achievementRequirementLine(lp, id) {
+    if (id == null) { return null; }
+    var defs = (typeof config !== "undefined" && config && config.achievementDefs) ? config.achievementDefs : null;
+    if (!defs) { return null; }
+    var def = null;
+    for (var i = 0; i < defs.length; i++) { if (defs[i].id === id) { def = defs[i]; break; } }
+    if (!def) { return null; }
+    var prog = (lp && !lp.isPrimary) ? null : ((typeof myProgression !== "undefined") ? myProgression : null);
+    if (!prog) { return def.desc; }
+    var val = (def.stat === 'wins') ? (prog.wins || 0) : ((prog.medal_counts || {})[def.stat] || 0);
+    return def.desc + " · " + Math.min(val, def.threshold) + "/" + def.threshold;
+}
+
 // Cached dark-silhouette thumbnails for not-yet-earned achievement cosmetics: the real
 // painter's SHAPE with all detail flattened to one dark fill (mystery teaser — the unlock
 // celebration is the reveal). Painters are procedural (no image decode race), so a
@@ -2115,10 +2132,13 @@ function stationPickCosmetic(lp, opt) {
         return;
     }
     // Don't burn a round-trip on a locked cosmetic — show the requirement (the server
-    // re-validates on equip regardless; this is just UX).
+    // re-validates on equip regardless; this is just UX). Achievement items show their
+    // actual "how to earn it" line + live progress (same data the 🏆 tab renders), not
+    // the slot's lock glyph.
     var lock = cartSkinUnlock(opt.id || null, lp);
     if (lock.locked) {
-        lp._cartLockMsg = lock.text ? ("Unlock at " + lock.text) : "Locked";
+        var achMsg = achievementRequirementLine(lp, opt.id);
+        lp._cartLockMsg = achMsg || (lock.text ? ("Unlock at " + lock.text) : "Locked");
         lp._cartLockAt = Date.now();
         return;
     }
@@ -2298,7 +2318,7 @@ function flagCosmeticRejected(slot, payload) {
     if (payload && payload.reason === "level" && payload.required) {
         msg = "Unlock at Lv " + payload.required;
     } else if (payload && payload.reason === "achievement") {
-        msg = "Earn the medal to unlock";
+        msg = achievementRequirementLine(lp, payload.id) || "Earn the medal to unlock";
     } else if (payload && payload.reason === "seasonal") {
         // Seasonal claim the player never claimed in its window. Match the locker's own wording:
         // still claimable -> "Sign in to claim"; window closed -> "Expired".

--- a/docs/cosmetics-analytics.md
+++ b/docs/cosmetics-analytics.md
@@ -101,6 +101,15 @@ These events exist to make that retune a measurement, not a guess.
   cheapen the curve to `min(400, 20+9n)`.
 - Both levers only ever make the curve cheaper, so no player can lose a level.
 
+### Sampling caveat (read before trusting the numbers)
+
+Pacing events fire on lobby arrival; for a player who quits at the results screen they
+fire on the **next session's** first lobby (durable `pending_toasts` queue) — delayed,
+not lost. The one cohort the GA data structurally excludes is **players who never
+return at all** — i.e. exactly the players the hook failed for. Survivorship-check any
+retune read against Supabase (`progression.xp` totals / `unlock_dates`) before
+concluding pacing is healthy.
+
 ### Dashboard
 
 GA4 has no dashboards-as-code; the standing setup is one saved Exploration per

--- a/docs/cosmetics-analytics.md
+++ b/docs/cosmetics-analytics.md
@@ -56,3 +56,55 @@ group by key order by players desc;
 
 Note: `unlock_dates` records *unlocking*; `cosmetics_equipped` (GA) records *choosing to
 race with* — together they show the funnel from unlock → actual use.
+
+## 3. Progression pacing (curve-retune monitoring)
+
+The capped-hook XP curve (`min(1000, 50+22n)`) was tuned assuming ~5-minute matches;
+real matches run 10–25 min, so wall-clock pacing ships ~3× slower than the design
+target (operator decision 2026-06-04: ship as-is, retune with data after ~1 week).
+These events exist to make that retune a measurement, not a guess.
+
+### Events (fired at `progressionToasts` arrival in client.js — signed-in humans only,
+### drained-once durable queue so they can't double-fire)
+
+| Event | Params | Fires |
+|-------|--------|-------|
+| `xp_earned` | `xp` (metric), `level` (metric) | once per match per signed-in player; also for the rewarded 2× bonus |
+| `level_up` | `level` (metric) | each level gained (GA4 recommended games event) |
+| `cosmetic_unlocked` | `cosmetic_id`, `cosmetic_slot`, `unlock_kind` (skin = level ladder / achievement / seasonal) | each newly earned cosmetic — **key event** |
+
+### The three retune questions → where to look
+
+1. **"How much XP does a real match pay?"** — `xp_earned`: `averageXp` (auto-derived
+   from the `xp` custom metric). If the average sits near ~100, the curve's
+   matches-per-level table holds; if real play (long matches, win rates) pushes it
+   higher, pacing is faster than feared. Data API: dimension `date`, metric
+   `averageXp` + `eventCount` on `eventName = xp_earned`.
+2. **"Where does the player base sit on the ladder after a week?"** — `level_up`
+   with the `level` metric: a histogram of `level` (dimension: `customEvent:level`
+   isn't needed — bucket the metric in an Exploration) shows how deep players get.
+   Healthy: a steady spread into the teens after week one; a wall at L4–6 means the
+   early curve is still too steep for real session lengths.
+3. **"How long between unlocks?"** (the actual hook) — two sources:
+   - GA approximation: `cosmetic_unlocked` count per active user per week
+     (Exploration: user-scoped segment, weekly cohort). Falling toward ≤1/week for
+     mid-level players = the cap era is too slow.
+   - **Precise source: Supabase `progression.unlock_dates`** (`{cosmetic_id: ISO
+     timestamp}` per row). Median gap between consecutive unlocks per player:
+     sort each row's values, diff adjacent timestamps, take the median by the
+     player's level band. This is the number the retune decision should use.
+
+### Decision levers (pre-agreed, demotion-safe — level is derived from xp on read)
+
+- Median unlock gap (mid-level band) > ~3 play sessions → **(a)** add per-round-raced
+  XP (~+12/round) so long matches pay like long matches — preferred; or **(b)**
+  cheapen the curve to `min(400, 20+9n)`.
+- Both levers only ever make the curve cheaper, so no player can lose a level.
+
+### Dashboard
+
+GA4 has no dashboards-as-code; the standing setup is one saved Exploration per
+question above (build once in GA4 UI → Explorations, names: "XP per match",
+"Level distribution", "Unlock cadence"). For on-demand checks the same three
+queries run through the Analytics Data API (the agent can run them via the
+google-analytics MCP `run_report`).

--- a/server/achievements.js
+++ b/server/achievements.js
@@ -1,24 +1,17 @@
 'use strict';
 
+// Medal display names live in progression.js (MEDAL_TITLES) so the end-of-match medal
+// cards here and the achievement requirement lines ("Earn the <medal> medal N times")
+// can never drift apart.
+var MEDAL_TITLES = require('./progression.js').MEDAL_TITLES;
+
 // End-of-match medal tallying. Mixed into Game.prototype, so methods use `this`.
 module.exports = {
 	gatherAchievements() {
-		var achievements = {
-			mostKills: { ids: [], value: 0, title: "Serial killer" },
-			savior: { ids: [], value: 0, title: "Savior" },
-			survivalist: { ids: [], value: 0, title: "Survivalist" },
-			brutalist: { ids: [], value: 0, title: "Brutalist" },
-			mostMurdered: { ids: [], value: 0, title: "Picked on" },
-			resourceful: { ids: [], value: 0, title: "Resouceful" },
-			bully: { ids: [], value: 0, title: "Bully" },
-			doubleKill: { ids: [], value: 0, title: "Double Kill" },
-			tripleKill: { ids: [], value: 0, title: "Triple Kill" },
-			megaKill: { ids: [], value: 0, title: "Mega Kill" },
-			zombieSlayer: { ids: [], value: 0, title: "Zombie Slayer" },
-			heavyHitter: { ids: [], value: 0, title: "Heavy Hitter" },
-			pinball: { ids: [], value: 0, title: "Pinball" },
-			iceSkater: { ids: [], value: 0, title: "Ice Skater" },
-		};
+		var achievements = {};
+		for (var stat in MEDAL_TITLES) {
+			achievements[stat] = { ids: [], value: 0, title: MEDAL_TITLES[stat] };
+		}
 		// Competitive medals need a real opponent — 2+ humans present (guests count; bots don't).
 		var humanCount = 0;
 		for (var hid in this.playerList) { if (this.playerList[hid] && !this.playerList[hid].isAI) { humanCount++; } }

--- a/server/auth.js
+++ b/server/auth.js
@@ -313,9 +313,15 @@ async function getProgression(userId) {
 
 function normalizeProgression(row) {
     var def = progression.defaultProgression();
+    var xp = (row && typeof row.xp === 'number') ? row.xp : def.xp;
     return {
-        xp: (row && typeof row.xp === 'number') ? row.xp : def.xp,
-        level: (row && typeof row.level === 'number') ? row.level : def.level,
+        xp: xp,
+        // Level is DERIVED from xp on every read, never trusted from the stored column.
+        // The column is only a write-time cache (addProgression keeps it current for
+        // analytics): after a curve retune the stored value goes stale until the
+        // player's next match, which would leave the badge, equip gating, and the
+        // recomputed xpThisLevel/nextUnlock fields in the same payload disagreeing.
+        level: progression.levelForXp(xp),
         unlocked_skins: (row && Array.isArray(row.unlocked_skins)) ? row.unlocked_skins : def.unlocked_skins,
         medal_counts: (row && row.medal_counts && typeof row.medal_counts === 'object') ? row.medal_counts : def.medal_counts,
         wins: (row && typeof row.wins === 'number') ? row.wins : def.wins,

--- a/server/auth.js
+++ b/server/auth.js
@@ -458,6 +458,7 @@ async function addProgression(userId, opts) {
             // on the game-over screen). Appended to the durable pending_toasts queue.
             var builtToasts = progression.buildToastEvents({
                 xpDelta: opts.xpDelta || 0,
+                oldXp: cur.xp,
                 oldLevel: oldLevel,
                 newLevel: newLevel,
                 levelSkinsUnlocked: skinRegistry.levelSkinsUnlockedBetween,

--- a/server/game.js
+++ b/server/game.js
@@ -1283,6 +1283,7 @@ class Game {
 				}
 				events = progression.buildToastEvents({
 					xpDelta: breakdown.total,
+					oldXp: prog.xp || 0,
 					oldLevel: oldLevel,
 					newLevel: newLevel,
 					levelSkinsUnlocked: skinRegistry.levelSkinsUnlockedBetween,

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -6,6 +6,10 @@ var c = utils.loadConfig();
 // config payload that already ships to every client) so the skin picker's swatches
 // and its "is this color taken?" preview match the server's validation set.
 c.colorPalette = utils.getColorPalette();
+// Achievement-cosmetic definitions (id/name/slot/stat/threshold + player-facing "how to
+// earn it" text), shipped in the same config payload — the unlock celebrations and the
+// profile panel render from this, so the ladder lives only in server/progression.js.
+c.achievementDefs = require('./progression.js').clientAchievementDefs();
 var compressor = require('./compressor.js');
 var debug = require('./debug.js');
 var mapFormat = require('./mapFormat.js');
@@ -983,6 +987,18 @@ function buildProgressionPayload(row) {
 		return null;
 	}
 	var prog = progression.levelProgress(row.xp || 0);
+	// The next level-ladder cosmetic this player is working toward, with the exact XP
+	// gap — drives the client's "next unlock: X, ~N matches away" teaser. null when the
+	// ladder is exhausted (Lv100).
+	var next = skinRegistry.nextLevelSkin(prog.level);
+	var nextUnlock = null;
+	if (next) {
+		nextUnlock = {
+			id: next.id,
+			level: next.level,
+			xpToGo: Math.max(0, progression.cumulativeXpForLevel(next.level) - (row.xp || 0))
+		};
+	}
 	return {
 		xp: row.xp || 0,
 		level: row.level || prog.level,
@@ -990,7 +1006,8 @@ function buildProgressionPayload(row) {
 		medal_counts: row.medal_counts || {},
 		wins: row.wins || 0,
 		xpThisLevel: prog.xpThisLevel,
-		xpForNextLevel: prog.xpForNextLevel
+		xpForNextLevel: prog.xpForNextLevel,
+		nextUnlock: nextUnlock
 	};
 }
 // Attach a signed-in player's progression to the player object (for server-side

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -1001,7 +1001,11 @@ function buildProgressionPayload(row) {
 	}
 	return {
 		xp: row.xp || 0,
-		level: row.level || prog.level,
+		// ALWAYS the level derived from xp (levelProgress above) — never row.level. The
+		// stored column is a write-time cache that goes stale across curve retunes, and
+		// a `row.level ||` fallback here would silently re-introduce the badge-vs-bar
+		// payload inconsistency normalizeProgression exists to prevent.
+		level: prog.level,
 		unlocked_skins: row.unlocked_skins || [],
 		medal_counts: row.medal_counts || {},
 		wins: row.wins || 0,

--- a/server/progression.js
+++ b/server/progression.js
@@ -60,12 +60,16 @@ function cumulativeXpForLevel(level) {
     return CURVE_CUM[CURVE_CAP_LEVEL] + (level - CURVE_CAP_LEVEL) * CURVE_CAP;
 }
 
-// Highest level whose cumulative floor a given total XP has reached.
+// Highest level whose cumulative floor a given total XP has reached. Clamped at a
+// far-beyond-the-ladder ceiling so a corrupt/absurd xp row renders a bounded badge
+// ("Lv 9999") instead of a ten-digit one — the skin ladder tops out at 100, so no
+// legitimate value gets near the clamp.
+var LEVEL_HARD_CAP = 9999;
 function levelForXp(totalXp) {
     var xp = totalXp || 0;
     var capFloor = CURVE_CUM[CURVE_CAP_LEVEL];
     if (xp >= capFloor) {
-        return CURVE_CAP_LEVEL + Math.floor((xp - capFloor) / CURVE_CAP);
+        return Math.min(LEVEL_HARD_CAP, CURVE_CAP_LEVEL + Math.floor((xp - capFloor) / CURVE_CAP));
     }
     var lvl = 1;
     while (lvl + 1 <= CURVE_CAP_LEVEL && CURVE_CUM[lvl + 1] <= xp) {

--- a/server/progression.js
+++ b/server/progression.js
@@ -35,22 +35,40 @@ function xpRequiredForLevel(n) {
     return Math.min(1000, Math.round((50 + 22 * n) / 5) * 5);
 }
 
+// Precomputed cumulative floors make cumulativeXpForLevel/levelForXp O(1). This is a
+// hardening requirement, not just speed: past the cap every level costs a flat 1000,
+// so a naive walk is ~xp/1000 iterations — a corrupt/oversized xp row (nothing bounds
+// the column) would stall the single-threaded event loop for seconds (measured 2.4s at
+// xp=1e12). CURVE_CAP_LEVEL = first level whose cost hits the cap; CURVE_CUM[l] = the
+// cumulative floor of level l up to there; beyond it the floor is closed-form.
+var CURVE_CAP = 1000;
+var CURVE_CAP_LEVEL = (function () {
+    var n = 2;
+    while (xpRequiredForLevel(n) < CURVE_CAP) { n++; }
+    return n;
+})();
+var CURVE_CUM = (function () {
+    var cum = [0, 0]; // levels 0 and 1 have a 0 floor
+    for (var n = 2; n <= CURVE_CAP_LEVEL; n++) { cum[n] = cum[n - 1] + xpRequiredForLevel(n); }
+    return cum;
+})();
+
 // Total cumulative XP required to BE level `level` (i.e. the floor of that level).
 function cumulativeXpForLevel(level) {
-    var total = 0;
-    for (var n = 2; n <= level; n++) {
-        total += xpRequiredForLevel(n);
-    }
-    return total;
+    if (level <= 1) { return 0; }
+    if (level <= CURVE_CAP_LEVEL) { return CURVE_CUM[level]; }
+    return CURVE_CUM[CURVE_CAP_LEVEL] + (level - CURVE_CAP_LEVEL) * CURVE_CAP;
 }
 
 // Highest level whose cumulative floor a given total XP has reached.
 function levelForXp(totalXp) {
     var xp = totalXp || 0;
+    var capFloor = CURVE_CUM[CURVE_CAP_LEVEL];
+    if (xp >= capFloor) {
+        return CURVE_CAP_LEVEL + Math.floor((xp - capFloor) / CURVE_CAP);
+    }
     var lvl = 1;
-    var cumulative = 0;
-    while (cumulative + xpRequiredForLevel(lvl + 1) <= xp) {
-        cumulative += xpRequiredForLevel(lvl + 1);
+    while (lvl + 1 <= CURVE_CAP_LEVEL && CURVE_CUM[lvl + 1] <= xp) {
         lvl++;
     }
     return lvl;
@@ -125,14 +143,16 @@ var ACHIEVEMENT_UNLOCKS = [
     { id: 'checkered', name: "Checkered", slot: 'pattern', stat: 'mapsSubmitted', threshold: 5 },
 ];
 
-// Player-facing "how to earn it" text for an achievement unlock. Medal stats phrase as
-// "Earn the <medal> medal N times" (titles match gatherAchievements in achievements.js);
-// self-counter stats get bespoke phrasing. Shipped to the client (clientAchievementDefs)
-// so unlock celebrations and the profile panel can show the requirement.
+// THE single source of medal display names: achievements.js builds its end-of-match
+// medal cards from this map, and describeAchievement phrases requirement lines from it
+// ("Earn the <medal> medal N times") — so the game-over banner, the profile tab, and
+// the unlock celebration can never disagree on what a medal is called.
 var MEDAL_TITLES = {
-    mostKills: 'Serial Killer', savior: 'Savior', survivalist: 'Survivalist',
-    brutalist: 'Brutalist', mostMurdered: 'Picked On', zombieSlayer: 'Zombie Slayer',
-    heavyHitter: 'Heavy Hitter', pinball: 'Pinball', iceSkater: 'Ice Skater'
+    mostKills: 'Serial killer', savior: 'Savior', survivalist: 'Survivalist',
+    brutalist: 'Brutalist', mostMurdered: 'Picked on', resourceful: 'Resouceful',
+    bully: 'Bully', doubleKill: 'Double Kill', tripleKill: 'Triple Kill',
+    megaKill: 'Mega Kill', zombieSlayer: 'Zombie Slayer', heavyHitter: 'Heavy Hitter',
+    pinball: 'Pinball', iceSkater: 'Ice Skater'
 };
 function describeAchievement(u) {
     var n = u.threshold;
@@ -248,6 +268,7 @@ module.exports = {
     levelForXp: levelForXp,
     levelProgress: levelProgress,
     ACHIEVEMENT_UNLOCKS: ACHIEVEMENT_UNLOCKS,
+    MEDAL_TITLES: MEDAL_TITLES,
     describeAchievement: describeAchievement,
     clientAchievementDefs: clientAchievementDefs,
     achievementsUnlocked: achievementsUnlocked,

--- a/server/progression.js
+++ b/server/progression.js
@@ -21,13 +21,18 @@ function rewardedBonusXp(originalXpDelta) {
     return base * (XP_MULTIPLIER_REWARDED - 1);
 }
 
-// XP needed to advance FROM level n-1 TO level n. Fast-early, slow-late:
-//   xpRequiredForLevel(2) ≈ 152, (5) ≈ 657, (13) ≈ 3084.
-// Tuned (with the config XP awards, ~150-250 XP/match) for ~4-5 unlocks in a
-// player's first session.
+// XP needed to advance FROM level n-1 TO level n. Linear with a hard ceiling
+// ("capped hook", operator-approved 2026-06-04): 50 + 22n, capped at 1000/level
+// (the cap kicks in at Lv44). With ~100 XP/match (winners ~195) that paces the
+// every-2-levels cosmetic ladder at ~2-3 matches per unlock early, growing to a
+// permanent ceiling of ~20 matches — the next skin always feels reachable.
+// L100 ≈ 80k XP ≈ ~800 matches lifetime.
+//   xpRequiredForLevel(2) = 95, (10) = 270, (44+) = 1000.
+// MIGRATION SAFETY: this is strictly cheaper than the old 50·n^1.6 curve at every
+// level, so levelForXp(existing xp) can only go UP — no player ever demotes.
 function xpRequiredForLevel(n) {
     if (n <= 1) { return 0; }
-    return Math.round(50 * Math.pow(n, 1.6));
+    return Math.min(1000, Math.round((50 + 22 * n) / 5) * 5);
 }
 
 // Total cumulative XP required to BE level `level` (i.e. the floor of that level).
@@ -120,6 +125,43 @@ var ACHIEVEMENT_UNLOCKS = [
     { id: 'checkered', name: "Checkered", slot: 'pattern', stat: 'mapsSubmitted', threshold: 5 },
 ];
 
+// Player-facing "how to earn it" text for an achievement unlock. Medal stats phrase as
+// "Earn the <medal> medal N times" (titles match gatherAchievements in achievements.js);
+// self-counter stats get bespoke phrasing. Shipped to the client (clientAchievementDefs)
+// so unlock celebrations and the profile panel can show the requirement.
+var MEDAL_TITLES = {
+    mostKills: 'Serial Killer', savior: 'Savior', survivalist: 'Survivalist',
+    brutalist: 'Brutalist', mostMurdered: 'Picked On', zombieSlayer: 'Zombie Slayer',
+    heavyHitter: 'Heavy Hitter', pinball: 'Pinball', iceSkater: 'Ice Skater'
+};
+function describeAchievement(u) {
+    var n = u.threshold;
+    switch (u.stat) {
+        case 'wins': return 'Win ' + n + ' matches';
+        case 'winStreak': return 'Win ' + n + ' matches in a row';
+        case 'gamesPlayed': return 'Play ' + n + ' matches';
+        case 'goalsReached': return 'Reach the goal ' + n + ' times';
+        case 'abilitiesUsed': return 'Use ' + n + ' abilities';
+        case 'cosmeticGames': return 'Play ' + n + ' matches with a cosmetic equipped';
+        case 'recapAppearances': return 'Star in ' + n + ' match recaps';
+        case 'joinInProgress': return 'Join ' + n + ' matches already in progress';
+        case 'mapsSubmitted': return n === 1 ? 'Publish a map from the editor' : ('Publish ' + n + ' maps from the editor');
+        default: {
+            var title = MEDAL_TITLES[u.stat] || u.stat;
+            return 'Earn the ' + title + ' medal ' + n + (n === 1 ? ' time' : ' times');
+        }
+    }
+}
+
+// The achievement ladder shaped for the client (config payload): everything the UI
+// needs to render locked silhouettes, requirement text and progress bars — no
+// client-side mirror of ACHIEVEMENT_UNLOCKS to keep in lockstep.
+function clientAchievementDefs() {
+    return ACHIEVEMENT_UNLOCKS.map(function (u) {
+        return { id: u.id, name: u.name, slot: u.slot, stat: u.stat, threshold: u.threshold, desc: describeAchievement(u) };
+    });
+}
+
 // winStreak is a MAX/streak, not a count: maintained explicitly after the additive medal
 // merge. `_streak` (underscore = internal, not a cosmetic stat) is the current run; `winStreak`
 // is the best-ever, which the achievement ladder gates on. Call once per match after merging.
@@ -169,7 +211,16 @@ function buildToastEvents(opts) {
     opts = opts || {};
     var events = [];
     if (opts.xpDelta > 0) {
-        events.push({ type: 'xp', amount: opts.xpDelta });
+        var xpEv = { type: 'xp', amount: opts.xpDelta };
+        // When the caller knows the player's pre-match XP total, attach before/after
+        // level-bar snapshots so the client can ANIMATE the bar filling (and rolling
+        // over on level-up) instead of just printing "+N XP". Optional: events without
+        // them (old queued toasts, not-yet-loaded rows) fall back to plain text.
+        if (typeof opts.oldXp === 'number') {
+            xpEv.from = levelProgress(opts.oldXp);
+            xpEv.to = levelProgress(opts.oldXp + opts.xpDelta);
+        }
+        events.push(xpEv);
     }
     var oldLevel = opts.oldLevel || 1;
     var newLevel = opts.newLevel || oldLevel;
@@ -197,6 +248,8 @@ module.exports = {
     levelForXp: levelForXp,
     levelProgress: levelProgress,
     ACHIEVEMENT_UNLOCKS: ACHIEVEMENT_UNLOCKS,
+    describeAchievement: describeAchievement,
+    clientAchievementDefs: clientAchievementDefs,
     achievementsUnlocked: achievementsUnlocked,
     applyWinStreak: applyWinStreak,
     mergeMedalCounts: mergeMedalCounts,

--- a/server/skinRegistry.js
+++ b/server/skinRegistry.js
@@ -165,6 +165,19 @@ function levelSkinsUnlockedBetween(oldLevel, newLevel) {
     return out;
 }
 
+// The NEXT level-gated cosmetic above `level` (lowest unlock.level > level), or null at
+// the top of the ladder. Drives the "next unlock" teaser in the progression payload —
+// the single biggest "one more match" pull, so the client always knows what's coming.
+function nextLevelSkin(level) {
+    var best = null;
+    for (var i = 0; i < SKINS.length; i++) {
+        var s = SKINS[i];
+        if (s.unlock.kind !== 'level' || s.unlock.level <= level) { continue; }
+        if (!best || s.unlock.level < best.unlock.level) { best = s; }
+    }
+    return best ? { id: best.id, level: best.unlock.level } : null;
+}
+
 // True if `unlock` is a seasonal-claim rule whose window is currently open (claimStart <=
 // now < claimEnd). Missing/invalid bounds read as closed so a malformed entry can't grant
 // forever. `now` is epoch ms (pass Date.now()); injected so callers/tests stay deterministic.
@@ -193,6 +206,7 @@ module.exports = {
     getSkin: getSkin,
     getSkinSlot: getSkinSlot,
     levelSkinsUnlockedBetween: levelSkinsUnlockedBetween,
+    nextLevelSkin: nextLevelSkin,
     isClaimWindowOpen: isClaimWindowOpen,
     currentSeasonalClaims: currentSeasonalClaims
 };


### PR DESCRIPTION
Overhauls the entire unlock loop to maximize the "one more match" hook.

## Player-facing

- **XP curve retuned** to `min(1000, 50+22n)`/level: first level-up in your first match, no level ever costs more than ~10 matches, L100 ≈ 800 matches (was ~30,000). Strictly cheaper at every level — **nobody demotes**; existing players jump up instantly on sign-in (level now derived from XP on read) with every earned skin immediately equippable.
- **Three-tier celebrations** replace the one-line toasts: animated XP bar with count-up + level rollover + "Next: Donut · ~3 matches away" teaser; LEVEL UP burst; full-screen unlock reveal with the actual cosmetic animating in your color, rarity accent, rotating rays, confetti, crowd cheer. Bulk unlocks (4+) collapse to one summary grid card. Click-to-skip; torn down at race start; mid-race rewarded-XP acks fall back to the quiet text toast.
- **🏆 Profile tab** in the Skins station: every achievement cosmetic as a silhouette + "?" with a live progress bar and "how to earn it" line; locked achievement items in the picker are mystery "???" cells (the celebration is the reveal); tapping one shows its requirement + progress.

## Engineering notes

- Level is derived from XP on every read (`normalizeProgression`); the stored column is a write-time cache. A CI guard now pins the original curve — any future retune that would demote players fails the progression test.
- O(1) curve math (precomputed table + closed form past the cap); corrupt-XP rows can't stall the event loop, badge clamped at Lv 9999.
- Medal display names single-sourced (`progression.MEDAL_TITLES` → achievements.js medal cards + requirement lines).
- GA pacing instrumentation: `xp_earned` / `level_up` / `cosmetic_unlocked` events + config-as-code dims/metrics/key-event (CI-applies on merge) + retune runbook (`docs/cosmetics-analytics.md` §3) with survivorship caveat.
- Known pacing decision: real matches run 10–25 min, so wall-clock pacing ships ~3× slower than the original design target — deliberate "ship and tune with data" call; retune levers are pre-agreed and demotion-safe.
- Reviewed: two multi-agent passes + a Codex pass; all actionable findings fixed in-branch. Deferred cleanups (cosmetic-painter unification, celebration shell dedup) tracked for a follow-up PR.

## Test plan

- `npm run build` + smoke + progression (incl. new no-demotion CI guard) + rewarded-ads + unit + content validation: all green post-rebase.
- Live-verified in browser: XP card fill/rollover/teaser, LEVEL UP burst, single unlock reveal, profile tab (incl. coexistence with the v0.28.3 🎲 Random row + Equipped preview), picker mystery cells, requirement-on-tap.
- Curve equivalence + demotion-safety proven by exhaustive sweep (0 mismatches; 0 demotions across 0–300k XP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)