### PR TITLE
HUD polish: unified in-game HUD, map announcement card, larger shaped carts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### General
 
-- The in-game HUD got a face-lift: the game ID / player count / round readout is now a clean panel at the top of the screen, the race timer sits in its own dark pill so it's readable over any terrain, the map name & author show on a proper plaque in the corner, brutal-round badges have rounded tiles, and the "Waiting for more players" notice is a centered banner with an animated ellipsis — everything matching the lobby's panel style.
+- The in-game HUD got a face-lift: every round now opens with a proper map announcement card (map name + author — taking its turn politely after any Brutal Round reveal), the race timer sits in its own dark pill so it's readable over any terrain, the round number shows in a clean panel at the top, the map name & author also live on a small plaque in the corner, brutal-round badges have rounded tiles, and the "Waiting for more players" notice is a centered banner with an animated ellipsis. The lobby's info banners (seasonal claim, AI bots, playlist) stack neatly at the top of the screen, and the old game-ID / player-count text is tucked away (visible again with `?debughud=1` if you need it).
 
 ## v0.29.2 — 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 ### General
 
 - Shaped cart skins (Drone, Dino, Hoverbike, Starfighter, and friends) now ride 20% larger, so they read clearly bigger than the base sphere cart — looks only, hitboxes are exactly the same.
-- The in-game HUD got a face-lift: every round now opens with a proper map announcement card (map name + author — taking its turn politely after any Brutal Round reveal), the race timer sits in its own dark pill so it's readable over any terrain, the round number shows in a clean panel at the top, the map name & author also live on a small plaque in the corner, brutal-round badges have rounded tiles, and the "Waiting for more players" notice is a centered banner with an animated ellipsis. The lobby's info banners (seasonal claim, AI bots, playlist) stack neatly at the top of the screen, and the game ID / player count / round readout is a clean, frameless strip up top that fades out of your way once the race is on.
+- The in-game HUD got a face-lift: every round now opens with a proper map announcement card (map name + author — taking its turn politely after any Brutal Round reveal), the race timer sits in its own dark pill so it's readable over any terrain, the map name & author keep a subtle credit in the corner, brutal-round badges have rounded tiles, and the "Waiting for more players" notice is a centered banner with an animated ellipsis. The lobby's info banners (seasonal claim, AI bots, playlist) stack neatly at the top of the screen, and the game ID / player count / round readout is a clean, frameless strip up top that fades out of your way once the race is on.
 
 ## v0.29.2 — 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### General
 
+- Shaped cart skins (Drone, Dino, Hoverbike, Starfighter, and friends) now ride 20% larger, so they read clearly bigger than the base sphere cart — looks only, hitboxes are exactly the same.
 - The in-game HUD got a face-lift: every round now opens with a proper map announcement card (map name + author — taking its turn politely after any Brutal Round reveal), the race timer sits in its own dark pill so it's readable over any terrain, the round number shows in a clean panel at the top, the map name & author also live on a small plaque in the corner, brutal-round badges have rounded tiles, and the "Waiting for more players" notice is a centered banner with an animated ellipsis. The lobby's info banners (seasonal claim, AI bots, playlist) stack neatly at the top of the screen, and the old game-ID / player-count text is tucked away (visible again with `?debughud=1` if you need it).
 
 ## v0.29.2 — 2026-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- The in-game HUD got a face-lift: the game ID / player count / round readout is now a clean panel at the top of the screen, the race timer sits in its own dark pill so it's readable over any terrain, the map name & author show on a proper plaque in the corner, brutal-round badges have rounded tiles, and the "Waiting for more players" notice is a centered banner with an animated ellipsis — everything matching the lobby's panel style.
 
 ## v0.29.2 — 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 ### General
 
 - Shaped cart skins (Drone, Dino, Hoverbike, Starfighter, and friends) now ride 20% larger, so they read clearly bigger than the base sphere cart — looks only, hitboxes are exactly the same.
-- The in-game HUD got a face-lift: every round now opens with a proper map announcement card (map name + author — taking its turn politely after any Brutal Round reveal), the race timer sits in its own dark pill so it's readable over any terrain, the round number shows in a clean panel at the top, the map name & author also live on a small plaque in the corner, brutal-round badges have rounded tiles, and the "Waiting for more players" notice is a centered banner with an animated ellipsis. The lobby's info banners (seasonal claim, AI bots, playlist) stack neatly at the top of the screen, and the old game-ID / player-count text is tucked away (visible again with `?debughud=1` if you need it).
+- The in-game HUD got a face-lift: every round now opens with a proper map announcement card (map name + author — taking its turn politely after any Brutal Round reveal), the race timer sits in its own dark pill so it's readable over any terrain, the round number shows in a clean panel at the top, the map name & author also live on a small plaque in the corner, brutal-round badges have rounded tiles, and the "Waiting for more players" notice is a centered banner with an animated ellipsis. The lobby's info banners (seasonal claim, AI bots, playlist) stack neatly at the top of the screen, and the game ID / player count / round readout is a clean, frameless strip up top that fades out of your way once the race is on.
 
 ## v0.29.2 — 2026-06-05
 

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -5529,6 +5529,72 @@ function drawAimer(aimer) {
     }
 }
 
