### PR TITLE
fix(analytics): GA-safe metric display names + charset validation in dry-run

### DIFF
--- a/analytics/ga-config.json
+++ b/analytics/ga-config.json
@@ -148,14 +148,14 @@
     },
     {
       "parameterName": "duration_seconds",
-      "displayName": "Duration (s)",
+      "displayName": "Duration seconds",
       "scope": "EVENT",
       "measurementUnit": "SECONDS",
       "description": "Elapsed seconds: round length on round_complete (gate release - overview), match length on match_end (first race - game over)."
     },
     {
       "parameterName": "time_to_first_match",
-      "displayName": "Time to first match (s)",
+      "displayName": "Time to first match seconds",
       "scope": "EVENT",
       "measurementUnit": "SECONDS",
       "description": "Seconds from page navigation start to the player's first-ever race (first_match event). Onboarding-friction metric."

--- a/analytics/reconcile-ga.js
+++ b/analytics/reconcile-ga.js
@@ -54,6 +54,10 @@ const group = async (title, fn) => {
 // is how an over-length description once slipped through review and broke the main
 // apply (playlist, 170 > 150).
 const GA_FIELD_LIMITS = { parameterName: 40, displayName: 82, description: 150 };
+// displayName charset, same reasoning: the API rejects anything beyond alphanumeric,
+// underscore, or space — which is how "Duration (s)" (parentheses) slipped past the
+// dry-run and broke the main apply mid-run (dimensions created, metrics/keyEvents not).
+const GA_DISPLAY_NAME_RE = /^[A-Za-z0-9_ ]+$/;
 function validateFieldLimits(kind, entries) {
   for (const e of entries || []) {
     for (const [field, max] of Object.entries(GA_FIELD_LIMITS)) {
@@ -63,6 +67,12 @@ function validateFieldLimits(kind, entries) {
           `${kind} "${e.parameterName}": ${field} is ${v.length} chars (GA4 max ${max}). Shorten it in ga-config.json.`
         );
       }
+    }
+    if (typeof e.displayName === 'string' && !GA_DISPLAY_NAME_RE.test(e.displayName)) {
+      throw new Error(
+        `${kind} "${e.parameterName}": displayName "${e.displayName}" has characters GA4 rejects ` +
+        `(only letters, digits, underscores, and spaces are allowed). Fix it in ga-config.json.`
+      );
     }
   }
 }

--- a/analytics/reconcile-ga.js
+++ b/analytics/reconcile-ga.js
@@ -54,10 +54,14 @@ const group = async (title, fn) => {
 // is how an over-length description once slipped through review and broke the main
 // apply (playlist, 170 > 150).
 const GA_FIELD_LIMITS = { parameterName: 40, displayName: 82, description: 150 };
-// displayName charset, same reasoning: the API rejects anything beyond alphanumeric,
-// underscore, or space — which is how "Duration (s)" (parentheses) slipped past the
-// dry-run and broke the main apply mid-run (dimensions created, metrics/keyEvents not).
+// Charset rules, same reasoning: the API rejects these only at apply time — which is
+// how "Duration (s)" (parentheses in a displayName) slipped past the dry-run and broke
+// the main apply mid-run (dimensions created, metrics/keyEvents not).
+//   displayName:   letters, digits, underscores, spaces
+//   parameterName: letters, digits, underscores; must start with a letter
+//   keyEvent name: same rules as parameterName (GA event-name constraints)
 const GA_DISPLAY_NAME_RE = /^[A-Za-z0-9_ ]+$/;
+const GA_PARAMETER_NAME_RE = /^[A-Za-z][A-Za-z0-9_]*$/;
 function validateFieldLimits(kind, entries) {
   for (const e of entries || []) {
     for (const [field, max] of Object.entries(GA_FIELD_LIMITS)) {
@@ -74,6 +78,23 @@ function validateFieldLimits(kind, entries) {
         `(only letters, digits, underscores, and spaces are allowed). Fix it in ga-config.json.`
       );
     }
+    if (typeof e.parameterName === 'string' && !GA_PARAMETER_NAME_RE.test(e.parameterName)) {
+      throw new Error(
+        `${kind} "${e.parameterName}": parameterName must start with a letter and contain only ` +
+        `letters, digits, and underscores. Fix it in ga-config.json.`
+      );
+    }
+  }
+}
+function validateKeyEvents(entries) {
+  for (const e of entries || []) {
+    const name = e.eventName;
+    if (typeof name !== 'string' || name.length > 40 || !GA_PARAMETER_NAME_RE.test(name)) {
+      throw new Error(
+        `keyEvent "${name}": eventName must be 1-40 chars, start with a letter, and contain only ` +
+        `letters, digits, and underscores. Fix it in ga-config.json.`
+      );
+    }
   }
 }
 
@@ -85,6 +106,7 @@ function loadConfig() {
   }
   validateFieldLimits('customDimension', raw.customDimensions);
   validateFieldLimits('customMetric', raw.customMetrics);
+  validateKeyEvents(raw.keyEvents);
   return {
     parent: `properties/${propertyId}`,
     propertyId,


### PR DESCRIPTION
## Summary

The #269 merge's GA apply job failed mid-run: the GA Admin API only allows **letters, digits, underscores, and spaces** in `display_name`, and two new metric display names contained parentheses ("Duration (s)", "Time to first match (s)"). The dry-run couldn't catch it — its load-time validation (c485a07) only checks field lengths, and dry-run never calls the real API.

State after the partial apply (verified against the property):
- ✅ all 8 new dimensions created (5 user-scoped + `method`/`state`/`reason`)
- ❌ the 3 new metrics (`duration_seconds`, `time_to_first_match`, `round_number`) and 2 key events (`first_match`, `login`) never ran

## Changes

- Rename the two display names: `Duration seconds`, `Time to first match seconds`
- `validateFieldLimits` in `reconcile-ga.js` now also rejects out-of-charset display names, so the **PR dry-run fails on this class** before it can break a main apply — same hardening pattern c485a07 applied for lengths

## On merge

The reconcile is idempotent: the apply will no-op the existing dimensions and create the 3 metrics + 2 key events, completing #269's plan. Until merged, every push to main re-fails the apply job.

## Test plan

- Config passes the new validation; negative test confirms `Duration (s)` is rejected by the new charset check
- `node --check` clean on `reconcile-ga.js`
- The PR dry-run job exercises the new validator against the real config

🤖 Generated with [Claude Code](https://claude.com/claude-code)