### PR TITLE
feat(analytics): user-scoped cohorts + funnel/churn/onboarding GA events

### DIFF
--- a/analytics/ga-config.json
+++ b/analytics/ga-config.json
@@ -24,7 +24,7 @@
       "parameterName": "playlist",
       "displayName": "Playlist",
       "scope": "EVENT",
-      "description": "Active map playlist on round_start/round_complete/match_end (featured | hardcore | pure | all | \u2026) \u2014 segments gameplay per playlist."
+      "description": "Active map playlist on round_start/round_complete/match_end (featured | hardcore | pure | all | …) — segments gameplay per playlist."
     },
     {
       "parameterName": "trap_source",
@@ -67,6 +67,54 @@
       "displayName": "Unlock Kind",
       "scope": "EVENT",
       "description": "How the cosmetic was earned on cosmetic_unlocked: skin (level ladder) | achievement | seasonal."
+    },
+    {
+      "parameterName": "method",
+      "displayName": "Login Method",
+      "scope": "EVENT",
+      "description": "OAuth provider on the login event: google | discord."
+    },
+    {
+      "parameterName": "state",
+      "displayName": "Game State",
+      "scope": "EVENT",
+      "description": "Game state the player was in when match_abandon fired: gated | racing | collapsing | overview."
+    },
+    {
+      "parameterName": "reason",
+      "displayName": "Disconnect Reason",
+      "scope": "EVENT",
+      "description": "socket.io close reason on the disconnect/connect_error events (transport close, ping timeout, ...)."
+    },
+    {
+      "parameterName": "auth_state",
+      "displayName": "Auth State",
+      "scope": "USER",
+      "description": "How the player is signed in: guest | google | discord. User-scoped so retention/engagement can be cohorted by sign-in status."
+    },
+    {
+      "parameterName": "player_level",
+      "displayName": "Player Level Bucket",
+      "scope": "USER",
+      "description": "Progression level bucket: none | 1 | 2-5 | 6-10 | 11-20 | 21+. Refreshed on progressionUpdate and level-up."
+    },
+    {
+      "parameterName": "input_method",
+      "displayName": "Input Method",
+      "scope": "USER",
+      "description": "Primary input device this session: gamepad | touch | keyboard."
+    },
+    {
+      "parameterName": "perf_profile",
+      "displayName": "Perf Profile",
+      "scope": "USER",
+      "description": "Active graphics profile: high | balanced | low (manual pin) or auto_high/auto_balanced/auto_low (Auto's pick) - the device-capability mix."
+    },
+    {
+      "parameterName": "embed_host",
+      "displayName": "Embed Host",
+      "scope": "USER",
+      "description": "Portal hostname when running inside an iframe (itch.io / CrazyGames / Poki / ...), else none. Attributes traffic + quality per portal."
     }
   ],
   "customMetrics": [
@@ -97,6 +145,27 @@
       "scope": "EVENT",
       "measurementUnit": "STANDARD",
       "description": "Player level on level_up (level reached) and xp_earned (level after the award). Distribution over time shows curve pacing."
+    },
+    {
+      "parameterName": "duration_seconds",
+      "displayName": "Duration (s)",
+      "scope": "EVENT",
+      "measurementUnit": "SECONDS",
+      "description": "Elapsed seconds: round length on round_complete (gate release - overview), match length on match_end (first race - game over)."
+    },
+    {
+      "parameterName": "time_to_first_match",
+      "displayName": "Time to first match (s)",
+      "scope": "EVENT",
+      "measurementUnit": "SECONDS",
+      "description": "Seconds from page navigation start to the player's first-ever race (first_match event). Onboarding-friction metric."
+    },
+    {
+      "parameterName": "round_number",
+      "displayName": "Round number",
+      "scope": "EVENT",
+      "measurementUnit": "STANDARD",
+      "description": "Match round counter on round_complete / match_abandon - locates where in a match players quit."
     }
   ],
   "keyEvents": [
@@ -110,6 +179,14 @@
     },
     {
       "eventName": "cosmetic_unlocked",
+      "countingMethod": "ONCE_PER_EVENT"
+    },
+    {
+      "eventName": "first_match",
+      "countingMethod": "ONCE_PER_EVENT"
+    },
+    {
+      "eventName": "login",
       "countingMethod": "ONCE_PER_EVENT"
     }
   ]

