### PR TITLE
Momentum ramp: karts wind up to top speed on a held line

### DIFF
--- a/.github/scripts/momentum-ramp-test.js
+++ b/.github/scripts/momentum-ramp-test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+// Focused regression test for the human-player momentum ramp (engine.updatePlayers
+// + config.momentumRamp). Boots the real engine headlessly and drives a single
+// player object tick-by-tick — no network, no map needed (updatePlayers only reads
+// the player's drive/drag fields).
+//
+// Asserts the intended feel:
+//   * a human starts at the `floor` drive factor and winds up to full top speed
+//     over rampTime seconds (so the START is slower; the old top speed is the cap);
+//   * a hard turn/reverse AT SPEED dumps the momentum back to the floor;
+//   * a gentle (45°) steering nudge keeps it;
+//   * AI bots are EXEMPT — they keep the old full-thrust physics from tick 1
+//     (the ramp's floor + jittery-heading reset would freeze them on slow terrain;
+//     see ai-fitness.js).
+//
+// Any failed assertion exits 1.
+
+const path = require('path');
+const repoRoot = path.join(__dirname, '..', '..');
+const engineMod = require(path.join(repoRoot, 'server', 'engine.js'));
+const c = require(path.join(repoRoot, 'server', 'config.json'));
+
+const DT = c.serverTickSpeed / 1000;
+const ramp = c.momentumRamp;
+
+if (ramp == null) {
+    console.log('::error::config.momentumRamp is missing — the momentum ramp was removed?');
+    process.exit(1);
+}
+
+function makePlayer(isAI) {
+    return {
+        alive: true, isAI: !!isAI,
+        moveForward: false, moveBackward: false, turnLeft: false, turnRight: false,
+        staminaExhausted: false, dripUntil: null,
+        velX: 0, velY: 0, newX: 0, newY: 0,
+        acel: c.playerBaseAcel, brakeCoeff: c.playerBrakeCoeff, dragCoeff: c.playerDragCoeff,
+        maxVelocity: c.playerMaxSpeed, dragMultiplier: 1, currentSpeedBonus: 0,
+        momentum: 0, lastMoveDirX: 0, lastMoveDirY: 0, targetDirX: 0, targetDirY: 0, braking: false,
+        getSpeedBonus() { return this.currentSpeedBonus; },
+        getDragBonus() { return this.dragMultiplier; },
+        getMomentumFactor() {
+            if (c.momentumRamp == null) return 1;
+            const floor = c.momentumRamp.floor;
+            return floor + (1 - floor) * this.momentum;
+        }
+    };
+}
+
+const speed = (p) => Math.hypot(p.velX, p.velY);
+let fails = 0;
+function check(cond, msg) {
+    if (!cond) { fails++; console.log('::error::' + msg); }
+    else { console.log('ok: ' + msg); }
+}
+
+// --- Human holds UP from a standstill: floor start, winds up to full cap ---
+const human = makePlayer(false);
+const eng = engineMod.getEngine({ p: human }, {}, {});
+human.moveForward = true;
+
+let t = 0;
+while (t < 0.6) { eng.update(DT); t += DT; } // < rampTime
+const earlySpeed = speed(human);
+const earlyFactor = human.getMomentumFactor();
+
+while (t < ramp.rampTime + 1.0) { eng.update(DT); t += DT; } // past rampTime
+const fullSpeed = speed(human);
+
+check(human.momentum >= 0.999, 'momentum reaches 1 after rampTime');
+check(earlyFactor >= ramp.floor - 1e-6 && earlyFactor < 1, 'early drive factor sits near floor, below full');
+check(fullSpeed > earlySpeed + 1, 'kart winds up: full-ramp cruise faster than the early cruise');
+check(fullSpeed * ramp.floor < earlySpeed + 5, 'early cruise ≈ floor * full cruise (the start is genuinely slower)');
+
+// --- Hard reverse (180°) at speed dumps momentum ---
+human.moveForward = false; human.moveBackward = true;
+eng.update(DT);
+check(human.momentum === 0, 'hard reverse at speed dumps momentum to the floor');
+
+// --- 45° steering nudge at full momentum keeps it ---
+const human2 = makePlayer(false);
+const eng2 = engineMod.getEngine({ p: human2 }, {}, {});
+human2.moveForward = true;
+let t2 = 0;
+while (t2 < ramp.rampTime + 1.0) { eng2.update(DT); t2 += DT; }
+human2.turnLeft = true; // UP -> UP-LEFT, 45° (dot .707 > resetDot)
+eng2.update(DT);
+check(human2.momentum > 0.9, '45° steering nudge preserves momentum');
+
+// --- AI bot is exempt: full thrust from tick 1 ---
+const bot = makePlayer(true);
+const engBot = engineMod.getEngine({ b: bot }, {}, {});
+bot.targetDirX = 0; bot.targetDirY = -1;
+engBot.update(DT);
+const botFirst = speed(bot);
+
+const human3 = makePlayer(false);
+const engHuman = engineMod.getEngine({ h: human3 }, {}, {});
+human3.moveForward = true;
+engHuman.update(DT);
+const humanFirst = speed(human3);
+
+check(bot.momentum === 0, 'bot momentum field stays untouched (engine forces factor 1 for AI)');
+check(botFirst > humanFirst, 'bot accelerates at full thrust while a human starts at the floor');
+
+console.log(fails === 0
+    ? 'Momentum ramp test passed.'
+    : `Momentum ramp test FAILED (${fails}).`);
+process.exit(fails === 0 ? 0 : 1);

