### PR TITLE
fix(preview): show bomb icon for ability tiles in next-map thumbnail

### DIFF
--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3590,6 +3590,12 @@ function loadPatterns() {
     // thumbnail (buildMapThumbnailCanvas), which draws straight from maps[i]'s
     // un-replaced cell ids. Without it the thumbnail fell back to flat purple.
     patterns[config.tileMap.random.id] = makePattern(randomTileIcon, config.tileMap.random.color);
+    // Likewise, committed maps store ability cells as the un-rolled ability.id
+    // (applyAbilites swaps them to a specific ability id only on the LIVE map at
+    // round start). The next-map preview thumbnail draws those un-rolled ids, so
+    // without this it fell back to flat grey. Show the bomb icon over dirt,
+    // matching the editor's map-list thumbnail (create.js).
+    patterns[config.tileMap.ability.id] = makePattern(bombIcon, makeSeamlessPattern(gDirt));
 
 
 


### PR DESCRIPTION
## Problem
The in-game **next-map preview thumbnail** rendered ability tiles as a flat light-grey blank instead of the bomb-icon pattern.

## Root cause
Committed maps store ability cells as the un-rolled `tileMap.ability.id` (5). `applyAbilites` only swaps those to a specific ability id (bomb=102, swap, …) on the **live** map at round start — never on the `maps[]` copy the thumbnail draws from. The play-side `loadPatterns()` built patterns for each *rolled* ability id and for the `random` tile, but never for the base `ability.id`, so `buildMapThumbnailCanvas` fell back to `ability.color` (`#C8C8C8`) — flat grey.

The editor's own map-list thumbnail already renders the bomb icon (`create.js`); this just brings the in-game preview in line.

## Fix
Add the missing pattern in `draw.js` `loadPatterns()`, mirroring the existing random-tile fix:
```js
patterns[config.tileMap.ability.id] = makePattern(bombIcon, makeSeamlessPattern(gDirt));
```

## Testing
- `npm run build` — OK
- `.github/scripts/smoke-test.js` — passes (52 maps ticked)
- Verified locally in dev: next-map preview now shows the bomb icon over dirt for ability tiles.

Client render-only change (no `config.json`/`game.js`/`engine.js`), so no CHANGELOG entry required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)