### PR TITLE
feat(hud): on-screen combat log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- **There's a combat log now.** A small feed in the top-right corner flashes the moments as they happen — who knocked out whom, who melted into the lava, who grabbed an Ice Cannon, and who's crossing the finish line — each with the racer's kart and name. In team modes the names and kart rings show their team colors, and finishes show the points they banked. Rows fade after a few seconds, and the ones you're in stand out.
 
 ## v0.36.0 — 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### General
 
-- **There's a combat log now.** A small feed in the top-right corner flashes the moments as they happen — who knocked out whom, who melted into the lava, who grabbed an Ice Cannon, and who's crossing the finish line — each with the racer's kart and name. In team modes the names and kart rings show their team colors, and finishes show the points they banked. Rows fade after a few seconds, and the ones you're in stand out.
+- **There's a combat log now.** A small feed in the top-right corner flashes the moments as they happen — who knocked out whom, who melted into the lava, who grabbed an Ice Cannon, who snagged a bonus orb, and who's crossing the finish line — each with the racer's kart and name. In team modes the names and kart rings show their team colors, and finishes (and orbs) show the points they banked. Rows fade after a few seconds, and the ones you're in stand out.
 
 ## v0.36.0 — 2026-06-13
 

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -1906,6 +1906,10 @@ function registerAbilityHandlers(server) {
 			orb.popAt = Date.now();
 		}
 		playSoundVaried(collectItem, 0.14);
