### PR TITLE
feat(camera): closer cruise zoom, velocity look-ahead, finish-line punch-in + spawn-anchored gate intro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+- The dynamic camera now rides a little closer to your kart (your skin is easier to admire), looks further ahead in the direction you're driving, and punches in for an intense close-up as you and the goal converge at the finish line — without ever letting a local player slip off screen.
 
 ## v0.29.0 — 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### General
 - The dynamic camera now rides a little closer to your kart (your skin is easier to admire), looks further ahead in the direction you're driving, and punches in for an intense close-up as you and the goal converge at the finish line — without ever letting a local player slip off screen.
+- Round intros got cinematic: the countdown camera now opens tight on your kart at its spawn, pans out to reveal the whole arena, then dives back in right as the gate opens.
 
 ## v0.29.0 — 2026-06-04
 

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -4110,17 +4110,34 @@ function computeWorldViewTarget(dt) {
     }
     var focusedView = computeFocusedView(dt);
 
-    // During the gate countdown, run a slow, eased zoom timed to the countdown:
-    // whole-map at the start (take in the arena + goal), arriving at the focused
-    // zoom right as the gate opens. Crucially we ONLY ramp the zoom and keep the
-    // centre anchored on the player (clamped to the world) the whole time — at
-    // scale 1 the clamp shows the whole map, and it homes in on the player as it
-    // zooms, so the player can never slide out of frame mid-transition.
+    // During the gate countdown, run a slow, eased camera arc timed to the
+    // countdown — anchored on YOUR SPAWN, not the map centre: open tight on the
+    // kart (admire the skin / find yourself), pan OUT from the spawn to reveal
+    // the whole arena (take in the layout + goal), then ease back into the
+    // focused zoom, landing exactly as the gate opens. e is the "how focused"
+    // weight (1 = tight, 0 = whole map); the centre stays anchored on the
+    // player (clamped to the world) throughout — at scale 1 the clamp shows the
+    // whole map, and it homes back in on the player as it re-zooms, so the
+    // player can never slide out of frame mid-transition. (The very first gated
+    // frame snaps the camera to this close-up in updateWorldCamera — the world
+    // isn't visible during the overview scoreboard, so the cut is invisible.)
     if (currentState === config.stateMap.gated) {
-        var dur = ((config.gatedWaitTime || 9) * 1000) - WORLD_ZOOM_HOLD_MS;
-        var elapsed = worldViewFocusedElapsed - WORLD_ZOOM_HOLD_MS;
-        var p = (dur > 0) ? Math.max(0, Math.min(1, elapsed / dur)) : 1;
-        var e = p * p * (3 - 2 * p); // smoothstep: gentle in (see the map) and out (settle)
+        var rest = ((config.gatedWaitTime || 9) * 1000) - WORLD_ZOOM_HOLD_MS;
+        var tt = worldViewFocusedElapsed - WORLD_ZOOM_HOLD_MS;
+        var e = 1; // hold phase (and degenerate configs): stay tight on the spawn
+        if (rest > 0 && tt > 0) {
+            var outMs = rest * WORLD_ZOOM_GATE_OUT_FRAC;
+            var inMs = rest * WORLD_ZOOM_GATE_IN_FRAC;
+            if (tt < outMs) {
+                var u = tt / outMs;                       // pan out from the spawn
+                e = 1 - u * u * (3 - 2 * u);
+            } else if (tt >= rest - inMs) {
+                var v = Math.min(1, (tt - (rest - inMs)) / inMs); // ease back in
+                e = v * v * (3 - 2 * v);
+            } else {
+                e = 0;                                    // whole-map beat
+            }
+        }
         var scale = 1 + (focusedView.scale - 1) * e;
         return clampViewToWorld(focusedView.cx, focusedView.cy, scale);
     }
