### PR TITLE
Login-nudge rework + kick/login analytics attribution

### DIFF
--- a/analytics/ga-config.json
+++ b/analytics/ga-config.json
@@ -78,19 +78,19 @@
       "parameterName": "source",
       "displayName": "Login Source",
       "scope": "EVENT",
-      "description": "Which entry point launched the sign-in on the login event: nudge (scoreboard login nudge) | navbar (header popover). Measures whether the nudge actually drives conversions."
+      "description": "Sign-in entry point on the login event: nudge (scoreboard nudge) | navbar (header popover). Shows whether the nudge drives conversions."
     },
     {
       "parameterName": "state",
       "displayName": "Game State",
       "scope": "EVENT",
-      "description": "Game state the player was in when match_abandon or server_kick fired: waiting | lobby | overview | gated | racing | collapsing | gameOver. Separates a benign lobby idle-out from a mid-race AFK kick."
+      "description": "Game state on match_abandon / server_kick (gated | racing | collapsing | overview | lobby | waiting | gameOver). Idle-out vs mid-race kick."
     },
     {
       "parameterName": "reason",
       "displayName": "Disconnect Reason",
       "scope": "EVENT",
-      "description": "Close/kick reason: socket.io close reason on disconnect/connect_error (transport close, ping timeout, ...) and the kick cause on server_kick (afk)."
+      "description": "Close/kick reason: socket.io close on disconnect/connect_error (transport close, ping timeout, ...), or the server_kick cause (afk)."
     },
     {
       "parameterName": "auth_state",

--- a/analytics/ga-config.json
+++ b/analytics/ga-config.json
@@ -75,16 +75,22 @@
       "description": "OAuth provider on the login event: google | discord."
     },
     {
+      "parameterName": "source",
+      "displayName": "Login Source",
+      "scope": "EVENT",
+      "description": "Which entry point launched the sign-in on the login event: nudge (scoreboard login nudge) | navbar (header popover). Measures whether the nudge actually drives conversions."
+    },
+    {
       "parameterName": "state",
       "displayName": "Game State",
       "scope": "EVENT",
-      "description": "Game state the player was in when match_abandon fired: gated | racing | collapsing | overview."
+      "description": "Game state the player was in when match_abandon or server_kick fired: waiting | lobby | overview | gated | racing | collapsing | gameOver. Separates a benign lobby idle-out from a mid-race AFK kick."
     },
     {
       "parameterName": "reason",
       "displayName": "Disconnect Reason",
       "scope": "EVENT",
-      "description": "socket.io close reason on the disconnect/connect_error events (transport close, ping timeout, ...)."
+      "description": "Close/kick reason: socket.io close reason on disconnect/connect_error (transport close, ping timeout, ...) and the kick cause on server_kick (afk)."
     },
     {
       "parameterName": "auth_state",

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -219,6 +219,10 @@ nav .auth-control ~ .theme-toggle {
     display: flex;
     align-items: center;
     gap: 12px;
+    /* Size to content, not to the shrink-to-fit half-viewport that left:50% + auto
+       width would impose (which wraps longer messages mid-line); max-width still
+       caps it on narrow screens, where it wraps gracefully. */
+    width: max-content;
     max-width: 92vw;
     padding: 12px 14px;
     border-radius: 10px;

--- a/client/scripts/auth.js
+++ b/client/scripts/auth.js
@@ -296,53 +296,91 @@
     }
 
     // --- Scoreboard login nudge ---------------------------------------------
-    // A transient, dismissible toast reminding a NOT-signed-in player to log in
-    // to save progress and earn skins. Fired from the game-over/scoreboard
-    // screen (client.js). No-op when auth is unavailable or already signed in.
-    var toastEl = null, toastTimer = null;
-    function buildToast() {
+    // A dismissible toast reminding a NOT-signed-in player to log in to start
+    // earning XP and skins. Fired from the game-over/scoreboard screen (client.js).
+    // No-op when auth is unavailable or already signed in.
+    //
+    // Redesigned after launch data showed ~5% CTR (22 shown / 1 click): the old
+    // toast auto-hid after 9s (often before the player read the busy scoreboard)
+    // and re-fired on EVERY game over (banner blindness). Now it (1) persists until
+    // the player acts or dismisses — client.js hides it on race start so it never
+    // covers gameplay, (2) leads with a concrete value prop (how many skins are up
+    // for grabs), and (3) snoozes for a few days once dismissed or acted on, so it
+    // stops nagging.
+    var NUDGE_SNOOZE_KEY = 'chaochao.nudgeSnoozeUntil';
+    var NUDGE_SNOOZE_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+    var toastEl = null, nudgeVisible = false, nudgeDismissed = false;
+    function nudgeSnoozed() {
+        try { return parseInt(window.localStorage.getItem(NUDGE_SNOOZE_KEY) || '0', 10) > Date.now(); }
+        catch (e) { return false; }
+    }
+    function snoozeNudge() {
+        nudgeDismissed = true; // also blocks re-show for the rest of this session
+        try { window.localStorage.setItem(NUDGE_SNOOZE_KEY, String(Date.now() + NUDGE_SNOOZE_MS)); }
+        catch (e) { /* private mode — session flag still suppresses */ }
+    }
+    function nudgeMessage(opts) {
+        var n = opts && opts.unlockCount;
+        if (typeof n === 'number' && n > 0) {
+            return 'Sign in to start earning XP and unlock ' + n + ' skins as you level up.';
+        }
+        return 'Sign in to save your progress and earn skins.';
+    }
+    function buildToast(message) {
         if (toastEl || !document.body) { return; }
         toastEl = document.createElement('div');
         toastEl.className = 'cc-toast';
         toastEl.setAttribute('role', 'status');
         toastEl.innerHTML =
-            '<span class="cc-toast-msg">Sign in to save your progress and earn skins.</span>' +
+            '<span class="cc-toast-msg"></span>' +
             '<button class="cc-toast-action" type="button">Log in</button>' +
             '<button class="cc-toast-close" type="button" aria-label="Dismiss">×</button>';
+        toastEl.querySelector('.cc-toast-msg').textContent = message; // numeric count, but textContent keeps it XSS-safe
         document.body.appendChild(toastEl);
         toastEl.querySelector('.cc-toast-action').addEventListener('click', function () {
             // Nudge funnel numerator (denominator = login_nudge_shown); the
-            // conversion itself lands as `login` after the OAuth round-trip.
+            // conversion itself lands as `login` (source=nudge) after the OAuth round-trip.
             if (typeof trackEvent === 'function') { trackEvent('login_nudge_clicked'); }
             // Attribute the upcoming signIn() to the nudge — the action button just
             // opens the navbar popover, whose provider buttons call signIn() directly.
             markSignInSource('nudge');
+            snoozeNudge(); // acted on — don't re-nag while the OAuth round-trip plays out
             hideToast();
             var login = document.getElementById('authLogin');
             if (login) { login.click(); } // open the navbar sign-in popover
         });
-        toastEl.querySelector('.cc-toast-close').addEventListener('click', hideToast);
+        toastEl.querySelector('.cc-toast-close').addEventListener('click', function () {
+            snoozeNudge(); // explicit dismissal — snooze across sessions
+            hideToast();
+        });
     }
     function hideToast() {
         if (toastEl) { toastEl.classList.remove('visible'); }
-        if (toastTimer) { clearTimeout(toastTimer); toastTimer = null; }
+        nudgeVisible = false;
     }
-    function showLoginNudge() {
-        if (!sb || currentUser) { return; } // only signed-out players, auth on
-        buildToast();
+    function showLoginNudge(opts) {
+        if (!sb || currentUser) { return; }               // signed-out players only, auth on
+        if (nudgeDismissed || nudgeSnoozed()) { return; }  // respect a recent dismiss/login
+        if (nudgeVisible) { return; }                      // already up — don't double-count the show
+        buildToast(nudgeMessage(opts));
         if (!toastEl) { return; }
+        // First open caches the message; later openings still need their text refreshed
+        // if the count changed (e.g. unlocks added mid-session).
+        var msgEl = toastEl.querySelector('.cc-toast-msg');
+        if (msgEl) { msgEl.textContent = nudgeMessage(opts); }
         toastEl.classList.add('visible');
-        // Nudge funnel denominator (clicked/shown = nudge CTR; login/shown = the
-        // guest -> registered conversion rate the nudge actually drives).
+        nudgeVisible = true;
+        // Funnel denominator (clicked/shown = nudge CTR; login[source=nudge]/shown = the
+        // guest -> registered conversion the nudge actually drives). Persistent now;
+        // client.js hideLoginNudge() clears it at race start so it can't cover the game.
         if (typeof trackEvent === 'function') { trackEvent('login_nudge_shown'); }
-        if (toastTimer) { clearTimeout(toastTimer); }
-        toastTimer = setTimeout(hideToast, 9000);
     }
 
     window.chaochaoAuth = {
         ready: ready,
         available: !!sb,   // Supabase configured + CDN loaded (auth actually usable)
         showLoginNudge: showLoginNudge,
+        hideLoginNudge: hideToast, // clear the nudge without dismissing it (e.g. on race start)
         deviceId: deviceId,
         getHandshake: getHandshake,
         getProfile: getProfile,

--- a/client/scripts/auth.js
+++ b/client/scripts/auth.js
@@ -77,6 +77,16 @@
     // first sight, and a stale one (player bailed at the OAuth screen and came
     // back later) is swept by a short timer below so it can't mis-fire days later.
     var SIGNIN_PENDING_KEY = 'chaochao.signInPending';
+    // Set when the player launches sign-in from the scoreboard login nudge, so the
+    // resulting `login` (which lands a full page-load later, post-OAuth) can be
+    // attributed to the nudge vs the navbar popover. Self-expires so an abandoned
+    // nudge can't mis-attribute a much later, unrelated navbar sign-in.
+    var pendingSignInSource = null, pendingSignInSourceTimer = null;
+    function markSignInSource(source) {
+        pendingSignInSource = source;
+        if (pendingSignInSourceTimer) { clearTimeout(pendingSignInSourceTimer); }
+        pendingSignInSourceTimer = setTimeout(function () { pendingSignInSource = null; }, 30000);
+    }
     function consumeSignInPending(user) {
         if (!user) { return; }
         var pending = null;
@@ -84,9 +94,18 @@
             pending = window.localStorage.getItem(SIGNIN_PENDING_KEY);
             if (pending) { window.localStorage.removeItem(SIGNIN_PENDING_KEY); }
         } catch (e) { /* storage unavailable */ }
-        if (pending && typeof trackEvent === 'function') {
-            // GA4's recommended sign-in event name; `method` = google | discord.
-            trackEvent('login', { method: pending });
+        if (!pending) { return; }
+        // Stamps written since the source split are JSON {provider, source}; older
+        // ones were a bare provider string. Tolerate both.
+        var provider = pending, source = 'navbar';
+        if (pending.charAt(0) === '{') {
+            try { var parsed = JSON.parse(pending); provider = parsed.provider || null; source = parsed.source || 'navbar'; }
+            catch (e) { provider = null; }
+        }
+        if (provider && typeof trackEvent === 'function') {
+            // GA4's recommended sign-in event name; `method` = google | discord,
+            // `source` = nudge | navbar (which entry point actually converted).
+            trackEvent('login', { method: provider, source: source });
         }
     }
     // Sweep a stale pending stamp: if no session showed up shortly after load,
@@ -135,9 +154,13 @@
             console.log('[auth] sign-in unavailable (auth disabled).');
             return;
         }
-        // Stamp the provider so the post-redirect load can fire the GA `login`
-        // conversion (see consumeSignInPending above).
-        try { window.localStorage.setItem(SIGNIN_PENDING_KEY, provider); } catch (e) { /* ignore */ }
+        // Stamp the provider (and which entry point launched this) so the
+        // post-redirect load can fire the GA `login` conversion with attribution
+        // (see consumeSignInPending above). Default source = navbar popover.
+        var source = pendingSignInSource || 'navbar';
+        pendingSignInSource = null;
+        if (pendingSignInSourceTimer) { clearTimeout(pendingSignInSourceTimer); pendingSignInSourceTimer = null; }
+        try { window.localStorage.setItem(SIGNIN_PENDING_KEY, JSON.stringify({ provider: provider, source: source })); } catch (e) { /* ignore */ }
         // Redirect back to the current page; supabase-js completes the session
         // from the URL on return, then a fresh socket handshake carries the token.
         sb.auth.signInWithOAuth({
@@ -291,6 +314,9 @@
             // Nudge funnel numerator (denominator = login_nudge_shown); the
             // conversion itself lands as `login` after the OAuth round-trip.
             if (typeof trackEvent === 'function') { trackEvent('login_nudge_clicked'); }
+            // Attribute the upcoming signIn() to the nudge — the action button just
+            // opens the navbar popover, whose provider buttons call signIn() directly.
+            markSignInSource('nudge');
             hideToast();
             var login = document.getElementById('authLogin');
             if (login) { login.click(); } // open the navbar sign-in popover

--- a/client/scripts/auth.js
+++ b/client/scripts/auth.js
@@ -320,11 +320,13 @@
         catch (e) { /* private mode — session flag still suppresses */ }
     }
     function nudgeMessage(opts) {
+        // `unlockCount` spans every cosmetic slot (carts / patterns / trails /
+        // borders), so it's "cosmetics", not "skins". Guests start with none.
         var n = opts && opts.unlockCount;
         if (typeof n === 'number' && n > 0) {
-            return 'Sign in to start earning XP and unlock ' + n + ' skins as you level up.';
+            return 'Sign in to start earning XP and unlock ' + n + ' cosmetics.';
         }
-        return 'Sign in to save your progress and earn skins.';
+        return 'Sign in to save your progress and earn cosmetics.';
     }
     function buildToast(message) {
         if (toastEl || !document.body) { return; }

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -679,11 +679,21 @@ function registerConnectionHandlers(server) {
 		window.location.href = "./join.html?notfound=1";
 	});
 
-	server.on("serverKick", function () {
+	server.on("serverKick", function (payload) {
 		debugLog("serverKick received -- being booted");
 		// Engagement signal: how often players idle out (AFK kick) vs leave on
 		// their own. Fired before teardown so it can't be skipped by navigation.
-		trackEvent('server_kick');
+		// `reason` defaults to 'afk' (the server's only kick path today is
+		// Room.checkAFK); a future server payload {reason} overrides it. `state`
+		// separates a benign lobby idle-out from a player who went AFK mid-race.
+		var kickReason = (payload && typeof payload === "object" && payload.reason) || "afk";
+		var kickState = "unknown";
+		if (typeof config !== "undefined" && config && config.stateMap && currentState != null) {
+			for (var sName in config.stateMap) {
+				if (config.stateMap[sName] === currentState) { kickState = sName; break; }
+			}
+		}
+		trackEvent('server_kick', { reason: kickReason, state: kickState });
 		// Per-slot teardown (§6.17): drop the primary slot. With no other local
 		// players this disconnects and navigates exactly as before (N=1); with pad
 		// players still in the game it fails over to one of them instead of ending

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -1177,6 +1177,12 @@ function registerStateHandlers(server) {
 		// Stamp the gate-release moment so the start line can flash green as it fades.
 		raceStartTime = Date.now();
 		currentState = config.stateMap.racing;
+		// Clear the scoreboard login nudge (if up) so the persistent toast can never
+		// cover live gameplay. Not a dismissal — it re-shows on the next scoreboard
+		// until the player acts or dismisses it.
+		if (window.chaochaoAuth && typeof window.chaochaoAuth.hideLoginNudge === "function") {
+			window.chaochaoAuth.hideLoginNudge();
+		}
 		// Fires once per round (racing state is re-entered each round), so this is a
 		// round-start signal. `players` counts humans only (clientList = room's
 		// client roster, excludes bots); `bots` counts AI fill via the spawn-packet
@@ -1377,10 +1383,15 @@ function registerStateHandlers(server) {
 			matchEndParams.duration_seconds = Math.round((Date.now() - matchStartedAt) / 1000);
 		}
 		trackEvent('match_end', matchEndParams);
-		// Nudge signed-out players to log in (save progress / earn skins). No-op
-		// when auth is off or already signed in. Primary screen only.
+		// Nudge signed-out players to log in (start earning XP / skins). No-op
+		// when auth is off or already signed in. Primary screen only. Pass the
+		// count of unlockable cosmetics so the toast can lead with a concrete
+		// value prop (guests have no server XP/level to quote — myProgression is
+		// null for them — so the opportunity count is the honest hook).
 		if (window.chaochaoAuth && typeof window.chaochaoAuth.showLoginNudge === "function") {
-			window.chaochaoAuth.showLoginNudge();
+			var unlockableSkins = (typeof COSMETIC_OPTIONS !== "undefined" && COSMETIC_OPTIONS)
+				? COSMETIC_OPTIONS.filter(function (o) { return o.id != null; }).length : 0;
+			window.chaochaoAuth.showLoginNudge({ unlockCount: unlockableSkins });
 		}
 		// Monetization: arm the between-matches interstitial. The ad is intentionally
 		// NOT shown here — it runs at the gameOver -> lobby edge (see the startLobby


### PR DESCRIPTION
## Why
The Friday launch session (~26 humans, only 3 signed in) exposed two GA blind spots and a leaky conversion surface:

- **`server_kick`** fired with no params — AFK kicks (16 that night) couldn't be told apart from anything else or located by game state.
- **`login`** carried only `method` — a sign-in couldn't be attributed to the scoreboard nudge vs the navbar, so "does the nudge convert?" was unanswerable.
- **The login nudge converted at ~5%** (22 shown / 1 click): it auto-hid after 9s (often before players read the busy scoreboard) and re-fired on every game over (banner blindness).

## What changed
**Analytics attribution** (`client.js`, `auth.js`, `analytics/ga-config.json`)
- `server_kick` now stamps `reason` (defaults to `afk` — `Room.checkAFK` is the only kick path; a future server `{reason}` payload overrides) and `state` (lobby idle-out vs mid-race AFK).
- `login` now carries `source` = `nudge` | `navbar`, threaded through the post-OAuth pending stamp (now JSON, back-compatible with old bare-provider strings).
- Registered the new `source` event dimension and broadened the `state`/`reason` descriptions to cover `server_kick`.

**Login-nudge rework** (`auth.js`, `client.js`)
- **Persistent**, no 9s auto-hide — stays until the player acts/dismisses; `client.js` hides it at race start so it never covers gameplay (re-shows next scoreboard until dismissed).
- **Concrete value prop** — leads with the count of unlockable cosmetics ("…unlock N cosmetics"). Guests have no server XP/level to quote (`myProgression` is null for them), so the opportunity count is the honest hook.
- **Snooze** for 3 days (+ rest of session) once dismissed or acted on — kills the every-game-over re-fire.

**CSS** (`styles.css`)
- Fixed a pre-existing `.cc-toast` wrap: `left:50%` + `width:auto` shrink-fit the toast to half the viewport, wrapping longer messages mid-line. Added `width:max-content` (still capped by `max-width:92vw`) — also fixes the same latent wrap for the progression/reward toasts that share the class.

## Notes
- Client/UI + analytics-config only — no `game.js`/`engine.js`/`config.json` change, so no CHANGELOG entry (release-notes gate exempt).
- The new `source` dimension only becomes queryable after the `ga-config.yml` workflow applies it on merge (`reason`/`state` already exist, so `server_kick` is queryable immediately).
- Verified in-browser (single-line toast, correct copy, project styling); `npm run build` + headless smoke test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)