--- a/.github/scripts/momentum-ramp-test.js
+++ b/.github/scripts/momentum-ramp-test.js
@@ -16,10 +16,17 @@
 //
 // Any failed assertion exits 1.
 
+const fs = require('fs');
 const path = require('path');
 const repoRoot = path.join(__dirname, '..', '..');
 const engineMod = require(path.join(repoRoot, 'server', 'engine.js'));
+const game = require(path.join(repoRoot, 'server', 'game.js'));
+const mapFormat = require(path.join(repoRoot, 'server', 'mapFormat.js'));
+const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
 const c = require(path.join(repoRoot, 'server', 'config.json'));
+
+// io stand-in so room/world emits (worldResize, startRace, …) don't throw.
+messenger.build({ to() { return { emit() { } }; }, sockets: { emit() { } } });
 
 const DT = c.serverTickSpeed / 1000;
 const ramp = c.momentumRamp;
@@ -103,6 +110,40 @@ const humanFirst = speed(human3);
 
 check(bot.momentum === 0, 'bot momentum field stays untouched (engine forces factor 1 for AI)');
 check(botFirst > humanFirst, 'bot accelerates at full thrust while a human starts at the floor');
+
+// --- Integration: the gated countdown must NOT pre-charge momentum ---
+// The engine ticks through every state, so a human holding a direction behind
+// the start gate would build momentum to full before the race opens and skip
+// the slow start. startRace() resets it; this drives a real room to prove it.
+(function gatedStartGuard() {
+    const mapsDir = path.join(repoRoot, 'client', 'maps');
+    const file = fs.readdirSync(mapsDir).find(f => f.endsWith('.json'));
+    let map = JSON.parse(fs.readFileSync(path.join(mapsDir, file), 'utf8'));
+    if (mapFormat.isSitesOnly(map)) { map = mapFormat.reconstruct(map); }
+
+    const room = game.getRoom('momentum-gate-test', 4);
+    room.game.gameBoard.isPreview = true;
+    room.game.gameBoard.previewMap = map;
+
+    const id = 'momentum-gate-test-p0';
+    const player = room.world.createNewPlayer(id);
+    room.playerList[id] = player;
+    room.game.determineGameState(player);
+
+    room.game.startLobby();
+    room.game.startGated();
+
+    // Hold a steady heading through the countdown (engine keeps integrating).
+    player.moveForward = true;
+    for (let f = 0; f < 120; f++) { room.update(DT); }
+    const gatedMomentum = player.momentum;
+
+    room.game.startRace();
+    const startMomentum = player.momentum;
+
+    check(gatedMomentum > 0.5, 'momentum does build while ticking behind the gate (proves the risk is real)');
+    check(startMomentum === 0, 'startRace resets momentum to the floor — no pre-charge through the gate');
+})();
 
 console.log(fails === 0
     ? 'Momentum ramp test passed.'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -199,6 +199,9 @@ jobs:
       - name: "Headless bumper-wall test (slingshot wall geometry, bounce physics, bots route around)"
         run: node .github/scripts/bumper-wall-test.js
 
+      - name: "Headless momentum-ramp test (human slow-start/wind-up, hard-turn reset, bots exempt, no gate pre-charge)"
+        run: node .github/scripts/momentum-ramp-test.js
+
   perf-tick-budget:
     # Server-side worst-case load: a full 25-kart grid in a stacked brutal round.
     # Proves one room still ticks well within the 30 Hz interval. Zero new deps —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- **Karts now build up to speed.** Instead of hitting full pace the instant you press a direction, your kart starts a little slower and winds up to its top speed over a couple of seconds of holding a steady line. Cut a hard turn or stomp the brakes and you dump that momentum and have to wind back up — so committing to a clean racing line is now faster than constantly jinking around. Top speed itself is unchanged; you just have to earn it.
 
 ## v0.35.1 — 2026-06-13
 

--- a/client/scripts/learn.js
+++ b/client/scripts/learn.js
@@ -66,6 +66,11 @@
                     detail: "Every round is a dash to the glowing goal zone — cross into it and you bank a notch toward the match win. The more racers in the room, the fewer notches it takes, and leading is dangerous: fall just short and rivals gun for you, eager to knock the leader down."
                 },
                 {
+                    id: "momentum", name: "Building Speed", icon: swatch("#5ad1ff"), anim: "goalRun",
+                    blurb: "Hold a line to wind up to top speed.",
+                    detail: "Your kart doesn't snap to full pace the instant you push a direction — it starts a touch slower and winds up to its top speed over a couple of seconds of holding a steady heading. Small steering corrections keep that momentum, but cut a hard turn or stomp the brakes and you dump it and have to wind back up. Your top speed itself hasn't changed; you just have to earn it, so committing to a clean racing line beats constantly jinking around. (Surface still rules: this rides on top of each tile's own grip.)"
+                },
+                {
                     id: "collapse", name: "The Collapse", icon: tex("lava.png"), anim: "collapse",
                     blurb: "The floor turns to lava and squeezes everyone inward.",
                     detail: "Once the front-runners are home, the arena turns to lava from the edges inward, shrinking the safe ground and herding everyone toward the middle. It's the round's clock — but when one racer is left, the lava eases up to give them a fair shot at the goal."

--- a/server/config.json
+++ b/server/config.json
@@ -522,6 +522,13 @@
     "playerMaxSpeed_prod": 50,
     "playerMaxSpeed_test": 350,
     "playerBaseAcel": 375,
+    "momentumRamp": {
+        "_doc": "Momentum ramp: top speed builds while you hold a steady heading and resets when you cut hard or stop. The drive force is scaled by floor..1 — a freshly-started (or just-turned) kart drives at `floor` of its normal acceleration (so it cruises at `floor` of its usual top speed) and climbs to full over `rampTime` seconds of committed movement. resetDot = the cos() of the heading change that resets the ramp (0.4 ≈ 66°, so small steering nudges keep your momentum but a hard turn/reverse dumps it). resetSpeedMin = the hard-turn reset only fires when you're already carrying this much speed; a near-stationary kart (just starting, maneuvering, or shoved into a wall) keeps building so it can get going instead of being pinned at the floor. Full ramp is identical to the old physics, so this only ever slows you down — commit to a line to go fast.",
+        "floor": 0.7,
+        "rampTime": 2.5,
+        "resetDot": 0.4,
+        "resetSpeedMin": 15
+    },
     "lobbyRespawnInvulnMs": 8000,
     "lobbyAbilityTileRespawnMs": 4000,
     "lobbyIdleResetMs": 15000

--- a/server/engine.js
+++ b/server/engine.js
@@ -134,9 +134,50 @@ class Engine {
 				driveMult *= c.tileMap.water.dripMoveFactor;
 			}
 
+			// Momentum ramp (human players only): hold a steady heading and your drive
+			// force climbs from `floor` to full over rampTime seconds; cut hard the other
+			// way (or stop) and it dumps back to the floor. Makes starts and hard turns a
+			// touch slower and rewards committing to a line — at full ramp it's a no-op,
+			// so the old top speed stays the cap.
+			//
+			// Bots are exempt: they steer with a continuously-jittering pathfinding
+			// heading and were tuned around full thrust, so the floor traps them on slow
+			// terrain and the hard-turn reset pins them at the floor — they freeze against
+			// walls instead of powering out (measured via ai-fitness). A bot keeps the old
+			// physics (momentum stays 1 → factor 1).
+			var ramp = c.momentumRamp;
+			if (ramp != null && !player.isAI) {
+				if (braking) {
+					player.momentum = 0;
+					player.lastMoveDirX = 0;
+					player.lastMoveDirY = 0;
+				}
+				else {
+					var moveMag = utils.getMag(dirX, dirY);
+					var ndx = moveMag > 0 ? dirX / moveMag : 0;
+					var ndy = moveMag > 0 ? dirY / moveMag : 0;
+					var hadHeading = player.lastMoveDirX !== 0 || player.lastMoveDirY !== 0;
+					var dot = ndx * player.lastMoveDirX + ndy * player.lastMoveDirY;
+					// Only dump momentum on a hard turn if you're actually carrying speed —
+					// a near-stationary kart (starting up, or pinned/wiggling against a wall)
+					// keeps building so it can power out instead of stalling at the floor.
+					var carryingSpeed = utils.getMag(player.velX, player.velY) > ramp.resetSpeedMin;
+					if (hadHeading && dot < ramp.resetDot && carryingSpeed) {
+						// turned hard enough at speed to break momentum
+						player.momentum = 0;
+					}
+					else {
+						player.momentum = Math.min(1, player.momentum + this.dt / ramp.rampTime);
+					}
+					player.lastMoveDirX = ndx;
+					player.lastMoveDirY = ndy;
+				}
+			}
+			var momentumFactor = (ramp != null && !player.isAI) ? player.getMomentumFactor() : 1;
+
 			var newVelX, newVelY, newVel, newDirX, newDirY;
-			newVelX = player.velX + (player.acel + player.getSpeedBonus()) * driveMult * dirX * this.dt;
-			newVelY = player.velY + (player.acel + player.getSpeedBonus()) * driveMult * dirY * this.dt;
+			newVelX = player.velX + (player.acel + player.getSpeedBonus()) * driveMult * momentumFactor * dirX * this.dt;
+			newVelY = player.velY + (player.acel + player.getSpeedBonus()) * driveMult * momentumFactor * dirY * this.dt;
 
 			if (braking) {
 				newVelX -= player.brakeCoeff * player.velX;

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -252,6 +252,14 @@ class Player extends Circle {
 		this.maxVelocity = c.playerMaxSpeed;
 		this.acel = c.playerBaseAcel;
 
+		// Momentum ramp: drive force scales up from `floor` to 1 the longer you hold a
+		// steady heading; a hard turn or a stop dumps it back to the floor (see engine
+		// updatePlayers + config.momentumRamp). momentum is the current 0..1 progress;
+		// lastMoveDirX/Y is last tick's NORMALIZED input heading (0,0 = not moving).
+		this.momentum = 0;
+		this.lastMoveDirX = 0;
+		this.lastMoveDirY = 0;
+
 		this.currentSpeedBonus = 0;
 
 		//AI (set on bot players by world.createNewBot; humans leave these untouched)
@@ -795,6 +803,15 @@ class Player extends Circle {
 	}
 	getSpeedBonus() {
 		return this.currentSpeedBonus;
+	}
+	// 0..1 → floor..1 multiplier applied to the drive force this tick. Full ramp
+	// returns 1 (old behavior); a fresh start/hard turn returns `floor`.
+	getMomentumFactor() {
+		if (c.momentumRamp == null) {
+			return 1;
+		}
+		var floor = c.momentumRamp.floor;
+		return floor + (1 - floor) * this.momentum;
 	}
 	increaseDragMultiplier(newValue) {
 		this.dragMultiplier *= newValue;

--- a/server/game.js
+++ b/server/game.js
@@ -1171,6 +1171,13 @@ class Game {
 				// spectators join AFTER this loop, so they never get the flag — the
 				// rateMap handler uses it to reject ratings from non-participants.
 				this.playerList[rid].racedCurrentMap = true;
+				// Clear the momentum ramp at the gun: the engine keeps ticking through
+				// the gated countdown, so a player holding a direction would otherwise
+				// build to full momentum behind the gate and skip the slow start. Reset
+				// so everyone launches from the floor and has to wind up on the track.
+				this.playerList[rid].momentum = 0;
+				this.playerList[rid].lastMoveDirX = 0;
+				this.playerList[rid].lastMoveDirY = 0;
 			}
 		}
 


### PR DESCRIPTION
## What

Human karts now **build up to speed** instead of snapping to full pace the instant you press a direction. Hold a steady heading and your drive force climbs from a `floor` fraction up to full over `rampTime` seconds; a hard turn/reverse at speed (or a full stop) dumps that momentum and you wind back up. **Top speed itself is unchanged** — the old cruise speed is the cap you ramp toward — so this only ever slows the start and rewards committing to a clean racing line.

## How

The real in-race top speed is the **drag equilibrium**, which sits far below `maxVelocity` (e.g. ~40 u/s on normal tiles, ~78 on fast, vs a 500 cap). So capping `maxVelocity` would do nothing on actual races. Instead the momentum factor scales the **acceleration/drive term** in `engine.updatePlayers`, which lowers the cruise equilibrium itself and ramps it back up to today's value. At full ramp it's a mathematical no-op — identical to the old physics.

- `momentum` (0..1) advances while a steady heading is held; small steering corrections (≤ `resetDot`, ~66°) keep it, a hard turn at speed resets it, a full stop resets it.
- A near-stationary kart keeps building (`resetSpeedMin` gate) so it can power out of a wall instead of stalling at the floor.
- All tuning lives in `config.momentumRamp` (`floor` 0.7, `rampTime` 2.5s, `resetDot` 0.4, `resetSpeedMin` 15).
- `startRace()` resets momentum at the gun so a player leaning on the stick during the gated countdown still launches from the floor.

## AI bots are exempt — and verified

Bots steer with a continuously-jittering pathfinding heading and were tuned around full thrust, so the floor traps them on slow terrain and the hard-turn reset pins them at the floor (they freeze against walls). **ai-fitness A/B (Crossroads / FastAndSlow / IcyLake, 16 seeds):** with bots included, frozen-bot count jumped 0→16–27; with bots exempt, finishers/frozen/deaths match baseline **exactly**. The ramp is human-only.

## Tests

- New `momentum-ramp-test.js` (wired into `pr-validation.yml`): asserts the floor start → wind-up → hard-turn reset → 45° nudge preserves → bots exempt, plus a real gated→race integration check (momentum builds behind the gate, `startRace` floors it).
- Reviewed by Codex; both findings (gate pre-charge P2, test-not-in-CI P3) fixed in this branch.
- build ✅, smoke (53 maps) ✅, ai-fitness A/B ✅. No compressor/network changes.

## Notes

This is a game-mechanic change; `CHANGELOG.md` Unreleased and the learn-page Codex ("Building Speed") are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)