@@ -4140,12 +4157,24 @@ function updateWorldCamera(dt) {
     var target = computeWorldViewTarget(cdt);
     if (worldView == null) {
         worldView = { cx: target.cx, cy: target.cy, scale: target.scale };
+        // The init IS the snap if we're born into gated — record it so the
+        // snap-to-spawn cut below doesn't re-fire on the next frame.
+        worldViewGatedPrev = (cameraZoomEnabled && typeof config !== "undefined" && config && currentState === config.stateMap.gated);
         return;
     }
     // During the gate countdown the target is already a precise, eased time-ramp,
     // so follow it directly (a=1) for the arc to finish exactly as the gate opens.
     // Everywhere else, smooth exponentially for natural player/goal tracking.
     var gatedNow = (cameraZoomEnabled && typeof config !== "undefined" && config && currentState === config.stateMap.gated);
+    if (gatedNow && !worldViewGatedPrev) {
+        // First gated frame: CUT straight to the spawn close-up the arc opens
+        // on. Invisible — the world isn't drawn during the overview scoreboard,
+        // and the first race swaps the whole map (lobby -> arena) on this frame
+        // anyway. Without the snap the camera would visibly glide in from
+        // wherever the previous state left it before the pan-out could begin.
+        worldView.cx = target.cx; worldView.cy = target.cy; worldView.scale = target.scale;
+    }
+    worldViewGatedPrev = gatedNow;
     var a = gatedNow ? 1 : (1 - Math.exp(-cdt / WORLD_ZOOM_TAU));
     worldView.cx += (target.cx - worldView.cx) * a;
     worldView.cy += (target.cy - worldView.cy) * a;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3954,11 +3954,11 @@ function focusWorldPoints() {
     var pts = [];
     var living = livingLocalPlayers();
     for (var i = 0; i < living.length; i++) {
-        // vx/vy feed the camera's velocity look-ahead in computeFocusedView.
-        pts.push({ x: living[i].x, y: living[i].y, vx: living[i].velX || 0, vy: living[i].velY || 0 });
+        // id keys the per-player smoothed look-ahead state; vx/vy feed it.
+        pts.push({ id: living[i].id, x: living[i].x, y: living[i].y, vx: living[i].velX || 0, vy: living[i].velY || 0 });
     }
     if (pts.length === 0 && myPlayer && myPlayer.alive) {
-        pts.push({ x: myPlayer.x, y: myPlayer.y, vx: myPlayer.velX || 0, vy: myPlayer.velY || 0 });
+        pts.push({ id: myPlayer.id, x: myPlayer.x, y: myPlayer.y, vx: myPlayer.velX || 0, vy: myPlayer.velY || 0 });
     }
     return pts;
 }
@@ -3971,13 +3971,13 @@ function focusWorldPoints() {
 // goal itself stays framed — the close-up only lands once everyone framed has
 // converged on it. Centre is kept separate from the zoom so a transition can
 // ramp only the zoom (players can't slide out of frame).
-function computeFocusedView() {
+function computeFocusedView(dt) {
     var wholeMap = { cx: LOGICAL_WIDTH / 2, cy: LOGICAL_HEIGHT / 2, scale: 1 };
     var pts = focusWorldPoints();
     if (pts.length === 0) {
         // Nobody local alive to follow -> whole map (watch the action). Drop the
-        // goal latch so it can't carry stale engagement into the next round/map.
-        worldGoalEngaged = false;
+        // smoothed look-ahead so it can't carry stale lead into the next round.
+        worldLeadSmooth = {};
         return wholeMap;
     }
     // Nearest goal (to any framed player) first: its distance drives the dynamic
@@ -3991,61 +3991,72 @@ function computeFocusedView() {
             if (d < nd) { nd = d; ng = goals[g]; }
         }
     }
-    // Hysteresis: engage the goal framing once within ENGAGE, but don't let go
-    // until clearly past RELEASE. Otherwise a player drifting at the ENGAGE edge
-    // (e.g. circling the spawn gate beside the goal) flips the framing every few
-    // frames, which the gate-countdown ramp follows directly (a=1) and jerks.
-    if (!ng) {
-        worldGoalEngaged = false;
-    } else if (worldGoalEngaged) {
-        if (nd > WORLD_ZOOM_RELEASE) { worldGoalEngaged = false; }
-    } else if (nd <= WORLD_ZOOM_ENGAGE) {
-        worldGoalEngaged = true;
+    // Goal-framing weight: blends the goal into the framing box continuously —
+    // 1 within ENGAGE, fading to 0 by RELEASE. Continuity matters because the
+    // gate-countdown ramp follows the target directly (a=1): a binary engage
+    // latch made the target scale STEP the instant the goal popped in/out of
+    // the box, which read as a sudden zoom jerk in the gated view.
+    var w = 0;
+    if (ng) {
+        w = 1 - (nd - WORLD_ZOOM_ENGAGE) / (WORLD_ZOOM_RELEASE - WORLD_ZOOM_ENGAGE);
+        w = Math.max(0, Math.min(1, w));
+        w = w * w * (3 - 2 * w);
     }
-    // Finish-line punch-in: while the goal is engaged, raise the zoom cap from
-    // WORLD_ZOOM_MAX toward (MAX + BOOST) as the group closes from ENGAGE down to
-    // GOAL_FULL. Smoothstepped, and the goal + every player stay inside the
-    // framing box below, so the fit only reaches the boosted cap once everyone
-    // has actually converged on the goal — the last stretch reads as a lunge.
+    // Finish-line punch-in: raise the zoom cap from WORLD_ZOOM_MAX toward
+    // (MAX + BOOST) as the group closes from ENGAGE down to GOAL_FULL.
+    // Smoothstepped (and 0 at/beyond ENGAGE, so it's continuous with w), and
+    // the goal + every player stay inside the framing box below, so the fit
+    // only reaches the boosted cap once everyone has actually converged on the
+    // goal — the last stretch reads as a lunge.
     var effMax = WORLD_ZOOM_MAX;
-    if (ng && worldGoalEngaged) {
+    if (ng) {
         var gt = (WORLD_ZOOM_ENGAGE - nd) / (WORLD_ZOOM_ENGAGE - WORLD_ZOOM_GOAL_FULL);
         gt = Math.max(0, Math.min(1, gt));
         effMax += WORLD_ZOOM_GOAL_BOOST * gt * gt * (3 - 2 * gt);
     }
     var halfX = LOGICAL_WIDTH / (2 * effMax);
     var halfY = LOGICAL_HEIGHT / (2 * effMax);
+    // Velocity look-ahead: each player's half-box is centred ahead of them along
+    // a SMOOTHED lead vector (its own exponential lag, per player), so steering
+    // wiggle, punches and bounces swing the lead gently instead of snapping the
+    // camera. The target lead is zero while gated (players just rev in the pen,
+    // and the gate ramp follows its target unsmoothed), so any leftover lead
+    // drains out during the countdown and builds naturally off the line.
+    var la = 1 - Math.exp(-(dt || 16) / WORLD_ZOOM_LEAD_TAU);
+    var gatedNow = (currentState === config.stateMap.gated);
     var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
     for (var i = 0; i < pts.length; i++) {
-        // Velocity look-ahead: centre this player's half-box ahead of them along
-        // their travel (capped well under the half-box, so the player always
-        // stays comfortably inside their own box -> on screen). Lead targets are
-        // clamped to the world so ramming a wall can't inflate the box. The
-        // camera's exponential smoothing absorbs sudden velocity flips
-        // (punches/bounces) into a gentle drift rather than a snap.
-        var lx = pts[i].x, ly = pts[i].y;
+        var tx = 0, ty = 0;
         var spd = Math.sqrt(pts[i].vx * pts[i].vx + pts[i].vy * pts[i].vy);
-        if (spd > 1) {
+        if (!gatedNow && spd > 1) {
             // Lead scales with speed up to full cruise (LEAD_REF), and is also
             // capped at a fraction of the (zoom-dependent) half-box so the goal
             // punch-in's tighter box can't shove a fast kart to the screen edge
             // — at least ~45% of the half-box always stays behind them.
             var lead = Math.min(WORLD_ZOOM_LEAD_MAX, halfY * 0.55) * Math.min(1, spd / WORLD_ZOOM_LEAD_REF);
-            lx += pts[i].vx / spd * lead;
-            ly += pts[i].vy / spd * lead;
-            lx = Math.max(world.x, Math.min(world.x + world.width, lx));
-            ly = Math.max(world.y, Math.min(world.y + world.height, ly));
+            tx = pts[i].vx / spd * lead;
+            ty = pts[i].vy / spd * lead;
         }
+        var sm = worldLeadSmooth[pts[i].id];
+        if (!sm) { sm = worldLeadSmooth[pts[i].id] = { x: 0, y: 0 }; }
+        sm.x += (tx - sm.x) * la;
+        sm.y += (ty - sm.y) * la;
+        // Clamp the led point to the world so ramming a wall can't inflate the box.
+        var lx = Math.max(world.x, Math.min(world.x + world.width, pts[i].x + sm.x));
+        var ly = Math.max(world.y, Math.min(world.y + world.height, pts[i].y + sm.y));
         minX = Math.min(minX, lx - halfX);
         maxX = Math.max(maxX, lx + halfX);
         minY = Math.min(minY, ly - halfY);
         maxY = Math.max(maxY, ly + halfY);
     }
-    if (ng && worldGoalEngaged) {
-        minX = Math.min(minX, ng.x - WORLD_ZOOM_PAD);
-        maxX = Math.max(maxX, ng.x + WORLD_ZOOM_PAD);
-        minY = Math.min(minY, ng.y - WORLD_ZOOM_PAD);
-        maxY = Math.max(maxY, ng.y + WORLD_ZOOM_PAD);
+    if (w > 0) {
+        // Stretch each box edge toward the goal pad by the blend weight — at
+        // w=1 the goal is fully framed (same as the old hard include), and the
+        // approach/retreat over the ENGAGE..RELEASE band is perfectly smooth.
+        minX -= Math.max(0, minX - (ng.x - WORLD_ZOOM_PAD)) * w;
+        maxX += Math.max(0, (ng.x + WORLD_ZOOM_PAD) - maxX) * w;
+        minY -= Math.max(0, minY - (ng.y - WORLD_ZOOM_PAD)) * w;
+        maxY += Math.max(0, (ng.y + WORLD_ZOOM_PAD) - maxY) * w;
     }
     var boxW = Math.max(1, maxX - minX), boxH = Math.max(1, maxY - minY);
     var scale = Math.min(LOGICAL_WIDTH / boxW, LOGICAL_HEIGHT / boxH);
@@ -4063,7 +4074,7 @@ function computeWorldViewTarget(dt) {
     var wholeMap = { cx: LOGICAL_WIDTH / 2, cy: LOGICAL_HEIGHT / 2, scale: 1 };
     if (!cameraZoomEnabled || myPlayer == null || typeof world === "undefined" || world == null) {
         worldViewFocusedElapsed = 0;
-        worldGoalEngaged = false;
+        worldLeadSmooth = {};
         return wholeMap;
     }
     // Focus once the round is live (gate countdown + race); plus the LOBBY whenever
@@ -4080,7 +4091,7 @@ function computeWorldViewTarget(dt) {
         inLobby);
     if (!focused) {
         worldViewFocusedElapsed = 0;
-        worldGoalEngaged = false;
+        worldLeadSmooth = {};
         return wholeMap;
     }
     // Advance the gate-intro clock ONLY while in the gated countdown, and zero it
@@ -4097,7 +4108,7 @@ function computeWorldViewTarget(dt) {
     } else {
         worldViewFocusedElapsed = 0;
     }
-    var focusedView = computeFocusedView();
+    var focusedView = computeFocusedView(dt);
 
     // During the gate countdown, run a slow, eased zoom timed to the countdown:
     // whole-map at the start (take in the arena + goal), arriving at the focused
@@ -4138,7 +4149,18 @@ function updateWorldCamera(dt) {
     var a = gatedNow ? 1 : (1 - Math.exp(-cdt / WORLD_ZOOM_TAU));
     worldView.cx += (target.cx - worldView.cx) * a;
     worldView.cy += (target.cy - worldView.cy) * a;
-    worldView.scale += (target.scale - worldView.scale) * a;
+    if (gatedNow) {
+        // Direct follow, but rate-limited: the ramp itself moves the scale far
+        // slower than this cap, so the cap is invisible in the normal arc — it
+        // only bites when the FOCUSED target moves abruptly mid-countdown (a
+        // player sliding fast across the goal blend band, a death changing the
+        // framed group), turning what was a visible zoom jerk into a quick glide.
+        var ds = target.scale - worldView.scale;
+        var maxStep = WORLD_ZOOM_GATE_RATE * cdt / 1000;
+        worldView.scale += Math.max(-maxStep, Math.min(maxStep, ds));
+    } else {
+        worldView.scale += (target.scale - worldView.scale) * a;
+    }
 }
 
 // True while a local player is dealing with an aimed ability — holding a bomb /

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3954,20 +3954,23 @@ function focusWorldPoints() {
     var pts = [];
     var living = livingLocalPlayers();
     for (var i = 0; i < living.length; i++) {
-        pts.push({ x: living[i].x, y: living[i].y });
+        // vx/vy feed the camera's velocity look-ahead in computeFocusedView.
+        pts.push({ x: living[i].x, y: living[i].y, vx: living[i].velX || 0, vy: living[i].velY || 0 });
     }
     if (pts.length === 0 && myPlayer && myPlayer.alive) {
-        pts.push({ x: myPlayer.x, y: myPlayer.y });
+        pts.push({ x: myPlayer.x, y: myPlayer.y, vx: myPlayer.velX || 0, vy: myPlayer.velY || 0 });
     }
     return pts;
 }
 
 // The fully-focused view: the DESIRED (unclamped) centre + zoom that frames every
 // live local player (local co-op widens the zoom as players spread, tightens as
-// they cluster), growing toward the nearest goal as the group approaches it. A
-// single player gets a tight WORLD_ZOOM_MAX framing exactly as before, since each
-// player contributes a max-zoom half-box. Centre is kept separate from the zoom
-// so a transition can ramp only the zoom (players can't slide out of frame).
+// they cluster). Each player contributes a max-zoom half-box, shifted ahead along
+// their velocity (look-ahead) so the tight cruise zoom keeps forward visibility.
+// Near the nearest goal the zoom cap ramps up (finish-line punch-in) while the
+// goal itself stays framed — the close-up only lands once everyone framed has
+// converged on it. Centre is kept separate from the zoom so a transition can
+// ramp only the zoom (players can't slide out of frame).
 function computeFocusedView() {
     var wholeMap = { cx: LOGICAL_WIDTH / 2, cy: LOGICAL_HEIGHT / 2, scale: 1 };
     var pts = focusWorldPoints();
@@ -3977,17 +3980,8 @@ function computeFocusedView() {
         worldGoalEngaged = false;
         return wholeMap;
     }
-    var halfX = LOGICAL_WIDTH / (2 * WORLD_ZOOM_MAX);
-    var halfY = LOGICAL_HEIGHT / (2 * WORLD_ZOOM_MAX);
-    var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
-    for (var i = 0; i < pts.length; i++) {
-        minX = Math.min(minX, pts[i].x - halfX);
-        maxX = Math.max(maxX, pts[i].x + halfX);
-        minY = Math.min(minY, pts[i].y - halfY);
-        maxY = Math.max(maxY, pts[i].y + halfY);
-    }
-    // Pull the nearest goal (to any framed player) into frame as the group gets
-    // close to it -> the view zooms out to keep players and the goal visible.
+    // Nearest goal (to any framed player) first: its distance drives the dynamic
+    // zoom cap below, so it must be known before the framing boxes are sized.
     var goals = worldGoalPoints();
     var ng = null, nd = Infinity;
     for (var g = 0; g < goals.length; g++) {
@@ -4008,6 +4002,45 @@ function computeFocusedView() {
     } else if (nd <= WORLD_ZOOM_ENGAGE) {
         worldGoalEngaged = true;
     }
+    // Finish-line punch-in: while the goal is engaged, raise the zoom cap from
+    // WORLD_ZOOM_MAX toward (MAX + BOOST) as the group closes from ENGAGE down to
+    // GOAL_FULL. Smoothstepped, and the goal + every player stay inside the
+    // framing box below, so the fit only reaches the boosted cap once everyone
+    // has actually converged on the goal — the last stretch reads as a lunge.
+    var effMax = WORLD_ZOOM_MAX;
+    if (ng && worldGoalEngaged) {
+        var gt = (WORLD_ZOOM_ENGAGE - nd) / (WORLD_ZOOM_ENGAGE - WORLD_ZOOM_GOAL_FULL);
+        gt = Math.max(0, Math.min(1, gt));
+        effMax += WORLD_ZOOM_GOAL_BOOST * gt * gt * (3 - 2 * gt);
+    }
+    var halfX = LOGICAL_WIDTH / (2 * effMax);
+    var halfY = LOGICAL_HEIGHT / (2 * effMax);
+    var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (var i = 0; i < pts.length; i++) {
+        // Velocity look-ahead: centre this player's half-box ahead of them along
+        // their travel (capped well under the half-box, so the player always
+        // stays comfortably inside their own box -> on screen). Lead targets are
+        // clamped to the world so ramming a wall can't inflate the box. The
+        // camera's exponential smoothing absorbs sudden velocity flips
+        // (punches/bounces) into a gentle drift rather than a snap.
+        var lx = pts[i].x, ly = pts[i].y;
+        var spd = Math.sqrt(pts[i].vx * pts[i].vx + pts[i].vy * pts[i].vy);
+        if (spd > 1) {
+            // Lead scales with speed up to full cruise (LEAD_REF), and is also
+            // capped at a fraction of the (zoom-dependent) half-box so the goal
+            // punch-in's tighter box can't shove a fast kart to the screen edge
+            // — at least ~45% of the half-box always stays behind them.
+            var lead = Math.min(WORLD_ZOOM_LEAD_MAX, halfY * 0.55) * Math.min(1, spd / WORLD_ZOOM_LEAD_REF);
+            lx += pts[i].vx / spd * lead;
+            ly += pts[i].vy / spd * lead;
+            lx = Math.max(world.x, Math.min(world.x + world.width, lx));
+            ly = Math.max(world.y, Math.min(world.y + world.height, ly));
+        }
+        minX = Math.min(minX, lx - halfX);
+        maxX = Math.max(maxX, lx + halfX);
+        minY = Math.min(minY, ly - halfY);
+        maxY = Math.max(maxY, ly + halfY);
+    }
     if (ng && worldGoalEngaged) {
         minX = Math.min(minX, ng.x - WORLD_ZOOM_PAD);
         maxX = Math.max(maxX, ng.x + WORLD_ZOOM_PAD);
@@ -4016,7 +4049,7 @@ function computeFocusedView() {
     }
     var boxW = Math.max(1, maxX - minX), boxH = Math.max(1, maxY - minY);
     var scale = Math.min(LOGICAL_WIDTH / boxW, LOGICAL_HEIGHT / boxH);
-    scale = Math.max(1, Math.min(WORLD_ZOOM_MAX, scale)); // never zoom out past the whole map
+    scale = Math.max(1, Math.min(effMax, scale)); // never zoom out past the whole map
     var cx = (minX + maxX) / 2, cy = (minY + maxY) / 2;
     // Defensive: a NaN coordinate would poison setTransform and blank the canvas.
     if (!isFinite(cx) || !isFinite(cy) || !isFinite(scale)) {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3971,7 +3971,10 @@ function focusWorldPoints() {
 // goal itself stays framed — the close-up only lands once everyone framed has
 // converged on it. Centre is kept separate from the zoom so a transition can
 // ramp only the zoom (players can't slide out of frame).
-function computeFocusedView(dt) {
+// gatedNow is computed ONCE in computeWorldViewTarget and threaded through so the
+// gated behaviors here (goal framing suppressed, look-ahead zeroed) can never
+// drift out of sync with the gated handling in updateWorldCamera.
+function computeFocusedView(dt, gatedNow) {
     var wholeMap = { cx: LOGICAL_WIDTH / 2, cy: LOGICAL_HEIGHT / 2, scale: 1 };
     var pts = focusWorldPoints();
     if (pts.length === 0) {
@@ -3996,8 +3999,13 @@ function computeFocusedView(dt) {
     // gate-countdown ramp follows the target directly (a=1): a binary engage
     // latch made the target scale STEP the instant the goal popped in/out of
     // the box, which read as a sudden zoom jerk in the gated view.
+    // Suppressed entirely while GATED: the intro arc's opening close-up (and its
+    // snap) consume this view directly, and on the many maps whose spawn gate
+    // sits within RELEASE of a goal the blend would offset/widen what is meant
+    // to be a tight shot of YOUR kart. The goal blends back in smoothly once
+    // racing starts (the racing path's exponential smoothing absorbs it).
     var w = 0;
-    if (ng) {
+    if (ng && !gatedNow) {
         w = 1 - (nd - WORLD_ZOOM_ENGAGE) / (WORLD_ZOOM_RELEASE - WORLD_ZOOM_ENGAGE);
         w = Math.max(0, Math.min(1, w));
         w = w * w * (3 - 2 * w);
@@ -4007,9 +4015,11 @@ function computeFocusedView(dt) {
     // Smoothstepped (and 0 at/beyond ENGAGE, so it's continuous with w), and
     // the goal + every player stay inside the framing box below, so the fit
     // only reaches the boosted cap once everyone has actually converged on the
-    // goal — the last stretch reads as a lunge.
+    // goal — the last stretch reads as a lunge. Suppressed while gated for the
+    // same reason as the blend above (also keeps the gated ease-in's peak rate
+    // comfortably under WORLD_ZOOM_GATE_RATE — boosted targets never reach it).
     var effMax = WORLD_ZOOM_MAX;
-    if (ng) {
+    if (ng && !gatedNow) {
         var gt = (WORLD_ZOOM_ENGAGE - nd) / (WORLD_ZOOM_ENGAGE - WORLD_ZOOM_GOAL_FULL);
         gt = Math.max(0, Math.min(1, gt));
         effMax += WORLD_ZOOM_GOAL_BOOST * gt * gt * (3 - 2 * gt);
@@ -4025,7 +4035,6 @@ function computeFocusedView(dt) {
     // lobby -> first-race path. Players just rev in the pen anyway, and the
     // lead still builds naturally from zero off the line.
     var la = 1 - Math.exp(-(dt || 16) / WORLD_ZOOM_LEAD_TAU);
-    var gatedNow = (currentState === config.stateMap.gated);
     var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
     for (var i = 0; i < pts.length; i++) {
         var tx = 0, ty = 0;
@@ -4109,12 +4118,13 @@ function computeWorldViewTarget(dt) {
     // whenever we're not gated makes the intro play on EVERY entry into the gate
     // (first race out of the lobby, and later rounds out of overview alike).
     // Frame-dt (already clamped) not wall-clock, so a backgrounded tab pauses it.
-    if (currentState === config.stateMap.gated) {
+    var gatedNow = (currentState === config.stateMap.gated);
+    if (gatedNow) {
         worldViewFocusedElapsed += (dt || 16);
     } else {
         worldViewFocusedElapsed = 0;
     }
-    var focusedView = computeFocusedView(dt);
+    var focusedView = computeFocusedView(dt, gatedNow);
 
     // During the gate countdown, run a slow, eased camera arc timed to the
     // countdown — anchored on YOUR SPAWN, not the map centre: open tight on the
@@ -4127,7 +4137,16 @@ function computeWorldViewTarget(dt) {
     // player can never slide out of frame mid-transition. (The very first gated
     // frame snaps the camera to this close-up in updateWorldCamera — the world
     // isn't visible during the overview scoreboard, so the cut is invisible.)
-    if (currentState === config.stateMap.gated) {
+    if (gatedNow) {
+        // The cinematic only runs when the camera actually witnessed the gate
+        // ENTRY (worldGatedIntroActive, managed in updateWorldCamera). If the
+        // dynamic camera was toggled on mid-countdown there is no hidden frame
+        // to cut on — replaying the arc would hard-CUT to the close-up with the
+        // world fully visible — so just frame the karts like racing and let the
+        // exponential smoothing glide there.
+        if (!worldGatedIntroActive) {
+            return clampViewToWorld(focusedView.cx, focusedView.cy, focusedView.scale);
+        }
         var rest = ((config.gatedWaitTime || 9) * 1000) - WORLD_ZOOM_HOLD_MS;
         var tt = worldViewFocusedElapsed - WORLD_ZOOM_HOLD_MS;
         var e = 1; // hold phase (and degenerate configs): stay tight on the spawn
@@ -4160,19 +4179,32 @@ function updateWorldCamera(dt) {
     // Clamp the frame delta so a long stall / tab-refocus catch-up frame can't
     // snap the camera (drives both the gate ramp and the exponential smoothing).
     var cdt = Math.min(dt || 16, 100);
+    // --- gate-intro lifecycle (BEFORE the target is computed, so the arc-vs-
+    // plain-focus choice inside computeWorldViewTarget sees fresh flags). The
+    // STATE transition is tracked independently of the camera toggle: the intro
+    // (snap cut + a=1 arc) only arms when the camera was already on at the
+    // moment the gated state began — that's the frame hidden behind the
+    // overview scoreboard / lobby->arena map swap, the only frame where a hard
+    // cut is invisible. Toggling the camera off mid-countdown disarms it for
+    // the rest of that countdown, so re-enabling can never re-fire the cut
+    // with the world on screen (it glides via the smoothing instead).
+    var stateGated = (typeof config !== "undefined" && config && currentState === config.stateMap.gated);
+    var freshGate = stateGated && !worldViewGatedPrev;
+    worldViewGatedPrev = stateGated;
+    if (freshGate) {
+        worldGatedIntroActive = cameraZoomEnabled;
+    } else if (!stateGated || !cameraZoomEnabled) {
+        worldGatedIntroActive = false;
+    }
+    var followArc = (cameraZoomEnabled && stateGated && worldGatedIntroActive);
     var target = computeWorldViewTarget(cdt);
     if (worldView == null) {
+        // The init IS the snap if we're born into gated (target is already the
+        // arc's opening close-up).
         worldView = { cx: target.cx, cy: target.cy, scale: target.scale };
-        // The init IS the snap if we're born into gated — record it so the
-        // snap-to-spawn cut below doesn't re-fire on the next frame.
-        worldViewGatedPrev = (cameraZoomEnabled && typeof config !== "undefined" && config && currentState === config.stateMap.gated);
         return;
     }
-    // During the gate countdown the target is already a precise, eased time-ramp,
-    // so follow it directly (a=1) for the arc to finish exactly as the gate opens.
-    // Everywhere else, smooth exponentially for natural player/goal tracking.
-    var gatedNow = (cameraZoomEnabled && typeof config !== "undefined" && config && currentState === config.stateMap.gated);
-    if (gatedNow && !worldViewGatedPrev) {
+    if (freshGate && followArc) {
         // First gated frame: CUT straight to the spawn close-up the arc opens
         // on. Invisible — the world isn't drawn during the overview scoreboard,
         // and the first race swaps the whole map (lobby -> arena) on this frame
@@ -4180,16 +4212,18 @@ function updateWorldCamera(dt) {
         // wherever the previous state left it before the pan-out could begin.
         worldView.cx = target.cx; worldView.cy = target.cy; worldView.scale = target.scale;
     }
-    worldViewGatedPrev = gatedNow;
-    var a = gatedNow ? 1 : (1 - Math.exp(-cdt / WORLD_ZOOM_TAU));
+    // While the intro arc runs, the target is a precise, eased time-ramp — follow
+    // it directly (a=1) so it finishes exactly as the gate opens. Everywhere else
+    // (racing, lobby, and a mid-countdown camera re-enable) smooth exponentially.
+    var a = followArc ? 1 : (1 - Math.exp(-cdt / WORLD_ZOOM_TAU));
     worldView.cx += (target.cx - worldView.cx) * a;
     worldView.cy += (target.cy - worldView.cy) * a;
-    if (gatedNow) {
+    if (followArc) {
         // Direct follow, but rate-limited: the ramp itself moves the scale far
         // slower than this cap, so the cap is invisible in the normal arc — it
         // only bites when the FOCUSED target moves abruptly mid-countdown (a
-        // player sliding fast across the goal blend band, a death changing the
-        // framed group), turning what was a visible zoom jerk into a quick glide.
+        // death changing the framed group), turning what would be a visible
+        // zoom jerk into a quick glide.
         var ds = target.scale - worldView.scale;
         var maxStep = WORLD_ZOOM_GATE_RATE * cdt / 1000;
         worldView.scale += Math.max(-maxStep, Math.min(maxStep, ds));

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -4006,9 +4006,7 @@ function computeFocusedView(dt, gatedNow) {
     // racing starts (the racing path's exponential smoothing absorbs it).
     var w = 0;
     if (ng && !gatedNow) {
-        w = 1 - (nd - WORLD_ZOOM_ENGAGE) / (WORLD_ZOOM_RELEASE - WORLD_ZOOM_ENGAGE);
-        w = Math.max(0, Math.min(1, w));
-        w = w * w * (3 - 2 * w);
+        w = smoothstep(1 - (nd - WORLD_ZOOM_ENGAGE) / (WORLD_ZOOM_RELEASE - WORLD_ZOOM_ENGAGE));
     }
     // Finish-line punch-in: raise the zoom cap from WORLD_ZOOM_MAX toward
     // (MAX + BOOST) as the group closes from ENGAGE down to GOAL_FULL.
@@ -4020,9 +4018,7 @@ function computeFocusedView(dt, gatedNow) {
     // comfortably under WORLD_ZOOM_GATE_RATE — boosted targets never reach it).
     var effMax = WORLD_ZOOM_MAX;
     if (ng && !gatedNow) {
-        var gt = (WORLD_ZOOM_ENGAGE - nd) / (WORLD_ZOOM_ENGAGE - WORLD_ZOOM_GOAL_FULL);
-        gt = Math.max(0, Math.min(1, gt));
-        effMax += WORLD_ZOOM_GOAL_BOOST * gt * gt * (3 - 2 * gt);
+        effMax += WORLD_ZOOM_GOAL_BOOST * smoothstep((WORLD_ZOOM_ENGAGE - nd) / (WORLD_ZOOM_ENGAGE - WORLD_ZOOM_GOAL_FULL));
     }
     var halfX = LOGICAL_WIDTH / (2 * effMax);
     var halfY = LOGICAL_HEIGHT / (2 * effMax);
@@ -4041,10 +4037,11 @@ function computeFocusedView(dt, gatedNow) {
         var spd = Math.sqrt(pts[i].vx * pts[i].vx + pts[i].vy * pts[i].vy);
         if (!gatedNow && spd > 1) {
             // Lead scales with speed up to full cruise (LEAD_REF), and is also
-            // capped at a fraction of the (zoom-dependent) half-box so the goal
-            // punch-in's tighter box can't shove a fast kart to the screen edge
-            // — at least ~45% of the half-box always stays behind them.
-            var lead = Math.min(WORLD_ZOOM_LEAD_MAX, halfY * 0.55) * Math.min(1, spd / WORLD_ZOOM_LEAD_REF);
+            // capped at LEAD_BOX_FRAC of the (zoom-dependent) half-box so the
+            // goal punch-in's tighter box can't shove a fast kart to the screen
+            // edge — at least (1 - LEAD_BOX_FRAC) of the half-box always stays
+            // behind them.
+            var lead = Math.min(WORLD_ZOOM_LEAD_MAX, halfY * WORLD_ZOOM_LEAD_BOX_FRAC) * clamp01(spd / WORLD_ZOOM_LEAD_REF);
             tx = pts[i].vx / spd * lead;
             ty = pts[i].vy / spd * lead;
         }
@@ -4154,11 +4151,9 @@ function computeWorldViewTarget(dt) {
             var outMs = rest * WORLD_ZOOM_GATE_OUT_FRAC;
             var inMs = rest * WORLD_ZOOM_GATE_IN_FRAC;
             if (tt < outMs) {
-                var u = tt / outMs;                       // pan out from the spawn
-                e = 1 - u * u * (3 - 2 * u);
+                e = 1 - smoothstep(tt / outMs);           // pan out from the spawn
             } else if (tt >= rest - inMs) {
-                var v = Math.min(1, (tt - (rest - inMs)) / inMs); // ease back in
-                e = v * v * (3 - 2 * v);
+                e = smoothstep((tt - (rest - inMs)) / inMs); // ease back in
             } else {
                 e = 0;                                    // whole-map beat
             }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -4019,9 +4019,11 @@ function computeFocusedView(dt) {
     // Velocity look-ahead: each player's half-box is centred ahead of them along
     // a SMOOTHED lead vector (its own exponential lag, per player), so steering
     // wiggle, punches and bounces swing the lead gently instead of snapping the
-    // camera. The target lead is zero while gated (players just rev in the pen,
-    // and the gate ramp follows its target unsmoothed), so any leftover lead
-    // drains out during the countdown and builds naturally off the line.
+    // camera. While GATED the lead state is hard-zeroed (not just decayed):
+    // the intro snaps the camera to this frame's target on gated entry, so a
+    // stale lobby lead would anchor the spawn close-up off-centre on the
+    // lobby -> first-race path. Players just rev in the pen anyway, and the
+    // lead still builds naturally from zero off the line.
     var la = 1 - Math.exp(-(dt || 16) / WORLD_ZOOM_LEAD_TAU);
     var gatedNow = (currentState === config.stateMap.gated);
     var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
@@ -4039,8 +4041,12 @@ function computeFocusedView(dt) {
         }
         var sm = worldLeadSmooth[pts[i].id];
         if (!sm) { sm = worldLeadSmooth[pts[i].id] = { x: 0, y: 0 }; }
-        sm.x += (tx - sm.x) * la;
-        sm.y += (ty - sm.y) * la;
+        if (gatedNow) {
+            sm.x = 0; sm.y = 0;
+        } else {
+            sm.x += (tx - sm.x) * la;
+            sm.y += (ty - sm.y) * la;
+        }
         // Clamp the led point to the world so ramming a wall can't inflate the box.
         var lx = Math.max(world.x, Math.min(world.x + world.width, pts[i].x + sm.x));
         var ly = Math.max(world.y, Math.min(world.y + world.height, pts[i].y + sm.y));

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -58,7 +58,12 @@ var server = null,
     // then ease back IN over the final IN_FRAC, landing as the gate opens.
     WORLD_ZOOM_GATE_OUT_FRAC = 0.34,
     WORLD_ZOOM_GATE_IN_FRAC = 0.40,
-    worldViewGatedPrev = false, // was last frame gated? (drives the intro snap-to-spawn cut)
+    worldViewGatedPrev = false, // was last frame in the gated STATE? (edge-detects gate entry, camera-toggle-independent)
+    // True only when the camera was ON at the moment the gated state began —
+    // the one frame where the intro's snap cut is hidden (overview scoreboard /
+    // map swap). Toggling the camera off mid-countdown disarms the intro so a
+    // re-enable can never replay the cut with the world visible.
+    worldGatedIntroActive = false,
     // Goal-approach intensity zoom: once the goal is engaged, the zoom cap ramps
     // from WORLD_ZOOM_MAX up to (MAX + BOOST) as the group closes from ENGAGE
     // down to GOAL_FULL world-units — a finish-line punch-in. The framing box

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -52,7 +52,13 @@ var server = null,
     WORLD_ZOOM_RELEASE = 620,  // world-units: goal framing fades smoothly to nothing by here (continuous blend, no pop)
     WORLD_ZOOM_PAD = 120,      // world-units padding around framed points
     WORLD_ZOOM_TAU = 620,      // smoothing time-constant (ms); higher = slower, gentler glide
-    WORLD_ZOOM_HOLD_MS = 1100, // hold the whole-map view this long when a round starts, before easing in
+    WORLD_ZOOM_HOLD_MS = 1100, // gate intro: hold the opening spawn close-up this long before panning out
+    // Gate-intro arc shape, as fractions of the countdown after HOLD: pan OUT
+    // from the spawn over OUT_FRAC, sit on the whole map for the remainder,
+    // then ease back IN over the final IN_FRAC, landing as the gate opens.
+    WORLD_ZOOM_GATE_OUT_FRAC = 0.34,
+    WORLD_ZOOM_GATE_IN_FRAC = 0.40,
+    worldViewGatedPrev = false, // was last frame gated? (drives the intro snap-to-spawn cut)
     // Goal-approach intensity zoom: once the goal is engaged, the zoom cap ramps
     // from WORLD_ZOOM_MAX up to (MAX + BOOST) as the group closes from ENGAGE
     // down to GOAL_FULL world-units — a finish-line punch-in. The framing box
@@ -71,9 +77,11 @@ var server = null,
     WORLD_ZOOM_LEAD_MAX = 110,
     WORLD_ZOOM_LEAD_TAU = 700,
     // Max zoom-scale change per second while GATED (the countdown follows its
-    // eased ramp directly, with no exponential smoothing) — the designed ramp
-    // moves ~0.15/s, so this only catches abrupt target shifts mid-countdown.
-    WORLD_ZOOM_GATE_RATE = 0.5,
+    // eased arc directly, with no exponential smoothing) — the designed arc
+    // peaks ~0.6/s mid-smoothstep, so this only catches abrupt target shifts
+    // mid-countdown (fast slide across the goal blend band, a death reshaping
+    // the framed group), never the arc itself.
+    WORLD_ZOOM_GATE_RATE = 0.8,
     // Sustained camera back-off while holding/throwing an aimed ability (bomb/ice)
     // until it detonates, so it's easier to aim. Multiplies the focused scale
     // (0.62 => ~38% wider); the smoothing eases it out and back.

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -46,12 +46,27 @@ var server = null,
     // edge of WORLD_ZOOM_ENGAGE (e.g. drifting around the spawn gate next to the
     // goal). Engage at ENGAGE, only release past RELEASE — hysteresis kills the jerk.
     worldGoalEngaged = false,
-    WORLD_ZOOM_MAX = 1.8,      // tightest focus on the player while racing (shows some surroundings)
+    WORLD_ZOOM_MAX = 2.05,     // tightest cruise focus while racing (close enough to read the skin, far enough to navigate)
     WORLD_ZOOM_ENGAGE = 460,   // world-units: nearest goal pulls into frame within this
     WORLD_ZOOM_RELEASE = 620,  // world-units: once engaged, only let go of the goal past this (hysteresis band)
     WORLD_ZOOM_PAD = 120,      // world-units padding around framed points
     WORLD_ZOOM_TAU = 620,      // smoothing time-constant (ms); higher = slower, gentler glide
     WORLD_ZOOM_HOLD_MS = 1100, // hold the whole-map view this long when a round starts, before easing in
+    // Goal-approach intensity zoom: once the goal is engaged, the zoom cap ramps
+    // from WORLD_ZOOM_MAX up to (MAX + BOOST) as the group closes from ENGAGE
+    // down to GOAL_FULL world-units — a finish-line punch-in. The framing box
+    // still includes every living local player AND the goal, so the close-up
+    // only lands when everyone has converged on it; the boost can never push a
+    // local player off-screen.
+    WORLD_ZOOM_GOAL_BOOST = 0.55,
+    WORLD_ZOOM_GOAL_FULL = 140,
+    // Velocity look-ahead: each player's framing box shifts ahead along their
+    // velocity, up to LEAD_MAX world-units at/above LEAD_REF speed (≈ top speed
+    // on normal tiles, measured ~83 u/s), so the tighter cruise zoom never costs
+    // forward visibility — at speed the camera leads the kart; parked, you get
+    // the tight skin-admiring view centred on it.
+    WORLD_ZOOM_LEAD_REF = 80,
+    WORLD_ZOOM_LEAD_MAX = 110,
     // Sustained camera back-off while holding/throwing an aimed ability (bomb/ice)
     // until it detonates, so it's easier to aim. Multiplies the focused scale
     // (0.62 => ~38% wider); the smoothing eases it out and back.

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -42,13 +42,14 @@ var server = null,
     // palette. Persisted in localStorage (see the #colorblindControl wiring).
     colorblindEnabled = false,
     worldViewFocusedElapsed = 0,  // ms accumulated in the focus phase (frame-dt based, not wall-clock)
-    // Latched goal-engage state, so the framing can't flap when a player skims the
-    // edge of WORLD_ZOOM_ENGAGE (e.g. drifting around the spawn gate next to the
-    // goal). Engage at ENGAGE, only release past RELEASE — hysteresis kills the jerk.
-    worldGoalEngaged = false,
+    // Per-player smoothed look-ahead vectors keyed by player id (see
+    // computeFocusedView). Smoothing the lead itself keeps steering wiggle,
+    // punches and bounces from snapping the camera; cleared whenever the
+    // camera leaves the focused states so no stale lead carries over.
+    worldLeadSmooth = {},
     WORLD_ZOOM_MAX = 2.05,     // tightest cruise focus while racing (close enough to read the skin, far enough to navigate)
-    WORLD_ZOOM_ENGAGE = 460,   // world-units: nearest goal pulls into frame within this
-    WORLD_ZOOM_RELEASE = 620,  // world-units: once engaged, only let go of the goal past this (hysteresis band)
+    WORLD_ZOOM_ENGAGE = 460,   // world-units: nearest goal is FULLY framed within this
+    WORLD_ZOOM_RELEASE = 620,  // world-units: goal framing fades smoothly to nothing by here (continuous blend, no pop)
     WORLD_ZOOM_PAD = 120,      // world-units padding around framed points
     WORLD_ZOOM_TAU = 620,      // smoothing time-constant (ms); higher = slower, gentler glide
     WORLD_ZOOM_HOLD_MS = 1100, // hold the whole-map view this long when a round starts, before easing in
@@ -64,9 +65,15 @@ var server = null,
     // velocity, up to LEAD_MAX world-units at/above LEAD_REF speed (≈ top speed
     // on normal tiles, measured ~83 u/s), so the tighter cruise zoom never costs
     // forward visibility — at speed the camera leads the kart; parked, you get
-    // the tight skin-admiring view centred on it.
+    // the tight skin-admiring view centred on it. The lead vector itself is
+    // smoothed per player with LEAD_TAU (ms) so direction flips sway gently.
     WORLD_ZOOM_LEAD_REF = 80,
     WORLD_ZOOM_LEAD_MAX = 110,
+    WORLD_ZOOM_LEAD_TAU = 700,
+    // Max zoom-scale change per second while GATED (the countdown follows its
+    // eased ramp directly, with no exponential smoothing) — the designed ramp
+    // moves ~0.15/s, so this only catches abrupt target shifts mid-countdown.
+    WORLD_ZOOM_GATE_RATE = 0.5,
     // Sustained camera back-off while holding/throwing an aimed ability (bomb/ice)
     // until it detonates, so it's easier to aim. Multiplies the focused scale
     // (0.62 => ~38% wider); the smoothing eases it out and back.

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -81,6 +81,11 @@ var server = null,
     WORLD_ZOOM_LEAD_REF = 80,
     WORLD_ZOOM_LEAD_MAX = 110,
     WORLD_ZOOM_LEAD_TAU = 700,
+    // LOAD-BEARING screen-edge guarantee: the lead is additionally capped at this
+    // fraction of the (zoom-dependent) half-box, so at least (1 - this) of the
+    // half-box always stays behind a fast kart — i.e. it can never be led off
+    // screen, no matter how the zoom caps above are retuned.
+    WORLD_ZOOM_LEAD_BOX_FRAC = 0.55,
     // Max zoom-scale change per second while GATED (the countdown follows its
     // eased arc directly, with no exponential smoothing) — the designed arc
     // peaks ~0.6/s mid-smoothstep, so this only catches abrupt target shifts

--- a/client/scripts/utils.js
+++ b/client/scripts/utils.js
@@ -132,6 +132,13 @@ function clamp01(t) {
 function lerp(a, b, t) {
     return a + (b - a) * t;
 }
+// Smoothstep: the classic 0..1 cubic with zero slope at both ends (camera
+// blends, gate-intro arc). Clamps t NaN-safely via clamp01, so out-of-range or
+// 0/0 inputs degrade to the nearest endpoint instead of poisoning a transform.
+function smoothstep(t) {
+    t = clamp01(t);
+    return t * t * (3 - 2 * t);
+}
 function easeOutQuad(t) {
     return 1 - (1 - t) * (1 - t);
 }

--- a/server/entities/world.js
+++ b/server/entities/world.js
@@ -5,6 +5,7 @@ var messenger = require('../messenger.js');
 var compressor = require('../compressor.js');
 var { Rect } = require('./shapes.js');
 var { Player } = require('./player.js');
+var skinRegistry = require('../skinRegistry.js');
 
 class World extends Rect {
 	constructor(x, y, width, height, engine, playerList, hazardList, roomSig) {
@@ -37,7 +38,33 @@ class World extends Rect {
 		// Full personality profile (trait weights) for the AI brain; the
 		// suffix-numbered duplicates share their base personality's traits.
 		bot.profile = identity;
+		if (c.randomBotCosmetics) {
+			this.dressBotRandomly(bot);
+		}
 		return bot;
+	}
+	// Dev/testing seam (RANDOM_BOT_COSMETICS, see utils.js): dress a bot in random
+	// cosmetics so a local playtest shows the full skin spread without 9 signed-in
+	// humans. Cart + trail always land (every bot reads as "skinned"); pattern and
+	// border roll independently so the mix varies. Cosmetic ids ride the normal
+	// spawn packet (compressor slots 13-16), so the client needs nothing special.
+	dressBotRandomly(bot) {
+		var bySlot = { cart: [], pattern: [], trail: [], border: [] };
+		for (var i = 0; i < skinRegistry.SKINS.length; i++) {
+			var s = skinRegistry.SKINS[i];
+			if (bySlot[s.slot]) {
+				bySlot[s.slot].push(s.id);
+			}
+		}
+		var pick = function (arr) { return arr[Math.floor(Math.random() * arr.length)]; };
+		bot.cart = pick(bySlot.cart);
+		bot.trailFx = pick(bySlot.trail);
+		if (Math.random() < 0.7) {
+			bot.pattern = pick(bySlot.pattern);
+		}
+		if (Math.random() < 0.5) {
+			bot.border = pick(bySlot.border);
+		}
 	}
 	spawnPlayerRandomLoc(player) {
 		var loc = this.findFreeLoc(player);

--- a/server/entities/world.js
+++ b/server/entities/world.js
@@ -45,25 +45,29 @@ class World extends Rect {
 	}
 	// Dev/testing seam (RANDOM_BOT_COSMETICS, see utils.js): dress a bot in random
 	// cosmetics so a local playtest shows the full skin spread without 9 signed-in
-	// humans. Cart + trail always land (every bot reads as "skinned"); pattern and
-	// border roll independently so the mix varies. Cosmetic ids ride the normal
-	// spawn packet (compressor slots 13-16), so the client needs nothing special.
+	// humans. Slots and their Player fields come straight from the registry
+	// (SLOTS / SLOT_FIELD), so a newly-added slot is dressed automatically: cart +
+	// trail always land (every bot reads as "skinned"), other slots roll their
+	// listed chance (unlisted ones default to a coin flip). Cosmetic ids ride the
+	// normal spawn packet (compressor slots 13-16), so the client needs nothing.
 	dressBotRandomly(bot) {
-		var bySlot = { cart: [], pattern: [], trail: [], border: [] };
-		for (var i = 0; i < skinRegistry.SKINS.length; i++) {
-			var s = skinRegistry.SKINS[i];
-			if (bySlot[s.slot]) {
-				bySlot[s.slot].push(s.id);
+		var chance = { cart: 1, trail: 1, pattern: 0.7, border: 0.5 };
+		for (var i = 0; i < skinRegistry.SLOTS.length; i++) {
+			var slot = skinRegistry.SLOTS[i];
+			var field = skinRegistry.SLOT_FIELD[slot];
+			var odds = (chance[slot] != null) ? chance[slot] : 0.5;
+			if (field == null || Math.random() >= odds) {
+				continue;
 			}
-		}
-		var pick = function (arr) { return arr[Math.floor(Math.random() * arr.length)]; };
-		bot.cart = pick(bySlot.cart);
-		bot.trailFx = pick(bySlot.trail);
-		if (Math.random() < 0.7) {
-			bot.pattern = pick(bySlot.pattern);
-		}
-		if (Math.random() < 0.5) {
-			bot.border = pick(bySlot.border);
+			var ids = [];
+			for (var k = 0; k < skinRegistry.SKINS.length; k++) {
+				if (skinRegistry.SKINS[k].slot === slot) {
+					ids.push(skinRegistry.SKINS[k].id);
+				}
+			}
+			if (ids.length > 0) {
+				bot[field] = utils.pick(ids);
+			}
 		}
 	}
 	spawnPlayerRandomLoc(player) {

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -18,12 +18,12 @@ var ratings = require('./ratings.js');
 var auth = require('./auth.js');
 var progression = require('./progression.js');
 var skinRegistry = require('./skinRegistry.js');
-// Maps a cosmetic slot to the Player field that holds its equipped id. `trail` uses
-// `trailFx` (the EFFECT id) so it never collides with the client's `player.trail`
-// motion-trail object. Also the allow-list of valid slot names for setCosmetic.
+// Maps a cosmetic slot to the Player field that holds its equipped id (single-
+// sourced from the server skin registry — see SLOT_FIELD there for the field
+// naming rationale). Also the allow-list of valid slot names for setCosmetic.
 // `border` is its OWN 4th slot (player.border / selected_border) — a pattern and a border can
 // be equipped at once. Mirrors the client COSMETIC_SLOT_FIELD (skinRegistry.js).
-var COSMETIC_SLOT_FIELD = { cart: 'cart', pattern: 'pattern', trail: 'trailFx', border: 'border' };
+var COSMETIC_SLOT_FIELD = skinRegistry.SLOT_FIELD;
 var mailBoxList = {},
 	identityList = {},
 	roomMailList = {},

--- a/server/skinRegistry.js
+++ b/server/skinRegistry.js
@@ -19,6 +19,12 @@
 // column via COSMETIC_SLOT_FIELD / COSMETIC_SLOT_COLUMN) but is its own slot for setCosmetic
 // validation (a border id has slot:'border').
 var SLOTS = ['cart', 'pattern', 'trail', 'border'];
+// Live Player-object field per slot ('trail' stores the EFFECT id in `trailFx`
+// so it never collides with the client's `player.trail` motion object). Single
+// source for everything that writes cosmetics onto a player server-side — the
+// setCosmetic equip path (messenger.js) and the RANDOM_BOT_COSMETICS dev seam
+// (entities/world.js) both consume this; add new slots HERE alongside SLOTS.
+var SLOT_FIELD = { cart: 'cart', pattern: 'pattern', trail: 'trailFx', border: 'border' };
 
 var SKINS = [
     // --- Carts (body shape; tints to player colour) ---
@@ -202,6 +208,7 @@ function currentSeasonalClaims(now) {
 
 module.exports = {
     SLOTS: SLOTS,
+    SLOT_FIELD: SLOT_FIELD,
     SKINS: SKINS,
     getSkin: getSkin,
     getSkinSlot: getSkinSlot,

--- a/server/utils.js
+++ b/server/utils.js
@@ -438,6 +438,14 @@ function getRandomInt(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
+// Uniform random element from an array (undefined when empty — callers that
+// can't tolerate that should length-guard). The canonical home for the
+// `arr[Math.floor(Math.random() * arr.length)]` pattern repeated around the
+// server (color picker, bot emotes, bot cosmetics).
+exports.pick = function (arr) {
+    return arr[Math.floor(Math.random() * arr.length)];
+};
+
 function angle(originX, originY, targetX, targetY) {
     var dx = originX - targetX;
     var dy = originY - targetY;

--- a/server/utils.js
+++ b/server/utils.js
@@ -22,6 +22,11 @@ c.unlockAllCosmetics = (process.env.UNLOCK_ALL_COSMETICS === 'true');
 // the page URL) — and index.js registers the dev-only POST /__perf/report sink. Default
 // OFF so the harness can never activate in prod.
 c.perfHarness = (process.env.PERF_HARNESS === '1' || process.env.PERF_HARNESS === 'true');
+// Dev/testing seam: when set, AI bots spawn wearing random cosmetics (cart/trail
+// always, pattern/border by coin-flip) so camera/cosmetic work can be eyeballed
+// against a fully-dressed grid without 9 signed-in humans. Default OFF so prod
+// bots stay plain — set RANDOM_BOT_COSMETICS=true on a local test server only.
+c.randomBotCosmetics = (process.env.RANDOM_BOT_COSMETICS === 'true');
 
 // Test-only config override seam (CI perf harness). When CHAO_PERF_OVERRIDE is a
 // JSON object, deep-merge it over the loaded config so a separate-process server


### PR DESCRIPTION
## What players notice

- The dynamic camera rides closer to your kart (cruise zoom 1.8 → 2.05) so skins read better, and **leads ahead along your direction of travel** so the tighter view never costs forward visibility (lead scales with speed; measured real cruise is ~83 u/s).
- Approaching the goal now **punches in** (up to ~2.6×) as the group converges on the finish line — inverted from the old zoom-out — while always keeping every local player *and* the goal on screen (verified for 4-player couch co-op: spread = whole-map, all framed through convergence, survivor reframe on deaths).
- Round intros are cinematic and **anchored on your spawn**: open tight on your kart (admire the skin), pan out to reveal the arena, dive back in landing exactly as the gate opens. The opening cut is hidden behind the overview scoreboard.

## Feel/correctness hardening (playtests + Codex review + /code-review)

- Continuous goal-framing blend replaces the binary hysteresis latch — killed the sudden zoom pop in the gated view.
- Look-ahead lead vector is smoothed **per player** (700ms tau, keyed by id) so steering wiggle/punches/bounces sway the camera gently instead of snapping it.
- Stale lobby look-ahead is zeroed on gate entry (Codex finding) so the intro close-up centres exactly on the spawn.
- Goal blend/boost suppressed while gated, so the intro stays kart-anchored even on the 13 maps whose spawn gate sits within 620u of a goal; the goal re-blends smoothly once racing starts.
- The intro only arms when the camera witnessed the gate entry — toggling the dynamic camera off/on mid-countdown glides instead of re-firing a visible cut.
- Gated zoom is rate-limited (0.8/s) as a backstop against abrupt mid-countdown target shifts (e.g. a death reshaping the framed group).

## Dev/testing seams (default OFF in prod)

- `RANDOM_BOT_COSMETICS=true` — AI bots spawn wearing random cosmetics (cart/trail always, pattern/border by roll), registry-driven so new slots are dressed automatically. Mirrors the existing `UNLOCK_ALL_COSMETICS` seam. Used together they let a solo playtest eyeball camera + cosmetic work against a fully-dressed grid.
- `skinRegistry.SLOT_FIELD` exported as the single slot→Player-field source (messenger's equip path now aliases it); `utils.pick()` added as the canonical random-array pick; shared `smoothstep()` joins the client easing family (replaces 4 inlines).

## Testing

- Headless camera-math suite (18 assertions driving the real draw.js functions frame-by-frame): intro arc shape + landing, blend continuity at 3×-cruise drift, velocity-flip sway bounds, stale-lead regression, goal-adjacent intro anchoring, mid-gated toggle glide, 4-player co-op convergence/deaths.
- Headless bot-dressing test through a real room boot + race ticks.
- `npm run build` + CI smoke test green. Camera is fully client-side; the compressor/network contract is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