+		if (typeof combatLogOrb === "function") {
+			var orbPts = (typeof config !== "undefined" && config && config.bonusOrb && config.bonusOrb.pointsValue != null) ? config.bonusOrb.pointsValue : 1;
+			combatLogOrb(payload.by, orbPts);
+		}
 	});
 	// Late-join seed of invuln state so already-protected players flash on this client.
 	server.on("lobbyInvulnStates", function (states) {

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -379,6 +379,13 @@ function registerLobbyHubHandlers(server) {
 		if (typeof pushTeamPointFloat === "function") {
 			pushTeamPointFloat(payload);
 		}
+		// Combat log: fold the points a finish earned into that player's scoring row.
+		// Kill/death points are already represented by their own kill/death rows.
+		if (payload != null && typeof combatLogScore === "function") {
+			var rankByReason = { first: "1st", second: "2nd", finish: "Finished" };
+			var rank = rankByReason[payload.reason];
+			if (rank != null) { combatLogScore(payload.id, rank, payload.amount); }
+		}
 	});
 	server.on("stationEnter", function (payload) {
 		if (payload != null && typeof setSlotNearStation === "function") {
@@ -982,9 +989,11 @@ function registerConnectionHandlers(server) {
 function registerScoreHandlers(server) {
 	server.on("firstPlaceWinner", function (id) {
 		createFirstRankSymbol(id);
+		if (typeof combatLogScore === "function") { combatLogScore(id, "1st", null); }
 	});
 	server.on("secondPlaceWinner", function (id) {
 		createSecondRankSymbol(id);
+		if (typeof combatLogScore === "function") { combatLogScore(id, "2nd", null); }
 	});
 	server.on("playerConcluded", function (packet) {
 		var id = (packet != null && packet.id != null) ? packet.id : packet;
@@ -1001,6 +1010,10 @@ function registerScoreHandlers(server) {
 			playerList[id].recapState = RECAP_SCORED; // recap: vanish with a goal poof, not hover the goal
 		}
 		recapMarkHighlight('goal', [id]); // flag a scoring moment for the recap
+		// Combat log: every goal-cross is a scoring moment. firstPlaceWinner /
+		// secondPlaceWinner (and teamPointsDelta) later upgrade this same row's
+		// rank/points rather than stacking a duplicate.
+		if (typeof combatLogScore === "function") { combatLogScore(id, "Finished", null); }
 		// A buzzy celebratory pop on the finishing local player's own pad.
 		if (typeof padPulseForId === "function" && isLocalId(id)) {
 			padPulseForId(id, 0.5, 0.65, 320);
@@ -1057,6 +1070,11 @@ function registerScoreHandlers(server) {
 			}
 		}
 		recapMarkHighlight('death', [id]); // flag an elimination moment for the recap
+		// Combat log: a real attacker (packet.by) → a kill row; otherwise an
+		// environmental/self death row (with the lava/other cause for the icon tint).
+		if (typeof combatLogDeath === "function") {
+			combatLogDeath(id, (packet != null ? packet.by : null), (packet != null ? packet.cause : null));
+		}
 		createDownRankSymbol(id);
 		// Solo preview pops back to the editor the instant the creator dies. In a co-op
 		// preview (2+ local players) one death shouldn't yank everyone out — let the round
@@ -1244,6 +1262,7 @@ function registerStateHandlers(server) {
 		oldNotches = {};
 		resetTrails();
 		resetPlayerRanks();
+		if (typeof combatLogReset === "function") { combatLogReset(); } // fresh feed each round
 		recapReset(); // start a fresh recap buffer for this round's map
 		// Anchor the HUD timer to the CLIENT's Date.now() at receipt — mixing
 		// server's Date.now() with the browser's local Date.now() would drift
@@ -1872,6 +1891,9 @@ function registerAbilityHandlers(server) {
 	server.on("abilityAcquired", function (payload) {
 		playerPickedUpAbility(payload);
 		playSoundVaried(collectItem, 0.06);
+		if (payload != null && typeof combatLogAbility === "function") {
+			combatLogAbility(payload.owner, payload.ability);
+		}
 	});
 	// Bonus orb banked (team modes): latch the orb collected + stamp the pop burst,
 	// and ring a brighter collect chime. The floating +1 over the collector rides

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -178,6 +178,13 @@ var windIcon = new Image(576, 512);
 windIcon.src = "../assets/img/wind-solid.svg";
 var hourglassIcon = new Image(576, 512);
 hourglassIcon.src = "../assets/img/hourglass-start-solid.svg";
+// Ability icons used by the combat log (the others above double as its icons too).
+var cutIcon = new Image(576, 512);
+cutIcon.src = "../assets/img/scissors-solid.svg";
+var starIcon = new Image(576, 512);
+starIcon.src = "../assets/img/star-solid.svg";
+var orbitalBeamIcon = new Image(576, 512);
+orbitalBeamIcon.src = "../assets/img/orbital-beam-solid.svg";
 
 var lightningIcon = new Image(576, 512);
 lightningIcon.src = "../assets/img/bolt-solid.svg";
@@ -10155,6 +10162,7 @@ var combatLog = []; // newest first
 var COMBAT_LOG_MAX = 6;
 var COMBAT_LOG_LIFE_MS = { kill: 6500, death: 6500, ability: 4500, score: 7500 };
 var _combatAbilityLabels = null;
+var _combatAbilityIcons = null;
 
 function combatLogReset() { combatLog.length = 0; }
 
@@ -10189,6 +10197,50 @@ function abilityLabelFor(id) {
         _combatAbilityLabels = m;
     }
     return (_combatAbilityLabels != null && _combatAbilityLabels[id]) ? _combatAbilityLabels[id] : "Ability";
+}
+
+// Ability id → icon Image (reusing the HUD ability sprites). Used in place of the
+// ability name in the combat log; falls back to the name text if the icon for an
+// ability is missing or not yet decoded.
+function abilityIconFor(id) {
+    if (_combatAbilityIcons == null && typeof config !== "undefined" && config != null &&
+        config.tileMap != null && config.tileMap.abilities != null) {
+        var ab = config.tileMap.abilities, m = {};
+        function put(entry, img) { if (entry != null && entry.id != null && img != null) { m[entry.id] = img; } }
+        put(ab.blindfold, typeof blindfoldIcon !== "undefined" ? blindfoldIcon : null);
+        put(ab.swap, typeof transferIcon !== "undefined" ? transferIcon : null);
+        put(ab.bomb, typeof bombIcon !== "undefined" ? bombIcon : null);
+        put(ab.bombTrigger, typeof bombIcon !== "undefined" ? bombIcon : null);
+        put(ab.speedBuff, typeof windIcon !== "undefined" ? windIcon : null);
+        put(ab.speedDebuff, typeof hourglassIcon !== "undefined" ? hourglassIcon : null);
+        put(ab.tileSwap, typeof copyIcon !== "undefined" ? copyIcon : null);
+        put(ab.iceCannon, typeof snowFlakeIcon !== "undefined" ? snowFlakeIcon : null);
+        put(ab.cut, typeof cutIcon !== "undefined" ? cutIcon : null);
+        put(ab.starPower, typeof starIcon !== "undefined" ? starIcon : null);
+        put(ab.orbitalBeam, typeof orbitalBeamIcon !== "undefined" ? orbitalBeamIcon : null);
+        _combatAbilityIcons = m;
+    }
+    return (_combatAbilityIcons != null && _combatAbilityIcons[id]) ? _combatAbilityIcons[id] : null;
+}
+
+// A white circular token carrying a dark ability glyph (the ability SVGs are dark
+// silhouettes, so they need a light backing to read — same trick as drawBrutalBadges).
+function drawAbilityIconToken(img, cx, cy, r) {
+    gameContext.beginPath();
+    gameContext.arc(cx, cy, r, 0, Math.PI * 2);
+    gameContext.fillStyle = "rgba(255,255,255,0.92)";
+    gameContext.fill();
+    gameContext.lineWidth = 1.2;
+    gameContext.strokeStyle = "rgba(0,0,0,0.35)";
+    gameContext.stroke();
+    if (img != null && img.complete !== false && (img.naturalWidth == null || img.naturalWidth > 0)) {
+        try {
+            var ratio = (img.width && img.height) ? (img.height / img.width) : 0.88;
+            var iw = r * 1.5, ih = iw * ratio;
+            if (ih > r * 1.6) { ih = r * 1.6; iw = ih / ratio; }
+            gameContext.drawImage(img, cx - iw / 2, cy - ih / 2, iw, ih);
+        } catch (e) { /* not decoded yet — the token still marks the pickup */ }
+    }
 }
 
 function pushCombatEntry(entry) {
@@ -10342,7 +10394,13 @@ function combatRowSegments(entry) {
     } else if (entry.type === "ability") {
         segs.push({ k: "thumb", id: entry.ownerId });
         segs.push({ k: "text", text: entry.ownerName, color: combatColorOf(entry.ownerId, "#ffffff"), bold: false });
-        segs.push({ k: "text", text: abilityLabelFor(entry.abilityId), color: "#5fe0ee", bold: true });
+        var aimg = abilityIconFor(entry.abilityId);
+        if (aimg != null && aimg.complete !== false && (aimg.naturalWidth == null || aimg.naturalWidth > 0)) {
+            segs.push({ k: "abilityicon", img: aimg });
+        } else {
+            // Icon not ready — keep the name so the row never reads blank.
+            segs.push({ k: "text", text: abilityLabelFor(entry.abilityId), color: "#5fe0ee", bold: true });
+        }
     } else { // score
         segs.push({ k: "thumb", id: entry.playerId });
         segs.push({ k: "text", text: entry.playerName, color: combatColorOf(entry.playerId, "#ffffff"), bold: false });
@@ -10389,6 +10447,7 @@ function drawCombatLog() {
             var seg = segs[s];
             if (seg.k === "badge") { seg.w = badgeR * 2; }
             else if (seg.k === "thumb") { seg.w = thumbR * 2; }
+            else if (seg.k === "abilityicon") { seg.w = badgeR * 2; }
             else { // text
                 gameContext.font = (seg.bold ? "bold " : "") + (seg.small ? "11px" : "13px") + " Arial";
                 seg.w = gameContext.measureText(seg.text).width;
@@ -10427,6 +10486,8 @@ function drawCombatLog() {
             } else if (sg.k === "thumb") {
                 drawCombatThumb(sg.id, cx + thumbR, cy, thumbR);
                 gameContext.globalAlpha = alpha; // drawOverviewKart resets alpha via save/restore — re-assert
+            } else if (sg.k === "abilityicon") {
+                drawAbilityIconToken(sg.img, cx + badgeR, cy, badgeR);
             } else {
                 gameContext.font = (sg.bold ? "bold " : "") + (sg.small ? "11px" : "13px") + " Arial";
                 gameContext.textAlign = "left";

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -10160,7 +10160,7 @@ function drawBrutalBadges() {
 // Sits below the race timer + brutal badges, screen-space (drawn inside drawHUD).
 var combatLog = []; // newest first
 var COMBAT_LOG_MAX = 6;
-var COMBAT_LOG_LIFE_MS = { kill: 6500, death: 6500, ability: 4500, score: 7500 };
+var COMBAT_LOG_LIFE_MS = { kill: 6500, death: 6500, ability: 4500, score: 7500, orb: 6500 };
 var _combatAbilityLabels = null;
 var _combatAbilityIcons = null;
 
@@ -10267,6 +10267,12 @@ function combatLogAbility(ownerId, abilityId) {
     pushCombatEntry({ type: "ability", ownerId: ownerId, ownerName: combatNameOf(ownerId), abilityId: abilityId });
 }
 
+// Teams modes: a racer drove over a bonus orb and banked points for their team.
+function combatLogOrb(ownerId, points) {
+    if (ownerId == null) { return; }
+    pushCombatEntry({ type: "orb", ownerId: ownerId, ownerName: combatNameOf(ownerId), points: (points != null) ? points : 1 });
+}
+
 // Scoring finishes. firstPlaceWinner / secondPlaceWinner / playerConcluded all
 // fire for a podium finisher, and teams modes add a teamPointsDelta — so this
 // upgrades an existing recent row (better rank / +points) instead of stacking
@@ -10301,6 +10307,24 @@ function combatScoreEmoji(rankLabel) {
     if (rankLabel === "1st") { return "🥇"; }
     if (rankLabel === "2nd") { return "🥈"; }
     return "🏁";
+}
+
+// Bonus-orb marker — the same gold sphere the player sees on the map (radial
+// sheen + config orb colour), shrunk to a row token so the feed reads true to
+// the in-game pickup.
+function drawCombatOrbToken(cx, cy, r) {
+    var color = (typeof config !== "undefined" && config && config.bonusOrb && config.bonusOrb.color) ? config.bonusOrb.color : "#FFD54A";
+    var grad = gameContext.createRadialGradient(cx - r * 0.3, cy - r * 0.3, r * 0.1, cx, cy, r);
+    grad.addColorStop(0, "#FFFDF0");
+    grad.addColorStop(0.45, color);
+    grad.addColorStop(1, "#C9962E");
+    gameContext.beginPath();
+    gameContext.arc(cx, cy, r, 0, Math.PI * 2);
+    gameContext.fillStyle = grad;
+    gameContext.fill();
+    gameContext.lineWidth = 1.3;
+    gameContext.strokeStyle = "rgba(255,255,255,0.85)";
+    gameContext.stroke();
 }
 
 // Cart-cosmetic thumbnail for a live player, with a team-coloured ring in teams
@@ -10353,6 +10377,12 @@ function combatRowSegments(entry) {
             segs.push({ k: "text", text: entry.ownerName, color: combatColorOf(entry.ownerId, "#ffffff"), bold: false });
             segs.push({ k: "text", text: abilityLabelFor(entry.abilityId), color: "#5fe0ee", bold: true });
         }
+    } else if (entry.type === "orb") {
+        // Bonus orb collected — the gold-sphere marker + the team points it banked.
+        segs.push({ k: "orb" });
+        segs.push({ k: "thumb", id: entry.ownerId });
+        segs.push({ k: "text", text: entry.ownerName, color: combatColorOf(entry.ownerId, "#ffffff"), bold: false });
+        segs.push({ k: "text", text: "+" + entry.points, color: "#ffd54a", bold: true });
     } else { // score — 🥇/🥈/🏁 marker conveys the placement
         segs.push({ k: "glyph", emoji: combatScoreEmoji(entry.rankLabel) });
         segs.push({ k: "thumb", id: entry.playerId });
@@ -10400,6 +10430,7 @@ function drawCombatLog() {
             if (seg.k === "glyph") { gameContext.font = "15px Arial"; seg.w = gameContext.measureText(seg.emoji).width; }
             else if (seg.k === "thumb") { seg.w = thumbR * 2; }
             else if (seg.k === "abilityicon") { seg.w = badgeR * 2; }
+            else if (seg.k === "orb") { seg.w = badgeR * 2; }
             else { // text
                 gameContext.font = (seg.bold ? "bold " : "") + (seg.small ? "11px" : "13px") + " Arial";
                 seg.w = gameContext.measureText(seg.text).width;
@@ -10442,6 +10473,8 @@ function drawCombatLog() {
                 gameContext.globalAlpha = alpha; // drawOverviewKart resets alpha via save/restore — re-assert
             } else if (sg.k === "abilityicon") {
                 drawAbilityIconToken(sg.img, cx + badgeR, cy, badgeR);
+            } else if (sg.k === "orb") {
+                drawCombatOrbToken(cx + badgeR, cy, badgeR);
             } else {
                 gameContext.font = (sg.bold ? "bold " : "") + (sg.small ? "11px" : "13px") + " Arial";
                 gameContext.textAlign = "left";

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -9963,6 +9963,7 @@ function drawHUD() {
     drawRaceTimer();
     drawTeamScoreHud();
     drawBrutalBadges();
+    drawCombatLog();
     drawSpectatorLeaderboard();
     drawWorldRecordBanner();
     drawHeatwaveWarnBanner();
@@ -10138,6 +10139,301 @@ function drawBrutalBadges() {
                 if (ih > bh - 6) { ih = bh - 6; iw = ih / ratio; }
                 gameContext.drawImage(ic, bx + (bw - iw) / 2, topY + (bh - ih) / 2, iw, ih);
             } catch (e) { /* icon not decoded — badge tile still flags it */ }
+        }
+    }
+    gameContext.restore();
+}
+
+// ---------------------------------------------------------------------------
+// Combat log — a small right-edge feed of recent moments (kills, environmental
+// deaths, ability pickups, scoring finishes). Each row carries the cart cosmetic
+// thumbnail(s) + player name(s); in teams modes the name uses the team colour and
+// the thumbnail gets a team-coloured ring (the "team cosmetic"). Entries are
+// pushed by the matching socket handlers in client.js and self-expire here.
+// Sits below the race timer + brutal badges, screen-space (drawn inside drawHUD).
+var combatLog = []; // newest first
+var COMBAT_LOG_MAX = 6;
+var COMBAT_LOG_LIFE_MS = { kill: 6500, death: 6500, ability: 4500, score: 7500 };
+var _combatAbilityLabels = null;
+
+function combatLogReset() { combatLog.length = 0; }
+
+// Resolve a player's display name at event time (cached on the entry so a player
+// who later leaves the room still reads correctly in the feed).
+function combatNameOf(id) {
+    var p = (typeof playerList !== "undefined" && playerList) ? playerList[id] : null;
+    return (p != null && p.name) ? p.name : "Someone";
+}
+
+// Live colour for a name/ring: team colour in teams modes, else the kart colour.
+function combatColorOf(id, fallback) {
+    var p = (typeof playerList !== "undefined" && playerList) ? playerList[id] : null;
+    if (p != null && p.teamId != null && typeof teamInfo !== "undefined" && teamInfo != null && Array.isArray(teamInfo.defs)) {
+        for (var i = 0; i < teamInfo.defs.length; i++) {
+            if (teamInfo.defs[i] != null && teamInfo.defs[i].id === p.teamId) { return teamInfo.defs[i].color; }
+        }
+    }
+    if (p != null && p.color) { return p.color; }
+    return fallback || "#dfe6ee";
+}
+
+function abilityLabelFor(id) {
+    if (_combatAbilityLabels == null && typeof config !== "undefined" && config != null &&
+        config.tileMap != null && config.tileMap.abilities != null) {
+        var ab = config.tileMap.abilities, m = {};
+        function put(entry, label) { if (entry != null && entry.id != null) { m[entry.id] = label; } }
+        put(ab.blindfold, "Blindfold"); put(ab.swap, "Swap"); put(ab.bomb, "Bomb");
+        put(ab.bombTrigger, "Bomb"); put(ab.speedBuff, "Speed Burst"); put(ab.speedDebuff, "Slowdown");
+        put(ab.tileSwap, "Tile Swap"); put(ab.iceCannon, "Ice Cannon"); put(ab.cut, "Cut");
+        put(ab.starPower, "Star Power"); put(ab.orbitalBeam, "Orbital Beam");
+        _combatAbilityLabels = m;
+    }
+    return (_combatAbilityLabels != null && _combatAbilityLabels[id]) ? _combatAbilityLabels[id] : "Ability";
+}
+
+function pushCombatEntry(entry) {
+    entry.bornAt = Date.now();
+    combatLog.unshift(entry);
+    if (combatLog.length > COMBAT_LOG_MAX) { combatLog.length = COMBAT_LOG_MAX; }
+}
+
+// playerDied → either a kill (a real attacker) or an environmental/self death.
+function combatLogDeath(victimId, attackerId, cause) {
+    if (victimId == null) { return; }
+    if (attackerId != null && attackerId !== victimId) {
+        pushCombatEntry({
+            type: "kill", attackerId: attackerId, victimId: victimId,
+            attackerName: combatNameOf(attackerId), victimName: combatNameOf(victimId)
+        });
+    } else {
+        pushCombatEntry({ type: "death", victimId: victimId, victimName: combatNameOf(victimId), cause: cause || null });
+    }
+}
+
+function combatLogAbility(ownerId, abilityId) {
+    if (ownerId == null) { return; }
+    pushCombatEntry({ type: "ability", ownerId: ownerId, ownerName: combatNameOf(ownerId), abilityId: abilityId });
+}
+
+// Scoring finishes. firstPlaceWinner / secondPlaceWinner / playerConcluded all
+// fire for a podium finisher, and teams modes add a teamPointsDelta — so this
+// upgrades an existing recent row (better rank / +points) instead of stacking
+// duplicates for the same player.
+var _combatRankRank = { "Finished": 1, "2nd": 2, "1st": 3 };
+function combatLogScore(playerId, rankLabel, points) {
+    if (playerId == null) { return; }
+    for (var i = 0; i < combatLog.length; i++) {
+        var e = combatLog[i];
+        if (e.type === "score" && e.playerId === playerId) {
+            if (rankLabel != null && (_combatRankRank[rankLabel] || 0) > (_combatRankRank[e.rankLabel] || 0)) {
+                e.rankLabel = rankLabel;
+            }
+            if (points != null) { e.points = points; }
+            e.bornAt = Date.now();
+            return;
+        }
+    }
+    pushCombatEntry({
+        type: "score", playerId: playerId,
+        playerName: combatNameOf(playerId),
+        rankLabel: rankLabel || "Finished",
+        points: (points != null) ? points : null
+    });
+}
+
+// A small circular type badge with a simple white vector glyph (kept sprite-free
+// and emoji-free to match the in-game HUD iconography).
+function drawCombatBadge(type, cause, cx, cy, r) {
+    var color;
+    if (type === "kill") { color = "#e8473f"; }
+    else if (type === "death") { color = (cause === "lava") ? "#ff7a26" : "#7d8794"; }
+    else if (type === "ability") { color = "#36c5d6"; }
+    else { color = "#ffcc3a"; } // score
+    gameContext.beginPath();
+    gameContext.arc(cx, cy, r, 0, Math.PI * 2);
+    gameContext.fillStyle = color;
+    gameContext.fill();
+    gameContext.lineWidth = 1.4;
+    gameContext.strokeStyle = "rgba(0,0,0,0.35)";
+    gameContext.stroke();
+    gameContext.save();
+    gameContext.strokeStyle = "#ffffff";
+    gameContext.fillStyle = "#ffffff";
+    gameContext.lineCap = "round";
+    gameContext.lineJoin = "round";
+    if (type === "kill") {
+        // Crossed swords (two short blades).
+        gameContext.lineWidth = 1.6;
+        var s = r * 0.62;
+        gameContext.beginPath();
+        gameContext.moveTo(cx - s, cy - s); gameContext.lineTo(cx + s, cy + s);
+        gameContext.moveTo(cx + s, cy - s); gameContext.lineTo(cx - s, cy + s);
+        gameContext.stroke();
+    } else if (type === "death") {
+        // Skull: rounded head with two eye sockets.
+        var hr = r * 0.55;
+        gameContext.beginPath();
+        gameContext.arc(cx, cy - r * 0.12, hr, 0, Math.PI * 2);
+        gameContext.fill();
+        gameContext.fillStyle = (cause === "lava") ? "#ff7a26" : "#7d8794";
+        gameContext.beginPath(); gameContext.arc(cx - hr * 0.45, cy - r * 0.16, hr * 0.32, 0, Math.PI * 2); gameContext.fill();
+        gameContext.beginPath(); gameContext.arc(cx + hr * 0.45, cy - r * 0.16, hr * 0.32, 0, Math.PI * 2); gameContext.fill();
+        gameContext.fillStyle = "#ffffff";
+        gameContext.fillRect(cx - r * 0.28, cy + r * 0.42, r * 0.56, r * 0.26);
+    } else if (type === "ability") {
+        // Plus sign (a pickup / power gained).
+        gameContext.lineWidth = 1.8;
+        var p = r * 0.55;
+        gameContext.beginPath();
+        gameContext.moveTo(cx - p, cy); gameContext.lineTo(cx + p, cy);
+        gameContext.moveTo(cx, cy - p); gameContext.lineTo(cx, cy + p);
+        gameContext.stroke();
+    } else {
+        // Finish flag: pole + pennant.
+        gameContext.lineWidth = 1.5;
+        var px = cx - r * 0.32;
+        gameContext.beginPath();
+        gameContext.moveTo(px, cy - r * 0.62); gameContext.lineTo(px, cy + r * 0.62);
+        gameContext.stroke();
+        gameContext.beginPath();
+        gameContext.moveTo(px, cy - r * 0.58);
+        gameContext.lineTo(px + r * 0.72, cy - r * 0.3);
+        gameContext.lineTo(px, cy - r * 0.02);
+        gameContext.closePath();
+        gameContext.fill();
+    }
+    gameContext.restore();
+}
+
+// Cart-cosmetic thumbnail for a live player, with a team-coloured ring in teams
+// modes. Falls back to a plain disc if the player object is gone (left the room).
+function drawCombatThumb(id, cx, cy, r) {
+    var p = (typeof playerList !== "undefined" && playerList) ? playerList[id] : null;
+    if (p != null && typeof drawOverviewKart === "function") {
+        drawOverviewKart(p, cx, cy, r);
+    } else {
+        gameContext.beginPath();
+        gameContext.arc(cx, cy, r, 0, Math.PI * 2);
+        gameContext.fillStyle = "rgba(120,130,140,0.85)";
+        gameContext.fill();
+    }
+    if (p != null && p.teamId != null && typeof teamInfo !== "undefined" && teamInfo != null && Array.isArray(teamInfo.defs)) {
+        var tc = combatColorOf(id, null);
+        gameContext.beginPath();
+        gameContext.arc(cx, cy, r + 1.6, 0, Math.PI * 2);
+        gameContext.lineWidth = 2;
+        gameContext.strokeStyle = tc;
+        gameContext.stroke();
+    }
+}
+
+// Build the ordered segment list for one row. Segments: badge / thumb / text / gap.
+function combatRowSegments(entry) {
+    var segs = [{ k: "badge", type: entry.type, cause: entry.cause }];
+    if (entry.type === "kill") {
+        segs.push({ k: "thumb", id: entry.attackerId });
+        segs.push({ k: "text", text: entry.attackerName, color: combatColorOf(entry.attackerId, "#ffffff"), bold: true });
+        segs.push({ k: "thumb", id: entry.victimId });
+        segs.push({ k: "text", text: entry.victimName, color: combatColorOf(entry.victimId, "#ffffff"), bold: false });
+    } else if (entry.type === "death") {
+        segs.push({ k: "thumb", id: entry.victimId });
+        segs.push({ k: "text", text: entry.victimName, color: combatColorOf(entry.victimId, "#ffffff"), bold: false });
+        segs.push({ k: "text", text: (entry.cause === "lava") ? "melted" : "out", color: "#9aa3ad", bold: false, small: true });
+    } else if (entry.type === "ability") {
+        segs.push({ k: "thumb", id: entry.ownerId });
+        segs.push({ k: "text", text: entry.ownerName, color: combatColorOf(entry.ownerId, "#ffffff"), bold: false });
+        segs.push({ k: "text", text: abilityLabelFor(entry.abilityId), color: "#5fe0ee", bold: true });
+    } else { // score
+        segs.push({ k: "thumb", id: entry.playerId });
+        segs.push({ k: "text", text: entry.playerName, color: combatColorOf(entry.playerId, "#ffffff"), bold: false });
+        var label = entry.rankLabel + (entry.points != null ? ("  +" + entry.points) : "");
+        segs.push({ k: "text", text: label, color: "#ffd54a", bold: true });
+    }
+    return segs;
+}
+
+function drawCombatLog() {
+    if (typeof config === "undefined" || config == null || config.stateMap == null) { return; }
+    if (currentState != config.stateMap.racing && currentState != config.stateMap.collapsing) { return; }
+    if (combatLog.length === 0) { return; }
+    var now = Date.now();
+    // Prune expired rows.
+    for (var i = combatLog.length - 1; i >= 0; i--) {
+        var life = COMBAT_LOG_LIFE_MS[combatLog[i].type] || 6000;
+        if (now - combatLog[i].bornAt > life) { combatLog.splice(i, 1); }
+    }
+    if (combatLog.length === 0) { return; }
+
+    var rightX = LOGICAL_WIDTH - 16;
+    var topY = 92;          // below the race timer + brutal-badge row
+    var rowH = 26, gapY = 5, padX = 8, thumbR = 9, badgeR = 8, segGap = 5;
+    var localId = (typeof myID !== "undefined") ? myID : null;
+
+    gameContext.save();
+    gameContext.textBaseline = "middle";
+    for (var j = 0; j < combatLog.length; j++) {
+        var entry = combatLog[j];
+        var life = COMBAT_LOG_LIFE_MS[entry.type] || 6000;
+        var age = now - entry.bornAt;
+        var fadeIn = Math.min(1, age / 130);
+        var fadeOut = (age > life - 500) ? Math.max(0, (life - age) / 500) : 1;
+        var alpha = Math.max(0, Math.min(1, fadeIn * fadeOut));
+        if (alpha <= 0) { continue; }
+        var rowY = topY + j * (rowH + gapY);
+        var cy = rowY + rowH / 2;
+
+        // Measure.
+        var segs = combatRowSegments(entry);
+        var contentW = 0;
+        for (var s = 0; s < segs.length; s++) {
+            var seg = segs[s];
+            if (seg.k === "badge") { seg.w = badgeR * 2; }
+            else if (seg.k === "thumb") { seg.w = thumbR * 2; }
+            else { // text
+                gameContext.font = (seg.bold ? "bold " : "") + (seg.small ? "11px" : "13px") + " Arial";
+                seg.w = gameContext.measureText(seg.text).width;
+            }
+            contentW += seg.w;
+            if (s < segs.length - 1) { contentW += segGap; }
+        }
+        var pillW = contentW + padX * 2;
+        var pillX = rightX - pillW;
+
+        gameContext.globalAlpha = alpha;
+        // Highlight rows the local player is involved in.
+        var mine = (localId != null) && (entry.attackerId === localId || entry.victimId === localId ||
+            entry.ownerId === localId || entry.playerId === localId);
+        if (typeof drawHudPanel === "function") {
+            drawHudPanel(pillX, rowY, pillW, rowH, {
+                fill: mine ? "rgba(28,34,44,0.86)" : "rgba(10,12,16,0.74)",
+                alpha: alpha,
+                borderAlpha: alpha,
+                radius: 7,
+                border: mine ? "rgba(255,255,255,0.55)" : "rgba(255,255,255,0.22)"
+            });
+        } else {
+            gameContext.fillStyle = "rgba(10,12,16,0.74)";
+            roundRectPath(gameContext, pillX, rowY, pillW, rowH, 7);
+            gameContext.fill();
+        }
+
+        // Draw left → right.
+        var cx = pillX + padX;
+        gameContext.globalAlpha = alpha;
+        for (var d = 0; d < segs.length; d++) {
+            var sg = segs[d];
+            if (sg.k === "badge") {
+                drawCombatBadge(sg.type, sg.cause, cx + badgeR, cy, badgeR);
+            } else if (sg.k === "thumb") {
+                drawCombatThumb(sg.id, cx + thumbR, cy, thumbR);
+                gameContext.globalAlpha = alpha; // drawOverviewKart resets alpha via save/restore — re-assert
+            } else {
+                gameContext.font = (sg.bold ? "bold " : "") + (sg.small ? "11px" : "13px") + " Arial";
+                gameContext.textAlign = "left";
+                gameContext.fillStyle = sg.color;
+                gameContext.fillText(sg.text, cx, cy + 0.5);
+            }
+            cx += sg.w + segGap;
         }
     }
     gameContext.restore();

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -10293,68 +10293,14 @@ function combatLogScore(playerId, rankLabel, points) {
     });
 }
 
-// A small circular type badge with a simple white vector glyph (kept sprite-free
-// and emoji-free to match the in-game HUD iconography).
-function drawCombatBadge(type, cause, cx, cy, r) {
-    var color;
-    if (type === "kill") { color = "#e8473f"; }
-    else if (type === "death") { color = (cause === "lava") ? "#ff7a26" : "#7d8794"; }
-    else if (type === "ability") { color = "#36c5d6"; }
-    else { color = "#ffcc3a"; } // score
-    gameContext.beginPath();
-    gameContext.arc(cx, cy, r, 0, Math.PI * 2);
-    gameContext.fillStyle = color;
-    gameContext.fill();
-    gameContext.lineWidth = 1.4;
-    gameContext.strokeStyle = "rgba(0,0,0,0.35)";
-    gameContext.stroke();
-    gameContext.save();
-    gameContext.strokeStyle = "#ffffff";
-    gameContext.fillStyle = "#ffffff";
-    gameContext.lineCap = "round";
-    gameContext.lineJoin = "round";
-    if (type === "kill") {
-        // Crossed swords (two short blades).
-        gameContext.lineWidth = 1.6;
-        var s = r * 0.62;
-        gameContext.beginPath();
-        gameContext.moveTo(cx - s, cy - s); gameContext.lineTo(cx + s, cy + s);
-        gameContext.moveTo(cx + s, cy - s); gameContext.lineTo(cx - s, cy + s);
-        gameContext.stroke();
-    } else if (type === "death") {
-        // Skull: rounded head with two eye sockets.
-        var hr = r * 0.55;
-        gameContext.beginPath();
-        gameContext.arc(cx, cy - r * 0.12, hr, 0, Math.PI * 2);
-        gameContext.fill();
-        gameContext.fillStyle = (cause === "lava") ? "#ff7a26" : "#7d8794";
-        gameContext.beginPath(); gameContext.arc(cx - hr * 0.45, cy - r * 0.16, hr * 0.32, 0, Math.PI * 2); gameContext.fill();
-        gameContext.beginPath(); gameContext.arc(cx + hr * 0.45, cy - r * 0.16, hr * 0.32, 0, Math.PI * 2); gameContext.fill();
-        gameContext.fillStyle = "#ffffff";
-        gameContext.fillRect(cx - r * 0.28, cy + r * 0.42, r * 0.56, r * 0.26);
-    } else if (type === "ability") {
-        // Plus sign (a pickup / power gained).
-        gameContext.lineWidth = 1.8;
-        var p = r * 0.55;
-        gameContext.beginPath();
-        gameContext.moveTo(cx - p, cy); gameContext.lineTo(cx + p, cy);
-        gameContext.moveTo(cx, cy - p); gameContext.lineTo(cx, cy + p);
-        gameContext.stroke();
-    } else {
-        // Finish flag: pole + pennant.
-        gameContext.lineWidth = 1.5;
-        var px = cx - r * 0.32;
-        gameContext.beginPath();
-        gameContext.moveTo(px, cy - r * 0.62); gameContext.lineTo(px, cy + r * 0.62);
-        gameContext.stroke();
-        gameContext.beginPath();
-        gameContext.moveTo(px, cy - r * 0.58);
-        gameContext.lineTo(px + r * 0.72, cy - r * 0.3);
-        gameContext.lineTo(px, cy - r * 0.02);
-        gameContext.closePath();
-        gameContext.fill();
-    }
-    gameContext.restore();
+// Action markers reuse the game's established emoji iconography (the same glyphs
+// the standings board stamps over karts and the gameOver medals card uses):
+// 💥 a kill, 💀 a death, 🥇/🥈 first/second place, 🏁 any other finish. Ability
+// pickups lead with the ability's own sprite token (drawAbilityIconToken).
+function combatScoreEmoji(rankLabel) {
+    if (rankLabel === "1st") { return "🥇"; }
+    if (rankLabel === "2nd") { return "🥈"; }
+    return "🏁";
 }
 
 // Cart-cosmetic thumbnail for a live player, with a team-coloured ring in teams
@@ -10379,33 +10325,39 @@ function drawCombatThumb(id, cx, cy, r) {
     }
 }
 
-// Build the ordered segment list for one row. Segments: badge / thumb / text / gap.
+// Build the ordered segment list for one row. Segments: glyph (emoji marker) /
+// abilityicon (ability sprite token) / thumb (cart cosmetic) / text.
 function combatRowSegments(entry) {
-    var segs = [{ k: "badge", type: entry.type, cause: entry.cause }];
+    var segs = [];
     if (entry.type === "kill") {
+        segs.push({ k: "glyph", emoji: "💥" });
         segs.push({ k: "thumb", id: entry.attackerId });
         segs.push({ k: "text", text: entry.attackerName, color: combatColorOf(entry.attackerId, "#ffffff"), bold: true });
         segs.push({ k: "thumb", id: entry.victimId });
         segs.push({ k: "text", text: entry.victimName, color: combatColorOf(entry.victimId, "#ffffff"), bold: false });
     } else if (entry.type === "death") {
+        segs.push({ k: "glyph", emoji: "💀" });
         segs.push({ k: "thumb", id: entry.victimId });
         segs.push({ k: "text", text: entry.victimName, color: combatColorOf(entry.victimId, "#ffffff"), bold: false });
-        segs.push({ k: "text", text: (entry.cause === "lava") ? "melted" : "out", color: "#9aa3ad", bold: false, small: true });
+        if (entry.cause === "lava") { segs.push({ k: "text", text: "melted", color: "#9aa3ad", bold: false, small: true }); }
     } else if (entry.type === "ability") {
-        segs.push({ k: "thumb", id: entry.ownerId });
-        segs.push({ k: "text", text: entry.ownerName, color: combatColorOf(entry.ownerId, "#ffffff"), bold: false });
+        // Lead with the ability's own icon as the action marker (operator request),
+        // falling back to the name only if the sprite isn't decoded yet.
         var aimg = abilityIconFor(entry.abilityId);
         if (aimg != null && aimg.complete !== false && (aimg.naturalWidth == null || aimg.naturalWidth > 0)) {
             segs.push({ k: "abilityicon", img: aimg });
+            segs.push({ k: "thumb", id: entry.ownerId });
+            segs.push({ k: "text", text: entry.ownerName, color: combatColorOf(entry.ownerId, "#ffffff"), bold: false });
         } else {
-            // Icon not ready — keep the name so the row never reads blank.
+            segs.push({ k: "thumb", id: entry.ownerId });
+            segs.push({ k: "text", text: entry.ownerName, color: combatColorOf(entry.ownerId, "#ffffff"), bold: false });
             segs.push({ k: "text", text: abilityLabelFor(entry.abilityId), color: "#5fe0ee", bold: true });
         }
-    } else { // score
+    } else { // score — 🥇/🥈/🏁 marker conveys the placement
+        segs.push({ k: "glyph", emoji: combatScoreEmoji(entry.rankLabel) });
         segs.push({ k: "thumb", id: entry.playerId });
         segs.push({ k: "text", text: entry.playerName, color: combatColorOf(entry.playerId, "#ffffff"), bold: false });
-        var label = entry.rankLabel + (entry.points != null ? ("  +" + entry.points) : "");
-        segs.push({ k: "text", text: label, color: "#ffd54a", bold: true });
+        if (entry.points != null) { segs.push({ k: "text", text: "+" + entry.points, color: "#ffd54a", bold: true }); }
     }
     return segs;
 }
@@ -10445,7 +10397,7 @@ function drawCombatLog() {
         var contentW = 0;
         for (var s = 0; s < segs.length; s++) {
             var seg = segs[s];
-            if (seg.k === "badge") { seg.w = badgeR * 2; }
+            if (seg.k === "glyph") { gameContext.font = "15px Arial"; seg.w = gameContext.measureText(seg.emoji).width; }
             else if (seg.k === "thumb") { seg.w = thumbR * 2; }
             else if (seg.k === "abilityicon") { seg.w = badgeR * 2; }
             else { // text
@@ -10481,8 +10433,10 @@ function drawCombatLog() {
         gameContext.globalAlpha = alpha;
         for (var d = 0; d < segs.length; d++) {
             var sg = segs[d];
-            if (sg.k === "badge") {
-                drawCombatBadge(sg.type, sg.cause, cx + badgeR, cy, badgeR);
+            if (sg.k === "glyph") {
+                gameContext.font = "15px Arial";
+                gameContext.textAlign = "left";
+                gameContext.fillText(sg.emoji, cx, cy + 0.5);
             } else if (sg.k === "thumb") {
                 drawCombatThumb(sg.id, cx + thumbR, cy, thumbR);
                 gameContext.globalAlpha = alpha; // drawOverviewKart resets alpha via save/restore — re-assert

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -1363,6 +1363,11 @@ class Player extends Circle {
 		messenger.messageRoomBySig(packet.roomSig, "playerDied", {
 			id: packet.id,
 			killed: packet.murderedBy != null,
+			// Attacker id for the client combat log. murderedBy is still set here at
+			// death time (checkForWinners clears it only AFTER crediting the kill on a
+			// later line), so it's the authoritative "who got the kill" — null for an
+			// environmental/self death (drove into the lava, gate, infection timer, AFK).
+			by: packet.murderedBy != null ? packet.murderedBy : null,
 			cause: cause || null,
 			x: packet.x,
 			y: packet.y


### PR DESCRIPTION
Adds a small **combat log** — a top-right feed that surfaces recent moments during racing/collapsing, newest on top, each row fading after a few seconds.

### What it shows
- **Kills** — `💥` + attacker → victim (both with cart thumbnails)
- **Deaths** (environmental/self) — `💀` + victim (lava deaths read "melted")
- **Ability pickups** — the ability's own sprite token + picker
- **Bonus orb collection** (team modes) — the in-game gold-orb token + collector + `+1` banked
- **Scoring finishes** — `🥇`/`🥈` for 1st/2nd, `🏁` otherwise; team points shown in team modes

Each row carries the racer's **cart cosmetic** + name. In **team modes** names and a thumbnail ring use the **team color** (the team cosmetic), and finishes/orbs show banked points. Rows involving the local player are highlighted.

### Iconography
Markers reuse the symbols the game already uses elsewhere (standings board over karts + the gameOver medals card): `💥` kill, `💀` death, `🥇`/`🥈`/`🏁` placement. Ability rows use the existing HUD ability sprites; the orb marker mirrors `drawBonusOrbs`' gold sphere.

### Server change
`playerDied` now carries `by` (the attacker id, read off `murderedBy` at death time before `checkForWinners` clears it) so the client can tell a kill from an environmental death and name the killer. Every other event reuses existing socket messages (`abilityAcquired`, `firstPlaceWinner`/`secondPlaceWinner`/`playerConcluded`, `teamPointsDelta`, `bonusOrbCollected`). Scoring rows dedupe + upgrade rank/points rather than stacking duplicates.

### Testing
- `npm run build` ✅ · headless smoke test ✅
- Verified in-browser across all five row types (FFA + teams), including team-colored names/rings and the bonus-orb row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)