### PR TITLE
Bunker — last-one-standing battle-royale brutal round

### DIFF
--- a/.github/scripts/bunker-test.js
+++ b/.github/scripts/bunker-test.js
@@ -24,6 +24,7 @@ const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
 const game = require(path.join(repoRoot, 'server', 'game.js'));
 const utils = require(path.join(repoRoot, 'server', 'utils.js'));
 const mapFormat = require(path.join(repoRoot, 'server', 'mapFormat.js'));
+const cellGraph = require(path.join(repoRoot, 'server', 'cellGraph.js'));
 const c = utils.loadConfig();
 
 const DT = c.serverTickSpeed / 1000;
@@ -97,6 +98,15 @@ console.log('Using map: ' + picked.name);
     check(countId(gb, c.tileMap.ice.id) > 0, 'ice tiles present');
     const lidCount = gb.bunkerLidIds.length;
     check(lidCount > 0, 'bunker lid remembered');
+
+    // Bots must still find a route while the goal is buried: with no goal tiles,
+    // the A* has to home on the bunker island via the goalSet option (otherwise it
+    // returns null and bots idle).
+    const far = { x: 30, y: 30 };
+    const buriedRoute = cellGraph.findPathToNearestGoal(gb.currentMap, far, { goalSet: gb.bunkerSafeIds });
+    const plainRoute = cellGraph.findPathToNearestGoal(gb.currentMap, far);
+    check(buriedRoute != null, 'A* finds a route to the buried bunker via goalSet');
+    check(plainRoute == null, 'A* finds NO route without goalSet (goal really is buried)');
 
     room.game.startRace();
     const lavaBefore = countId(gb, c.tileMap.lava.id);

--- a/.github/scripts/bunker-test.js
+++ b/.github/scripts/bunker-test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+// Headless state-machine test for the Bunker (battle-royale) brutal round.
+//
+// Like smoke-test.js, this boots the REAL server modules (no network/browser) and
+// drives the live tick loop, but it pins a single Bunker round (via the
+// brutalTypesForce seam) and asserts the whole lifecycle the mode is built around:
+//
+//   setup      -> goal buried: no goal tiles remain, a single bunker cluster is
+//                 carved into a safe ice island, every other goal sacrificed.
+//   racing     -> the closing ring converts perimeter cells to lava over time.
+//   1 survivor -> the goal emerges (lid cells restored to goal tiles).
+//   claim      -> the survivor reaching the emerged goal wins (firstPlaceSig set).
+//   0 alive    -> the round voids to overview with no winner.
+//   stalemate  -> survivors camping past maxRoundTime void via the safety valve.
+//
+// Any failed assertion exits 1.
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
+const game = require(path.join(repoRoot, 'server', 'game.js'));
+const utils = require(path.join(repoRoot, 'server', 'utils.js'));
+const mapFormat = require(path.join(repoRoot, 'server', 'mapFormat.js'));
+const c = utils.loadConfig();
+
+const DT = c.serverTickSpeed / 1000;
+let failures = 0;
+function check(cond, msg) {
+    if (!cond) { failures++; console.log('::error::Bunker: ' + msg); }
+    else { console.log('ok: ' + msg); }
+}
+
+const fakeIo = { to() { return { emit() { } }; }, sockets: { emit() { } } };
+messenger.build(fakeIo);
+
+// Controllable clock — a tight synchronous tick loop freezes wall-clock, so
+// bunkerStartTime / maxRoundTime would never advance.
+const realNow = Date.now;
+let fakeNow = 1000000;
+Date.now = () => fakeNow;
+
+function countId(gb, id) {
+    let n = 0;
+    const cells = gb.currentMap.cells;
+    for (let i = 0; i < cells.length; i++) { if (cells[i].id === id) { n++; } }
+    return n;
+}
+
+function pickMapWithGoal() {
+    const dir = path.join(repoRoot, 'client', 'maps');
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.json') && !f.startsWith('_'));
+    for (const file of files) {
+        let m = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+        if (mapFormat.isSitesOnly(m)) { m = mapFormat.reconstruct(m); }
+        if (m.cells && m.cells.some(cell => cell.id === c.tileMap.goal.id)) { return { name: file, map: m }; }
+    }
+    return null;
+}
+
+function buildRoom(sig, nPlayers, map) {
+    const room = game.getRoom(sig, 8);
+    room.game.gameBoard.isPreview = true;
+    room.game.gameBoard.previewMap = map;
+    for (let i = 0; i < nPlayers; i++) {
+        const id = sig + '-p' + i;
+        const player = room.world.createNewPlayer(id);
+        room.playerList[id] = player;
+        room.game.determineGameState(player);
+    }
+    return room;
+}
+
+function tick(room) { fakeNow += Math.round(DT * 1000); room.update(DT); }
+
+// Force every brutal roll to be a solo Bunker round.
+c.brutalTypesForce = [c.brutalRounds.bunker.id];
+
+const picked = pickMapWithGoal();
+if (picked == null) { console.log('::error::Bunker: no committed map with goal tiles found'); process.exit(1); }
+console.log('Using map: ' + picked.name);
+
+// ---- Lifecycle: bury -> ring -> emerge -> claim ----
+(function lifecycle() {
+    const room = buildRoom('bunker-life', 4, picked.map);
+    const gb = room.game.gameBoard;
+
+    room.game.startLobby();
+    room.game.startGated(); // setupMap -> applyBrutalBunkerRound (bury)
+
+    check(gb.goalBuried === true, 'goal is buried after setup');
+    check(gb.bunkerLoc != null, 'bunker location chosen');
+    check(countId(gb, c.tileMap.goal.id) === 0, 'no goal tiles exist while buried');
+    check(Object.keys(gb.bunkerSafeIds).length > 0, 'safe ice island carved');
+    check(countId(gb, c.tileMap.ice.id) > 0, 'ice tiles present');
+    const lidCount = gb.bunkerLidIds.length;
+    check(lidCount > 0, 'bunker lid remembered');
+
+    room.game.startRace();
+    const lavaBefore = countId(gb, c.tileMap.lava.id);
+    const lineBefore = gb.collapseLine;
+    for (let f = 0; f < 90; f++) { tick(room); }
+    check(gb.collapseLine < lineBefore, 'ring closed inward');
+    check(countId(gb, c.tileMap.lava.id) > lavaBefore, 'ring converted cells to lava');
+    check(countId(gb, c.tileMap.goal.id) === 0, 'goal still buried mid-race');
+
+    const ids = Object.keys(room.playerList);
+    const survivor = room.playerList[ids[0]];
+    for (let i = 1; i < ids.length; i++) { room.playerList[ids[i]].alive = false; }
+    tick(room); // alive==1 -> emergeBunker
+
+    check(gb.goalBuried === false, 'goal emerged once one survivor remained');
+    check(countId(gb, c.tileMap.goal.id) === lidCount, 'lid cells restored to goal');
+
+    survivor.x = gb.bunkerLoc.x;
+    survivor.y = gb.bunkerLoc.y;
+    survivor.velX = 0; survivor.velY = 0;
+    for (let f = 0; f < 5; f++) { tick(room); }
+    check(room.game.firstPlaceSig != null || survivor.reachedGoal === true,
+        'survivor on the emerged goal won the round');
+})();
+
+// ---- Void: everyone dies -> overview, no winner ----
+(function voidAllDead() {
+    const room = buildRoom('bunker-void', 4, picked.map);
+    room.game.startLobby();
+    room.game.startGated();
+    room.game.startRace();
+    for (let f = 0; f < 20; f++) { tick(room); }
+    const ids = Object.keys(room.playerList);
+    for (let i = 0; i < ids.length; i++) { room.playerList[ids[i]].alive = false; }
+    tick(room);
+    check(room.game.currentState === c.stateMap.overview, 'all-dead round voided to overview');
+    check(room.game.firstPlaceSig == null, 'no winner on a voided round');
+})();
+
+// ---- Safety valve: campers past maxRoundTime -> void ----
+(function stalemateVoid() {
+    const room = buildRoom('bunker-stale', 4, picked.map);
+    const gb = room.game.gameBoard;
+    room.game.startLobby();
+    room.game.startGated();
+    room.game.startRace();
+    const ids = Object.keys(room.playerList);
+    room.playerList[ids[2]].alive = false;
+    room.playerList[ids[3]].alive = false;
+    for (let f = 0; f < 10; f++) { tick(room); } // stamp bunkerStartTime; ring freezes
+    check(gb.goalBuried === true, 'still buried with 2 campers alive');
+    fakeNow += (c.brutalRounds.bunker.maxRoundTime + 5) * 1000;
+    tick(room);
+    check(room.game.currentState === c.stateMap.overview, 'stalemate voided past maxRoundTime');
+    check(room.game.firstPlaceSig == null, 'no winner on a stalemate void');
+})();
+
+Date.now = realNow;
+if (failures > 0) { console.log('\nBunker test FAILED with ' + failures + ' error(s).'); process.exit(1); }
+console.log('\nBunker test passed.');
+process.exit(0);

--- a/.github/scripts/bunker-test.js
+++ b/.github/scripts/bunker-test.js
@@ -108,6 +108,16 @@ console.log('Using map: ' + picked.name);
     check(buriedRoute != null, 'A* finds a route to the buried bunker via goalSet');
     check(plainRoute == null, 'A* finds NO route without goalSet (goal really is buried)');
 
+    // tileSwap (ice<->fast) must not corrupt the ice bunker island.
+    const islandIds = Object.keys(gb.bunkerSafeIds);
+    gb.swapTiles();
+    let islandStillIce = true;
+    for (let i = 0; i < gb.currentMap.cells.length; i++) {
+        const cell = gb.currentMap.cells[i];
+        if (gb.bunkerSafeIds[cell.site.voronoiId] && cell.id !== c.tileMap.ice.id) { islandStillIce = false; }
+    }
+    check(islandStillIce, 'tileSwap leaves the bunker island ice intact');
+
     room.game.startRace();
     const lavaBefore = countId(gb, c.tileMap.lava.id);
     const lineBefore = gb.collapseLine;