--- a/build.js
+++ b/build.js
@@ -7,6 +7,7 @@ const bundles = {
         'client/scripts/rhill-voronoi-core.js',
         'client/scripts/game.js',
         'client/scripts/perf.js',
+        'client/scripts/metrics.js',
         'client/scripts/ads.js',
         'client/scripts/client.js',
         'client/scripts/audio.js',

--- a/client/play.html
+++ b/client/play.html
@@ -110,6 +110,7 @@
         <script src="scripts/rhill-voronoi-core.js"></script>
         <script src="scripts/game.js"></script>
         <script src="scripts/perf.js"></script>
+        <script src="scripts/metrics.js"></script>
         <script src="scripts/ads.js"></script>
         <script src="scripts/client.js"></script>
         <script src="scripts/audio.js"></script>

--- a/client/scripts/auth.js
+++ b/client/scripts/auth.js
@@ -69,13 +69,46 @@
         return user.id + '|' + (m.full_name || m.name || m.user_name || user.email || '') + '|' + (m.avatar_url || '');
     }
 
+    // GA login conversion. A fresh OAuth sign-in is a full-page redirect away and
+    // back, so "was a sign-in just completed?" can't be told apart from a routine
+    // session restore by auth events alone. Instead signIn() stamps the chosen
+    // provider in localStorage before redirecting; seeing a signed-in session with
+    // that stamp present = the player actually converted. The stamp is consumed on
+    // first sight, and a stale one (player bailed at the OAuth screen and came
+    // back later) is swept by a short timer below so it can't mis-fire days later.
+    var SIGNIN_PENDING_KEY = 'chaochao.signInPending';
+    function consumeSignInPending(user) {
+        if (!user) { return; }
+        var pending = null;
+        try {
+            pending = window.localStorage.getItem(SIGNIN_PENDING_KEY);
+            if (pending) { window.localStorage.removeItem(SIGNIN_PENDING_KEY); }
+        } catch (e) { /* storage unavailable */ }
+        if (pending && typeof trackEvent === 'function') {
+            // GA4's recommended sign-in event name; `method` = google | discord.
+            trackEvent('login', { method: pending });
+        }
+    }
+    // Sweep a stale pending stamp: if no session showed up shortly after load,
+    // the OAuth round-trip didn't complete (cancelled / abandoned).
+    setTimeout(function () {
+        if (currentUser) { return; }
+        try { window.localStorage.removeItem(SIGNIN_PENDING_KEY); } catch (e) { /* ignore */ }
+    }, 15000);
+
     function applySession(session) {
         accessToken = (session && session.access_token) || null;
         var newUser = (session && session.user) || null;
         var changed = navKey(currentUser) !== navKey(newUser);
         currentUser = newUser;
+        consumeSignInPending(newUser);
         if (changed) {
             renderAuthUI();
+            // Refresh the auth_state GA user property (defined by metrics.js in the
+            // play bundle; absent on pages without it).
+            if (typeof window.updateGAUserProperties === 'function') {
+                window.updateGAUserProperties();
+            }
         }
     }
 
@@ -102,6 +135,9 @@
             console.log('[auth] sign-in unavailable (auth disabled).');
             return;
         }
