### PR TITLE
fix(join): 'Start a new game' always opens a fresh room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+- "Start a new game" on the join screen now always opens a fresh game, instead of quietly dropping you into someone else's room that had space.
 
 ## v0.29.1 — 2026-06-05
 

--- a/client/join.html
+++ b/client/join.html
@@ -82,7 +82,7 @@
                 <button id="joinByIdButton" type="button" data-gp-nav class="btn btn-outline-info">Join</button>
             </div>
             <div class="start-new">
-                <a href="./play.html" data-gp-nav class="btn btn-success btn-lg btn-primary-cta">Start a new game</a>
+                <a href="./play.html?new=1" data-gp-nav class="btn btn-success btn-lg btn-primary-cta">Start a new game</a>
             </div>
         </div>
     </section>

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -432,6 +432,17 @@ function enterLobby() {
     if (playParams.has("gameid")) {
         var paramGameID = playParams.get("gameid");
         clientSendStart(paramGameID);
+    } else if (playParams.get("new") === "1") {
+        // "Start a new game" (join page): -2 tells the server to always spin up
+        // a fresh room instead of matchmaking into an existing one. Strip the
+        // param afterwards so a mid-game refresh matchmakes normally instead of
+        // stranding the player in yet another empty room.
+        clientSendStart(-2);
+        try {
+            playParams.delete("new");
+            var qs = playParams.toString();
+            history.replaceState(null, "", window.location.pathname + (qs ? "?" + qs : ""));
+        } catch (e) { /* ignore — cosmetic only */ }
     } else {
         clientSendStart(-1);
     }

--- a/server/hostess.js
+++ b/server/hostess.js
@@ -98,6 +98,13 @@ exports.findARoom = function (clientID) {
 	}
 	return generateNewRoom();
 }
+// Explicit "Start a new game": always spin up a fresh room, never matchmake into an
+// existing one (that's findARoom's job). Used by enterGame's id == -2 sentinel.
+exports.startNewRoom = function () {
+	var sig = generateNewRoom();
+	console.log("Starting a fresh room on request:" + sig);
+	return sig;
+}
 exports.kickFromRoom = function (clientID) {
 	var room = searchForRoom(clientID);
 	if (room != undefined) {

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -492,6 +492,10 @@ function checkForMail(client) {
 			roomSig = hostess.getTarpitRoom();
 		} else if (id == -1) {
 			roomSig = hostess.findARoom(client.id);
+		} else if (id == -2) {
+			// "Start a new game" (play.html?new=1): always a fresh room, never
+			// matchmade into an existing one.
+			roomSig = hostess.startNewRoom();
 		} else {
 			roomSig = id;
 		}


### PR DESCRIPTION
## Problem

The join page's **Start a new game** button was a plain link to `play.html` with no params, which takes the matchmaking path (`enterGame(-1)` → `hostess.findARoom`) — joining any existing unlocked room with space. It only created a new room when none existed, making the button behave identically to quick play.

## Fix

- `client/join.html` — the button now links to `play.html?new=1`
- `client/scripts/game.js` — `?new=1` sends a new `-2` sentinel (explicit `?gameid=` still takes precedence); the param is then stripped via `history.replaceState` so a mid-game refresh matchmakes normally instead of piling up fresh empty rooms
- `server/messenger.js` — `enterGame` handles `id == -2` by always minting a fresh room; the botGuard tarpit check still runs first, so flagged bots can't use it to escape the tarpit
- `server/hostess.js` — new `startNewRoom()` helper (always `generateNewRoom()`, never matchmakes)
- `CHANGELOG.md` — player-facing bullet under Unreleased

## Verification

- `npm run build` clean; `.github/scripts/smoke-test.js` passes
- Targeted headless test through the real `messenger` `enterGame` handler: `-1` still reuses an open room, `-2` mints a distinct fresh room every time (two in a row), join-by-id unchanged
- Codex review: clean, no regressions found
- Operator-confirmed on a local dev server: matchmake tab and Start-a-new-game tab land in different rooms; join page lists both

🤖 Generated with [Claude Code](https://claude.com/claude-code)