--- a/.github/scripts/bunker-test.js
+++ b/.github/scripts/bunker-test.js
@@ -118,6 +118,17 @@ console.log('Using map: ' + picked.name);
     }
     check(islandStillIce, 'tileSwap leaves the bunker island ice intact');
 
+    // A lava explosion (or bomb/iceCannon — same guard) must not alter the island.
+    // Contained radius: covers the island + neighbours but leaves the far map for
+    // the ring assertion below to still have cells to convert.
+    gb.explodeLava({ x: gb.bunkerLoc.x, y: gb.bunkerLoc.y }, 120);
+    let islandSurvivedBlast = true;
+    for (let i = 0; i < gb.currentMap.cells.length; i++) {
+        const cell = gb.currentMap.cells[i];
+        if (gb.bunkerSafeIds[cell.site.voronoiId] && cell.id !== c.tileMap.ice.id) { islandSurvivedBlast = false; }
+    }
+    check(islandSurvivedBlast, 'explosions cannot lava/alter the bunker island');
+
     room.game.startRace();
     const lavaBefore = countId(gb, c.tileMap.lava.id);
     const lineBefore = gb.collapseLine;

--- a/.github/scripts/bunker-test.js
+++ b/.github/scripts/bunker-test.js
@@ -83,6 +83,21 @@ const picked = pickMapWithGoal();
 if (picked == null) { console.log('::error::Bunker: no committed map with goal tiles found'); process.exit(1); }
 console.log('Using map: ' + picked.name);
 
