### PR TITLE
fix(ai): bots time moving-bumper rail crossings instead of stalling at the rail

### DIFF
--- a/.github/scripts/ai-bumper-cross-test.js
+++ b/.github/scripts/ai-bumper-cross-test.js
@@ -30,6 +30,7 @@ const aiController = require(path.join(repoRoot, 'server', 'aiController.js'));
 
 const T = config.tileMap;
 const GRASS = T.fast.id;
+const SLOW = T.slow.id;
 const EMPTY = T.empty.id;
 const GOAL = T.goal.id;
 const DT = config.serverTickSpeed / 1000;
@@ -63,12 +64,13 @@ const COLS = [76, 228, 380, 532, 684, 836, 988, 1140, 1290];
 const ROWS = [77, 280, 384, 488, 691];
 const RAIL_X = COLS[4];          // 684 — mid-corridor column
 const CORRIDOR_TOP = (ROWS[1] + ROWS[2]) / 2;  // 332
-function buildMap(name, hazards) {
+function buildMap(name, hazards, tile) {
+    const corridorTile = tile != null ? tile : GRASS;
     const sites = [];
     for (let col = 0; col < COLS.length; col++) {
         for (let row = 0; row < ROWS.length; row++) {
             let id = EMPTY;
-            if (row === 2) { id = (col === 8) ? GOAL : GRASS; }
+            if (row === 2) { id = (col === 8) ? GOAL : corridorTile; }
             sites.push({ x: COLS[col], y: ROWS[row], id: id });
         }
     }
@@ -174,6 +176,37 @@ try {
         if (reachedGoalAt >= 0) {
             console.log('  ..  - crossing completed in ' + reachedGoalAt + ' ticks (~' + (reachedGoalAt * DT).toFixed(1) + 's)');
         }
+    }
+
+    // ----------------------------------------------------------------------
+    console.log('\n[C] SLOW-ground rail crossing darts behind the bumper (no stuck-beeline stall)');
+    {
+        // Codex-review repro: on slow tiles (terminal ~17px/s) no provably-safe
+        // window exists on a 100px rail, and the original absolute dart bound was
+        // unsatisfiable from the staging band — staged bots sat ~57s until the
+        // 4.5s-stuck beeline rammed them through. The relative dart (go behind the
+        // receding bumper while most of the pass's headroom remains) must cross
+        // without ever needing the beeline.
+        const map = buildMap('railgate-slow', [{ id: MOVING_BUMPER, x: RAIL_X, y: CORRIDOR_TOP, angle: 90 }], SLOW);
+        const { room, bot } = bootRoom('bumper-cross-slow', map, { id: 'mud', name: 'Mud', title: '', skill: 0.85, aggression: 0.2, tempo: 0.5, risk: 0.3, focus: 'race' });
+
+        const maxTicks = 4200; // ~140s: the whole corridor is a ~17px/s crawl
+        let maxX = -Infinity, reachedGoalAt = -1, maxStallMs = 0;
+        for (let f = 0; f < maxTicks; f++) {
+            room.game.notchesToWin = 0;
+            room.update(DT);
+            clock += config.serverTickSpeed;
+            if (bot.x > maxX) { maxX = bot.x; }
+            if (bot.alive && bot.ai && bot.ai.headwayAt != null) {
+                const stall = clock - bot.ai.headwayAt;
+                if (stall > maxStallMs) { maxStallMs = stall; }
+            }
+            if (reachedGoalAt < 0 && bot.reachedGoal) { reachedGoalAt = f; }
+            if (room.game.currentState === config.stateMap.gameOver) { break; }
+        }
+        check(maxX > RAIL_X + 60, 'the bot CROSSED the rail line on slow ground (max x=' + maxX.toFixed(0) + ')');
+        check(maxStallMs < 4500, 'no stuck-beeline was needed (max continuous stall ' + maxStallMs.toFixed(0) + 'ms < 4500ms)');
+        check(bot.reachedGoal === true, 'the bot reached the goal (tick ' + reachedGoalAt + ', ~' + (reachedGoalAt * DT).toFixed(1) + 's)');
     }
 } finally {
     Date.now = realNow;

--- a/.github/scripts/ai-bumper-cross-test.js
+++ b/.github/scripts/ai-bumper-cross-test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+// Real-engine headless test for "bots can time a moving-bumper rail crossing".
+//
+// Repro for the field report: on maps where a moving bumper's rail spans the only
+// corridor to the goal, bots lined up in front of the rail and oscillated forever —
+// hazardRepulsion treated the WHOLE swept segment as a permanent wall, so the gap
+// never "opened" for them and they never attempted the crossing.
+//
+//   [A] Window predicate (pure, deterministic). railCrossingOpen must say CLOSED when
+//       the bumper is bearing down on the bot's crossing point, and OPEN when the
+//       bumper has just swept past it / is parked at the far end — including the
+//       reflect-at-the-ends round trip in the prediction.
+//
+//   [B] Rail-only crossing completes (full live tick loop). A single-corridor map
+//       whose ONLY route to the goal crosses a moving-bumper rail that sweeps the
+//       corridor's full height. A bot must wait out the bumper and dart across —
+//       the round reaches gameOver — instead of lining up at the rail forever.
+//
+// Like ai-swim-test.js this boots the REAL server modules and drives room.update(dt)
+// with Date.now mocked into a per-tick clock and Math.random seeded (mulberry32) so
+// the bot-brain jitter can't make [B] flaky.
+
+const path = require('path');
+const repoRoot = path.join(__dirname, '..', '..');
+const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
+const config = require(path.join(repoRoot, 'server', 'config.json'));
+const mapFormat = require(path.join(repoRoot, 'server', 'mapFormat.js'));
+const aiController = require(path.join(repoRoot, 'server', 'aiController.js'));
+
+const T = config.tileMap;
+const GRASS = T.fast.id;
+const EMPTY = T.empty.id;
+const GOAL = T.goal.id;
+const DT = config.serverTickSpeed / 1000;
+const MOVING_BUMPER = config.hazards.movingBumper.id; // 901
+
+let failures = 0;
+function check(cond, msg) {
+    if (cond) { console.log('  ok  - ' + msg); }
+    else { failures++; console.log('::error::FAIL - ' + msg); }
+}
+
+function mulberry32(seed) {
+    let a = seed >>> 0;
+    return function () {
+        a |= 0; a = (a + 0x6D2B79F5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+// Recording fake io so messageRoomBySig() doesn't throw (no emit assertions here).
+const fakeIo = { to() { return { emit() { } }; }, sockets: { emit() { } } };
+messenger.build(fakeIo);
+
+// Single-corridor grid: row 2 is the only walkable lane (left start -> right goal),
+// rows 1/3 squeezed in so the corridor is ~104px tall — fully swept by one 100px
+// moving-bumper rail dropped at mid-corridor (origin at the corridor's top edge,
+// angle 90 = sweeping straight down). No detour exists: time it or never finish.
+const COLS = [76, 228, 380, 532, 684, 836, 988, 1140, 1290];
+const ROWS = [77, 280, 384, 488, 691];
+const RAIL_X = COLS[4];          // 684 — mid-corridor column
+const CORRIDOR_TOP = (ROWS[1] + ROWS[2]) / 2;  // 332
+function buildMap(name, hazards) {
+    const sites = [];
+    for (let col = 0; col < COLS.length; col++) {
+        for (let row = 0; row < ROWS.length; row++) {
+            let id = EMPTY;
+            if (row === 2) { id = (col === 8) ? GOAL : GRASS; }
+            sites.push({ x: COLS[col], y: ROWS[row], id: id });
+        }
+    }
+    return mapFormat.reconstruct({
+        bbox: { xl: 0, xr: config.worldWidth, yt: 0, yb: config.worldHeight },
+        sites: sites, hazards: hazards, startEdges: ['left'], name: name, author: 'test', id: 'bumpertest-' + name
+    });
+}
+
+const realNow = Date.now;
+const realRandom = Math.random;
+let clock = 1000000;
+
+function bootRoom(sig, map, profile) {
+    const game = require(path.join(repoRoot, 'server', 'game.js'));
+    const room = game.getRoom(sig, 8);
+    room.game.gameBoard.isPreview = true;
+    room.game.gameBoard.previewMap = map;
+    const bid = sig + '-bot0';
+    const bot = room.world.createNewBot(bid, profile);
+    room.playerList[bid] = bot;
+    room.game.determineGameState(bot);
+    room.game.startLobby(); room.game.startGated(); room.game.startRace();
+    return { room, bot };
+}
+
+try {
+    Date.now = () => clock;
+    Math.random = mulberry32(0xB0B0);
+
+    // ----------------------------------------------------------------------
+    console.log('[A] railCrossingOpen predicts the bumper, including end reflections');
+    {
+        const open = aiController._test.railCrossingOpen;
+        check(typeof open === 'function', 'railCrossingOpen is exported for tests');
+        if (typeof open === 'function') {
+            // A vertical 100px rail at x=684, y 332..432, like map [B] below. The fake
+            // bot sits 40px left of the rail line, level with the corridor middle.
+            const rail = { x: RAIL_X, y: CORRIDOR_TOP, angle: 90, width: 100, lengthSq: 100 * 100 };
+            const mkBumper = (t, outward) => ({
+                x: RAIL_X, y: CORRIDOR_TOP + t, radius: 10,
+                speed: config.hazards.movingBumper.speed,
+                angle: outward ? 90 : -90, rail: rail, moveable: true
+            });
+            const bot = { x: RAIL_X - 40, y: CORRIDOR_TOP + 50, velX: 0, velY: 0 };
+            // Bumper sitting right on the crossing point, heading at it -> closed.
+            check(open(bot, mkBumper(50, true), DT) === false,
+                'CLOSED with the bumper parked on the crossing point');
+            // Bumper closing in from 30px up-rail -> closed.
+            check(open(bot, mkBumper(20, true), DT) === false,
+                'CLOSED with the bumper 30px away and closing');
+            // Mid-rail, right behind the bumper as it sweeps away: on a 100px rail at
+            // ~67px/s the bumper is back within strike of the midpoint ~0.7s after
+            // passing it — quicker than any dash across — so mid-rail stays CLOSED.
+            // (This is why the waiting behavior slides bots toward a rail END.)
+            check(open(bot, mkBumper(78, true), DT) === false,
+                'CLOSED mid-rail even right behind the bumper (round trip beats the dash)');
+            // Crossing near a rail END while the bumper retreats into the long arm ->
+            // the round trip back is the whole rail -> open.
+            const botAtEnd = { x: RAIL_X - 40, y: CORRIDOR_TOP + 90, velX: 0, velY: 0 };
+            check(open(botAtEnd, mkBumper(40, false), DT) === true,
+                'OPEN near the rail end with the bumper retreating to the far end');
+            // Same end-crossing but the bumper is heading FOR that end -> closed: the
+            // prediction must include the reflection-free direct arrival.
+            check(open(botAtEnd, mkBumper(60, true), DT) === false,
+                'CLOSED near the rail end with the bumper inbound to that end');
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    console.log('\n[B] a bot times the rail and finishes a corridor only a bumper crossing serves');
+    {
+        // Rail origin at the corridor's top edge, sweeping down its full ~104px height:
+        // there is no way around, only through — exactly the field-reported lineup spot.
+        const map = buildMap('railgate', [{ id: MOVING_BUMPER, x: RAIL_X, y: CORRIDOR_TOP, angle: 90 }]);
+        const { room, bot } = bootRoom('bumper-cross', map, { id: 'timer', name: 'Timer', title: '', skill: 0.85, aggression: 0.2, tempo: 0.5, risk: 0.3, focus: 'race' });
+        check(Object.keys(room.game.gameBoard.hazardList).length > 0, 'the moving bumper spawned from the map hazard entry');
+
+        const maxTicks = 2400; // ~80s game time; a timed crossing lands well under this
+        let maxX = -Infinity, reachedGoalAt = -1, everNearRail = false, maxStallMs = 0;
+        for (let f = 0; f < maxTicks; f++) {
+            room.game.notchesToWin = 0; // first finish = outright win -> gameOver on goal touch
+            room.update(DT);
+            clock += config.serverTickSpeed;
+            if (bot.x > maxX) { maxX = bot.x; }
+            if (Math.abs(bot.x - RAIL_X) < 120) { everNearRail = true; }
+            // Continuous no-headway time: the last-resort beeline fires at 4500ms of
+            // this. A bot that TIMES the gap keeps moving (staging, sliding to the rail
+            // end, darting) and never gets near it — pre-fix, the lineup blew past it.
+            if (bot.alive && bot.ai && bot.ai.headwayAt != null) {
+                const stall = clock - bot.ai.headwayAt;
+                if (stall > maxStallMs) { maxStallMs = stall; }
+            }
+            if (reachedGoalAt < 0 && bot.reachedGoal) { reachedGoalAt = f; }
+            if (room.game.currentState === config.stateMap.gameOver) { break; }
+        }
+        check(everNearRail, 'the bot reached the rail (drove the corridor)');
+        check(maxX > RAIL_X + 60, 'the bot actually CROSSED the rail line (max x=' + maxX.toFixed(0) + ', rail at ' + RAIL_X + ')');
+        check(maxStallMs < 4500, 'the crossing came from gap timing, not the stuck-beeline ram (max continuous stall ' + maxStallMs.toFixed(0) + 'ms < 4500ms)');
+        check(bot.reachedGoal === true, 'the bot reached the goal beyond the bumper (reachedGoal at tick ' + reachedGoalAt + ')');
+        check(room.game.currentState === config.stateMap.gameOver,
+            'the round reached gameOver (state=' + room.game.currentState + ') — a rail-gated corridor does not stall');
+        if (reachedGoalAt >= 0) {
+            console.log('  ..  - crossing completed in ' + reachedGoalAt + ' ticks (~' + (reachedGoalAt * DT).toFixed(1) + 's)');
+        }
+    }
+} finally {
+    Date.now = realNow;
+    Math.random = realRandom;
+}
+
+console.log('');
+if (failures > 0) {
+    console.log('AI-bumper-cross test FAILED with ' + failures + ' error(s).');
+    process.exit(1);
+}
+console.log('AI-bumper-cross test passed.');
+process.exit(0);

--- a/.github/scripts/ai-fitness.js
+++ b/.github/scripts/ai-fitness.js
@@ -1,0 +1,96 @@
+'use strict';
+
+// AI fitness harness — the measurement protocol from the PR #181 ice-nav work,
+// made durable. For each seed it runs a full 120s race window on the pinned map
+// with 6 cast bots (real engine, mocked clock, seeded RNG) and reports per-map:
+//
+//   finishers     cumulative finish EVENTS (reachedGoal rising edges — rounds
+//                 cycle inside the window and reset the flag, so edges are
+//                 counted, not the end-state)
+//   frozen        bots alive but motionless (<40px) over the window's last 5s —
+//                 the "parked at an obstacle" pathology
+//   deaths        cumulative death events, with medianDeathX (how far along the
+//                 map bots die)
+//   avgX          mean of each bot's max x reached (progress proxy)
+//
+// Use it A/B: run the same maps+seeds against two checkouts (REPO_ROOT) and
+// diff. Maps with no moving hazards should produce IDENTICAL lines for an
+// AI-steering change — a built-in determinism check. Known-completable control
+// maps: crossroads, FastandSlow, IcyLake.
+//
+// Usage: REPO_ROOT=<repo checkout> node ai-fitness.js <MapName> [nSeeds=8]
+// Not CI-wired (a 14-map sweep is minutes of CPU); run it when touching
+// server/aiController.js steering or pathing.
+const W = process.env.REPO_ROOT;
+const fs = require('fs');
+// Mock clock + scheduled timeouts BEFORE requiring game modules (harness memo).
+let simNow = 1e6; const realDateNow = Date.now; Date.now = () => simNow;
+const pend = [];
+global.setTimeout = (fn, d, ...a) => { pend.push({ at: simNow + (d || 0), fn, a }); return pend.length; };
+global.clearTimeout = () => { };
+function tickClock(ms) { simNow += ms; pend.sort((a, b) => a.at - b.at); while (pend.length && pend[0].at <= simNow) { const t = pend.shift(); try { t.fn(...t.a); } catch (e) { } } }
+const messenger = require(W + '/server/messenger.js');
+messenger.build({ to() { return { emit() { } }; }, sockets: { emit() { } } });
+const config = require(W + '/server/config.json');
+const mapFormat = require(W + '/server/mapFormat.js');
+const game = require(W + '/server/game.js');
+const DT = config.serverTickSpeed / 1000;
+const TICKS = Math.round(120 / DT); // 120s window
+const mapName = process.argv[2];
+const N_SEEDS = parseInt(process.argv[3] || '8', 10);
+const raw = JSON.parse(fs.readFileSync(W + '/client/maps/' + mapName + '.json'));
+const cast = (config.aiRacers && config.aiRacers.cast) || [];
+
+function mulberry32(seed) { let a = seed >>> 0; return function () { a |= 0; a = (a + 0x6D2B79F5) | 0; let t = Math.imul(a ^ (a >>> 15), 1 | a); t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t; return ((t ^ (t >>> 14)) >>> 0) / 4294967296; }; }
+
+let finishers = 0, frozen = 0, total = 0;
+const deathXs = []; let sumMaxX = 0;
+for (let s = 0; s < N_SEEDS; s++) {
+  Math.random = mulberry32(0xA11CE + s * 7919);
+  const map = raw.sites ? mapFormat.reconstruct(JSON.parse(JSON.stringify(raw))) : JSON.parse(JSON.stringify(raw));
+  const room = game.getRoom('fit-' + mapName + '-' + s, 8);
+  room.game.gameBoard.isPreview = true;
+  room.game.gameBoard.previewMap = map;
+  const bots = [];
+  for (let i = 0; i < 6; i++) {
+    const bid = 'fit' + s + '-bot' + i;
+    const b = room.world.createNewBot(bid, cast.length ? cast[i % cast.length] : null);
+    room.playerList[bid] = b; bots.push(b);
+  }
+  room.game.determineGameState(bots[0]);
+  room.game.startLobby(); room.game.startGated();
+  for (let g = 0; g < 30; g++) { tickClock(config.serverTickSpeed); room.update(DT); }
+  room.game.startRace();
+  const lateMark = TICKS - Math.round(5 / DT); // positions 5s before window end
+  const lastPos = {}; const maxXById = {};
+  // Rounds cycle inside the 120s window (reachedGoal/alive reset each round), so
+  // count finish/death EVENTS on edges, cumulatively across the window.
+  const prevGoal = {}, prevAlive = {};
+  for (const b of bots) { prevGoal[b.id] = false; prevAlive[b.id] = true; }
+  for (let f = 0; f < TICKS; f++) {
+    room.game.notchesToWin = 99; // don't end the match on a finish; measure everyone
+    tickClock(config.serverTickSpeed);
+    try { room.update(DT); } catch (e) { console.log('TICK THROW seed ' + s + ': ' + e.message); break; }
+    if (f === lateMark) { for (const b of bots) { lastPos[b.id] = { x: b.x, y: b.y }; } }
+    if (f % 10 === 0) { for (const b of bots) { if (b.x > (maxXById[b.id] || -1e9)) { maxXById[b.id] = b.x; } } }
+    for (const b of bots) {
+      if (b.reachedGoal && !prevGoal[b.id]) { finishers++; }
+      prevGoal[b.id] = !!b.reachedGoal;
+      if (!b.alive && prevAlive[b.id]) { deathXs.push(Math.round(b.x)); }
+      prevAlive[b.id] = !!b.alive;
+    }
+    if (room.game.currentState === config.stateMap.gameOver) { break; }
+  }
+  for (const b of bots) {
+    total++;
+    sumMaxX += (maxXById[b.id] != null ? maxXById[b.id] : b.x);
+    if (b.alive && !b.reachedGoal) {
+      const lp = lastPos[b.id];
+      if (lp != null && Math.hypot(b.x - lp.x, b.y - lp.y) < 40) { frozen++; }
+    }
+  }
+}
+deathXs.sort((a, b) => a - b);
+const med = deathXs.length ? deathXs[Math.floor(deathXs.length / 2)] : -1;
+console.log(mapName + ': finishers=' + finishers + '/' + total + ' frozen=' + frozen + ' deaths=' + deathXs.length + ' medianDeathX=' + med + ' avgX=' + Math.round(sumMaxX / total));
+process.exit(0);

--- a/.github/scripts/ai-telegraph-engine-test.js
+++ b/.github/scripts/ai-telegraph-engine-test.js
@@ -9,6 +9,9 @@
 // the fake socket.io `io` RECORDS every emit so we can assert the ability actually
 // fired end-to-end (bombUsed/spawnBomb, iceCannon/spawnSnowFlake, swapUsed,
 // blindfoldUsed) and that the spawned projectile was aimed where we expect.
+// Math.random is seeded (mulberry32, repo headless-test convention) — unseeded, the
+// AI brain's per-tick jitter (wander, off-moments, ability dice) made this test
+// ~10% flaky, usually on the blindfold scenario.
 
 const fs = require('fs');
 const path = require('path');
@@ -58,7 +61,22 @@ function lavaWithin(map, x, y, r) {
 }
 
 const realNow = Date.now;
+const realRandom = Math.random;
 let clock = 1000000;
+
+// Deterministic PRNG (mulberry32) over Math.random for the whole run — same
+// convention as ai-swim-test.js / ai-bumper-cross-test.js, and the fix for this
+// test's long-standing ~10% flake (the unseeded AI-brain jitter occasionally
+// rolled a run where the blindfold deployment dithered past the tick budget).
+function mulberry32(seed) {
+    let a = seed >>> 0;
+    return function () {
+        a |= 0; a = (a + 0x6D2B79F5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
 
 // Boot a fresh room with `nBots` bots (+ optional human), pinned to `map`, in racing.
 function bootRoom(sig, map, nBots, withHuman) {
@@ -125,6 +143,7 @@ function tickUntil(room, pins, eventHeader, maxTicks) {
 
 try {
     Date.now = () => clock;
+    Math.random = mulberry32(0x7E1E);
 
     const mapsDir = path.join(repoRoot, 'client', 'maps');
     const file = fs.readdirSync(mapsDir).filter(f => f.endsWith('.json'))[0];
@@ -270,6 +289,7 @@ try {
     }
 } finally {
     Date.now = realNow;
+    Math.random = realRandom;
 }
 
 console.log('');

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -184,6 +184,9 @@ jobs:
       - name: "Headless AI telegraph-dodge test (bots steer out of Orbital Beam line / lava-explosion aimer)"
         run: node .github/scripts/ai-telegraph-dodge-test.js
 
+      - name: "Headless AI bumper-cross test (bots time a moving-bumper rail instead of lining up forever)"
+        run: node .github/scripts/ai-bumper-cross-test.js
+
   perf-tick-budget:
     # Server-side worst-case load: a full 25-kart grid in a stacked brutal round.
     # Proves one room still ticks well within the 30 Hz interval. Zero new deps —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- AI racers can finally get past **moving bumpers**. They used to treat the bumper's whole sweep as a wall — lining up in front of it and shuffling back and forth forever without ever crossing. Now they time it like a player: hold just outside the strike zone, drift toward the end of the bumper's run where the gap stays open longest, and dart through behind it as it sweeps away. On slow ground, where no perfectly safe window exists, they'll chance a crossing right behind the bumper rather than freeze.
 
 ## v0.32.1 — 2026-06-11
 

--- a/client/scripts/learn.js
+++ b/client/scripts/learn.js
@@ -114,7 +114,7 @@
                   detail: "A pickup pad. Roll across it to grab a random single-use power. It goes dormant briefly after someone claims it, then lights back up for the next racer." },
                 { id: "tile-bumper", name: "Bumpers", icon: art("bumper"), anim: "bumper",
                   blurb: "Springy obstacles that fling you back.",
-                  detail: "Bump one and you're flung away — maddening in a hurry, but a clever way to launch a chasing rival off their line. Some maps add moving bumpers that sweep across the track, so the safe lane keeps shifting." },
+                  detail: "Bump one and you're flung away — maddening in a hurry, but a clever way to launch a chasing rival off their line. Some maps add moving bumpers that sweep across the track, so the safe lane keeps shifting. Rival AI racers time those sweeps like you do — they hold at the edge of the bumper's path and dart through behind it, favoring the ends of its run where the gap stays open longest." },
                 { id: "tile-random", name: "Random Ground", icon: swatch("#7c3aed"), anim: "randomTile",
                   blurb: "A wildcard disguised as another surface.",
                   detail: "A trickster tile. It masquerades as one of the ordinary surfaces, so you won't know whether you're about to hit speedy grass or draggy sand until you're already committed to it." }

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -31,6 +31,41 @@ var BRAKE_SPEED_MIN = 30;       // only brake for turns/lava when moving faster 
 var HAZARD_AVOID_RADIUS = 64;   // px: start steering away from a bumper within this
 var HAZARD_AVOID_STRENGTH = 1.7;// weight of hazard repulsion vs desired heading
 var BUMPER_DANGER_PAD = 22;     // px: extra clearance for a bumper's strike (radius+punch)
+// MOVING-bumper rail crossing. The whole swept rail used to be a permanent
+// repulsive wall, so on a route that HAD to cross it the bots queued up at the
+// rail and oscillated forever — there was no notion of timing the gap. But the
+// bumper's motion is fully deterministic (constant sweep, exact reflection at the
+// rail ends), so it can be predicted: when the bumper cannot come within strike
+// range of the bot's crossing point before the bot has cleared the strike band,
+// the gap is OPEN — drop the rail repulsion and let the carrot carry the bot
+// across, exactly like a human darting through behind the bumper. While the gap
+// is CLOSED, stage just outside the strike band (not the big avoid radius, so the
+// dash is short when it opens) and slide toward the nearer rail END, where the
+// bumper spends the least time and the windows are widest.
+var RAIL_STRIKE = c.hazards.movingBumper.attackRadius + c.playerBaseRadius + 4; // px: bumper strike reach vs a kart (+pad)
+var RAIL_WAIT_GAP = 16;         // px: staging standoff outside the strike band while the gap is closed
+var RAIL_WAIT_STRENGTH = 2.5;   // closed-gap wall: holds the equilibrium just outside the band
+var RAIL_END_SLIDE = 0.35;      // tangential drift toward the nearer rail end while waiting
+var RAIL_CROSS_SPEED = 48;      // px/s: dash-speed fallback when the tile under the bot is unknown
+var RAIL_CROSS_MARGIN = 1.05;   // safety factor on the predicted exposure time
+var RAIL_SAMPLE_STEP = 0.06;    // s: resolution of the predicted bumper walk
+// On slow ground (terminal speed ~17-21px/s) NO window on a standard 100px rail is
+// ever provably safe — the crossing takes longer than the bumper's whole round
+// trip. A human there darts right behind the bumper as it sweeps past and accepts
+// the risk of a glancing bump (knockback, not death). When the best window the
+// rail can EVER offer doesn't cover the exposure, degrade to that: go once the
+// bumper has swept past and at least this fraction of the exposure fits before it
+// can return. Without this, slow-tile rails freeze bots exactly like the old wall.
+var RAIL_DART_FRACTION = 0.6;
+// Tile id -> tile def, for estimating the dash speed off the ground under the bot
+// (terminal speed = acel*dt/drag, times the engine's 0.8 bot-input scale).
+var TILE_BY_ID = {};
+for (var tileKey in c.tileMap) {
+    var tileDef = c.tileMap[tileKey];
+    if (tileDef && tileDef.id != null && tileDef.acel != null && tileDef.dragCoeff != null) {
+        TILE_BY_ID[tileDef.id] = tileDef;
+    }
+}
 var COLLAPSE_DANGER_MARGIN = 55;// px: also block cells this close to the lava front
 var LAVA_AVOID_RADIUS = 70;     // px: soft repulsion from a lava cell center within this
 var LAVA_AVOID_STRENGTH = 2.2;  // weight of the soft lava field
@@ -235,14 +270,80 @@ function carrotPoint(bot, waypoints, startIndex) {
     return { x: waypoints[last].x, y: waypoints[last].y };
 }
 
+// Whether the gap is open for THIS bot to cross h's rail right now. Walks the
+// bumper's deterministic future (constant sweep, reflecting at the rail ends)
+// across the bot's exposure window — from entering the strike band to clearing
+// its far side — and reports closed if the bumper can be within strike range of
+// the bot's crossing point at any sampled moment of that window.
+function railCrossingOpen(bot, h, dt, vFloor) {
+    var rail = h.rail;
+    var rad = rail.angle * Math.PI / 180;
+    var dirX = Math.cos(rad), dirY = Math.sin(rad);
+    var len = rail.width;
+    var tB = (h.x - rail.x) * dirX + (h.y - rail.y) * dirY;     // bumper's rail param
+    var tP = (bot.x - rail.x) * dirX + (bot.y - rail.y) * dirY; // bot's crossing param
+    if (tP < 0) { tP = 0; } else if (tP > len) { tP = len; }
+    // Perpendicular distance from the bot to the rail line.
+    var perp = Math.abs((bot.x - rail.x) * dirY - (bot.y - rail.y) * dirX);
+    // engine.updateHazards steps the rail param by speed*dt² per tick -> speed*dt px/s.
+    var vBump = h.speed * dt;
+    if (!(vBump > 0)) { return true; } // frozen bumper: nothing to time
+    var vBot = mag(bot.velX, bot.velY);
+    var floor = vFloor != null ? vFloor : RAIL_CROSS_SPEED;
+    if (vBot < floor) { vBot = floor; }
+    var tEnter = (perp - RAIL_STRIKE) / vBot;                    // first moment the bot is strikable
+    if (tEnter < 0) { tEnter = 0; }
+    var tExit = ((perp + RAIL_STRIKE) / vBot) * RAIL_CROSS_MARGIN; // bot fully clear of the band
+    var dir = (h.angle === rail.angle) ? 1 : -1;
+    // The longest gap this rail can EVER offer at this crossing point: the bumper
+    // retreating from it into the longer arm and coming all the way back. If even
+    // that doesn't cover the exposure (slow ground), no safe window exists — dart
+    // right behind the receding bumper instead, once enough of the exposure fits
+    // before it can possibly return (best effort; a glancing bump beats freezing).
+    var longArm = (tP > len - tP ? tP : len - tP) - RAIL_STRIKE;
+    if (longArm < 0) { longArm = 0; }
+    if (tExit >= (2 * longArm) / vBump) {
+        if ((tP - tB) * dir >= 0) { return false; } // still bearing down on the crossing point
+        if (Math.abs(tP - tB) < RAIL_STRIKE) { return false; } // not clear of it yet
+        var end = dir > 0 ? len : 0;
+        var timeBack = (Math.abs(end - tB) + Math.abs(end - tP) - RAIL_STRIKE) / vBump;
+        return timeBack >= tExit * RAIL_DART_FRACTION;
+    }
+    var t = tB;
+    for (var s = 0; s <= tExit; s += RAIL_SAMPLE_STEP) {
+        if (s >= tEnter && Math.abs(t - tP) < RAIL_STRIKE) { return false; }
+        t += dir * vBump * RAIL_SAMPLE_STEP;
+        if (t >= len) { t = len; dir = -1; }
+        else if (t <= 0) { t = 0; dir = 1; }
+    }
+    return true;
+}
+
+// Dash-speed floor for the crossing prediction, from the ground under the bot:
+// terminal speed on the tile (acel*dt/drag) times the engine's 0.8 bot-input
+// scale. Slow tiles crawl (~17px/s) while fast tiles fly (~62px/s) — assuming one
+// global dash speed opened windows on slow ground that weren't really safe.
+function railDashFloor(bot, ctx) {
+    var tile = TILE_BY_ID[nearestTileId(ctx, bot.x, bot.y)];
+    if (!tile) { return RAIL_CROSS_SPEED; }
+    var v = (tile.acel * (c.serverTickSpeed / 1000) / tile.dragCoeff) * 0.8;
+    return v < 14 ? 14 : v;
+}
+
 // Sum of repulsion away from nearby bumpers/moving bumpers, scaled so it ramps
 // up sharply as the bot closes on a hazard's strike range. Returns {x,y} (may be
 // {0,0} when clear). A moving bumper (has a rail) is dodged from the closest point
 // on the WHOLE swept segment — not its flickering instantaneous position — so the
 // push stays a stable "stay off the track" vector instead of jittering as the
 // bumper races back and forth, which is what let bots thread in and get clipped.
-function hazardRepulsion(bot, hazardList) {
+// EXCEPT when the bot's route actually crosses the rail: then the segment-as-wall
+// would pin it there forever, so it times the gap instead (railCrossingOpen) —
+// commit across while open, stage at the band edge and drift toward a rail end
+// while closed.
+function hazardRepulsion(bot, ctx, desiredX, desiredY, dt) {
     var rx = 0, ry = 0;
+    var hazardList = ctx.hazardList;
+    var vFloor = null; // computed lazily, once, only when a railed bumper is in play
     for (var id in hazardList) {
         var h = hazardList[id];
         if (h.alive === false) { continue; }
@@ -250,6 +351,34 @@ function hazardRepulsion(bot, hazardList) {
         if (h.moveable && h.rail != null) {
             var seg = bumperSegment(h);
             var cp = closestOnSegment(bot.x, bot.y, seg.ax, seg.ay, seg.bx, seg.by);
+            // Crossing intent: the desired heading drives INTO the rail (the route
+            // continues on the other side). Only then does gap timing apply — a bot
+            // merely skirting alongside keeps the plain stay-away field below.
+            var nx = bot.x - cp.x, ny = bot.y - cp.y;
+            var nd = mag(nx, ny);
+            if (nd > 0.0001 && (desiredX * nx + desiredY * ny) / nd < -0.1) {
+                if (vFloor == null) { vFloor = railDashFloor(bot, ctx); }
+                if (railCrossingOpen(bot, h, dt, vFloor)) { continue; } // gap open: commit across
+                // Gap closed: hold just outside the strike band so the dash is short
+                // when it opens...
+                var waitRange = RAIL_STRIKE + RAIL_WAIT_GAP;
+                if (nd < waitRange) {
+                    var ww = (waitRange - nd) / waitRange; // linear: a hard wall, not a soft field
+                    rx += (nx / nd) * ww * RAIL_WAIT_STRENGTH;
+                    ry += (ny / nd) * ww * RAIL_WAIT_STRENGTH;
+                }
+                // ...and drift toward the nearer rail END, where the bumper spends the
+                // least time and the crossing windows are widest.
+                if (nd < HAZARD_AVOID_RADIUS + waitRange) {
+                    var radR = h.rail.angle * Math.PI / 180;
+                    var ax = Math.cos(radR), ay = Math.sin(radR);
+                    var tP = (bot.x - h.rail.x) * ax + (bot.y - h.rail.y) * ay;
+                    var toEnd = (tP < h.rail.width / 2) ? -1 : 1;
+                    rx += ax * toEnd * RAIL_END_SLIDE;
+                    ry += ay * toEnd * RAIL_END_SLIDE;
+                }
+                continue;
+            }
             hx = cp.x; hy = cp.y;
         }
         var dx = bot.x - hx, dy = bot.y - hy;
@@ -394,7 +523,12 @@ var TELEGRAPH_AVOID_MARGIN = 26;   // px clearance beyond the strike zone's edge
 var TELEGRAPH_BEAM_STRENGTH = 2.8; // perpendicular push out of an Orbital Beam band
 var TELEGRAPH_CIRCLE_STRENGTH = 2.6; // push away from a lava-explosion aimer center
 var LIGHTNING_FEELER_MULT = 1.45; // see farther ahead when everyone's sped up
-var HAZARD_PATH_PENALTY = 12;     // cost x for routing a path through a bumper's cell
+// Cost multiplier for routing a path through a bumper's cell. Was 12 back when a
+// moving bumper's rail was an uncrossable wall to the local steering — which sent
+// routes on absurd detours and, where no detour existed, parked the bots in front
+// of the rail forever. Now that they can TIME a rail crossing (railCrossingOpen),
+// a rail cell just costs "a short wait + some risk", so price it like one.
+var HAZARD_PATH_PENALTY = 4;
 
 var AB = c.tileMap.abilities;
 
@@ -1405,7 +1539,7 @@ function steerBot(bot, ctx, dt) {
     // wants no avoidance bending its decisive line (it has been frozen for seconds).
     var ignoreLava = bot.isZombie === true || beelining;
     var fl = ignoreLava ? { x: 0, y: 0, brake: false } : feelerAvoid(bot, ctx, headX, headY, speed);
-    var hz = beelining ? { x: 0, y: 0 } : hazardRepulsion(bot, ctx.hazardList);
+    var hz = beelining ? { x: 0, y: 0 } : hazardRepulsion(bot, ctx, desiredX, desiredY, dt);
     var lv = ignoreLava ? { x: 0, y: 0 } : lavaRepulsion(bot, ctx.lavaCells);
 
     // Lava dead ahead means the current line is bad — re-path next tick to find a
@@ -1875,6 +2009,7 @@ module.exports._test = {
     bumperSegment: bumperSegment,
     closestOnSegment: closestOnSegment,
     hazardRepulsion: hazardRepulsion,
+    railCrossingOpen: railCrossingOpen,
     telegraphRepulsion: telegraphRepulsion,
     decideAbility: decideAbility,
     newBotState: newBotState,

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -52,10 +52,11 @@ var RAIL_SAMPLE_STEP = 0.06;    // s: resolution of the predicted bumper walk
 // On slow ground (terminal speed ~17-21px/s) NO window on a standard 100px rail is
 // ever provably safe — the crossing takes longer than the bumper's whole round
 // trip. A human there darts right behind the bumper as it sweeps past and accepts
-// the risk of a glancing bump (knockback, not death). When the best window the
-// rail can EVER offer doesn't cover the exposure, degrade to that: go once the
-// bumper has swept past and at least this fraction of the exposure fits before it
-// can return. Without this, slow-tile rails freeze bots exactly like the old wall.
+// the risk of a glancing bump (knockback, not death). When the rail can't offer a
+// safe window ANYWHERE for this bot's speed, degrade to that dart: go behind the
+// receding bumper while at least this fraction of the pass's best headroom
+// remains (relative, so it fires once per sweep at any ground speed — an absolute
+// time bound is unsatisfiable on slow tiles and froze staged bots).
 var RAIL_DART_FRACTION = 0.6;
 // Tile id -> tile def, for estimating the dash speed off the ground under the bot
 // (terminal speed = acel*dt/drag, times the engine's 0.8 bot-input scale).
@@ -103,6 +104,14 @@ var WATER_ENTRY_LOOKAHEAD = 60; // px ahead (plus a speed term) to sniff for upc
 // lava field + kills the random wobble so it can hug a wall and thread the gap.
 var STUCK_RADIUS = 40;          // px: staying within this of an anchor spot = no real headway
 var STUCK_TRIGGER = 1.6;        // s loitering inside STUCK_RADIUS before an escape fires
+// A bot CRUISING isn't stuck. On slow tiles the terminal speed (~17-21px/s)
+// covers less than STUCK_RADIUS per STUCK_TRIGGER window, so without a speed
+// gate the escape branch re-anchors every window while the bot drives flat-out
+// — a treadmill that pins every slow-ground bot in permanent escape/beeline
+// (headwayAt can never reset because the anchor leapfrogs along). Only treat a
+// bot as wedged when it's actually near-stationary; 12px/s sits safely under
+// every tile's bot terminal speed while still catching real pinch grinds.
+var STUCK_SPEED_MAX = 12;
 var ESCAPE_MS = 1400;           // ms an escape lasts once triggered
 var ESCAPE_LAVA_RELAX = 0.45;   // shrink the SOFT lava-centering field during an escape (thread the gap)
 var ESCAPE_WANDER_KILL = true;  // suppress the random wobble during an escape so it doesn't fight the gap
@@ -295,19 +304,27 @@ function railCrossingOpen(bot, h, dt, vFloor) {
     if (tEnter < 0) { tEnter = 0; }
     var tExit = ((perp + RAIL_STRIKE) / vBot) * RAIL_CROSS_MARGIN; // bot fully clear of the band
     var dir = (h.angle === rail.angle) ? 1 : -1;
-    // The longest gap this rail can EVER offer at this crossing point: the bumper
-    // retreating from it into the longer arm and coming all the way back. If even
-    // that doesn't cover the exposure (slow ground), no safe window exists — dart
-    // right behind the receding bumper instead, once enough of the exposure fits
-    // before it can possibly return (best effort; a glancing bump beats freezing).
-    var longArm = (tP > len - tP ? tP : len - tP) - RAIL_STRIKE;
-    if (longArm < 0) { longArm = 0; }
-    if (tExit >= (2 * longArm) / vBump) {
+    // The longest gap this rail can offer ANYWHERE (crossing right at an end while
+    // the bumper runs the full rail and back). If even that doesn't cover this
+    // bot's exposure — slow ground — then no safe window exists at any crossing
+    // point and waiting can never pay off (the old absolute check here was
+    // unsatisfiable from the staging band, so staged bots sat until the stuck
+    // beeline rammed them through). Dart instead: go right behind the receding
+    // bumper while most of THIS pass's headroom remains — best effort, judged
+    // relative to the best this pass can offer, so it actually fires once per
+    // sweep at any ground speed (a glancing bump beats freezing).
+    if (tExit >= (2 * (len - RAIL_STRIKE)) / vBump) {
         if ((tP - tB) * dir >= 0) { return false; } // still bearing down on the crossing point
         if (Math.abs(tP - tB) < RAIL_STRIKE) { return false; } // not clear of it yet
         var end = dir > 0 ? len : 0;
-        var timeBack = (Math.abs(end - tB) + Math.abs(end - tP) - RAIL_STRIKE) / vBump;
-        return timeBack >= tExit * RAIL_DART_FRACTION;
+        var arm = Math.abs(end - tP); // run the bumper is heading into, from the crossing point
+        var head = arm - RAIL_STRIKE; // headroom left at the moment the bumper CLEARS the point
+        if (head <= 0) { return false; } // it reflects right back onto the point — wait for the other sweep
+        var timeBack = (Math.abs(end - tB) + arm - RAIL_STRIKE) / vBump;
+        // Judge against the most a post-clearance dart can ever have (2*head/vBump),
+        // NOT a gap-0 ideal the clearance guard makes unreachable — that off-by-a-
+        // strike-radius made the window ~0.1s and slow bots never caught it.
+        return timeBack >= (2 * head / vBump) * RAIL_DART_FRACTION;
     }
     var t = tB;
     for (var s = 0; s <= tExit; s += RAIL_SAMPLE_STEP) {
@@ -358,7 +375,22 @@ function hazardRepulsion(bot, ctx, desiredX, desiredY, dt) {
             var nd = mag(nx, ny);
             if (nd > 0.0001 && (desiredX * nx + desiredY * ny) / nd < -0.1) {
                 if (vFloor == null) { vFloor = railDashFloor(bot, ctx); }
-                if (railCrossingOpen(bot, h, dt, vFloor)) { continue; } // gap open: commit across
+                // Committed dart in flight: once a window fires, hold the door open
+                // for the whole estimated crossing. Without this latch a slow bot
+                // re-evaluates every tick, the brief window flickers shut before it
+                // has moved, and the wait wall shoves it right back out.
+                var aiSt = bot.ai;
+                var goKey = 'rg' + id;
+                var nowMs = Date.now();
+                if (aiSt && aiSt.railGo && aiSt.railGo[goKey] > nowMs) { continue; }
+                if (railCrossingOpen(bot, h, dt, vFloor)) { // gap open: commit across
+                    if (aiSt) {
+                        if (aiSt.railGo == null) { aiSt.railGo = {}; }
+                        var crossMs = ((nd + RAIL_STRIKE) / (vFloor < 14 ? 14 : vFloor)) * 1500; // 1.5x est. crossing time
+                        aiSt.railGo[goKey] = nowMs + (crossMs > 8000 ? 8000 : crossMs);
+                    }
+                    continue;
+                }
                 // Gap closed: hold just outside the strike band so the dash is short
                 // when it opens...
                 var waitRange = RAIL_STRIKE + RAIL_WAIT_GAP;
@@ -523,12 +555,16 @@ var TELEGRAPH_AVOID_MARGIN = 26;   // px clearance beyond the strike zone's edge
 var TELEGRAPH_BEAM_STRENGTH = 2.8; // perpendicular push out of an Orbital Beam band
 var TELEGRAPH_CIRCLE_STRENGTH = 2.6; // push away from a lava-explosion aimer center
 var LIGHTNING_FEELER_MULT = 1.45; // see farther ahead when everyone's sped up
-// Cost multiplier for routing a path through a bumper's cell. Was 12 back when a
-// moving bumper's rail was an uncrossable wall to the local steering — which sent
-// routes on absurd detours and, where no detour existed, parked the bots in front
-// of the rail forever. Now that they can TIME a rail crossing (railCrossingOpen),
-// a rail cell just costs "a short wait + some risk", so price it like one.
-var HAZARD_PATH_PENALTY = 4;
+// Cost multipliers for routing through a bumper's cell — priced per hazard class.
+// STATIC bumpers stay harsh (12): they sit on the spot forever and a route through
+// one means getting knocked, so only a big detour saving justifies it. MOVING
+// rails are mild (4): the bots can TIME a rail crossing (railCrossingOpen), so a
+// rail cell just costs "a short wait + some risk". Lowering the static penalty
+// along with the rail one made A* thread static-bumper fields (goldeyes,
+// sidewinder) for modest detour savings — exactly the knock/stuck routes the
+// penalty exists to prevent.
+var HAZARD_PATH_PENALTY = 12;
+var RAIL_PATH_PENALTY = 4;
 
 var AB = c.tileMap.abilities;
 
@@ -1331,7 +1367,8 @@ function steerBot(bot, ctx, dt) {
             ai.progressAt = nowProbe;
             ai.headwayAt = nowProbe; // real headway -> reset the continuous-stuck clock
             ai.escapeUntil = 0; ai.escapeStage = 0; ai.lastEscapeAt = 0; // real headway -> escape over
-        } else if ((nowProbe - ai.progressAt) / 1000 >= STUCK_TRIGGER && nowProbe >= ai.escapeUntil) {
+        } else if ((nowProbe - ai.progressAt) / 1000 >= STUCK_TRIGGER && nowProbe >= ai.escapeUntil &&
+            mag(bot.velX, bot.velY) < STUCK_SPEED_MAX) {
             // Re-triggering after a previous escape that real progress never cleared
             // means the gentle approach didn't free it -> escalate the push (keyed off
             // lastEscapeAt, which only survives if no re-anchor reset it — so a different,
@@ -1364,8 +1401,10 @@ function steerBot(bot, ctx, dt) {
             blocked: blocked,
             noiseSeed: ai.pathSeed,
             noiseAmount: 0.15 + (1 - ai.skill) * 0.2,
-            penaltySet: ctx.hazardCells, // route AROUND bumper cells (soft penalty)
-            penaltyMult: HAZARD_PATH_PENALTY
+            penaltySet: ctx.staticHazardCells, // route AROUND static bumpers (harsh soft penalty)
+            penaltyMult: HAZARD_PATH_PENALTY,
+            penaltySet2: ctx.railCells, // moving rails are timeable — mild penalty
+            penaltyMult2: RAIL_PATH_PENALTY
         };
         // Bunker round: the goal is buried (no goal tiles), so home the A* on the
         // safe bunker island instead — otherwise findPathToNearestGoal returns null
@@ -1376,7 +1415,7 @@ function steerBot(bot, ctx, dt) {
         // goal (better a tight line than freezing in front of the lava). Keep the
         // hazard penalty on the retry — it's soft, so it never nulls the path.
         if (route == null && blocked != null) {
-            route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, { noiseSeed: ai.pathSeed, noiseAmount: pathOpts.noiseAmount, penaltySet: ctx.hazardCells, penaltyMult: HAZARD_PATH_PENALTY, goalSet: pathOpts.goalSet });
+            route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, { noiseSeed: ai.pathSeed, noiseAmount: pathOpts.noiseAmount, penaltySet: ctx.staticHazardCells, penaltyMult: HAZARD_PATH_PENALTY, penaltySet2: ctx.railCells, penaltyMult2: RAIL_PATH_PENALTY, goalSet: pathOpts.goalSet });
         }
         if (route != null) {
             var pts = [];
@@ -1860,9 +1899,12 @@ function update(gameBoard, currentState, dt) {
     // those cells so routes go AROUND. Recomputed each tick so a moving bumper's
     // cell is tracked (re-pathing is throttled; local repulsion handles the rest).
     // A MOVING bumper sweeps a whole rail at ~2000px/s, so penalizing only the cell
-    // it sits in this instant is useless — the route must go around the entire
-    // track. Penalize every cell whose center is near the swept segment.
-    var hazardCells = null;
+    // it sits in this instant is useless — penalize every cell whose center is near
+    // the swept segment. The two classes are priced separately (see the penalty
+    // constants): static bumpers in staticHazardCells (harsh), timeable moving
+    // rails in railCells (mild).
+    var staticHazardCells = null;
+    var railCells = null;
     var hazardList = gameBoard.hazardList;
     var RAIL_PENALTY_MARGIN = 48; // px from the swept segment to still penalize a cell
     for (var hkey in hazardList) {
@@ -1877,8 +1919,8 @@ function update(gameBoard, currentState, dt) {
                 var cpr = closestOnSegment(rc.site.x, rc.site.y, seg.ax, seg.ay, seg.bx, seg.by);
                 var rdx = rc.site.x - cpr.x, rdy = rc.site.y - cpr.y;
                 if (rdx * rdx + rdy * rdy < marginSq) {
-                    if (hazardCells == null) { hazardCells = new Set(); }
-                    hazardCells.add(rc.site.voronoiId);
+                    if (railCells == null) { railCells = new Set(); }
+                    railCells.add(rc.site.voronoiId);
                 }
             }
             continue;
@@ -1892,8 +1934,8 @@ function update(gameBoard, currentState, dt) {
             if (dd < bestD) { bestD = dd; bestI = ci2; }
         }
         if (bestI >= 0) {
-            if (hazardCells == null) { hazardCells = new Set(); }
-            hazardCells.add(map.cells[bestI].site.voronoiId);
+            if (staticHazardCells == null) { staticHazardCells = new Set(); }
+            staticHazardCells.add(map.cells[bestI].site.voronoiId);
         }
     }
 
@@ -1974,7 +2016,8 @@ function update(gameBoard, currentState, dt) {
         lavaCells: lavaCells,
         goalTiles: goalTiles, // for zombie intercept (prey are racing to a goal)
         bunkerSafeIds: bunkerSafeIds, // Bunker round: A* homes on these cells (buried goal)
-        hazardCells: hazardCells, // bumper cells to penalize in pathing
+        staticHazardCells: staticHazardCells, // static bumper cells (harsh path penalty)
+        railCells: railCells, // moving-rail swept cells (mild path penalty — timeable)
         players: playerList,
         projectileList: gameBoard.projectileList,
         hazardList: gameBoard.hazardList,

--- a/server/cellGraph.js
+++ b/server/cellGraph.js
@@ -266,16 +266,19 @@ function findPathToNearestGoal(map, point, options) {
     // a last resort (e.g. cells holding bumper hazards, which aren't in the graph).
     // A multiplier (not a hard block) so a hazard in a chokepoint doesn't null the
     // path. options.penaltySet: Set/array of voronoiIds; options.penaltyMult: cost x.
-    var penaltyMult = options.penaltyMult || 1;
+    // A second independent pair (penaltySet2/penaltyMult2) lets a caller price two
+    // hazard classes differently (e.g. static bumpers harsh, timeable moving rails
+    // mild); on overlap the harsher multiplier wins.
     var penalty = null;
-    if (options.penaltySet && penaltyMult > 1) {
-        penalty = {};
-        if (options.penaltySet.forEach) {
-            options.penaltySet.forEach(function (id) { penalty[id] = true; });
-        } else {
-            for (var pj = 0; pj < options.penaltySet.length; pj++) { penalty[options.penaltySet[pj]] = true; }
-        }
+    function addPenalties(set, mult) {
+        if (!set || !(mult > 1)) { return; }
+        if (penalty == null) { penalty = {}; }
+        var put = function (id) { if (!(penalty[id] >= mult)) { penalty[id] = mult; } };
+        if (set.forEach) { set.forEach(put); }
+        else { for (var pj = 0; pj < set.length; pj++) { put(set[pj]); } }
     }
+    addPenalties(options.penaltySet, options.penaltyMult || 1);
+    addPenalties(options.penaltySet2, options.penaltyMult2 || 1);
 
     // Optional explicit goal cells (voronoiId set/array). When given, the search
     // homes on THESE cells instead of GOAL-id tiles — used by the Bunker round,
@@ -353,7 +356,7 @@ function findPathToNearestGoal(map, point, options) {
                 continue;
             }
             var step = dist(cells[u].site, cells[v].site);
-            var pen = (penalty && penalty[cells[v].site.voronoiId]) ? penaltyMult : 1;
+            var pen = (penalty && penalty[cells[v].site.voronoiId]) || 1;
             // Kart fits but it's a squeeze: take it only when no wider lane exists.
             var tight = (doors[k] < MIN_DOORWAY) ? TIGHT_DOORWAY_PENALTY : 1;
             var nc = cost[u] + step * tileWeight(cells[v].id) * cellJitter(cells[v].site.voronoiId) * pen * tight;

--- a/server/mapClassifier.js
+++ b/server/mapClassifier.js
@@ -186,7 +186,9 @@ function pathPoints(map, path) {
 // so the overlay's routes dodge the same obstacles the bots do. Returns null
 // when the map has no hazards. Built from the raw map JSON (anchor + angle +
 // config rail width), not live hazard objects — balanceDebug runs pre-game.
-var HAZARD_PATH_PENALTY = 12; // cost x — keep in step with aiController.js
+var HAZARD_PATH_PENALTY = 12; // cost x — matches aiController's STATIC bumper penalty
+                              // (bots price MOVING rails milder — RAIL_PATH_PENALTY 4,
+                              //  they time the gaps; the overlay stays conservative)
 var HAZARD_CLEARANCE = 40;    // px a drawn racing line keeps from a bumper point
                               // (~attackRadius 15 + player radius + dodge pad,
                               //  mirroring aiController's BUMPER_DANGER_PAD idea)


### PR DESCRIPTION
## Problem

Field report: bots on maps with moving bumpers line up in front of the rail and shuffle back and forth forever, never attempting to cross. Root cause: `hazardRepulsion` treated a moving bumper's whole swept rail as a permanent repulsive wall (deliberately, to stop bots threading in and getting clipped), and the repulsion strength always beats the path-following pull. There was no concept of *timing* the gap — and the 12x A* penalty on rail cells kept routes nominally pointed "around" rails, so nothing ever engaged even where no real detour existed.

## Fix

The bumper's motion is fully deterministic (constant sweep, exact reflection at the rail ends), so predict it:

- **`railCrossingOpen()`** walks the bumper's future across the bot's exposure window (band entry → clear of the far side). If the bumper can't come within strike range of the crossing point in that time, the gap is OPEN — repulsion drops and the carrot carries the bot across, like a player darting through behind the bumper.
- While CLOSED, bots **stage just outside the strike band** (not the old 96px standoff) and **drift toward the nearer rail end** — mid-rail on a standard 100px rail is never provably safe (the bumper returns ~0.7s after passing), so the end-bias is load-bearing.
- Dash speed is estimated from the **tile under the bot** (terminal = acel·dt/drag x the 0.8 bot input scale): slow ~17px/s, fast ~62px/s.
- On ground so slow that **no safe window exists anywhere on the rail**, bots dart right behind the receding bumper while most of that pass's headroom remains, and **latch the commitment** (`ai.railGo`) for the estimated crossing time — accepting a possible glancing knockback over freezing forever.
- Routing: rails priced at **4x** (`RAIL_PATH_PENALTY` — "a short wait + some risk") via a new second penalty channel in `cellGraph` (`penaltySet2`/`penaltyMult2`, harsher wins on overlap); **static bumpers stay at 12x**.
- Latent bug found under Codex review: the stuck-probe **treadmills on slow tiles** (terminal speed covers < `STUCK_RADIUS` per `STUCK_TRIGGER` window, so escapes re-anchored every 1.6s while bots drove flat-out — every slow-ground bot ran permanently in escape/beeline). Gated the trigger on actual speed (`STUCK_SPEED_MAX` 12): cruising isn't stuck.

## Verification

- **New CI test** `.github/scripts/ai-bumper-cross-test.js`: predictor unit cases (incl. end reflections), a live fast-corridor crossing via timing (max stall 2.4s, under the 4.5s beeline), and the slow-ground corridor (Codex's repro — 57s stall+ram before, 2.2s max stall now).
- **AI fitness protocol** (committed as `.github/scripts/ai-fitness.js` — the PR #181 method: 8 seeds x 120s x 6 cast bots, finishers/frozen/median death-x/avgMaxX, baseline vs branch across 15 maps): bumper maps **+31 finish events** net (dragonbreath 18→25 dying 148px deeper, RushHour 74→84, Zoomies 20→26, WhatGoesUp 3→8, sidewinder's first finisher ever), goldeyes confirms static penalties hold (87→91). The stuck-probe fix also lifts the *control* maps (crossroads 35→40, IcyLake 26→35, frozen-at-end 15→1).
- **Live browser verification** (real client, Chrome, preview room + perf-harness pipeline): 16 monitored rail crossings across organic rotation rounds — Risky Business (4 bots through one gap window), path of pain, and dragon breath (the original report's map); bots win rounds and full matches on rail-gated maps.
- Known watch item: GoodLuck reads 2→0 finishes, but median death-x is 76 on *both* builds — spawn-area lava deaths (the known gate-spawn issue), not rail behavior.

Full headless suite green (incl. classifier/map-format tests since `cellGraph` changed). CHANGELOG bullet + Codex (learn.js) entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)