+// ---- Round-start map announcement -------------------------------------------
+// A prominent lower-third title card ("Map Name" / "by author") at the start of
+// every round, so the map credit is actually seen (the corner plaque stays as a
+// subtle persistent reference). Spatially clear of the centre-screen brutal
+// round card, AND when a brutal round is announcing, the map card additionally
+// waits until the brutal card's hold ends (~2.6s) so the two reveals sequence
+// instead of competing for attention.
+var mapAnnounceKey = null;
+var mapAnnounceStart = null;
+function drawMapAnnouncement() {
+    if (currentMap == null) { return; }
+    var inRace = currentState == config.stateMap.gated ||
+        currentState == config.stateMap.racing ||
+        currentState == config.stateMap.collapsing;
+    if (!inRace) {
+        mapAnnounceKey = null; // re-arm for the next round
+        return;
+    }
+    var key = round + ":" + currentMap.name;
+    if (key !== mapAnnounceKey) {
+        mapAnnounceKey = key;
+        mapAnnounceStart = Date.now() + (brutalRound ? 2600 : 0);
+    }
+    var e = Date.now() - mapAnnounceStart;
+    var inMs = 320, holdMs = 2400, outMs = 700;
+    if (e < 0 || e > inMs + holdMs + outMs) { return; }
+    var alpha, rise;
+    if (e < inMs) {
+        var p = e / inMs;
+        alpha = clamp01(p);
+        rise = (1 - easeOutBack(p)) * 26; // slide up into place with overshoot
+    } else if (e < inMs + holdMs) {
+        alpha = 1;
+        rise = 0;
+    } else {
+        var fp = (e - inMs - holdMs) / outMs;
+        alpha = clamp01(1 - fp);
+        rise = -10 * fp; // gentle drift up as it fades
+    }
+    var name = "" + currentMap.name;
+    var credit = "by " + currentMap.author;
+    var nameFont = "bold 34px sans-serif";
+    var creditFont = "16px sans-serif";
+    gameContext.save();
+    gameContext.font = nameFont;
+    var nw = gameContext.measureText(name).width;
+    gameContext.font = creditFont;
+    var cw = gameContext.measureText(credit).width;
+    var w = Math.max(nw, cw) + 64;
+    var h = 78;
+    var cx = LOGICAL_WIDTH / 2;
+    var top = LOGICAL_HEIGHT * 0.74 + rise;
+    drawHudPanel(cx - w / 2, top, w, h, { alpha: 0.88 * alpha, borderAlpha: alpha });
+    var ink = themeColor('ink', 'black');
+    gameContext.globalAlpha = alpha;
+    gameContext.textAlign = "center";
+    gameContext.textBaseline = "alphabetic";
+    gameContext.fillStyle = ink;
+    gameContext.font = nameFont;
+    gameContext.fillText(name, cx, top + 38);
+    gameContext.globalAlpha = 0.7 * alpha;
+    gameContext.font = creditFont;
+    gameContext.fillText(credit, cx, top + 62);
+    gameContext.restore();
+}
+
 // Bottom-left map plaque: the map's name (bold) over a dimmed "by <author>"
 // credit, on the shared HUD-panel chrome — replaces two bare strokeText lines
 // that were nearly invisible over busy terrain.
@@ -7772,6 +7838,7 @@ function drawHUD() {
     drawVirtualButtons();
     drawTouchControls();
     drawTitle();
+    drawMapAnnouncement();
 }
 
 // Deploy heads-up banner (top-center, every state — drawHUD runs in both the