+// ---- P1 regression: ability tile-mutators must not throw on a FRESH board ----
+// (lobby tutorial can fire bomb/iceCannon/lava/tileSwap before the first race, when
+// bunker state hasn't been set up by clean()/applyBrutalBunkerRound yet).
+(function freshBoardAbilities() {
+    const room = buildRoom('bunker-fresh', 2, picked.map);
+    const gb = room.game.gameBoard;
+    room.game.startLobby(); // loads the lobby map; clean()/bunker setup has NOT run yet
+    let threw = false;
+    try {
+        gb.swapTiles();
+        gb.explodeLava({ x: 100, y: 100 }, 60);
+    } catch (e) { threw = true; console.log('  (threw: ' + e.message + ')'); }
+    check(!threw, 'tile-mutating abilities in the lobby (pre-race) do not throw');
+})();
+
 // ---- Lifecycle: bury -> ring -> emerge -> claim ----
 (function lifecycle() {
     const room = buildRoom('bunker-life', 4, picked.map);

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Headless game-loop smoke test
         run: node .github/scripts/smoke-test.js
 
+      - name: Headless Bunker brutal-round test (bury -> ring -> emerge -> claim/void)
+        run: node .github/scripts/bunker-test.js
+
       - name: Headless playlist-selection test (playlist-aware rotation)
         run: node .github/scripts/playlist-selection-test.js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Brutal rounds
+
+- New **Bunker** brutal round — a last-one-standing battle royale. The goal sinks underground behind a silo door at the start, so there's nothing to race for: a wall of lava closes in from the edges, herding everyone together until only one racer is left alive. The moment you're the sole survivor the goal erupts back up for you to claim the win. Zombies don't count as "alive," so an infection can't keep the goal buried. Works on every map.
 
 ## v0.31.0 — 2026-06-09
 

--- a/client/assets/img/bunker-door.svg
+++ b/client/assets/img/bunker-door.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <g fill="#000">
+    <circle cx="256" cy="256" r="196" fill="none" stroke="#000" stroke-width="40"/>
+    <circle cx="256" cy="256" r="48"/>
+    <rect x="243" y="56" width="26" height="158" rx="7"/>
+    <rect x="243" y="298" width="26" height="158" rx="7"/>
+    <rect x="56" y="243" width="158" height="26" rx="7"/>
+    <rect x="298" y="243" width="158" height="26" rx="7"/>
+    <circle cx="256" cy="92" r="22"/>
+    <circle cx="256" cy="420" r="22"/>
+    <circle cx="92" cy="256" r="22"/>
+    <circle cx="420" cy="256" r="22"/>
+  </g>
+</svg>

--- a/client/scripts/audio.js
+++ b/client/scripts/audio.js
@@ -639,6 +639,32 @@ function getDriftNoiseBuffer(ctx) {
     return buf;
 }
 
+// Bunker silo door sealing — a one-shot pneumatic "pshhh" (Star-Trek-door hiss),
+// synthesized from the shared noise buffer through a bandpass that sweeps down as
+// it vents, with a sharp attack and a quick decay. Pure Web Audio (no asset), like
+// the drift skid; routed through sfxBus so the master toggle/lobby dampen apply.
+function playBunkerDoorHiss() {
+    var ctx = getCtx();
+    if (!ctx || ctx.state !== "running") { return; }
+    if (gameMuted || masterVolume === 0) { return; }
+    var now = ctx.currentTime;
+    var src = ctx.createBufferSource();
+    src.buffer = getDriftNoiseBuffer(ctx);
+    src.loop = true;
+    var filt = ctx.createBiquadFilter();
+    filt.type = "bandpass";
+    filt.Q.value = 1.1;
+    filt.frequency.setValueAtTime(5200, now);                       // bright burst...
+    filt.frequency.exponentialRampToValueAtTime(800, now + 0.42);   // ...venting down
+    var g = ctx.createGain();
+    var peak = Math.max(0.0002, 0.16 * masterVolume * sfxVolumeScalar);
+    g.gain.setValueAtTime(0.0001, now);
+    g.gain.exponentialRampToValueAtTime(peak, now + 0.025);         // sharp "pss" onset
+    g.gain.exponentialRampToValueAtTime(0.0001, now + 0.46);        // vent out
+    src.connect(filt); filt.connect(g); g.connect(sfxBus);
+    try { src.start(now); src.stop(now + 0.5); } catch (e) { try { src.disconnect(); } catch (e2) {} }
+}
+
 // Start (first call) or update (later calls) the drift loop for a player.
 //   intensity 0..1 — how hard they're carving; rides gain + filter brightness so
 //                    a faster slide hisses higher.

--- a/client/scripts/audio.js
+++ b/client/scripts/audio.js
@@ -372,6 +372,10 @@ var zombieSwing = makeSound("./assets/sounds/zombieswing.mp3");
 
 var nearVictorySound = makeSound("./assets/sounds/rise.mp3");
 var fallFromVictorySound = makeSound("./assets/sounds/reverserise.mp3");
+// Bunker (battle royale): the goal erupting back up through the silo door for the
+// lone survivor — collapse stops, door opens. A distinct rising cue (own instance
+// so its level is tuned independently of the near-victory sting).
+var bunkerEmergeSound = makeSound("./assets/sounds/rise.mp3?v=bunker", { duck: true, maxVoices: 1 });
 
 // Announcer — routed through the voice bus and flagged to duck the music under them.
 var firstBlood = makeSound("./assets/sounds/firstBlood.mp3", { bus: "voice", duck: true });
@@ -506,6 +510,7 @@ function volumeChange() {
     gameOverSound.volume = .5 * sfx;
     nearVictorySound.volume = .3 * sfx;
     fallFromVictorySound.volume = .15 * sfx;
+    bunkerEmergeSound.volume = .45 * sfx;
     collectItem.volume = .75 * sfx;    // pickup source is very quiet; was buried near the noise floor
     bombShot.volume = .2 * sfx;
     bombExplosion.volume = .2 * sfx;

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -1583,6 +1583,10 @@ function registerCombatHandlers(server) {
 			lid: payload.lid || [],
 			phase: 'buried', animStart: Date.now()
 		};
+		// Catch-up replay for a mid-round joiner: the door is already shut, so don't
+		// re-run the sink animation or fire the seal hiss (the racing-phase clamp in
+		// tfxDrawBunker renders it sealed immediately).
+		if (payload.sealed) { bunkerFX.closeHissPlayed = true; }
 	});
 	server.on('bunkerEmerge', function (payload) {
 		if (bunkerFX == null) {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -870,6 +870,11 @@ function registerConnectionHandlers(server) {
 	});
 
 	server.on("newMap", function (payload) {
+		// Clear the bunker overlay SYNCHRONOUSLY (not in the deferred block below):
+		// the server sends newMap then bunkerStart, and bunkerStart's handler runs
+		// before this .then() microtask resolves — clearing it in there would wipe
+		// the door right after bunkerStart armed it (so the door never shows).
+		if (typeof bunkerFX !== "undefined") { bunkerFX = null; }
 		$.when.apply($, promises).then(function () {
 			currentState = payload.currentState;
 			loadNewMap(payload.id);
@@ -880,7 +885,6 @@ function registerConnectionHandlers(server) {
 			applyBrutalMap(payload.brutalRoundConfig);
 			loadPatterns();
 			clearInfection();
-			if (typeof bunkerFX !== "undefined") { bunkerFX = null; } // cleared each round; bunkerStart re-arms it
 			stopSound(lobbyMusic);
 		});
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -880,6 +880,7 @@ function registerConnectionHandlers(server) {
 			applyBrutalMap(payload.brutalRoundConfig);
 			loadPatterns();
 			clearInfection();
+			if (typeof bunkerFX !== "undefined") { bunkerFX = null; } // cleared each round; bunkerStart re-arms it
 			stopSound(lobbyMusic);
 		});
 
@@ -1568,6 +1569,23 @@ function registerCombatHandlers(server) {
 			collapseCells(cells);
 		});
 		if (typeof recapMarkMapDirty === "function") { recapMarkMapDirty(); } // map changed -> recap re-snapshots
+	});
+	// Bunker (battle royale): the goal sinks below a silo door at round start and
+	// rises again for the lone survivor. The tile flips (goal<->ice/normal) arrive
+	// via the normal tileChanges path; these two events drive the door animation.
+	server.on('bunkerStart', function (payload) {
+		bunkerFX = {
+			x: payload.x, y: payload.y, radius: payload.radius,
+			lid: payload.lid || [],
+			phase: 'buried', animStart: Date.now()
+		};
+	});
+	server.on('bunkerEmerge', function (payload) {
+		if (bunkerFX == null) {
+			bunkerFX = { x: payload.x, y: payload.y, radius: 80, lid: payload.lid || [] };
+		}
+		bunkerFX.phase = 'emerging';
+		bunkerFX.animStart = Date.now();
 	});
 	server.on('explodedCells', function (cells) {
 		if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing || currentState == config.stateMap.lobby) {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -1586,6 +1586,14 @@ function registerCombatHandlers(server) {
 		}
 		bunkerFX.phase = 'emerging';
 		bunkerFX.animStart = Date.now();
+		// Fire the "goal erupts / collapse stops" cue at the pan's peak — the instant
+		// the door bursts open (BUNKER_EMERGE.panOut into the cinematic).
+		var panOut = (typeof BUNKER_EMERGE !== "undefined") ? BUNKER_EMERGE.panOut : 700;
+		setTimeout(function () {
+			if (typeof playSound === "function" && typeof bunkerEmergeSound !== "undefined") {
+				playSound(bunkerEmergeSound);
+			}
+		}, panOut);
 	});
 	server.on('explodedCells', function (cells) {
 		if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing || currentState == config.stateMap.lobby) {

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -4251,6 +4251,27 @@ function computeWorldViewTarget(dt) {
     if (localStarPowerUntil() > 0) {
         racingScale = Math.max(1, racingScale * (STAR_ZOOM_OUT_FACTOR + 0.03 * Math.sin(Date.now() / 480)));
     }
+    // Bunker emerge cinematic: when the goal erupts for the lone survivor, pull the
+    // camera back to frame the bunker — peaking as the door bursts open and the SFX
+    // fires (BUNKER_EMERGE timeline) — hold, then ease back to following the survivor.
+    if (typeof bunkerFX !== "undefined" && bunkerFX != null && bunkerFX.phase === "emerging" &&
+        typeof BUNKER_EMERGE !== "undefined" && bunkerFX.x != null) {
+        var ems = Date.now() - bunkerFX.animStart;
+        var peakEnd = BUNKER_EMERGE.panOut + BUNKER_EMERGE.hold;
+        var emTotal = peakEnd + BUNKER_EMERGE.panIn;
+        var w; // 0 = follow survivor, 1 = pulled back on the bunker
+        if (ems < BUNKER_EMERGE.panOut) { w = smoothstep(ems / BUNKER_EMERGE.panOut); }
+        else if (ems < peakEnd) { w = 1; }
+        else if (ems < emTotal) { w = 1 - smoothstep((ems - peakEnd) / BUNKER_EMERGE.panIn); }
+        else { w = 0; }
+        if (w > 0) {
+            var pbScale = 1 + (focusedView.scale - 1) * 0.15; // pull most of the way to whole-map
+            var pcx = focusedView.cx + (bunkerFX.x - focusedView.cx) * w;
+            var pcy = focusedView.cy + (bunkerFX.y - focusedView.cy) * w;
+            racingScale = racingScale + (pbScale - racingScale) * w;
+            return clampViewToWorld(pcx, pcy, racingScale);
+        }
+    }
     return clampViewToWorld(focusedView.cx, focusedView.cy, racingScale);
 }
 

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -4218,6 +4218,24 @@ function computeWorldViewTarget(dt) {
                 e = 0;                                    // whole-map beat
             }
         }
+        // Bunker silo door: hold open while the camera pans out to reveal the buried
+        // goal, seal shut during the whole-map beat (e≈0) so the player watches it
+        // close on the full map, then stay shut as the camera zooms back in to race.
+        if (typeof bunkerFX !== "undefined" && bunkerFX != null && bunkerFX.phase === "buried") {
+            var cover;
+            if (!(rest > 0)) {
+                cover = 1;
+            } else if (tt <= 0) {
+                cover = 0; // still holding tight on the spawn — door open
+            } else {
+                var beatStart = rest * WORLD_ZOOM_GATE_OUT_FRAC;
+                var beatEnd = rest - rest * WORLD_ZOOM_GATE_IN_FRAC;
+                if (tt < beatStart) { cover = 0; }
+                else if (beatEnd > beatStart && tt < beatEnd) { cover = smoothstep((tt - beatStart) / (beatEnd - beatStart)); }
+                else { cover = 1; }
+            }
+            bunkerFX.camCover = cover;
+        }
         var scale = 1 + (focusedView.scale - 1) * e;
         return clampViewToWorld(focusedView.cx, focusedView.cy, scale);
     }

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -213,6 +213,8 @@ var scissorsIcon = new Image(576, 512);
 scissorsIcon.src = "../assets/img/scissors-solid.svg";
 var starIcon = new Image(576, 512);
 starIcon.src = "../assets/img/star-solid.svg";
+var bunkerIcon = new Image(512, 512);
+bunkerIcon.src = "../assets/img/bunker-door.svg";
 
 //TileTextures
 var lava = new Image(256, 256);
@@ -3615,6 +3617,7 @@ function loadPatterns() {
     brutalRoundImages[config.brutalRounds.hockey.id] = puckIcon;
     brutalRoundImages[config.brutalRounds.explosive.id] = explosionIcon;
     brutalRoundImages[config.brutalRounds.blackout.id] = moonIcon;
+    brutalRoundImages[config.brutalRounds.bunker.id] = bunkerIcon;
 
     if (brutalRoundConfig != null && brutalPatterns[brutalRoundConfig.brutalTypes.toString()] == null) {
         brutalPatterns[brutalRoundConfig.brutalTypes.toString()] = makeComplexPattern(brutalRoundConfig.brutalTypes);

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3923,6 +3923,13 @@ function drawOffscreenGoalIndicator() {
         return;
     }
     var goals = worldGoalPoints();
+    // Bunker round: the goal is buried (no goal tiles), but players still need to
+    // know where it is — point the arrow at the bunker. Scoped to the arrow so the
+    // camera's finish-line punch-in doesn't fire on the buried goal.
+    if (goals.length === 0 && typeof bunkerFX !== "undefined" && bunkerFX != null &&
+        bunkerFX.phase === "buried" && bunkerFX.x != null) {
+        goals = [{ x: bunkerFX.x, y: bunkerFX.y }];
+    }
     if (goals.length === 0) {
         return;
     }

--- a/client/scripts/terrainfx.js
+++ b/client/scripts/terrainfx.js
@@ -318,6 +318,13 @@ function tfxDrawBunker(t, camX, camY) {
         return; // done — beacon handles the exposed goal
     }
 
+    // Pneumatic seal: fire the door-close hiss once, the instant the iris finishes
+    // shutting (Star-Trek-door "pshhh").
+    if (!fx.closeHissPlayed && fx.phase === "buried" && door >= 0.97) {
+        fx.closeHissPlayed = true;
+        if (typeof playBunkerDoorHiss === "function") { playBunkerDoorHiss(); }
+    }
+
     var ctx = gameContext;
     // Without the goal-tile polygon we can't clip the door to the tile bounds — skip
     // this frame rather than draw an oversized circle (geometry is retried next frame).
@@ -333,6 +340,17 @@ function tfxDrawBunker(t, camX, camY) {
     // them to the tile shape.
     tfxPathCells(ctx, fx.doorCells, camX, camY);
     ctx.clip();
+
+    // Goal floor BENEATH the door: paint the tile gold (+ a soft beacon core) so it
+    // reads as the goal being sealed under the hatch, not a sheet of ice. The iris
+    // closes over this; on emerge it's revealed before the real beacon takes over.
+    ctx.fillStyle = config.tileMap.goal.color;
+    ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
+    var goalCore = ctx.createRadialGradient(cx, cy, 1, cx, cy, Math.max(2, R));
+    goalCore.addColorStop(0, "rgba(255,248,210," + (0.45 + 0.25 * pulse) + ")");
+    goalCore.addColorStop(1, "rgba(255,203,48,0)");
+    ctx.fillStyle = goalCore;
+    ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
 
     // Goal glow leaking through the iris — shrinks as the door closes, blooms as it opens.
     var glowR = Math.max(2, R * (0.5 + 0.8 * (1 - door)));

--- a/client/scripts/terrainfx.js
+++ b/client/scripts/terrainfx.js
@@ -257,12 +257,13 @@ function tfxComputeBunkerDoor(fx) {
     if (typeof currentMap === "undefined" || currentMap == null || currentMap.cells == null) { return false; }
     var lidSet = {};
     for (var i = 0; i < fx.lid.length; i++) { lidSet[fx.lid[i]] = true; }
-    var verts = [], sx = 0, sy = 0, n = 0;
+    var doorCells = [], verts = [], sx = 0, sy = 0, n = 0;
     for (var i = 0; i < currentMap.cells.length; i++) {
         var cell = currentMap.cells[i];
         if (!lidSet[cell.site.voronoiId]) { continue; }
         var vv = tfxCellVerts(cell);
         if (!vv) { continue; }
+        doorCells.push({ verts: vv }); // for clipping the door to the tile polygon
         for (var v = 0; v < vv.length; v++) { verts.push(vv[v]); sx += vv[v].x; sy += vv[v].y; n++; }
     }
     if (n === 0) { return false; }
@@ -271,6 +272,7 @@ function tfxComputeBunkerDoor(fx) {
         var dx = verts[v].x - cx, dy = verts[v].y - cy, d = Math.sqrt(dx * dx + dy * dy);
         if (d > r) { r = d; }
     }
+    fx.doorCells = doorCells;
     fx.doorCx = cx; fx.doorCy = cy; fx.doorR = Math.max(r, 20);
     return true;
 }
@@ -302,38 +304,40 @@ function tfxDrawBunker(t, camX, camY) {
     }
 
     var ctx = gameContext;
-    var cx = (fx.doorCx != null ? fx.doorCx : fx.x) + camX;
-    var cy = (fx.doorCy != null ? fx.doorCy : fx.y) + camY;
-    var R = (fx.doorR != null ? fx.doorR : Math.max(40, Math.min(fx.radius * 0.8, 72)));
+    // Without the goal-tile polygon we can't clip the door to the tile bounds — skip
+    // this frame rather than draw an oversized circle (geometry is retried next frame).
+    if (fx.doorCells == null || fx.doorCells.length === 0) { return; }
+    var cx = fx.doorCx + camX, cy = fx.doorCy + camY, R = fx.doorR;
+    var pulse = 0.5 + 0.5 * Math.sin(t * 2.0);
+    var cover = door;
 
     ctx.save();
+    // Clip EVERYTHING to the goal tile's actual polygon, so the door can never spill
+    // past the tile edge — the iris/glow are sized to overshoot and the clip trims
+    // them to the tile shape.
+    tfxPathCells(ctx, fx.doorCells, camX, camY);
+    ctx.clip();
+
     // Goal glow leaking through the iris — shrinks as the door closes, blooms as it opens.
-    var glowR = R * (0.35 + 0.55 * (1 - door));
-    var pulse = 0.5 + 0.5 * Math.sin(t * 2.0);
+    var glowR = Math.max(2, R * (0.5 + 0.8 * (1 - door)));
     var glow = ctx.createRadialGradient(cx, cy, 1, cx, cy, glowR);
     glow.addColorStop(0, "rgba(255,210,90," + (0.55 * (1 - door) + 0.10 + 0.06 * pulse) + ")");
     glow.addColorStop(1, "rgba(255,180,40,0)");
     ctx.fillStyle = glow;
-    ctx.fillRect(cx - glowR, cy - glowR, glowR * 2, glowR * 2);
+    ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
 
-    // Silo rim (always there as the hatch frame).
-    ctx.lineWidth = 4;
-    ctx.strokeStyle = "rgba(90,96,104,0.9)";
-    ctx.beginPath(); ctx.arc(cx, cy, R, 0, 2 * Math.PI); ctx.stroke();
-    ctx.lineWidth = 2;
-    ctx.strokeStyle = "rgba(150,158,168,0.7)";
-    ctx.beginPath(); ctx.arc(cx, cy, R - 5, 0, 2 * Math.PI); ctx.stroke();
-
-    // Iris blades: 6 wedges that converge on the center as the door closes.
-    var NB = 6, cover = door;
+    // Iris blades: 6 wedges that converge on the center as the door closes. Sized to
+    // overshoot the tile (bladeR > R); the clip above trims them to the tile polygon.
+    var NB = 6;
     if (cover > 0.001) {
         var twist = (1 - cover) * 0.6;
         var inner = R * (1 - cover) * 0.95;
+        var bladeR = R * 1.3;
         for (var b = 0; b < NB; b++) {
             var a0 = (b / NB) * Math.PI * 2 + twist;
             var a1 = a0 + (Math.PI * 2 / NB);
             ctx.beginPath();
-            ctx.arc(cx, cy, R - 2, a0, a1);
+            ctx.arc(cx, cy, bladeR, a0, a1);
             ctx.arc(cx, cy, inner, a1, a0, true);
             ctx.closePath();
             ctx.fillStyle = (b % 2 === 0) ? "rgba(64,70,78,0.92)" : "rgba(52,58,66,0.92)";
@@ -344,9 +348,20 @@ function tfxDrawBunker(t, camX, camY) {
         }
         if (cover > 0.85) { // center bolt only when shut
             ctx.fillStyle = "rgba(150,158,168,0.9)";
-            ctx.beginPath(); ctx.arc(cx, cy, 4, 0, 2 * Math.PI); ctx.fill();
+            ctx.beginPath(); ctx.arc(cx, cy, Math.min(4, R * 0.18), 0, 2 * Math.PI); ctx.fill();
         }
     }
+
+    // Silo rim = the goal tile's own boundary. Drawn INSIDE the clip with a doubled
+    // line so only the inner half shows — the frame stays fully within the tile.
+    tfxPathCells(ctx, fx.doorCells, camX, camY);
+    ctx.lineWidth = 6;
+    ctx.strokeStyle = "rgba(70,76,84,0.95)";
+    ctx.stroke();
+    tfxPathCells(ctx, fx.doorCells, camX, camY);
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = "rgba(150,158,168,0.55)";
+    ctx.stroke();
     ctx.restore();
 }
 

--- a/client/scripts/terrainfx.js
+++ b/client/scripts/terrainfx.js
@@ -250,25 +250,61 @@ function drawTerrainFX(dtIgnored) {
 // over the goal at round start (sink), holds shut while the goal is buried (a warm
 // glow leaks through to telegraph where it is), then snaps open for the lone
 // survivor (emerge) — at which point the normal goal beacon takes back over.
+// Fit the silo door to the buried goal's ACTUAL footprint (its cell polygons), so
+// it hugs the goal tile(s) and never spills onto neighbours. Cached on fx — the
+// geometry doesn't move once set. Falls back to the server-sent centre/radius.
+function tfxComputeBunkerDoor(fx) {
+    if (typeof currentMap === "undefined" || currentMap == null || currentMap.cells == null) { return false; }
+    var lidSet = {};
+    for (var i = 0; i < fx.lid.length; i++) { lidSet[fx.lid[i]] = true; }
+    var verts = [], sx = 0, sy = 0, n = 0;
+    for (var i = 0; i < currentMap.cells.length; i++) {
+        var cell = currentMap.cells[i];
+        if (!lidSet[cell.site.voronoiId]) { continue; }
+        var vv = tfxCellVerts(cell);
+        if (!vv) { continue; }
+        for (var v = 0; v < vv.length; v++) { verts.push(vv[v]); sx += vv[v].x; sy += vv[v].y; n++; }
+    }
+    if (n === 0) { return false; }
+    var cx = sx / n, cy = sy / n, r = 0;
+    for (var v = 0; v < verts.length; v++) {
+        var dx = verts[v].x - cx, dy = verts[v].y - cy, d = Math.sqrt(dx * dx + dy * dy);
+        if (d > r) { r = d; }
+    }
+    fx.doorCx = cx; fx.doorCy = cy; fx.doorR = Math.max(r, 20);
+    return true;
+}
 function tfxDrawBunker(t, camX, camY) {
     if (typeof bunkerFX === "undefined" || bunkerFX == null) { return; }
     var fx = bunkerFX;
-    var SINK = 1.2, EMERGE = 0.5;
-    var elapsed = (Date.now() - fx.animStart) / 1000;
+    if (fx.doorR == null) { tfxComputeBunkerDoor(fx); }
+    var EMERGE = 0.5;
     var door; // 1 = fully closed (goal hidden), 0 = fully open (goal exposed)
     if (fx.phase === "emerging") {
-        var op = Math.min(1, elapsed / EMERGE);
+        var op = Math.min(1, (Date.now() - fx.animStart) / (EMERGE * 1000));
         door = 1 - op;
         if (op >= 1) { fx.phase = "done"; return; }
     } else if (fx.phase === "buried") {
-        door = Math.min(1, elapsed / SINK);
+        var racing = (typeof currentState !== "undefined") &&
+            (currentState === config.stateMap.racing || currentState === config.stateMap.collapsing);
+        if (racing) {
+            door = 1; // race underway — the door is fully sealed over the buried goal
+        } else if (fx.camCover != null) {
+            // Camera-driven close: sealed during the gated whole-map beat so the player
+            // actually watches it shut.
+            door = fx.camCover;
+        } else {
+            // Dynamic camera off (whole map always in view) — fixed sink.
+            door = Math.min(1, (Date.now() - fx.animStart) / 1200);
+        }
     } else {
         return; // done — beacon handles the exposed goal
     }
 
     var ctx = gameContext;
-    var cx = fx.x + camX, cy = fx.y + camY;
-    var R = Math.max(40, Math.min(fx.radius * 0.8, 72));
+    var cx = (fx.doorCx != null ? fx.doorCx : fx.x) + camX;
+    var cy = (fx.doorCy != null ? fx.doorCy : fx.y) + camY;
+    var R = (fx.doorR != null ? fx.doorR : Math.max(40, Math.min(fx.radius * 0.8, 72)));
 
     ctx.save();
     // Goal glow leaking through the iris — shrinks as the door closes, blooms as it opens.

--- a/client/scripts/terrainfx.js
+++ b/client/scripts/terrainfx.js
@@ -26,6 +26,14 @@ var terrainFX = {
 // socket handlers (client.js) and cleared each round (newMap). null when no
 // Bunker round is active.
 var bunkerFX = null;
+// Emerge cinematic timeline (ms from the bunkerEmerge event), shared by the door
+// animation (terrainfx), the camera pan (draw.js), and the SFX cue (client.js) so
+// the door bursts open + the sound + the camera's peak all land together:
+//   0..panOut        camera pulls back, door still sealed
+//   panOut           door bursts open + emerge SFX fire — camera at its peak
+//   panOut..+doorOpen iris retracts; camera holds at the peak
+//   ..+hold..+panIn  camera eases back to follow the survivor; overlay fades out
+var BUNKER_EMERGE = { panOut: 700, doorOpen: 450, hold: 450, panIn: 800 };
 // Map each ability tile id to its icon image (the same Images loadPatterns uses).
 function tfxBuildAbilityIcons() {
     var m = {};
@@ -280,12 +288,19 @@ function tfxDrawBunker(t, camX, camY) {
     if (typeof bunkerFX === "undefined" || bunkerFX == null) { return; }
     var fx = bunkerFX;
     if (fx.doorR == null) { tfxComputeBunkerDoor(fx); }
-    var EMERGE = 0.5;
     var door; // 1 = fully closed (goal hidden), 0 = fully open (goal exposed)
+    var overlayAlpha = 1; // fade the silo overlay out as the goal beacon takes over
     if (fx.phase === "emerging") {
-        var op = Math.min(1, (Date.now() - fx.animStart) / (EMERGE * 1000));
-        door = 1 - op;
-        if (op >= 1) { fx.phase = "done"; return; }
+        var ms = Date.now() - fx.animStart;
+        var total = BUNKER_EMERGE.panOut + BUNKER_EMERGE.hold + BUNKER_EMERGE.panIn;
+        if (ms >= total) { fx.phase = "done"; return; }
+        if (ms < BUNKER_EMERGE.panOut) {
+            door = 1; // camera still pulling back — keep it sealed for the reveal
+        } else {
+            door = Math.max(0, 1 - (ms - BUNKER_EMERGE.panOut) / BUNKER_EMERGE.doorOpen);
+        }
+        var fadeStart = BUNKER_EMERGE.panOut + BUNKER_EMERGE.doorOpen;
+        if (ms > fadeStart) { overlayAlpha = Math.max(0, 1 - (ms - fadeStart) / (total - fadeStart)); }
     } else if (fx.phase === "buried") {
         var racing = (typeof currentState !== "undefined") &&
             (currentState === config.stateMap.racing || currentState === config.stateMap.collapsing);
@@ -312,6 +327,7 @@ function tfxDrawBunker(t, camX, camY) {
     var cover = door;
 
     ctx.save();
+    if (overlayAlpha < 1) { ctx.globalAlpha = overlayAlpha; }
     // Clip EVERYTHING to the goal tile's actual polygon, so the door can never spill
     // past the tile edge — the iris/glow are sized to overshoot and the clip trims
     // them to the tile shape.

--- a/client/scripts/terrainfx.js
+++ b/client/scripts/terrainfx.js
@@ -22,6 +22,10 @@ var terrainFX = {
     lavaSeeds: [],
     abilityIcons: null   // lazily-built map: ability tile id -> icon Image
 };
+// Bunker (battle-royale) silo-door state, set by the bunkerStart/bunkerEmerge
+// socket handlers (client.js) and cleared each round (newMap). null when no
+// Bunker round is active.
+var bunkerFX = null;
 // Map each ability tile id to its icon image (the same Images loadPatterns uses).
 function tfxBuildAbilityIcons() {
     var m = {};
@@ -237,8 +241,77 @@ function drawTerrainFX(dtIgnored) {
         tfxDrawLavaConvection(t, camX, camY);
         tfxDrawIceReflections(camX, camY);
     }
+    tfxDrawBunker(t, camX, camY);        // battle-royale silo door (no-op when inactive)
     tfxDrawGoalBeacon(t, camX, camY);    // always — cheap + gameplay-critical
     tfxDrawAbilityIcons(t, camX, camY);  // always — gameplay-critical pickup markers
+}
+
+// Battle-royale silo door over the buried goal. An iris of metal blades closes
+// over the goal at round start (sink), holds shut while the goal is buried (a warm
+// glow leaks through to telegraph where it is), then snaps open for the lone
+// survivor (emerge) — at which point the normal goal beacon takes back over.
+function tfxDrawBunker(t, camX, camY) {
+    if (typeof bunkerFX === "undefined" || bunkerFX == null) { return; }
+    var fx = bunkerFX;
+    var SINK = 1.2, EMERGE = 0.5;
+    var elapsed = (Date.now() - fx.animStart) / 1000;
+    var door; // 1 = fully closed (goal hidden), 0 = fully open (goal exposed)
+    if (fx.phase === "emerging") {
+        var op = Math.min(1, elapsed / EMERGE);
+        door = 1 - op;
+        if (op >= 1) { fx.phase = "done"; return; }
+    } else if (fx.phase === "buried") {
+        door = Math.min(1, elapsed / SINK);
+    } else {
+        return; // done — beacon handles the exposed goal
+    }
+
+    var ctx = gameContext;
+    var cx = fx.x + camX, cy = fx.y + camY;
+    var R = Math.max(40, Math.min(fx.radius * 0.8, 72));
+
+    ctx.save();
+    // Goal glow leaking through the iris — shrinks as the door closes, blooms as it opens.
+    var glowR = R * (0.35 + 0.55 * (1 - door));
+    var pulse = 0.5 + 0.5 * Math.sin(t * 2.0);
+    var glow = ctx.createRadialGradient(cx, cy, 1, cx, cy, glowR);
+    glow.addColorStop(0, "rgba(255,210,90," + (0.55 * (1 - door) + 0.10 + 0.06 * pulse) + ")");
+    glow.addColorStop(1, "rgba(255,180,40,0)");
+    ctx.fillStyle = glow;
+    ctx.fillRect(cx - glowR, cy - glowR, glowR * 2, glowR * 2);
+
+    // Silo rim (always there as the hatch frame).
+    ctx.lineWidth = 4;
+    ctx.strokeStyle = "rgba(90,96,104,0.9)";
+    ctx.beginPath(); ctx.arc(cx, cy, R, 0, 2 * Math.PI); ctx.stroke();
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = "rgba(150,158,168,0.7)";
+    ctx.beginPath(); ctx.arc(cx, cy, R - 5, 0, 2 * Math.PI); ctx.stroke();
+
+    // Iris blades: 6 wedges that converge on the center as the door closes.
+    var NB = 6, cover = door;
+    if (cover > 0.001) {
+        var twist = (1 - cover) * 0.6;
+        var inner = R * (1 - cover) * 0.95;
+        for (var b = 0; b < NB; b++) {
+            var a0 = (b / NB) * Math.PI * 2 + twist;
+            var a1 = a0 + (Math.PI * 2 / NB);
+            ctx.beginPath();
+            ctx.arc(cx, cy, R - 2, a0, a1);
+            ctx.arc(cx, cy, inner, a1, a0, true);
+            ctx.closePath();
+            ctx.fillStyle = (b % 2 === 0) ? "rgba(64,70,78,0.92)" : "rgba(52,58,66,0.92)";
+            ctx.fill();
+            ctx.lineWidth = 1;
+            ctx.strokeStyle = "rgba(28,32,38,0.8)";
+            ctx.stroke();
+        }
+        if (cover > 0.85) { // center bolt only when shut
+            ctx.fillStyle = "rgba(150,158,168,0.9)";
+            ctx.beginPath(); ctx.arc(cx, cy, 4, 0, 2 * Math.PI); ctx.fill();
+        }
+    }
+    ctx.restore();
 }
 
 // Ability pickups: float the icon above the tile (gentle bob + soft ground

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -1593,6 +1593,15 @@ function update(gameBoard, currentState, dt) {
         }
     }
 
+    // Bunker (battle royale): while the goal is buried there are no goal tiles, so
+    // bots have nothing to path toward. Feed them the bunker center as a virtual goal
+    // so they converge on the shrinking safe island and the combat/leader machinery
+    // engages (knocking rivals into the closing ring). Real goal tiles reappear and
+    // take over the instant the goal emerges for the lone survivor.
+    if (gameBoard.goalBuried && gameBoard.bunkerLoc != null) {
+        goalTiles = [{ x: gameBoard.bunkerLoc.x, y: gameBoard.bunkerLoc.y }];
+    }
+
     // Cells holding a bumper hazard — bumpers aren't in the cell graph, so without
     // this A* routes straight through them and the bot gets knocked/stuck. Penalize
     // those cells so routes go AROUND. Recomputed each tick so a moving bumper's

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -909,9 +909,14 @@ function decidePunch(bot, ctx) {
     var landRange = c.punchRadius + bot.radius + nr.player.radius + 6;
     if (nr.dist > landRange) { return; }
     var shove = lavaBeyond(ctx, bot, nr.player, SHOVE_PROBE);
+    // Bunker (battle royale): the whole point is to kill, not race. Bots fight far
+    // more readily — routine punches need much less aggression, and a guaranteed
+    // shove into the closing ring bypasses the burst cooldown entirely (otherwise
+    // they'd stand around waiting out refractory while a free kill is right there).
+    var buriedBR = (ctx.bunkerSafeIds != null);
     // A free shove into the lava is always worth it; routine aggression only in bursts.
-    if (!shove && bot.ai.aggression < 0.6) { return; }
-    if (!offensiveCombatAllowed(bot, Date.now())) { return; }
+    if (!shove && bot.ai.aggression < (buriedBR ? 0.3 : 0.6)) { return; }
+    if (!(buriedBR && shove) && !offensiveCombatAllowed(bot, Date.now())) { return; }
     // Momentum-aware timing: punch power scales with speed, so for a routine
     // offensive punch the bot holds the swing until it's actually moving fast enough
     // to land a real hit — not a limp standing tap. A free lava shove (about position,
@@ -1138,12 +1143,16 @@ function steerBot(bot, ctx, dt) {
             penaltySet: ctx.hazardCells, // route AROUND bumper cells (soft penalty)
             penaltyMult: HAZARD_PATH_PENALTY
         };
+        // Bunker round: the goal is buried (no goal tiles), so home the A* on the
+        // safe bunker island instead — otherwise findPathToNearestGoal returns null
+        // and the bot just sits there.
+        if (ctx.bunkerSafeIds != null) { pathOpts.goalSet = ctx.bunkerSafeIds; }
         var route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, pathOpts);
         // If the danger ring walled us off, retry without it so we still aim at a
         // goal (better a tight line than freezing in front of the lava). Keep the
         // hazard penalty on the retry — it's soft, so it never nulls the path.
         if (route == null && blocked != null) {
-            route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, { noiseSeed: ai.pathSeed, noiseAmount: pathOpts.noiseAmount, penaltySet: ctx.hazardCells, penaltyMult: HAZARD_PATH_PENALTY });
+            route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, { noiseSeed: ai.pathSeed, noiseAmount: pathOpts.noiseAmount, penaltySet: ctx.hazardCells, penaltyMult: HAZARD_PATH_PENALTY, goalSet: pathOpts.goalSet });
         }
         if (route != null) {
             var pts = [];
@@ -1598,8 +1607,10 @@ function update(gameBoard, currentState, dt) {
     // so they converge on the shrinking safe island and the combat/leader machinery
     // engages (knocking rivals into the closing ring). Real goal tiles reappear and
     // take over the instant the goal emerges for the lone survivor.
+    var bunkerSafeIds = null;
     if (gameBoard.goalBuried && gameBoard.bunkerLoc != null) {
         goalTiles = [{ x: gameBoard.bunkerLoc.x, y: gameBoard.bunkerLoc.y }];
+        bunkerSafeIds = gameBoard.bunkerSafeIds;
     }
 
     // Cells holding a bumper hazard — bumpers aren't in the cell graph, so without
@@ -1700,6 +1711,7 @@ function update(gameBoard, currentState, dt) {
         siteById: buildSiteIndex(map),
         lavaCells: lavaCells,
         goalTiles: goalTiles, // for zombie intercept (prey are racing to a goal)
+        bunkerSafeIds: bunkerSafeIds, // Bunker round: A* homes on these cells (buried goal)
         hazardCells: hazardCells, // bumper cells to penalize in pathing
         players: playerList,
         projectileList: gameBoard.projectileList,

--- a/server/cellGraph.js
+++ b/server/cellGraph.js
@@ -261,6 +261,22 @@ function findPathToNearestGoal(map, point, options) {
         }
     }
 
+    // Optional explicit goal cells (voronoiId set/array). When given, the search
+    // homes on THESE cells instead of GOAL-id tiles — used by the Bunker round,
+    // where the goal is buried (no goal tiles exist) but bots must still path to
+    // the safe bunker island. Accepts a Set, an array, or an object map.
+    var goalSet = null;
+    if (options.goalSet) {
+        goalSet = {};
+        if (options.goalSet.forEach) {
+            options.goalSet.forEach(function (id) { goalSet[id] = true; });
+        } else if (Array.isArray(options.goalSet)) {
+            for (var gs = 0; gs < options.goalSet.length; gs++) { goalSet[options.goalSet[gs]] = true; }
+        } else {
+            for (var gk in options.goalSet) { if (options.goalSet[gk]) { goalSet[gk] = true; } }
+        }
+    }
+
     var start = nearestCellIndex(cells, point);
 
     // An empty hole is a hard no-go surface (players bounce off it), so a route can't
@@ -292,8 +308,9 @@ function findPathToNearestGoal(map, point, options) {
         }
         done[u] = true;
         // Goal found: Dijkstra pops nodes in cost order, so this is the
-        // cheapest-cost reachable goal.
-        if (cells[u].id === GOAL) {
+        // cheapest-cost reachable goal. An explicit goalSet (Bunker) overrides the
+        // GOAL-id test, since the buried goal has no goal tiles to find.
+        if (goalSet ? goalSet[cells[u].site.voronoiId] : cells[u].id === GOAL) {
             goalIndex = u;
             break;
         }

--- a/server/config.json
+++ b/server/config.json
@@ -333,6 +333,15 @@
             "id": 1011,
             "active": true,
             "title": "Blackout"
+        },
+        "bunker": {
+            "id": 1012,
+            "active": true,
+            "ringSpeed": 1.0,
+            "arenaPadding": 90,
+            "clusterGap": 90,
+            "maxRoundTime": 100,
+            "title": "Bunker"
         }
     },
     "hazards": {

--- a/server/config.json
+++ b/server/config.json
@@ -338,7 +338,6 @@
             "id": 1012,
             "active": true,
             "ringSpeed": 1.0,
-            "arenaPadding": 90,
             "clusterGap": 90,
             "maxRoundTime": 100,
             "title": "Bunker"

--- a/server/config.json
+++ b/server/config.json
@@ -337,7 +337,7 @@
         "bunker": {
             "id": 1012,
             "active": true,
-            "ringSpeed": 1.0,
+            "ringSpeed": 0.85,
             "clusterGap": 90,
             "maxRoundTime": 100,
             "title": "Bunker"

--- a/server/entities/gameBoard.js
+++ b/server/entities/gameBoard.js
@@ -114,6 +114,7 @@ class GameBoard {
 		aiController.update(this, currentState, dt);
 		this.engine.update(dt);
 		this.collapseMap(currentState);
+		this.bunkerRingTick(currentState);
 		this.checkCollisions(currentState);
 		this.updatePlayers(currentState, dt);
 		this.updateProjectiles(currentState);
@@ -1368,6 +1369,163 @@ class GameBoard {
 			}
 		}
 	}
+	// Group the map's goal cells into spatially-distinct clusters (a map can have
+	// more than one goal zone). Two goal cells join the same cluster when within
+	// bunker.clusterGap of each other (flood fill). Returns an array of clusters,
+	// each an array of cell references.
+	getGoalClusters() {
+		var cells = this.currentMap.cells;
+		var goals = [];
+		for (var i = 0; i < cells.length; i++) {
+			if (cells[i].id == c.tileMap.goal.id) { goals.push(cells[i]); }
+		}
+		if (goals.length === 0) { return []; }
+		var gap = c.brutalRounds.bunker.clusterGap;
+		var gap2 = gap * gap;
+		var clusters = [];
+		var assigned = new Array(goals.length);
+		for (var a = 0; a < goals.length; a++) {
+			if (assigned[a]) { continue; }
+			var stack = [a];
+			assigned[a] = true;
+			var members = [];
+			while (stack.length > 0) {
+				var idx = stack.pop();
+				members.push(goals[idx]);
+				for (var b = 0; b < goals.length; b++) {
+					if (assigned[b]) { continue; }
+					var dx = goals[idx].site.x - goals[b].site.x;
+					var dy = goals[idx].site.y - goals[b].site.y;
+					if (dx * dx + dy * dy <= gap2) { assigned[b] = true; stack.push(b); }
+				}
+			}
+			clusters.push(members);
+		}
+		return clusters;
+	}
+	// Bunker (battle-royale) round setup, run once at map setup (before racing).
+	// Randomly picks ONE goal cluster as the buried "bunker"; converts that cluster
+	// (plus a small padding disc) to ice and remembers it as the silo lid; every
+	// OTHER goal cluster loses its win-immunity by becoming normal floor (so the
+	// closing ring can swallow it and only one safe island exists). The goal stays
+	// underground (no goal tile = unclaimable) until emergeBunker() restores it once
+	// a single survivor remains.
+	applyBrutalBunkerRound() {
+		var clusters = this.getGoalClusters();
+		if (clusters.length === 0) {
+			// No goal on this map (shouldn't happen for committed maps) -> nothing to
+			// bury; leave the round as a plain race so it can't softlock.
+			return;
+		}
+		var chosen = clusters[utils.getRandomInt(0, clusters.length - 1)];
+		var chosenSet = {};
+		var cx = 0, cy = 0;
+		for (var i = 0; i < chosen.length; i++) {
+			chosenSet[chosen[i].site.voronoiId] = true;
+			cx += chosen[i].site.x;
+			cy += chosen[i].site.y;
+		}
+		cx /= chosen.length;
+		cy /= chosen.length;
+		var clusterRadius = 0;
+		for (var i = 0; i < chosen.length; i++) {
+			var d = utils.getMag(cx - chosen[i].site.x, cy - chosen[i].site.y);
+			if (d > clusterRadius) { clusterRadius = d; }
+		}
+		this.bunkerLoc = { x: cx, y: cy };
+		this.bunkerArenaRadius = clusterRadius + c.brutalRounds.bunker.arenaPadding;
+		this.goalBuried = true;
+		this.bunkerSafeIds = {};
+		this.bunkerLidIds = [];
+
+		var cells = this.currentMap.cells;
+		var arena2 = this.bunkerArenaRadius * this.bunkerArenaRadius;
+		var tileDelta = {};
+		var maxDist = 0;
+		for (var i = 0; i < cells.length; i++) {
+			var cell = cells[i];
+			var wasGoal = (cell.id == c.tileMap.goal.id);
+			var inChosen = chosenSet[cell.site.voronoiId] === true;
+			var dx = cx - cell.site.x, dy = cy - cell.site.y;
+			var dist = Math.sqrt(dx * dx + dy * dy);
+			if (dist > maxDist) { maxDist = dist; }
+			var solid = (cell.id != c.tileMap.lava.id && cell.id != c.tileMap.empty.id && cell.id != c.tileMap.background.id);
+			if (dist * dist <= arena2 && solid) {
+				// Part of the safe ice island.
+				cell.id = c.tileMap.ice.id;
+				this.tileChanges[cell.site.voronoiId] = cell.id;
+				tileDelta[cell.site.voronoiId] = cell.id;
+				this.bunkerSafeIds[cell.site.voronoiId] = true;
+			} else if (wasGoal) {
+				// A goal cell outside the bunker arena: sacrifice it to normal floor so
+				// it has no immunity and isn't claimable while the goal is buried.
+				cell.id = c.tileMap.normal.id;
+				this.tileChanges[cell.site.voronoiId] = cell.id;
+				tileDelta[cell.site.voronoiId] = cell.id;
+			}
+			if (inChosen) { this.bunkerLidIds.push(cell.site.voronoiId); }
+		}
+
+		// Ring starts fully open (line beyond the farthest cell) and closes inward
+		// toward the bunker each racing tick. collapseLoc/collapseLine are reused so
+		// the AI's existing ring awareness gets the bunker for free.
+		this.collapseLoc = { x: cx, y: cy };
+		this.collapseLine = maxDist + 50;
+		this.bunkerRingActive = true;
+		this.bunkerStartTime = null;
+
+		messenger.messageRoomBySig(this.roomSig, "tileChanges", JSON.stringify(tileDelta));
+		messenger.messageRoomBySig(this.roomSig, "bunkerStart", { x: cx, y: cy, radius: this.bunkerArenaRadius, lid: this.bunkerLidIds });
+	}
+	// Advances the closing ring during a Bunker round's racing phase: lava encroaches
+	// from the perimeter inward toward the bunker, never consuming the safe ice island.
+	// The shrinking arena forces survivors together and into combat/lava until one
+	// remains. No-op outside a racing Bunker round.
+	bunkerRingTick(currentState) {
+		if (!this.bunkerRingActive || currentState != c.stateMap.racing) { return; }
+		if (this.bunkerStartTime == null) { this.bunkerStartTime = Date.now(); }
+		if (this.collapseLine > this.bunkerArenaRadius) {
+			this.collapseLine -= c.brutalRounds.bunker.ringSpeed;
+			if (this.collapseLine < this.bunkerArenaRadius) { this.collapseLine = this.bunkerArenaRadius; }
+		}
+		var collapsedCells = [];
+		var cells = this.currentMap.cells;
+		for (var i = 0; i < cells.length; i++) {
+			var cell = cells[i];
+			if (this.bunkerSafeIds[cell.site.voronoiId]) { continue; }
+			if (cell.id == c.tileMap.lava.id || cell.id == c.tileMap.empty.id || cell.id == c.tileMap.background.id) { continue; }
+			var distance = utils.getMag(this.collapseLoc.x - cell.site.x, this.collapseLoc.y - cell.site.y);
+			if (this.collapseLine < distance) {
+				cell.id = c.tileMap.lava.id;
+				this.tileChanges[cell.site.voronoiId] = cell.id;
+				collapsedCells.push(cell.site.voronoiId);
+			}
+		}
+		if (collapsedCells.length > 0) {
+			messenger.messageRoomBySig(this.roomSig, 'collapsedCells', collapsedCells);
+		}
+	}
+	// Raise the buried goal once a single survivor remains: revert the silo-lid cells
+	// back to goal tiles (so the survivor can claim the win) and tell clients to play
+	// the quick emerge animation. Idempotent.
+	emergeBunker() {
+		if (!this.goalBuried) { return; }
+		this.goalBuried = false;
+		this.bunkerRingActive = false;
+		var tileDelta = {};
+		var cells = this.currentMap.cells;
+		var lidSet = {};
+		for (var i = 0; i < this.bunkerLidIds.length; i++) { lidSet[this.bunkerLidIds[i]] = true; }
+		for (var i = 0; i < cells.length; i++) {
+			if (lidSet[cells[i].site.voronoiId]) {
+				cells[i].id = c.tileMap.goal.id;
+				this.tileChanges[cells[i].site.voronoiId] = cells[i].id;
+				tileDelta[cells[i].site.voronoiId] = cells[i].id;
+			}
+		}
+		messenger.messageRoomBySig(this.roomSig, "tileChanges", JSON.stringify(tileDelta));
+		messenger.messageRoomBySig(this.roomSig, "bunkerEmerge", { x: this.bunkerLoc.x, y: this.bunkerLoc.y, lid: this.bunkerLidIds });
+	}
 	//Occurs at gameover
 	resetGame(currentState) {
 		this.mapsPlayed = [];
@@ -1529,6 +1687,14 @@ class GameBoard {
 		// AI vision-fairness state, reset each round.
 		this.visionBlockedUntil = 0;
 		this.blackoutActive = false;
+		// Bunker (battle-royale) brutal state, reset each round.
+		this.goalBuried = false;
+		this.bunkerRingActive = false;
+		this.bunkerLoc = null;
+		this.bunkerArenaRadius = 0;
+		this.bunkerSafeIds = {};
+		this.bunkerLidIds = [];
+		this.bunkerStartTime = null;
 		this.resetProjectiles();
 		this.resetHazards();
 	}
@@ -1695,6 +1861,10 @@ class GameBoard {
 				}
 				case c.brutalRounds.cloudy.id: {
 					this.applyBrutalCloudyRound();
+					break;
+				}
+				case c.brutalRounds.bunker.id: {
+					this.applyBrutalBunkerRound();
 					break;
 				}
 			}
@@ -1925,6 +2095,12 @@ class GameBoard {
 		}
 		activeBrutalTypes = utils.shuffleArray(activeBrutalTypes);
 		brutalRoundConfig.brutalTypes.push(activeBrutalTypes[0]);
+		// Bunker (battle royale) reshapes the whole arena with its own closing ring
+		// and buried goal — it must never combine with another collapse/hazard mode,
+		// so when it's the primary pick it runs solo.
+		if (activeBrutalTypes[0] == c.brutalRounds.bunker.id) {
+			return brutalRoundConfig;
+		}
 		if (activeBrutalTypes.length == 1) {
 			return brutalRoundConfig;
 		}
@@ -1934,6 +2110,8 @@ class GameBoard {
 			if (brutalRoundConfig.brutalTypes.length == c.maxTotalBrutals) {
 				return brutalRoundConfig;
 			}
+			// Bunker only ever runs as a solo primary, never bolted onto another mode.
+			if (activeBrutalTypes[i] == c.brutalRounds.bunker.id) { continue; }
 			//Roll for next Brutal
 			var nextBrutalChance = utils.getRandomInt(1, 100);
 			//console.log("Roll for additional brutal: " + nextBrutalChance);

--- a/server/entities/gameBoard.js
+++ b/server/entities/gameBoard.js
@@ -92,6 +92,16 @@ class GameBoard {
 		this.collapseLine = this.world.height;
 		this.visionBlockedUntil = 0;
 		this.blackoutActive = false;
+		// Bunker state — initialized here (not just in clean()) because lobby-tutorial
+		// abilities (bomb/iceCannon/lava/tileSwap) can run before the first race, and
+		// their island-protection guards index bunkerSafeIds; an undefined would throw.
+		this.goalBuried = false;
+		this.bunkerRingActive = false;
+		this.bunkerLoc = null;
+		this.bunkerArenaRadius = 0;
+		this.bunkerSafeIds = {};
+		this.bunkerLidIds = [];
+		this.bunkerStartTime = null;
 		this.soloMode = false;
 		this.soloCollapseSpeed = c.lastPlayerCollapseSpeed;
 		this.soloStartDistance = this.world.height + 400;

--- a/server/entities/gameBoard.js
+++ b/server/entities/gameBoard.js
@@ -1433,37 +1433,38 @@ class GameBoard {
 			if (d > clusterRadius) { clusterRadius = d; }
 		}
 		this.bunkerLoc = { x: cx, y: cy };
-		this.bunkerArenaRadius = clusterRadius + c.brutalRounds.bunker.arenaPadding;
+		// Ring floor = just the chosen cluster's own extent: the safe island is the
+		// goal tile(s) themselves, nothing more — the lava closes right up to the
+		// goal's edge (no padded disc spilling onto neighbouring tiles).
+		this.bunkerArenaRadius = clusterRadius;
 		this.goalBuried = true;
 		this.bunkerSafeIds = {};
 		this.bunkerLidIds = [];
 
 		var cells = this.currentMap.cells;
-		var arena2 = this.bunkerArenaRadius * this.bunkerArenaRadius;
 		var tileDelta = {};
 		var maxDist = 0;
 		for (var i = 0; i < cells.length; i++) {
 			var cell = cells[i];
-			var wasGoal = (cell.id == c.tileMap.goal.id);
 			var inChosen = chosenSet[cell.site.voronoiId] === true;
 			var dx = cx - cell.site.x, dy = cy - cell.site.y;
 			var dist = Math.sqrt(dx * dx + dy * dy);
 			if (dist > maxDist) { maxDist = dist; }
-			var solid = (cell.id != c.tileMap.lava.id && cell.id != c.tileMap.empty.id && cell.id != c.tileMap.background.id);
-			if (dist * dist <= arena2 && solid) {
-				// Part of the safe ice island.
+			if (inChosen) {
+				// The bunker island: exactly the chosen goal cluster's cells, turned to
+				// ice and remembered as the silo lid to restore on emerge.
 				cell.id = c.tileMap.ice.id;
 				this.tileChanges[cell.site.voronoiId] = cell.id;
 				tileDelta[cell.site.voronoiId] = cell.id;
 				this.bunkerSafeIds[cell.site.voronoiId] = true;
-			} else if (wasGoal) {
-				// A goal cell outside the bunker arena: sacrifice it to normal floor so
-				// it has no immunity and isn't claimable while the goal is buried.
+				this.bunkerLidIds.push(cell.site.voronoiId);
+			} else if (cell.id == c.tileMap.goal.id) {
+				// Any OTHER goal cluster: sacrifice it to normal floor so it has no
+				// win-immunity and isn't claimable while the goal is buried.
 				cell.id = c.tileMap.normal.id;
 				this.tileChanges[cell.site.voronoiId] = cell.id;
 				tileDelta[cell.site.voronoiId] = cell.id;
 			}
-			if (inChosen) { this.bunkerLidIds.push(cell.site.voronoiId); }
 		}
 
 		// Ring starts fully open (line beyond the farthest cell) and closes inward

--- a/server/entities/gameBoard.js
+++ b/server/entities/gameBoard.js
@@ -617,6 +617,9 @@ class GameBoard {
 		var cells = this.currentMap.cells;
 		var tileDelta = {};
 		for (var i = 0; i < cells.length; i++) {
+			// The Bunker island is ice; a tileSwap would otherwise flip it to fast,
+			// corrupting the safe core (and its look under the silo door). Leave it be.
+			if (this.bunkerSafeIds[cells[i].site.voronoiId]) { continue; }
 			if (cells[i].id == c.tileMap.fast.id) {
 				cells[i].id = c.tileMap.ice.id;
 				this.tileChanges[cells[i].site.voronoiId] = cells[i].id;

--- a/server/entities/gameBoard.js
+++ b/server/entities/gameBoard.js
@@ -743,6 +743,8 @@ class GameBoard {
 			if (cells[i].id == c.tileMap.goal.id || cells[i].id == c.tileMap.lava.id || cells[i].id == c.tileMap.background.id || cells[i].id == c.tileMap.empty.id || cells[i].id == c.tileMap.water.id) {
 				continue;
 			}
+			// The Bunker island is the protected safe core — no ability may alter it.
+			if (this.bunkerSafeIds[cells[i].site.voronoiId]) { continue; }
 			var distance = utils.getMag(explodeLoc.x - cells[i].site.x, explodeLoc.y - cells[i].site.y);
 			if (c.tileMap.abilities.bomb.explosionRadius > distance) {
 				cells[i].id = c.tileMap.slow.id;
@@ -771,6 +773,7 @@ class GameBoard {
 			if (cells[i].id == c.tileMap.goal.id || cells[i].id == c.tileMap.background.id || cells[i].id == c.tileMap.empty.id) {
 				continue;
 			}
+			if (this.bunkerSafeIds[cells[i].site.voronoiId]) { continue; } // protect the Bunker island
 			var distance = utils.getMag(explodeLoc.x - cells[i].site.x, explodeLoc.y - cells[i].site.y);
 			if (c.tileMap.abilities.iceCannon.explosionRadius > distance) {
 				cells[i].id = c.tileMap.ice.id;
@@ -791,6 +794,7 @@ class GameBoard {
 			if (cells[i].id == c.tileMap.goal.id || cells[i].id == c.tileMap.background.id || cells[i].id == c.tileMap.empty.id) {
 				continue;
 			}
+			if (this.bunkerSafeIds[cells[i].site.voronoiId]) { continue; } // never lava the Bunker island
 			var distance = utils.getMag(explodeLoc.x - cells[i].site.x, explodeLoc.y - cells[i].site.y);
 			if (radius > distance) {
 				cells[i].id = c.tileMap.lava.id;

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -89,6 +89,7 @@ class Player extends Circle {
 		this.gateIndex = 0;
 		this.reachedGoal = false;
 		this.timeReached = null;
+		this.eliminatedAt = null;
 		// True once this player has been gated into a race (startRace); gates the
 		// game-over map rating so only actual participants can vote.
 		this.racedCurrentMap = false;
@@ -1285,6 +1286,7 @@ class Player extends Circle {
 		this.attack = false;
 		this.reachedGoal = false;
 		this.timeReached = null;
+		this.eliminatedAt = null;
 		this.pbWritten = false;
 		this.collapseMargin = null;
 		this.stamina = c.punchStamina.max;

--- a/server/game.js
+++ b/server/game.js
@@ -283,6 +283,16 @@ class Game {
 		client.emit("newMap", this.gameBoard.newMapPayload);
 		//Send map tile changes
 		client.emit("tileChanges", JSON.stringify(this.gameBoard.gatherTileChanges()));
+		// Bunker round in progress: bunkerStart was a one-shot at setup, so a mid-round
+		// joiner/reconnect never set bunkerFX and would miss the silo door + offscreen
+		// bunker indicator. Replay it, flagged `sealed` so they see it already shut
+		// (no sink animation or close hiss replay).
+		if (this.gameBoard.goalBuried && this.gameBoard.bunkerLoc != null) {
+			client.emit("bunkerStart", {
+				x: this.gameBoard.bunkerLoc.x, y: this.gameBoard.bunkerLoc.y,
+				radius: this.gameBoard.bunkerArenaRadius, lid: this.gameBoard.bunkerLidIds, sealed: true
+			});
+		}
 		//Send current abilities
 		client.emit("allAbilityHoldings", JSON.stringify(this.gameBoard.gatherAbilities()));
 		// Late-join spectator: send the LIVE hazard list (the puck, mid-round volcano

--- a/server/game.js
+++ b/server/game.js
@@ -512,11 +512,22 @@ class Game {
 		//Start slow collapse if last player alive
 		if (this.alivePlayerCount == 1) {
 			// Battle-royale endgame: a lone survivor remains, so raise the buried goal
-			// for them to claim. The normal win path starts the finish collapse when
-			// they reach it; no generic last-player collapse during a Bunker round.
+			// for them to claim — then engage the SAME map-aware par collapse a normal
+			// last player gets, so they can't just run laps to burn everyone's time
+			// (grief). The collapse converges on the risen goal; an honest line beats
+			// it with margin, a staller gets swallowed (round ends, no winner).
 			if (this.gameBoard.checkForActiveBrutal(c.brutalRounds.bunker.id)) {
-				if (this.gameBoard.goalBuried) {
+				if (this.gameBoard.goalBuried && !this.collapseInitated) {
 					this.gameBoard.emergeBunker();
+					this.collapseInitated = true;
+					if (!this.scheduleSoloCollapse()) {
+						setTimeout(function (context) {
+							if (context.currentState == c.stateMap.racing || context.currentState == c.stateMap.collapsing) {
+								var goal = context.gameBoard.findRandomGoalTile();
+								if (goal != null) { context.startCollapse(goal.x, goal.y); }
+							}
+						}, 15000, this);
+					}
 				}
 			} else if (this.currentState != c.stateMap.collapsing && !this.collapseInitated) {
 				this.collapseInitated = true;

--- a/server/game.js
+++ b/server/game.js
@@ -407,6 +407,12 @@ class Game {
 			if (!this.playerList[player].alive && !this.playerList[player].reachedGoal) {
 				playersConcluded++;
 
+				// Survival-time stamp (used to rank Bunker non-winners by how long they
+				// lasted). Set once, the tick they're first seen concluded.
+				if (this.playerList[player].eliminatedAt == null) {
+					this.playerList[player].eliminatedAt = Date.now();
+				}
+
 				if (this.playerList[player].murderedBy != null) {
 					var killer = this.playerList[this.playerList[player].murderedBy];
 					if (killer != null) {
@@ -490,11 +496,29 @@ class Game {
 		if (playersConcluded == this.playerCount) {
 			this.gameBoard.killAFKPlayers();
 			this.startOverview();
+			return;
+		}
+
+		// Bunker (battle royale) safety valve: if survivors stalemate on the ice
+		// island past the cap (ring already frozen, goal still buried), void the round
+		// — no winner, no notch — so a camped last-man-standing can't hang the room.
+		if (this.gameBoard.bunkerRingActive && this.gameBoard.bunkerStartTime != null) {
+			if (Date.now() - this.gameBoard.bunkerStartTime > c.brutalRounds.bunker.maxRoundTime * 1000) {
+				this.startOverview();
+				return;
+			}
 		}
 
 		//Start slow collapse if last player alive
 		if (this.alivePlayerCount == 1) {
-			if (this.currentState != c.stateMap.collapsing && !this.collapseInitated) {
+			// Battle-royale endgame: a lone survivor remains, so raise the buried goal
+			// for them to claim. The normal win path starts the finish collapse when
+			// they reach it; no generic last-player collapse during a Bunker round.
+			if (this.gameBoard.checkForActiveBrutal(c.brutalRounds.bunker.id)) {
+				if (this.gameBoard.goalBuried) {
+					this.gameBoard.emergeBunker();
+				}
+			} else if (this.currentState != c.stateMap.collapsing && !this.collapseInitated) {
 				this.collapseInitated = true;
 				// A true single-player room (no rivals, no bots) gets a collapse
 				// tuned to the map so a competent line can win, instead of the


### PR DESCRIPTION
## Summary

New **Bunker** brutal round: a last-one-standing battle royale that works on every map. The goal sinks underground behind a silo door at round start (no goal tile = unclaimable), and a lava ring closes inward from the perimeter toward a randomly-chosen goal cluster, herding racers together until one survivor remains — then the goal erupts back up for them to claim. Zombies/AFK/dead don't count as alive, so an infection can't keep it buried.

### Mechanics
- **Bury:** one goal cluster (random) becomes the safe ice island (sized to the goal tile); every other goal cluster is sacrificed to floor. Win is impossible while buried.
- **Ring:** reuses the existing inward-converging collapse machinery; runs during racing. Bots get a `goalSet` A* target so they path to the bunker and fight (a guaranteed shove into the closing ring bypasses the burst cooldown — kill-first behavior).
- **Emerge (1 survivor):** silo door bursts open with a camera pan + synthesized pneumatic SFX (all driven by one shared timeline), then the **standard map-aware par collapse** engages so a survivor can't run laps to grief everyone's time.
- **Void:** everyone dead, or a stalemate past the cap, ends the round with no winner.
- **Exclusive:** never chains with another brutal mode (it reshapes the whole arena). The safe island is immune to every tile-mutating ability (bomb/tileSwap/lava/iceCannon).

### Client/visuals
- Silo iris door clipped to the goal-tile polygon (gold goal visible underneath, not ice), sealing during the gated whole-map camera beat with a Star-Trek-door hiss.
- Off-screen goal arrow points at the buried bunker; vault-door brutal-round icon + "Bunker" announcement/HUD badge.
- Catch-up replay of `bunkerStart` (flagged sealed) so mid-round joiners still see the door.

## Test plan
- New headless `bunker-test.js` (22 assertions) wired into PR validation: bury → ring narrows field → emerge → claim, plus both void paths, AI route-via-goalSet, tileSwap/explosion island-immunity, and the lobby-ability pre-race crash regression.
- `smoke-test` (52 maps), `validate-content`, and the bundle build all green after rebasing onto current main (incl. the new Water terrain).
- Reviewed by Codex; its two findings (a lobby-tutorial crash from uninitialized `bunkerSafeIds`, and missing late-join door state) are fixed in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)