### PR TITLE
fix(analytics): unbreak GA config apply — shorten playlist description + enforce field limits in dry-run

### DIFF
--- a/analytics/ga-config.json
+++ b/analytics/ga-config.json
@@ -24,7 +24,7 @@
       "parameterName": "playlist",
       "displayName": "Playlist",
       "scope": "EVENT",
-      "description": "Active map playlist on round_start/round_complete/match_end (featured | hardcore | pure | all | \u2026). Lets gameplay be segmented by playlist and surfaces per-playlist skew."
+      "description": "Active map playlist on round_start/round_complete/match_end (featured | hardcore | pure | all | \u2026) \u2014 segments gameplay per playlist."
     },
     {
       "parameterName": "trap_source",

--- a/analytics/reconcile-ga.js
+++ b/analytics/reconcile-ga.js
@@ -49,12 +49,32 @@ const group = async (title, fn) => {
   }
 };
 
+// GA4 Admin API field limits for custom dimensions/metrics. Enforced at LOAD time so
+// the PR dry-run fails on a violation — the API only rejects on the real apply, which
+// is how an over-length description once slipped through review and broke the main
+// apply (playlist, 170 > 150).
+const GA_FIELD_LIMITS = { parameterName: 40, displayName: 82, description: 150 };
+function validateFieldLimits(kind, entries) {
+  for (const e of entries || []) {
+    for (const [field, max] of Object.entries(GA_FIELD_LIMITS)) {
+      const v = e[field];
+      if (typeof v === 'string' && v.length > max) {
+        throw new Error(
+          `${kind} "${e.parameterName}": ${field} is ${v.length} chars (GA4 max ${max}). Shorten it in ga-config.json.`
+        );
+      }
+    }
+  }
+}
+
 function loadConfig() {
   const raw = JSON.parse(fs.readFileSync(configPath, 'utf8'));
   const propertyId = String(raw.propertyId || '').replace(/^properties\//, '');
   if (!/^\d+$/.test(propertyId)) {
     throw new Error(`config.propertyId must be a numeric GA4 property id, got: ${raw.propertyId}`);
   }
+  validateFieldLimits('customDimension', raw.customDimensions);
+  validateFieldLimits('customMetric', raw.customMetrics);
   return {
     parent: `properties/${propertyId}`,
     propertyId,


### PR DESCRIPTION
The post-merge `GA config (prod)` apply on main failed (run 26979347637): GA4 caps custom-dimension descriptions at **150 chars**, and the pre-existing `playlist` dimension's description was **170** (landed after the last successful apply, so the first apply to trip on it was v0.29.0's — which therefore never registered the new pacing dims/metrics/key event).

- Shorten `playlist` description 170 → 132 chars (same content, tighter phrasing).
- `reconcile-ga.js` now validates GA4 field limits (parameterName 40 / displayName 82 / description 150) at config-load time — so a violation fails the **PR dry-run** instead of the main apply, closing the gap that let this slip through.

Merging re-triggers the apply (the workflow watches both files), which will then create the v0.29.0 entries: `cosmetic_id`/`cosmetic_slot`/`unlock_kind` dims, `xp`/`level` metrics, `cosmetic_unlocked` key event.

No gameplay changes; analytics-only (no release notes needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)