+        // Stamp the provider so the post-redirect load can fire the GA `login`
+        // conversion (see consumeSignInPending above).
+        try { window.localStorage.setItem(SIGNIN_PENDING_KEY, provider); } catch (e) { /* ignore */ }
         // Redirect back to the current page; supabase-js completes the session
         // from the URL on return, then a fresh socket handshake carries the token.
         sb.auth.signInWithOAuth({
@@ -252,6 +288,9 @@
             '<button class="cc-toast-close" type="button" aria-label="Dismiss">×</button>';
         document.body.appendChild(toastEl);
         toastEl.querySelector('.cc-toast-action').addEventListener('click', function () {
+            // Nudge funnel numerator (denominator = login_nudge_shown); the
+            // conversion itself lands as `login` after the OAuth round-trip.
+            if (typeof trackEvent === 'function') { trackEvent('login_nudge_clicked'); }
             hideToast();
             var login = document.getElementById('authLogin');
             if (login) { login.click(); } // open the navbar sign-in popover
@@ -267,6 +306,9 @@
         buildToast();
         if (!toastEl) { return; }
         toastEl.classList.add('visible');
+        // Nudge funnel denominator (clicked/shown = nudge CTR; login/shown = the
+        // guest -> registered conversion rate the nudge actually drives).
+        if (typeof trackEvent === 'function') { trackEvent('login_nudge_shown'); }
         if (toastTimer) { clearTimeout(toastTimer); }
         toastTimer = setTimeout(hideToast, 9000);
     }
@@ -280,6 +322,13 @@
         getProfile: getProfile,
         signIn: signIn,
         signOut: signOut,
-        isSignedIn: function () { return !!currentUser; }
+        isSignedIn: function () { return !!currentUser; },
+        // For the auth_state GA user property: 'guest' or the OAuth provider the
+        // session was created with ('google' | 'discord').
+        getAuthState: function () {
+            if (!currentUser) { return 'guest'; }
+            var appMeta = currentUser.app_metadata || {};
+            return appMeta.provider || 'unknown';
+        }
     };
 })();

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -188,6 +188,10 @@ function showRewardOfferToast() {
 	rewardOfferToastEl = el;
 	el.querySelector(".cc-toast-action").addEventListener("click", rewardOfferWatch);
 	el.querySelector(".cc-toast-close").addEventListener("click", rewardOfferDismiss);
+	// The offer is now actually visible — fire the funnel DENOMINATOR so
+	// reward_claimed/reward_offered yields the claim-through rate. Same `bonus`
+	// value as reward_claimed so the funnel joins cleanly.
+	trackEvent('reward_offered', { bonus: 'xp_2x' });
 	requestAnimationFrame(function () { el.classList.add("visible"); });
 }
 function removeRewardOfferToast() {
@@ -552,6 +556,10 @@ function clearProgressionToasts() {
 // Fire the `cosmetics_equipped` GA event once per MATCH (cosmetics are fixed for a match),
 // not once per round. Reset when a new match's lobby forms (startLobby).
 var cosmeticsTrackedThisMatch = false;
+// First race of the current match (client clock), for match_end's duration_seconds.
+// Cleared when a new match's lobby forms; stamped by the first startRace after that
+// (which also covers a mid-match join — their match starts at their first race).
+var matchStartedAt = null;
 function registerConnectionHandlers(server) {
 	server.on('welcome', function (id) {
 		debugLog("welcome, myID=", id);
@@ -569,6 +577,9 @@ function registerConnectionHandlers(server) {
 	server.on('progressionUpdate', function (prog) {
 		myProgression = prog || null;
 		debugLog("progressionUpdate level=", prog && prog.level, "xp=", prog && prog.xp);
+		// Refresh the player_level GA user property so a level change moves this
+		// player's cohort mid-session (and the first update fills it post-join).
+		if (typeof updateGAUserProperties === "function") { updateGAUserProperties(); }
 	});
 	// Celebration toasts earned in a prior match, delivered on lobby arrival (NOT on
 	// the game-over screen). Server sends an ordered batch; we sequence them as
@@ -670,6 +681,9 @@ function registerConnectionHandlers(server) {
 
 	server.on("serverKick", function () {
 		debugLog("serverKick received -- being booted");
+		// Engagement signal: how often players idle out (AFK kick) vs leave on
+		// their own. Fired before teardown so it can't be skipped by navigation.
+		trackEvent('server_kick');
 		// Per-slot teardown (§6.17): drop the primary slot. With no other local
 		// players this disconnects and navigates exactly as before (N=1); with pad
 		// players still in the game it fails over to one of them instead of ending
@@ -693,7 +707,15 @@ function registerConnectionHandlers(server) {
 	// bare auto-reconnect would strand them roomless (nothing re-sends
 	// enterGame on the primary socket). Rather than guessing how long the new
 	// dyno takes to boot, poll until the server actually answers, then reload.
-	server.on("disconnect", function () {
+	server.on("disconnect", function (reason) {
+		// Connection-quality telemetry: ONE disconnect event per page session
+		// (socket.io auto-reconnect can cycle; the first drop is the signal). The
+		// reason dim separates server restarts ('transport close') from network
+		// trouble ('ping timeout') and intentional teardown ('io client disconnect').
+		if (!window.__disconnectSent) {
+			window.__disconnectSent = true;
+			trackEvent('disconnect', { reason: reason || 'unknown' });
+		}
 		if (serverMaintenance == null) { return; }
 		// Stale state guard: a hidden tab's draw loop never runs, so the
 		// banner's own expiry can't clear serverMaintenance — don't treat a
@@ -722,6 +744,15 @@ function registerConnectionHandlers(server) {
 		}, 2000);
 	});
 
+	// Couldn't reach the server at all (engine.io-level failure). Once per page
+	// session — socket.io retries in a loop and would otherwise spam GA. Catches
+	// "players who tried to play but never connected", invisible in every other
+	// gameplay event.
+	server.on("connect_error", function (err) {
+		if (window.__connectErrorSent) { return; }
+		window.__connectErrorSent = true;
+		trackEvent('connect_error', { reason: (err && err.message) ? String(err.message).slice(0, 90) : 'unknown' });
+	});
 
 	server.on("gameState", function (gameState) {
 		debugLog("gameState received, gameID=", gameState.gameID, "myID=", gameState.myID, "players=", Object.keys(gameState.clientList || {}).length);
@@ -1030,6 +1061,7 @@ function registerStateHandlers(server) {
 		currentState = config.stateMap.lobby;
 		trackEvent('lobby_entered');
 		cosmeticsTrackedThisMatch = false; // new match forming — re-arm the cosmetics event
+		matchStartedAt = null; // re-arm the match clock; the first startRace stamps it
 		spawnLobbyStartButton(packet);
 		setLobbySfxDampen(true);
 		playSoundAfterFinish(lobbyMusic);
@@ -1140,12 +1172,16 @@ function registerStateHandlers(server) {
 		// client roster, excludes bots); `bots` counts AI fill via the spawn-packet
 		// `name` marker (server compressor sets player.name only on bot append; humans
 		// stay null — see compressor.js gameState).
+		if (matchStartedAt == null) { matchStartedAt = Date.now(); } // first race of this match
 		trackEvent('round_start', {
 			players: clientList ? Object.keys(clientList).length : 0,
 			bots: countBotsInPlayerList(),
 			map: (currentMap && currentMap.name) || 'unknown',
 			playlist: currentPlaylistIdForMetrics()
 		});
+		// Lifetime-once onboarding conversion: the player's very first race, with
+		// time_to_first_match (seconds since navigation start). See metrics.js.
+		if (typeof trackFirstMatchIfNew === "function") { trackFirstMatchIfNew(); }
 		// Once per match: which cosmetics the LOCAL player chose to race with. One event with
 		// all four slots so GA can chart per-slot popularity AND popular combinations.
 		// 'none' = the slot's default (no cart shape / pattern / trail / border).
@@ -1204,10 +1240,17 @@ function registerStateHandlers(server) {
 		myMapRating = 0;
 		ratingStarHits = [];
 		ratingPadCursor = 0;
-		trackEvent('round_complete', {
+		// duration_seconds = gate release -> overview (raceStartedAt is stamped per
+		// round in startRace); round_number locates pacing skew within a match.
+		var roundCompleteParams = {
 			map: (currentMap && currentMap.name) || 'unknown',
-			playlist: currentPlaylistIdForMetrics()
-		});
+			playlist: currentPlaylistIdForMetrics(),
+			round_number: (typeof round === "number") ? round : 0
+		};
+		if (raceStartedAt != null) {
+			roundCompleteParams.duration_seconds = Math.round((Date.now() - raceStartedAt) / 1000);
+		}
+		trackEvent('round_complete', roundCompleteParams);
 	});
 	// Map leaderboard for the JUST-PLAYED map (rank/time per logged-in racer in
 	// this room). Drives the inline rank/time shown alongside each notch row on
@@ -1308,13 +1351,19 @@ function registerStateHandlers(server) {
 			? Colors.decode((winner._serverColor != null) ? winner._serverColor : winner.color)
 			: "";
 		currentState = config.stateMap.gameOver;
-		trackEvent('match_end', {
+		// duration_seconds = the player's first race of this match -> game over
+		// (matchStartedAt; a mid-match joiner's clock starts at their first race).
+		var matchEndParams = {
 			won: (packet.winner === myID),
 			map: (currentMap && currentMap.name) || 'unknown',
 			playlist: currentPlaylistIdForMetrics(),
 			players: clientList ? Object.keys(clientList).length : 0,
 			bots: countBotsInPlayerList()
-		});
+		};
+		if (matchStartedAt != null) {
+			matchEndParams.duration_seconds = Math.round((Date.now() - matchStartedAt) / 1000);
+		}
+		trackEvent('match_end', matchEndParams);
 		// Nudge signed-out players to log in (save progress / earn skins). No-op
 		// when auth is off or already signed in. Primary screen only.
 		if (window.chaochaoAuth && typeof window.chaochaoAuth.showLoginNudge === "function") {

--- a/client/scripts/metrics.js
+++ b/client/scripts/metrics.js
@@ -43,9 +43,19 @@ function metricsLevelBucket(level) {
 
 // Primary input this session. Gamepad wins over touch (a pad on an iPad is a pad
 // player); touch wins over keyboard. Coarse by design — it's a cohorting axis.
+// Touch is probed via input.js's isTouchDevice() (pure matchMedia detector), NOT
+// the isTouchScreen flag — that flag is only assigned inside initEventHandlers()
+// on the gameState/init() path, which runs AFTER the DOMContentLoaded refresh
+// below, and guests get no later auth/progression refresh to correct a miss.
 function metricsInputMethod() {
 	if (typeof gamepadConnected !== "undefined" && gamepadConnected === true) { return "gamepad"; }
-	if (typeof isTouchScreen !== "undefined" && isTouchScreen === true) { return "touch"; }
+	try {
+		if (typeof isTouchDevice === "function") {
+			if (isTouchDevice()) { return "touch"; }
+		} else if (typeof isTouchScreen !== "undefined" && isTouchScreen === true) {
+			return "touch";
+		}
+	} catch (e) { /* matchMedia unavailable */ }
 	return "keyboard";
 }
 

--- a/client/scripts/metrics.js
+++ b/client/scripts/metrics.js
@@ -1,0 +1,153 @@
+// metrics.js — GA4 enrichment beyond the bare trackEvent() helper (play.html head).
+//
+// Owns the cross-cutting analytics that no single feature file should:
+//   - USER-SCOPED properties (gtag 'set' user_properties): auth_state, player_level,
+//     input_method, perf_profile, embed_host. These let GA cohort *users* (retention
+//     by sign-in status, device class, portal) instead of only slicing events.
+//   - first_match (lifetime-once, localStorage-flagged) + time_to_first_match,
+//     the onboarding-friction key event.
+//   - match_abandon on pagehide while mid-match — the churn/quit-point signal.
+//
+// Everything here is fail-open: gtag may be blocked by an ad/tracker blocker, so
+// every call is guarded and analytics can never throw into gameplay. The file is
+// part of the play bundle (shares globals with client.js/game.js/perf.js); all
+// reads happen lazily at call time, so concat order doesn't matter.
+
+// The portal hostname when running inside an iframe, else 'none'. ancestorOrigins
+// is Chromium/WebKit-only; document.referrer is the cross-browser fallback (on an
+// embedded first load it points at the embedding page). 'unknown_embed' = we know
+// we're framed but the parent origin is unreadable (sandboxed/no-referrer portal).
+function metricsEmbedHost() {
+	try {
+		if (typeof isEmbedded !== "function" || !isEmbedded()) { return "none"; }
+		if (window.location.ancestorOrigins && window.location.ancestorOrigins.length) {
+			return new URL(window.location.ancestorOrigins[0]).hostname || "unknown_embed";
+		}
+		if (document.referrer) {
+			return new URL(document.referrer).hostname || "unknown_embed";
+		}
+	} catch (e) { /* URL parse / cross-origin read failed */ }
+	return "unknown_embed";
+}
+
+// Coarse level buckets so the user property stays low-cardinality and readable in
+// GA tables ('none' = no progression yet: guest, or signed-in pre-first-XP).
+function metricsLevelBucket(level) {
+	if (typeof level !== "number" || level < 1) { return "none"; }
+	if (level <= 1) { return "1"; }
+	if (level <= 5) { return "2-5"; }
+	if (level <= 10) { return "6-10"; }
+	if (level <= 20) { return "11-20"; }
+	return "21+";
+}
+
+// Primary input this session. Gamepad wins over touch (a pad on an iPad is a pad
+// player); touch wins over keyboard. Coarse by design — it's a cohorting axis.
+function metricsInputMethod() {
+	if (typeof gamepadConnected !== "undefined" && gamepadConnected === true) { return "gamepad"; }
+	if (typeof isTouchScreen !== "undefined" && isTouchScreen === true) { return "touch"; }
+	return "keyboard";
+}
+
+// Active graphics profile, distinguishing a manual pin ('low') from Auto's
+// resolution ('auto_low') — the former is a player choice, the latter is the
+// detector's verdict on the device.
+function metricsPerfProfile() {
+	try {
+		var pref = (typeof getPerfPref === "function") ? getPerfPref() : "auto";
+		if (pref === "auto") {
+			return "auto_" + ((typeof perfTier !== "undefined" && perfTier) ? perfTier : "high");
+		}
+		return pref;
+	} catch (e) { return "unknown"; }
+}
+
+// (Re)send the user-scoped properties. Cheap and idempotent — called at bundle
+// eval (input/perf/embed are known immediately), again when auth resolves
+// (auth.js calls this after applySession), and on every progressionUpdate so a
+// level-up moves the player_level cohort mid-session. Properties only attach to
+// events sent AFTER the set, hence the eager first call.
+function updateGAUserProperties() {
+	if (typeof gtag !== "function") { return; }
+	try {
+		var authState = "guest";
+		if (window.chaochaoAuth && typeof window.chaochaoAuth.getAuthState === "function") {
+			authState = window.chaochaoAuth.getAuthState();
+		}
+		gtag("set", "user_properties", {
+			auth_state: authState,
+			player_level: metricsLevelBucket((typeof myProgression !== "undefined" && myProgression) ? myProgression.level : null),
+			input_method: metricsInputMethod(),
+			perf_profile: metricsPerfProfile(),
+			embed_host: metricsEmbedHost()
+		});
+	} catch (e) { /* analytics must never break gameplay */ }
+}
+// Expose for the standalone (non-bundled) auth.js, which refreshes auth_state
+// after sign-in/out resolves.
+window.updateGAUserProperties = updateGAUserProperties;
+updateGAUserProperties();
+// Re-send once everything has evaluated: metrics.js sits early in the bundle, so
+// the eager call above ran before input.js set isTouchScreen (and before Auto's
+// perf tier resolved). By DOMContentLoaded the bundle's sync scripts AND the
+// deferred auth.js have run, so this pass has the real values — important for
+// guests, who never get the auth-change/progressionUpdate refreshes.
+document.addEventListener("DOMContentLoaded", updateGAUserProperties);
+
+// A gamepad connecting mid-session flips the input_method cohort.
+window.addEventListener("gamepadconnected", function () {
+	updateGAUserProperties();
+});
+
+// --- first_match -------------------------------------------------------------
+// Lifetime-once (per browser) "player actually raced" conversion, with
+// time_to_first_match = seconds from navigation start to that first gate
+// release. Fired from client.js's startRace handler. localStorage-flagged so
+// returning players never re-fire; private-mode storage failures degrade to
+// once-per-pageload via the in-memory flag.
+var FIRST_MATCH_KEY = "playedFirstMatch";
+var firstMatchTracked = false;
+function trackFirstMatchIfNew() {
+	if (firstMatchTracked) { return; }
+	firstMatchTracked = true;
+	try {
+		if (window.localStorage.getItem(FIRST_MATCH_KEY)) { return; }
+		window.localStorage.setItem(FIRST_MATCH_KEY, "1");
+	} catch (e) { /* storage unavailable — still fire, deduped per pageload */ }
+	var seconds = null;
+	try { seconds = Math.round(performance.now() / 1000); } catch (e) { /* ancient browser */ }
+	var params = {};
+	if (seconds != null) { params.time_to_first_match = seconds; }
+	trackEvent("first_match", params);
+}
+
+// --- match_abandon -------------------------------------------------------------
+// The quit-point signal: the page is going away while the player is mid-match
+// (gated/racing/collapsing/overview — NOT lobby/waiting/gameOver, where leaving
+// is a natural stopping point). gtag transports unload-time events via
+// sendBeacon, so firing inside pagehide is reliable. Once-guarded: pagehide can
+// fire again on bfcache restore + re-leave, but that's the same abandonment.
+var MATCH_ABANDON_STATES = ["gated", "racing", "collapsing", "overview"];
+var matchAbandonSent = false;
+window.addEventListener("pagehide", function () {
+	if (matchAbandonSent) { return; }
+	try {
+		if (typeof config === "undefined" || !config || !config.stateMap ||
+			typeof currentState === "undefined" || currentState == null) { return; }
+		var stateName = null;
+		for (var i = 0; i < MATCH_ABANDON_STATES.length; i++) {
+			if (currentState === config.stateMap[MATCH_ABANDON_STATES[i]]) {
+				stateName = MATCH_ABANDON_STATES[i];
+				break;
+			}
+		}
+		if (stateName == null) { return; }
+		matchAbandonSent = true;
+		trackEvent("match_abandon", {
+			state: stateName,
+			round_number: (typeof round === "number") ? round : 0,
+			map: (typeof currentMap !== "undefined" && currentMap && currentMap.name) || "unknown",
+			playlist: (typeof currentPlaylistIdForMetrics === "function") ? currentPlaylistIdForMetrics() : "unknown"
+		});
+	} catch (e) { /* analytics must never break page teardown */ }
+});

--- a/docs/ga-config.md
+++ b/docs/ga-config.md
@@ -81,3 +81,53 @@ npm install --no-save @google-analytics/admin@^9.1.0
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/ga-key.json
 node analytics/reconcile-ga.js --dry-run
 ```
+
+## Event catalog (what the client fires)
+
+Quick index of every `trackEvent()` call and where it lives. Params marked † are
+registered custom dimensions/metrics in `ga-config.json`.
+
+| Event | Fired when | Params | Where |
+|---|---|---|---|
+| `cta_click` | Landing CTA clicked | `target`† | index.html |
+| `tip_click` | Landing tip carousel clicked | `idx` | index.html |
+| `bot_trap` | Invisible honeypot decoy clicked | `trap_source`† | index/play.html |
+| `verified_human` | Server confirmed real kart input (once/session) | — | client.js |
+| `lobby_entered` | Player reaches a lobby | — | client.js |
+| `first_match` | Player's first-ever race (lifetime, localStorage) | `time_to_first_match`† | metrics.js → client.js |
+| `round_start` | Each round's gate release | `players`† `bots`† `map`† `playlist`† | client.js |
+| `round_complete` | Round's overview screen | `map`† `playlist`† `round_number`† `duration_seconds`† | client.js |
+| `match_end` | Match over (key event) | `won`† `map`† `playlist`† `players`† `bots`† `duration_seconds`† | client.js |
+| `match_abandon` | Page closed mid-match (pagehide) | `state`† `round_number`† `map`† `playlist`† | metrics.js |
+| `cosmetics_equipped` | Once per match, local player's loadout | `cart` `pattern` `trail` `border` | client.js |
+| `level_up` | Progression level reached | `level`† | client.js |
+| `cosmetic_unlocked` | Cosmetic earned (key event) | `cosmetic_id`† `cosmetic_slot`† `unlock_kind`† | client.js |
+| `xp_earned` | Per-match XP credited (incl. 2× bonus) | `xp`† `level`† | client.js — see docs/cosmetics-analytics.md |
+| `login` | Fresh OAuth sign-in completed (key event) | `method`† | auth.js |
+| `login_nudge_shown` / `login_nudge_clicked` | Post-match sign-in nudge funnel | — | auth.js |
+| `reward_offered` | 2× XP toast became visible (funnel denominator) | `bonus`† | client.js |
+| `reward_claimed` | Server credited the 2× XP bonus | `bonus`† `match_id` | client.js |
+| `ad_shown` / `ad_complete` / `ad_skipped` / `ad_error` / `ad_blocked` | Ad lifecycle | `type`† `placement`† | ads.js |
+| `disconnect` | Socket dropped (once/session) | `reason`† | client.js |
+| `connect_error` | Could not reach the server (once/session) | `reason`† | client.js |
+| `server_kick` | Kicked by the server (AFK etc.) | — | client.js |
+| `map_submitted` | Editor map submitted as a PR | — | create.js |
+
+User-scoped properties (set via `gtag('set','user_properties',…)` in
+`client/scripts/metrics.js`, refreshed on auth change / progression update /
+gamepad connect): `auth_state`, `player_level`, `input_method`, `perf_profile`,
+`embed_host`.
+
+## Operator checklist — console-only settings (NOT manageable by this pipeline)
+
+These two are one-time clicks in the GA web console; neither is retroactive, so the
+clock on their data starts only when they're enabled:
+
+1. **Event data retention → 14 months.** GA4's default is **2 months**, after which
+   event-level data ages out of Explorations. Admin → Data settings → Data retention →
+   Event data retention: `14 months` (also toggle "Reset user data on new activity" on).
+2. **BigQuery export (free tier).** Admin → Product links → BigQuery links → Link.
+   Daily export is free and is the only way to keep raw events past GA4's 14-month cap
+   (cohort/LTV analysis across launches, e.g. comparing portal launch cohorts). Pick the
+   same region as the GCP project hosting the service account; daily export only (streaming
+   costs money and isn't needed).


### PR DESCRIPTION
## Summary

Implements the "metrics we'll regret not tracking" plan: GA4 can now cohort **users** (not just slice events) and measure onboarding, churn, durations, and the sign-in/reward funnels.

### GA config (`analytics/ga-config.json` — applied by the GA pipeline on merge)
- **5 user-scoped dimensions** (first in the property): `auth_state`, `player_level`, `input_method`, `perf_profile`, `embed_host` (portal attribution, ready for the itch.io/CrazyGames/Poki push)
- **3 event dimensions**: `method` (login), `state` + `reason` (abandon/disconnect)
- **3 metrics**: `duration_seconds`, `time_to_first_match`, `round_number`
- **2 new key events**: `first_match`, `login`

### New `client/scripts/metrics.js` (play bundle)
- `gtag('set','user_properties',…)` — sent eagerly, re-sent on DOMContentLoaded / auth change / progressionUpdate / gamepad connect
- `first_match` — lifetime-once (localStorage) with `time_to_first_match` from navigation start
- `match_abandon` on `pagehide` while mid-match (state, round, map, playlist) — the quit-point signal

### client.js
- `duration_seconds` on `round_complete` (gate→overview) and `match_end` (first race→game over, new `matchStartedAt` clock)
- `round_number` on `round_complete`
- `reward_offered` when the 2× XP toast becomes visible — the denominator for `reward_claimed` claim-through rate
- `disconnect` / `connect_error` (once per session, with reason) + `server_kick`

### auth.js
- `login` key event that counts only **fresh** OAuth sign-ins via a pre-redirect provider stamp (session restores never fire it; stale stamps swept after 15s)
- `login_nudge_shown` / `login_nudge_clicked` funnel around the post-match nudge
- `chaochaoAuth.getAuthState()` → `guest` | provider, feeding the `auth_state` user property

### Docs
- `docs/ga-config.md`: full event catalog table + operator console checklist (14-month retention + BigQuery export — **both already done** on the property as of 2026-06-04)

## Notes for review
- Rebased over the v0.29.0 progression-analytics work: the originally-proposed `level_up`/`skin_unlocked`/`xp_gained` events were **dropped as duplicates** of main's `xp_earned`/`level_up`/`cosmetic_unlocked`; this PR only adds what main doesn't have.
- All new dim/metric descriptions validated against the GA field limits enforced since c485a07 (≤150 chars).
- Codex review finding addressed in the second commit: `input_method` probes `isTouchDevice()` directly because `isTouchScreen` is only assigned in `initEventHandlers()` (gameState/init path), after the DOMContentLoaded user-properties refresh.
- No `server/config.json`/`game.js`/`engine.js` changes → CHANGELOG-exempt (analytics only, no player-facing behavior).

## Test plan
- `npm run build` clean; headless smoke test (52 maps) green
- `ga-config.json` parses and passes the reconcile field-limit validation; the PR dry-run job will print the exact CREATE plan
- Manual: dev-server playtest shows `dataLayer` carrying user_properties + round/match events with durations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