@@ -8250,10 +8317,12 @@ function drawSpectatorBanner() {
 function drawHudPanel(x, y, w, h, opts) {
     opts = opts || {};
     gameContext.save();
+    if (opts.glow) { gameContext.shadowColor = opts.glow; gameContext.shadowBlur = 14; }
     gameContext.globalAlpha = (opts.alpha != null) ? opts.alpha : 0.88;
     gameContext.fillStyle = opts.fill || themeColor('surface', '#101216');
     roundRectPath(gameContext, x, y, w, h, (opts.radius != null) ? opts.radius : 9); // audience.js helper
     gameContext.fill();
+    gameContext.shadowBlur = 0;
     gameContext.globalAlpha = (opts.borderAlpha != null) ? opts.borderAlpha : 1;
     gameContext.lineWidth = (opts.borderWidth != null) ? opts.borderWidth : 2;
     gameContext.strokeStyle = opts.border || themeColor('ink', 'black');
@@ -8261,20 +8330,34 @@ function drawHudPanel(x, y, w, h, opts) {
     gameContext.restore();
 }
 
-// Top-centre session bar: GAME <id> | PLAYERS <n> | ROUND <r> as one panel of
-// label/value segments with hairline dividers, replacing the three floating
-// strokeText labels. ROUND only appears once a race exists (gated/racing/
-// collapsing) so the lobby isn't showing a meaningless "Round 0".
+// Opt-in HUD diagnostics (mirrors the ?debugtouch convention): the GAME id and
+// PLAYERS count are operator/debug info — players browse + join rooms via
+// join.html, not by reading the id off the HUD — so they only render with
+// ?debughud=1 in the URL, or after calling toggleHudDebug() in the console.
+var hudDebugInfo = false;
+try { hudDebugInfo = /[?&]debughud/.test(window.location.search); } catch (e) { hudDebugInfo = false; }
+if (typeof window !== "undefined") {
+    window.toggleHudDebug = function () { hudDebugInfo = !hudDebugInfo; return hudDebugInfo; };
+}
+
+// Top-centre session bar as one panel of label/value segments with hairline
+// dividers. Default shows just ROUND once a race exists (gated/racing/
+// collapsing); the GAME/PLAYERS debug segments join it behind ?debughud=1.
+// Draws nothing when there's nothing to show (e.g. lobby without debug).
 function drawGameInfo() {
-    var segs = [
-        { label: "GAME", value: (gameID != null && gameID !== "") ? ("" + gameID) : "—" },
-        { label: "PLAYERS", value: "" + totalPlayers }
-    ];
+    var segs = [];
+    if (hudDebugInfo) {
+        segs.push({ label: "GAME", value: (gameID != null && gameID !== "") ? ("" + gameID) : "—" });
+        segs.push({ label: "PLAYERS", value: "" + totalPlayers });
+    }
     var inRace = currentState == config.stateMap.gated ||
         currentState == config.stateMap.racing ||
         currentState == config.stateMap.collapsing;
     if (inRace && round > 0) {
         segs.push({ label: "ROUND", value: "" + round });
+    }
+    if (segs.length === 0) {
+        return;
     }
 
     var labelFont = "bold 10px sans-serif";

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -5529,19 +5529,36 @@ function drawAimer(aimer) {
     }
 }
 
+// Bottom-left map plaque: the map's name (bold) over a dimmed "by <author>"
+// credit, on the shared HUD-panel chrome — replaces two bare strokeText lines
+// that were nearly invisible over busy terrain.
 function drawMapTitle() {
-    if (currentMap != null) {
-        gameContext.save();
-        gameContext.strokeStyle = themeColor('inkOutline', 'white');
-        gameContext.lineWidth = 4;
-        gameContext.fillStyle = themeColor('ink', 'black');
-        gameContext.font = "14px Arial";
-        gameContext.strokeText('"' + currentMap.name + '"', 5, LOGICAL_HEIGHT - 25);
-        gameContext.strokeText('~' + currentMap.author, 5, LOGICAL_HEIGHT - 10);
-        gameContext.fillText('"' + currentMap.name + '"', 5, LOGICAL_HEIGHT - 25);
-        gameContext.fillText('~' + currentMap.author, 5, LOGICAL_HEIGHT - 10);
-        gameContext.restore();
+    if (currentMap == null) {
+        return;
     }
+    var name = "" + currentMap.name;
+    var credit = "by " + currentMap.author;
+    var nameFont = "bold 15px sans-serif";
+    var creditFont = "11px sans-serif";
+    var padX = 12, h = 44;
+    var ink = themeColor('ink', 'black');
+    gameContext.save();
+    gameContext.font = nameFont;
+    var nw = gameContext.measureText(name).width;
+    gameContext.font = creditFont;
+    var cw = gameContext.measureText(credit).width;
+    var w = Math.max(nw, cw) + padX * 2;
+    var x = 10, y = LOGICAL_HEIGHT - 10 - h;
+    drawHudPanel(x, y, w, h, { alpha: 0.82 });
+    gameContext.textAlign = "left";
+    gameContext.textBaseline = "alphabetic";
+    gameContext.fillStyle = ink;
+    gameContext.font = nameFont;
+    gameContext.fillText(name, x + padX, y + 19);
+    gameContext.globalAlpha = 0.65;
+    gameContext.font = creditFont;
+    gameContext.fillText(credit, x + padX, y + 34);
+    gameContext.restore();
 }
 
 // Accumulated time (seconds) driving cart-skin animation (fire-truck wheel spin,
@@ -7780,7 +7797,7 @@ function drawMaintenanceBanner() {
         line2 = "New races are paused — a quick restart follows shortly";
     }
     var cx = LOGICAL_WIDTH / 2;
-    var by = 28;
+    var by = 66; // headline baseline — panel sits below the session info bar
     // Urgency pulse on the headline once a restart countdown is live, same
     // accelerating-sine trick as the gate line.
     var alpha = 1;
@@ -7790,16 +7807,23 @@ function drawMaintenanceBanner() {
     gameContext.save();
     gameContext.textAlign = "center";
     gameContext.textBaseline = "alphabetic";
+    // Dark alert panel behind both lines so the warning reads over any terrain
+    // (and over the HUD chrome) without per-glyph stroking.
     gameContext.font = "bold 20px Arial";
-    gameContext.lineWidth = 3;
-    gameContext.strokeStyle = "rgba(0,0,0,0.85)";
+    var mw1 = gameContext.measureText(line1).width;
+    gameContext.font = "14px Arial";
+    var mw2 = gameContext.measureText(line2).width;
+    var mW = Math.max(mw1, mw2) + 36;
+    drawHudPanel(cx - mW / 2, by - 22, mW, 50, {
+        fill: "rgba(12, 14, 18, 0.78)", alpha: 1,
+        border: "rgba(255, 179, 71, 0.65)", borderWidth: 1.5
+    });
+    gameContext.font = "bold 20px Arial";
     gameContext.globalAlpha = alpha;
-    gameContext.strokeText(line1, cx, by);
     gameContext.fillStyle = "#ffb347";
     gameContext.fillText(line1, cx, by);
     gameContext.globalAlpha = 1;
     gameContext.font = "14px Arial";
-    gameContext.strokeText(line2, cx, by + 19);
     gameContext.fillStyle = "white";
     gameContext.fillText(line2, cx, by + 19);
     gameContext.restore();
@@ -7825,11 +7849,14 @@ function drawBrutalBadges() {
     gameContext.save();
     for (var k = 0; k < icons.length; k++) {
         var bx = startX + k * (bw + gap);
-        gameContext.fillStyle = "rgba(255,255,255,0.82)";
-        gameContext.fillRect(bx, topY, bw, bh);
-        gameContext.strokeStyle = "rgba(0,0,0,0.55)";
+        // Rounded tile, matching the shared HUD-panel chrome (light bg kept so
+        // the dark icon silhouettes stay readable in both themes).
+        gameContext.fillStyle = "rgba(255,255,255,0.88)";
+        roundRectPath(gameContext, bx, topY, bw, bh, 6);
+        gameContext.fill();
+        gameContext.strokeStyle = "rgba(0,0,0,0.45)";
         gameContext.lineWidth = 1.5;
-        gameContext.strokeRect(bx, topY, bw, bh);
+        gameContext.stroke();
         var ic = icons[k];
         if (ic.complete !== false && (ic.naturalWidth == null || ic.naturalWidth > 0)) {
             try {
@@ -8114,11 +8141,19 @@ function drawRaceTimer() {
         color = localTimerStopByDeath ? "#ff5a5a" : "#ffd54a";
     }
     gameContext.save();
-    gameContext.fillStyle = color;
     gameContext.font = "bold 28px Arial";
+    var label = formatRaceTime(elapsed);
+    // Fixed dark pill (not the theme surface) so the white/gold/red time keeps
+    // contrast in BOTH themes and over any terrain.
+    var tw = gameContext.measureText(label).width;
+    drawHudPanel(LOGICAL_WIDTH - 20 - tw - 12, 10, tw + 24, 38, {
+        fill: "rgba(12, 14, 18, 0.62)", alpha: 1,
+        border: "rgba(255, 255, 255, 0.25)", borderWidth: 1.5
+    });
+    gameContext.fillStyle = color;
     gameContext.textAlign = "right";
     gameContext.textBaseline = "alphabetic";
-    gameContext.fillText(formatRaceTime(elapsed), LOGICAL_WIDTH - 20, 40);
+    gameContext.fillText(label, LOGICAL_WIDTH - 20, 40);
     gameContext.restore();
 }
 
@@ -8187,11 +8222,11 @@ function drawSpectatorBanner() {
     var padX = 14;
     var w = textW + gap + swatchW + padX * 2;
     var cx = LOGICAL_WIDTH / 2;
-    var y = 52;
+    var y = 66; // below the session info bar (which spans y 8..38)
     var boxX = cx - w / 2;
 
     gameContext.fillStyle = "rgba(0, 0, 0, 0.55)";
-    roundRectPath(gameContext, boxX, y - 19, w, 28, 8); // in the play bundle (audience.js)
+    roundRectPath(gameContext, boxX, y - 19, w, 28, 9); // in the play bundle (audience.js)
     gameContext.fill();
 
     var textX = boxX + padX;
@@ -8207,22 +8242,87 @@ function drawSpectatorBanner() {
     gameContext.restore();
 }
 
-function drawGameInfo() {
-    // Drawn in the HUD pass (logical screen space), so centre on the logical
-    // width, not the world width (they're equal today, but the HUD shouldn't
-    // depend on world dims).
-    var startX = LOGICAL_WIDTH / 2 - 125;
+// ---- Shared HUD chrome -----------------------------------------------------
+// One rounded-panel language for every persistent HUD element (session info
+// bar, map plaque, waiting banner), borrowed from the lobby-hub banners
+// (lobbyHub.js drawLobbyBanner): theme surface fill, 2px ink border, 9px
+// corners. Keeps the in-race HUD reading as the same family as the lobby UI.
+function drawHudPanel(x, y, w, h, opts) {
+    opts = opts || {};
     gameContext.save();
-    gameContext.font = "14px Arial";
-    gameContext.strokeStyle = themeColor('inkOutline', 'white');
-    gameContext.lineWidth = 4;
-    gameContext.fillStyle = themeColor('ink', 'black');
-    gameContext.strokeText("GameID: " + gameID, startX + 10, 20);
-    gameContext.fillText("GameID: " + gameID, startX + 10, 20);
-    gameContext.strokeText("Players: " + totalPlayers, startX + 100, 20);
-    gameContext.fillText("Players: " + totalPlayers, startX + 100, 20);
-    gameContext.strokeText("Round: " + round, startX + 190, 20);
-    gameContext.fillText("Round: " + round, startX + 190, 20);
+    gameContext.globalAlpha = (opts.alpha != null) ? opts.alpha : 0.88;
+    gameContext.fillStyle = opts.fill || themeColor('surface', '#101216');
+    roundRectPath(gameContext, x, y, w, h, (opts.radius != null) ? opts.radius : 9); // audience.js helper
+    gameContext.fill();
+    gameContext.globalAlpha = (opts.borderAlpha != null) ? opts.borderAlpha : 1;
+    gameContext.lineWidth = (opts.borderWidth != null) ? opts.borderWidth : 2;
+    gameContext.strokeStyle = opts.border || themeColor('ink', 'black');
+    gameContext.stroke();
+    gameContext.restore();
+}
+
+// Top-centre session bar: GAME <id> | PLAYERS <n> | ROUND <r> as one panel of
+// label/value segments with hairline dividers, replacing the three floating
+// strokeText labels. ROUND only appears once a race exists (gated/racing/
+// collapsing) so the lobby isn't showing a meaningless "Round 0".
+function drawGameInfo() {
+    var segs = [
+        { label: "GAME", value: (gameID != null && gameID !== "") ? ("" + gameID) : "—" },
+        { label: "PLAYERS", value: "" + totalPlayers }
+    ];
+    var inRace = currentState == config.stateMap.gated ||
+        currentState == config.stateMap.racing ||
+        currentState == config.stateMap.collapsing;
+    if (inRace && round > 0) {
+        segs.push({ label: "ROUND", value: "" + round });
+    }
+
+    var labelFont = "bold 10px sans-serif";
+    var valueFont = "bold 15px sans-serif";
+    var padX = 16, labelGap = 6, dividerGap = 13, h = 30, y = 8;
+    var ink = themeColor('ink', 'black');
+
+    gameContext.save();
+    var total = 0;
+    for (var i = 0; i < segs.length; i++) {
+        gameContext.font = labelFont;
+        segs[i].lw = gameContext.measureText(segs[i].label).width;
+        gameContext.font = valueFont;
+        segs[i].vw = gameContext.measureText(segs[i].value).width;
+        segs[i].w = segs[i].lw + labelGap + segs[i].vw;
+        total += segs[i].w;
+    }
+    var w = padX * 2 + total + (segs.length - 1) * dividerGap * 2;
+    var x = (LOGICAL_WIDTH - w) / 2;
+    drawHudPanel(x, y, w, h, null);
+
+    gameContext.textBaseline = "middle";
+    gameContext.textAlign = "left";
+    var cy = y + h / 2 + 1;
+    var cx = x + padX;
+    for (var k = 0; k < segs.length; k++) {
+        if (k > 0) {
+            // Hairline divider between segments.
+            cx += dividerGap;
+            gameContext.globalAlpha = 0.25;
+            gameContext.strokeStyle = ink;
+            gameContext.lineWidth = 1;
+            gameContext.beginPath();
+            gameContext.moveTo(cx, y + 7);
+            gameContext.lineTo(cx, y + h - 7);
+            gameContext.stroke();
+            gameContext.globalAlpha = 1;
+            cx += dividerGap;
+        }
+        gameContext.fillStyle = ink;
+        gameContext.globalAlpha = 0.55;
+        gameContext.font = labelFont;
+        gameContext.fillText(segs[k].label, cx, cy);
+        gameContext.globalAlpha = 1;
+        gameContext.font = valueFont;
+        gameContext.fillText(segs[k].value, cx + segs[k].lw + labelGap, cy);
+        cx += segs[k].w;
+    }
     gameContext.restore();
 }
 
@@ -8461,11 +8561,24 @@ function drawTitle() {
         }
     }
     if (currentState == config.stateMap.waiting && lobbyStartButton == null) {
+        // Properly-centred pill in the shared HUD chrome, with a slow animated
+        // ellipsis so the screen reads "alive" while waiting. The panel is sized
+        // for the full three dots so it never resizes as they cycle.
+        var wMsg = "Waiting for more players";
+        var dots = new Array((Math.floor(Date.now() / 450) % 3) + 2).join(".");
+        var wFont = "bold 20px sans-serif";
+        var wPadX = 24, wH = 44;
         gameContext.save();
+        gameContext.font = wFont;
+        var wTextW = gameContext.measureText(wMsg + "...").width;
+        var wW = wTextW + wPadX * 2;
+        var wX = (LOGICAL_WIDTH - wW) / 2;
+        var wY = LOGICAL_HEIGHT / 2 - 60;
+        drawHudPanel(wX, wY, wW, wH, null);
         gameContext.fillStyle = themeColor('ink', 'black');
-        gameContext.lineWidth = 3;
-        gameContext.font = "30px Arial";
-        gameContext.fillText('Waiting for more players..', (LOGICAL_WIDTH / 2) - 200, (LOGICAL_HEIGHT / 2) - 25);
+        gameContext.textAlign = "left";
+        gameContext.textBaseline = "middle";
+        gameContext.fillText(wMsg + dots, wX + wPadX, wY + wH / 2 + 1);
         gameContext.restore();
     }
 }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -514,13 +514,16 @@ function drawKartAppearance(player, sx, sy, headingOverride) {
     // and the PATTERN (player.pattern) textures the plain sphere only. Both can be equipped at
     // once. Border FIRST — it rings from BEHIND so the cart body always sits on top (only the
     // rim past the body shows).
+    var painter = cartSkinPainter(player.cart);
     var bid = player.border;
     var bskin = (typeof getSkin === "function" && bid) ? getSkin(bid) : null;
     if (bskin && bskin.slot === 'border') {
         var bp = (typeof getSkinPainter === "function") ? getSkinPainter(bid) : null;
-        if (bp != null) { drawBorderOverlay(player, sx, sy, player.radius, bp); }
+        // Shaped carts render CART_SKIN_VISUAL_SCALE larger than the physics radius,
+        // so the border ring scales with them or its inner edge would be swallowed.
+        var br = player.radius * (painter != null ? CART_SKIN_VISUAL_SCALE : 1);
+        if (bp != null) { drawBorderOverlay(player, sx, sy, br, bp); }
     }
-    var painter = cartSkinPainter(player.cart);
     if (painter != null) {
         drawCartSkin(player, sx, sy, player.radius, painter, headingOverride);
     } else {
@@ -540,6 +543,13 @@ function drawKartAppearance(player, sx, sy, headingOverride) {
         }
     }
 }
+
+// Shaped cart bodies render 20% larger than the physics radius so they read
+// slightly bigger than the base sphere cart. Pure presentation: the server's
+// collision radius is untouched (the client never feeds this back). Applied at
+// the drawCartSkin chokepoint so every path (live racing, overview scoreboard,
+// lava-burn, recap, ice reflection) agrees on the size.
+var CART_SKIN_VISUAL_SCALE = 1.2;
 
 function drawCartSkin(player, centerX, centerY, radius, painter, headingOverride) {
     var ctx = gameContext;
@@ -570,7 +580,7 @@ function drawCartSkin(player, centerX, centerY, radius, painter, headingOverride
     ctx.save();
     ctx.translate(centerX, centerY);
     if (!statue) { ctx.rotate(heading); }
-    ctx.scale(radius, radius);
+    ctx.scale(radius * CART_SKIN_VISUAL_SCALE, radius * CART_SKIN_VISUAL_SCALE);
     if (punchK > 0) {
         ctx.translate(punchK * 0.12, 0);                    // lunge forward (heading is local +X)
         ctx.scale(1 + punchK * 0.14, 1 + punchK * 0.14);    // impact pop

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -5615,13 +5615,15 @@ function drawMapTitle() {
     var cw = gameContext.measureText(credit).width;
     var w = Math.max(nw, cw) + padX * 2;
     var x = 10, y = LOGICAL_HEIGHT - 10 - h;
-    drawHudPanel(x, y, w, h, { alpha: 0.82 });
+    var fade = hudChromeAlpha();
+    drawHudPanel(x, y, w, h, { alpha: 0.82 * fade, borderAlpha: fade });
     gameContext.textAlign = "left";
     gameContext.textBaseline = "alphabetic";
     gameContext.fillStyle = ink;
     gameContext.font = nameFont;
+    gameContext.globalAlpha = fade;
     gameContext.fillText(name, x + padX, y + 19);
-    gameContext.globalAlpha = 0.65;
+    gameContext.globalAlpha = 0.65 * fade;
     gameContext.font = creditFont;
     gameContext.fillText(credit, x + padX, y + 34);
     gameContext.restore();
@@ -8340,6 +8342,21 @@ if (typeof window !== "undefined") {
     window.toggleHudDebug = function () { hudDebugInfo = !hudDebugInfo; return hudDebugInfo; };
 }
 
+// Persistent-chrome fade: the round panel and the map plaque render at full
+// strength through the gate countdown, then ease down to a translucent
+// watermark shortly after the race starts so they stop competing with the
+// action. Re-arms every round (raceStartedAt is re-stamped on each startRace).
+var HUD_FADE_DELAY_MS = 800;   // grace period after the gate drops
+var HUD_FADE_MS = 900;         // fade duration
+var HUD_FADED_ALPHA = 0.4;     // resting opacity while racing
+function hudChromeAlpha() {
+    if (raceStartedAt == null) { return 1; }
+    if (currentState != config.stateMap.racing && currentState != config.stateMap.collapsing) { return 1; }
+    var e = Date.now() - raceStartedAt - HUD_FADE_DELAY_MS;
+    if (e <= 0) { return 1; }
+    return 1 - clamp01(e / HUD_FADE_MS) * (1 - HUD_FADED_ALPHA);
+}
+
 // Top-centre session bar as one panel of label/value segments with hairline
 // dividers. Default shows just ROUND once a race exists (gated/racing/
 // collapsing); the GAME/PLAYERS debug segments join it behind ?debughud=1.
@@ -8377,7 +8394,8 @@ function drawGameInfo() {
     }
     var w = padX * 2 + total + (segs.length - 1) * dividerGap * 2;
     var x = (LOGICAL_WIDTH - w) / 2;
-    drawHudPanel(x, y, w, h, null);
+    var fade = hudChromeAlpha();
+    drawHudPanel(x, y, w, h, { alpha: 0.88 * fade, borderAlpha: fade });
 
     gameContext.textBaseline = "middle";
     gameContext.textAlign = "left";
@@ -8387,21 +8405,20 @@ function drawGameInfo() {
         if (k > 0) {
             // Hairline divider between segments.
             cx += dividerGap;
-            gameContext.globalAlpha = 0.25;
+            gameContext.globalAlpha = 0.25 * fade;
             gameContext.strokeStyle = ink;
             gameContext.lineWidth = 1;
             gameContext.beginPath();
             gameContext.moveTo(cx, y + 7);
             gameContext.lineTo(cx, y + h - 7);
             gameContext.stroke();
-            gameContext.globalAlpha = 1;
             cx += dividerGap;
         }
         gameContext.fillStyle = ink;
-        gameContext.globalAlpha = 0.55;
+        gameContext.globalAlpha = 0.55 * fade;
         gameContext.font = labelFont;
         gameContext.fillText(segs[k].label, cx, cy);
-        gameContext.globalAlpha = 1;
+        gameContext.globalAlpha = fade;
         gameContext.font = valueFont;
         gameContext.fillText(segs[k].value, cx + segs[k].lw + labelGap, cy);
         cx += segs[k].w;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -5539,6 +5539,21 @@ function drawAimer(aimer) {
     }
 }
 
+// Truncate text with an ellipsis so it fits maxW in the CURRENT gameContext
+// font (binary search on the cut point). Guards the measureText-sized HUD
+// panels (map announcement/plaque, lobby banners) against user-authored
+// strings — a long map name must shrink the text, never the layout.
+function hudEllipsize(text, maxW) {
+    text = "" + text;
+    if (gameContext.measureText(text).width <= maxW) { return text; }
+    var lo = 0, hi = text.length;
+    while (lo < hi) {
+        var mid = (lo + hi + 1) >> 1;
+        if (gameContext.measureText(text.slice(0, mid) + "…").width <= maxW) { lo = mid; } else { hi = mid - 1; }
+    }
+    return text.slice(0, lo) + "…";
+}
+
 // ---- Round-start map announcement -------------------------------------------
 // A prominent lower-third title card ("Map Name" / "by author") at the start of
 // every round, so the map credit is actually seen (the corner plaque stays as a
@@ -5578,14 +5593,15 @@ function drawMapAnnouncement() {
         alpha = clamp01(1 - fp);
         rise = -10 * fp; // gentle drift up as it fades
     }
-    var name = "" + currentMap.name;
-    var credit = "by " + currentMap.author;
     var nameFont = "bold 34px sans-serif";
     var creditFont = "16px sans-serif";
+    var maxTextW = LOGICAL_WIDTH * 0.66; // cap so user-authored names can't push the card off-screen
     gameContext.save();
     gameContext.font = nameFont;
+    var name = hudEllipsize(currentMap.name, maxTextW);
     var nw = gameContext.measureText(name).width;
     gameContext.font = creditFont;
+    var credit = hudEllipsize("by " + currentMap.author, maxTextW);
     var cw = gameContext.measureText(credit).width;
     var w = Math.max(nw, cw) + 64;
     var h = 78;
@@ -5612,16 +5628,17 @@ function drawMapTitle() {
     if (currentMap == null) {
         return;
     }
-    var name = "" + currentMap.name;
-    var credit = "by " + currentMap.author;
     var nameFont = "bold 15px sans-serif";
     var creditFont = "11px sans-serif";
     var padX = 12, h = 44;
+    var maxTextW = 300; // corner plaque stays a corner plaque, whatever the map is called
     var ink = themeColor('ink', 'black');
     gameContext.save();
     gameContext.font = nameFont;
+    var name = hudEllipsize(currentMap.name, maxTextW);
     var nw = gameContext.measureText(name).width;
     gameContext.font = creditFont;
+    var credit = hudEllipsize("by " + currentMap.author, maxTextW);
     var cw = gameContext.measureText(credit).width;
     var w = Math.max(nw, cw) + padX * 2;
     var x = 10, y = LOGICAL_HEIGHT - 10 - h;

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -8359,16 +8359,6 @@ function drawHudPanel(x, y, w, h, opts) {
     gameContext.restore();
 }
 
-// Opt-in HUD diagnostics (mirrors the ?debugtouch convention): the GAME id and
-// PLAYERS count are operator/debug info — players browse + join rooms via
-// join.html, not by reading the id off the HUD — so they only render with
-// ?debughud=1 in the URL, or after calling toggleHudDebug() in the console.
-var hudDebugInfo = false;
-try { hudDebugInfo = /[?&]debughud/.test(window.location.search); } catch (e) { hudDebugInfo = false; }
-if (typeof window !== "undefined") {
-    window.toggleHudDebug = function () { hudDebugInfo = !hudDebugInfo; return hudDebugInfo; };
-}
-
 // Persistent-chrome fade: the round panel and the map plaque render at full
 // strength through the gate countdown, then ease down to a translucent
 // watermark shortly after the race starts so they stop competing with the
@@ -8384,30 +8374,30 @@ function hudChromeAlpha() {
     return 1 - clamp01(e / HUD_FADE_MS) * (1 - HUD_FADED_ALPHA);
 }
 
-// Top-centre session bar as one panel of label/value segments with hairline
-// dividers. Default shows just ROUND once a race exists (gated/racing/
-// collapsing); the GAME/PLAYERS debug segments join it behind ?debughud=1.
-// Draws nothing when there's nothing to show (e.g. lobby without debug).
+// Top-centre session readout: GAME <id> · PLAYERS <n> · ROUND <r>. Frameless
+// by design (operator preference — no panel box up here): small-caps dimmed
+// labels + bold values in the theme ink/ink-outline text treatment so the row
+// reads over any terrain, with small dot separators. GAME + PLAYERS always
+// show (friends read the room id off the host's screen); ROUND joins once a
+// race exists. The whole row fades to a watermark while racing (hudChromeAlpha).
 function drawGameInfo() {
-    var segs = [];
-    if (hudDebugInfo) {
-        segs.push({ label: "GAME", value: (gameID != null && gameID !== "") ? ("" + gameID) : "—" });
-        segs.push({ label: "PLAYERS", value: "" + totalPlayers });
-    }
+    var segs = [
+        { label: "GAME", value: (gameID != null && gameID !== "") ? ("" + gameID) : "—" },
+        { label: "PLAYERS", value: "" + totalPlayers }
+    ];
     var inRace = currentState == config.stateMap.gated ||
         currentState == config.stateMap.racing ||
         currentState == config.stateMap.collapsing;
     if (inRace && round > 0) {
         segs.push({ label: "ROUND", value: "" + round });
     }
-    if (segs.length === 0) {
-        return;
-    }
 
     var labelFont = "bold 10px sans-serif";
     var valueFont = "bold 15px sans-serif";
-    var padX = 16, labelGap = 6, dividerGap = 13, h = 30, y = 8;
+    var labelGap = 5, sepGap = 11;
     var ink = themeColor('ink', 'black');
+    var outline = themeColor('inkOutline', 'white');
+    var fade = hudChromeAlpha();
 
     gameContext.save();
     var total = 0;
@@ -8419,34 +8409,33 @@ function drawGameInfo() {
         segs[i].w = segs[i].lw + labelGap + segs[i].vw;
         total += segs[i].w;
     }
-    var w = padX * 2 + total + (segs.length - 1) * dividerGap * 2;
-    var x = (LOGICAL_WIDTH - w) / 2;
-    var fade = hudChromeAlpha();
-    drawHudPanel(x, y, w, h, { alpha: 0.88 * fade, borderAlpha: fade });
+    var w = total + (segs.length - 1) * sepGap * 2;
+    var cx = (LOGICAL_WIDTH - w) / 2;
+    var cy = 21;
 
     gameContext.textBaseline = "middle";
     gameContext.textAlign = "left";
-    var cy = y + h / 2 + 1;
-    var cx = x + padX;
+    gameContext.lineWidth = 3;
+    gameContext.strokeStyle = outline;
     for (var k = 0; k < segs.length; k++) {
         if (k > 0) {
-            // Hairline divider between segments.
-            cx += dividerGap;
-            gameContext.globalAlpha = 0.25 * fade;
-            gameContext.strokeStyle = ink;
-            gameContext.lineWidth = 1;
+            // Small dot separator between segments.
+            cx += sepGap;
+            gameContext.globalAlpha = 0.45 * fade;
+            gameContext.fillStyle = ink;
             gameContext.beginPath();
-            gameContext.moveTo(cx, y + 7);
-            gameContext.lineTo(cx, y + h - 7);
-            gameContext.stroke();
-            cx += dividerGap;
+            gameContext.arc(cx, cy, 1.8, 0, Math.PI * 2);
+            gameContext.fill();
+            cx += sepGap;
         }
         gameContext.fillStyle = ink;
-        gameContext.globalAlpha = 0.55 * fade;
+        gameContext.globalAlpha = 0.62 * fade;
         gameContext.font = labelFont;
+        gameContext.strokeText(segs[k].label, cx, cy);
         gameContext.fillText(segs[k].label, cx, cy);
         gameContext.globalAlpha = fade;
         gameContext.font = valueFont;
+        gameContext.strokeText(segs[k].value, cx + segs[k].lw + labelGap, cy);
         gameContext.fillText(segs[k].value, cx + segs[k].lw + labelGap, cy);
         cx += segs[k].w;
     }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -5621,38 +5621,39 @@ function drawMapAnnouncement() {
     gameContext.restore();
 }
 
-// Bottom-left map plaque: the map's name (bold) over a dimmed "by <author>"
-// credit, on the shared HUD-panel chrome — replaces two bare strokeText lines
-// that were nearly invisible over busy terrain.
+// Bottom-left map credit: the map's name (bold) over a dimmed "by <author>"
+// line. Frameless (operator preference — no corner box): the ink/ink-outline
+// stroke treatment keeps it readable over busy terrain, matching the top
+// session readout. Fades with the rest of the persistent chrome once racing.
 function drawMapTitle() {
     if (currentMap == null) {
         return;
     }
     var nameFont = "bold 15px sans-serif";
     var creditFont = "11px sans-serif";
-    var padX = 12, h = 44;
-    var maxTextW = 300; // corner plaque stays a corner plaque, whatever the map is called
+    var maxTextW = 300; // corner credit stays in the corner, whatever the map is called
     var ink = themeColor('ink', 'black');
+    var outline = themeColor('inkOutline', 'white');
+    var fade = hudChromeAlpha();
     gameContext.save();
     gameContext.font = nameFont;
     var name = hudEllipsize(currentMap.name, maxTextW);
-    var nw = gameContext.measureText(name).width;
     gameContext.font = creditFont;
     var credit = hudEllipsize("by " + currentMap.author, maxTextW);
-    var cw = gameContext.measureText(credit).width;
-    var w = Math.max(nw, cw) + padX * 2;
-    var x = 10, y = LOGICAL_HEIGHT - 10 - h;
-    var fade = hudChromeAlpha();
-    drawHudPanel(x, y, w, h, { alpha: 0.82 * fade, borderAlpha: fade });
+    var x = 12;
     gameContext.textAlign = "left";
     gameContext.textBaseline = "alphabetic";
+    gameContext.lineWidth = 3;
+    gameContext.strokeStyle = outline;
     gameContext.fillStyle = ink;
     gameContext.font = nameFont;
     gameContext.globalAlpha = fade;
-    gameContext.fillText(name, x + padX, y + 19);
-    gameContext.globalAlpha = 0.65 * fade;
+    gameContext.strokeText(name, x, LOGICAL_HEIGHT - 27);
+    gameContext.fillText(name, x, LOGICAL_HEIGHT - 27);
+    gameContext.globalAlpha = 0.7 * fade;
     gameContext.font = creditFont;
-    gameContext.fillText(credit, x + padX, y + 34);
+    gameContext.strokeText(credit, x, LOGICAL_HEIGHT - 12);
+    gameContext.fillText(credit, x, LOGICAL_HEIGHT - 12);
     gameContext.restore();
 }
 

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1059,9 +1059,24 @@ function assignPanelDocks(open) {
 // registry isn't re-scanned by each banner. Read by all three lobby banners.
 var lobbyBannerSeasonalClaim = null;
 
+// Y for lobby-banner row `row` (0 = top). The stack tucks directly under the
+// top-centre session info bar (draw.js drawGameInfo, y 8..38) so the whole
+// top-centre HUD reads as ONE column; it drops below the maintenance alert
+// panel (ends ~y94) when a deploy notice is up so the two never overlap.
+var LOBBY_BANNER_ROW_H = 38; // 32px pill + 6px gap
+function lobbyBannerRowY(row) {
+    var base = 46;
+    if (typeof serverMaintenance !== "undefined" && serverMaintenance != null) {
+        base = 102;
+    }
+    return base + row * LOBBY_BANNER_ROW_H;
+}
+
 // Draws ONE fixed top-centre lobby banner (rounded pill, centered bold text) at row `y`. Backs
-// all three lobby banners so their geometry stays identical. theme overrides the neutral hub
-// panel look: { fill, ink (border), text (defaults to ink), alpha, pad, glow }.
+// all three lobby banners so their geometry stays identical. The pill chrome itself is the
+// shared HUD panel (draw.js drawHudPanel) so these match the session bar / map plaque exactly.
+// theme overrides the neutral hub panel look: { fill, ink (border), text (defaults to ink),
+// alpha, pad, glow }.
 function drawLobbyBanner(text, y, theme) {
     theme = theme || {};
     var ink = theme.ink || hubInk();
@@ -1072,16 +1087,12 @@ function drawLobbyBanner(text, y, theme) {
     var w = tw + pad;
     var h = 32;
     var x = (LOGICAL_WIDTH - w) / 2;
-    if (theme.glow) { gameContext.shadowColor = theme.glow; gameContext.shadowBlur = 14; }
-    gameContext.globalAlpha = (theme.alpha != null) ? theme.alpha : 0.92;
-    gameContext.fillStyle = theme.fill || hubSurface();
-    lhRoundRect(gameContext, x, y, w, h, 9);
-    gameContext.fill();
-    gameContext.shadowBlur = 0;
-    gameContext.globalAlpha = 1;
-    gameContext.lineWidth = 2;
-    gameContext.strokeStyle = ink;
-    gameContext.stroke();
+    drawHudPanel(x, y, w, h, {
+        fill: theme.fill || hubSurface(),
+        alpha: (theme.alpha != null) ? theme.alpha : 0.92,
+        border: ink,
+        glow: theme.glow
+    });
     gameContext.fillStyle = theme.text || ink;
     gameContext.textAlign = "center";
     gameContext.textBaseline = "middle";
@@ -1095,7 +1106,7 @@ function drawLobbyPlaylistStatus() {
     if (!playlistDefList().length) { return; }
     var count = playlistCount(currentPlaylistId());
     var text = "🗺️ Playlist: " + currentPlaylistLabel() + (count != null ? " (" + count + ")" : "");
-    drawLobbyBanner(text, lobbyBannerSeasonalClaim ? 164 : 128);
+    drawLobbyBanner(text, lobbyBannerRowY(lobbyBannerSeasonalClaim ? 2 : 1));
 }
 
 // The seasonal claim the LOCAL player can still act on this frame — the first open claim they
@@ -1139,7 +1150,7 @@ function drawSeasonalClaimBanner() {
         ? ("🌟 Claim your " + label + " " + nm + " " + noun + tail)
         : ("🌟 Sign in to claim the limited " + label + " " + nm + " " + noun + tail);
     // Gold theme + soft glow so it reads as premium/limited, not a routine status band.
-    drawLobbyBanner(text, 92, { fill: "#3a2b06", ink: "#ffb31f", text: "#ffe9a8", alpha: 0.96, pad: 34, glow: "rgba(255,179,31,0.7)" });
+    drawLobbyBanner(text, lobbyBannerRowY(0), { fill: "#3a2b06", ink: "#ffb31f", text: "#ffe9a8", alpha: 0.96, pad: 34, glow: "rgba(255,179,31,0.7)" });
 }
 
 // Triangular-tier auto fill: a few bots scale up with humans (1H→1, 2-3H→2,
@@ -1171,8 +1182,8 @@ function drawLobbyAIStatus() {
         var eff = Math.min(lvl, aiMaxBots());
         text = "🤖 AI bots next race: " + eff + (eff === 1 ? " bot" : " bots");
     }
-    // Under the GameID/Players/Round info row; +1 row when the seasonal banner takes the top slot.
-    drawLobbyBanner(text, lobbyBannerSeasonalClaim ? 128 : 92);
+    // Under the session info bar; +1 row when the seasonal banner takes the top slot.
+    drawLobbyBanner(text, lobbyBannerRowY(lobbyBannerSeasonalClaim ? 1 : 0));
 }
 
 function lhRoundRect(ctx, x, y, w, h, r) {

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1087,6 +1087,11 @@ function drawLobbyBanner(text, y, theme) {
     var pad = (theme.pad != null) ? theme.pad : 30;
     gameContext.save();
     gameContext.font = "bold 16px sans-serif";
+    if (typeof hudEllipsize === "function") {
+        // Cap to the canvas (minus margins) so a long playlist/season label can't
+        // size the pill off-screen.
+        text = hudEllipsize(text, LOGICAL_WIDTH - 80 - pad);
+    }
     var tw = gameContext.measureText(text).width;
     var w = tw + pad;
     var h = 32;

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1059,13 +1059,17 @@ function assignPanelDocks(open) {
 // registry isn't re-scanned by each banner. Read by all three lobby banners.
 var lobbyBannerSeasonalClaim = null;
 
-// Y for lobby-banner row `row` (0 = top). The stack tucks directly under the
-// top-centre session info bar (draw.js drawGameInfo, y 8..38) so the whole
-// top-centre HUD reads as ONE column; it drops below the maintenance alert
-// panel (ends ~y94) when a deploy notice is up so the two never overlap.
+// Y for lobby-banner row `row` (0 = top). The stack hugs the top edge of the
+// canvas so the banners read as a fixed HUD strip, not stickers floating over
+// the lobby map's station zones. It only drops lower when something actually
+// renders above it: the debug session bar (?debughud=1, y 8..38) or the
+// maintenance alert panel (ends ~y94).
 var LOBBY_BANNER_ROW_H = 38; // 32px pill + 6px gap
 function lobbyBannerRowY(row) {
-    var base = 46;
+    var base = 12;
+    if (typeof hudDebugInfo !== "undefined" && hudDebugInfo) {
+        base = 46;
+    }
     if (typeof serverMaintenance !== "undefined" && serverMaintenance != null) {
         base = 102;
     }

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1059,17 +1059,13 @@ function assignPanelDocks(open) {
 // registry isn't re-scanned by each banner. Read by all three lobby banners.
 var lobbyBannerSeasonalClaim = null;
 
-// Y for lobby-banner row `row` (0 = top). The stack hugs the top edge of the
-// canvas so the banners read as a fixed HUD strip, not stickers floating over
-// the lobby map's station zones. It only drops lower when something actually
-// renders above it: the debug session bar (?debughud=1, y 8..38) or the
-// maintenance alert panel (ends ~y94).
+// Y for lobby-banner row `row` (0 = top). The stack tucks under the frameless
+// session readout (draw.js drawGameInfo, text row around y 12..30) so the
+// top-centre HUD reads as one column, and drops below the maintenance alert
+// panel (ends ~y94) when a deploy notice is up.
 var LOBBY_BANNER_ROW_H = 38; // 32px pill + 6px gap
 function lobbyBannerRowY(row) {
-    var base = 12;
-    if (typeof hudDebugInfo !== "undefined" && hudDebugInfo) {
-        base = 46;
-    }
+    var base = 40;
     if (typeof serverMaintenance !== "undefined" && serverMaintenance != null) {
         base = 102;
     }


### PR DESCRIPTION
## What

A visual overhaul of the in-game HUD plus a cosmetic sizing change:

- **Frameless top session readout** — `GAME <id> · PLAYERS <n> · ROUND <r>` in small-caps labels + bold values with the ink/outline treatment (no panel box); fades to a 40% watermark ~1s after each race starts and re-arms every round
- **Round-start map announcement card** — lower-third card with map name + "by author"; sequences politely after the Brutal Round reveal (2.6s delay) so the two never compete
- **Frameless bottom-left map credit** — bold name over dimmed author, same fade
- **Lobby banner stack** — seasonal claim / AI bots / playlist pills now draw through the shared `drawHudPanel` chrome and stack in tidy rows at the top (dropping below the maintenance alert when one is up)
- **Race timer** in a dark backdrop pill (readable over any terrain in both themes); **brutal badges** get rounded tiles; **"Waiting for more players"** is a properly centered banner with an animated ellipsis; **maintenance banner** gets a dark alert panel
- **Shaped cart skins render 20% larger** (`CART_SKIN_VISUAL_SCALE` at the `drawCartSkin` chokepoint → applies to live racing, overview, recap, burn, reflections; border rings scale along) — visual only, server hitbox untouched
- Long user-authored strings ellipsize (`hudEllipsize`) so no panel can size itself off-screen

## Why

The old HUD was bare 14px strokeText floating at fixed offsets — game info half-centered, map credit nearly invisible, the waiting notice hard-coded 200px off center. This unifies everything on one design language and makes the map author credit actually visible.

## Review & testing

- `npm run build` + headless smoke test green at every commit
- Two Codex reviews: full-branch review (1 finding — unbounded measureText panels — fixed in-branch) and a final delta review: **11/11 checks pass, no findings**, including verification that the rebase onto v0.29.1/v0.29.2 dropped the duplicate bot-cosmetics seam (main's `RANDOM_BOT_COSMETICS` is the single survivor) and that the camera goal-zoom work doesn't affect HUD anchors
- Playtested locally through lobby/gated/racing/overview/recap states

Carries `deploy:prod` — prod fast-forwards immediately on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)