### PR TITLE
feat(water): slow-boil collapse + fire-shield water crossing

### DIFF
--- a/.github/scripts/water-boil-flame-test.js
+++ b/.github/scripts/water-boil-flame-test.js
@@ -1,0 +1,218 @@
+'use strict';
+
+// Headless test for the water slow-boil + fire-walk water-crossing feature.
+//
+// Boots the real server engine (no network/browser), like smoke-test.js, and asserts:
+//
+//   Session 1 — fire-walk: a kart carrying a killstreak fire shield STRIDES across water
+//     (walking grip, no swim) while the shield rides down exactly like on lava, and only
+//     drops into the swim once the shield burns out (with a flameExtinguished cue).
+//
+//   Session 2 — slow-boil: during a collapse, water does NOT flash straight to lava. Each
+//     water cell the front reaches sits in gameBoard.boilingWater for ~collapseBoilMs
+//     (emitting tiered 'waterBoiling' warnings) before it converts.
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const messenger = require(path.join(repoRoot, 'server', 'messenger.js'));
+const game = require(path.join(repoRoot, 'server', 'game.js'));
+const config = require(path.join(repoRoot, 'server', 'config.json'));
+const mapFormat = require(path.join(repoRoot, 'server', 'mapFormat.js'));
+
+const TICK_MS = config.serverTickSpeed;
+
+let failures = 0;
+function fail(msg) { failures++; console.log('::error::' + msg); }
+function ok(msg) { console.log('  ok: ' + msg); }
+
+// Recording io: messageRoomBySig() -> io.to(sig).emit(header, payload). Capture every
+// room broadcast so we can assert on flameExtinguished / waterBoiling.
+const events = [];
+const recordingIo = {
+    to() { return { emit(header, payload) { events.push({ header: header, payload: payload }); } }; },
+    emit() { },
+    sockets: { emit() { } }
+};
+messenger.build(recordingIo);
+
+function approxEq(a, b) { return Math.abs(a - b) < 1e-6; }
+
+// ---------------------------------------------------------------------------
+// Session 1: fire-walk across water on the killstreak shield.
+// ---------------------------------------------------------------------------
+function sessionFireWalk() {
+    const water = config.tileMap.water;
+    const normal = config.tileMap.normal;
+    const waterCell = {
+        id: water.id, acel: water.acel, dragCoeff: water.dragCoeff,
+        brakeCoeff: water.brakeCoeff, voronoiId: 1
+    };
+
+    const room = game.getRoom('boil-firewalk', 4);
+    const p = room.world.createNewPlayer('fw-p');
+    room.playerList['fw-p'] = p;
+    p.currentState = config.stateMap.racing;
+    p.isZombie = false;
+
+    const realNow = Date.now;
+    let clock = realNow();
+    Date.now = () => clock;
+    try {
+        // (a) NOT on fire: water is deep water -> swim physics, onWater true.
+        p.onFire = 0; p.fireTimer = null; p.onWater = false;
+        p.handleMapCellHit(waterCell);
+        if (p.onWater !== true) fail('Session 1a: a non-burning kart on water should have onWater=true (swim)');
+        else if (!approxEq(p.acel, water.acel)) fail('Session 1a: swimmer should take deep-water acel, got ' + p.acel);
+        else ok('non-burning kart swims (onWater=true, deep-water grip)');
+
+        // (b) On fire: strides — walking grip, onWater cleared, shield still alive.
+        p.onFire = 1000; p.fireTimer = null;
+        const t0 = clock;
+        p.handleMapCellHit(waterCell);
+        if (p.onWater !== false) fail('Session 1b: a fire-walker should have onWater=false (no swim)');
+        else if (!approxEq(p.acel, normal.acel)) fail('Session 1b: fire-walker should take solid (normal) grip, got ' + p.acel);
+        else if (!(p.onFire > 0)) fail('Session 1b: the shield must NOT extinguish on contact (full-shield crossing)');
+        else if (p.fireTimer == null) fail('Session 1b: fire-walking should arm the shield timer (ride it down like lava)');
+        else ok('fire-walker strides across water (walking grip, shield rides down, no instant douse)');
+
+        // (c) Shield burns out over water: extinguished + douse cue, then back to swimming.
+        const beforeExtinguish = events.length;
+        clock = t0 + 1200; // past the 1000ms shield
+        p.handleMapCellHit(waterCell);
+        if (p.onFire !== 0) fail('Session 1c: shield should be fully spent after its duration, onFire=' + p.onFire);
+        const doused = events.slice(beforeExtinguish).some(e => e.header === 'flameExtinguished' && e.payload && e.payload.owner === 'fw-p');
+        if (!doused) fail('Session 1c: a flameExtinguished cue should fire when the shield boils away over water');
+        if (failures === 0) ok('shield boils away over water -> extinguished with a steam cue');
+
+        // (d) Next tick with the shield gone: deep-water swim resumes.
+        p.handleMapCellHit(waterCell);
+        if (p.onWater !== true || !approxEq(p.acel, water.acel)) fail('Session 1d: with the shield gone the kart should swim again');
+        else ok('shield gone -> kart drops back into the swim');
+    } finally {
+        Date.now = realNow;
+    }
+    if (failures === 0) console.log('Session 1 passed: fire-walk water crossing.');
+}
+
+// ---------------------------------------------------------------------------
+// Session 2: water slow-boils for collapseBoilMs before converting to lava.
+// ---------------------------------------------------------------------------
+function sessionSlowBoil() {
+    const water = config.tileMap.water;
+    const lavaId = config.tileMap.lava.id;
+    const boilMs = water.collapseBoilMs;
+
+    // A committed water map (the collapse front must actually pass water cells).
+    let map = JSON.parse(fs.readFileSync(path.join(repoRoot, 'client', 'maps', 'TheFlow.json'), 'utf8'));
+    if (mapFormat.isSitesOnly(map)) map = mapFormat.reconstruct(map);
+
+    const room = game.getRoom('boil-collapse', 4);
+    room.game.gameBoard.isPreview = true;
+    room.game.gameBoard.previewMap = map;
+    for (let i = 0; i < 2; i++) {
+        const id = 'bc-p' + i;
+        const player = room.world.createNewPlayer(id);
+        room.playerList[id] = player;
+        room.game.determineGameState(player);
+    }
+
+    const realNow = Date.now;
+    let clock = realNow();
+    Date.now = () => clock;
+    try {
+        room.game.startLobby();
+        room.game.startGated();
+        room.game.startRace();
+
+        // Drive the collapse mechanic DIRECTLY (not through the round state machine):
+        // with idle players the round would end before the front sweeps the water, so we
+        // sweep collapseLine across the whole board ourselves and tick collapseMap, which
+        // takes the state as an arg and is the single water-boil path.
+        const gb = room.game.gameBoard;
+        const cx = config.worldWidth / 2, cy = config.worldHeight / 2;
+        const cells = gb.currentMap.cells;
+        const firstBoilAt = {};   // vid -> mock-time it entered boilingWater
+        const convertAt = {};     // vid -> mock-time its cell flipped to lava
+        const wasWater = {};
+        let maxWaterDist = 0;
+        for (let i = 0; i < cells.length; i++) {
+            if (cells[i].id === water.id) {
+                wasWater[cells[i].site.voronoiId] = true;
+                const d = Math.hypot(cx - cells[i].site.x, cy - cells[i].site.y);
+                if (d > maxWaterDist) maxWaterDist = d;
+            }
+        }
+        const totalWater = Object.keys(wasWater).length;
+        if (totalWater === 0) { fail('Session 2: TheFlow has no water cells to boil'); return; }
+
+        gb.collapseLoc = { x: cx, y: cy };
+        gb.collapseLine = maxWaterDist + 20;       // start the front right at the water band
+        gb.firstPlaceSig = 'test-winner';          // game-concluded -> the fast sweep speed
+        gb.soloMode = false;
+
+        let sawBoilEvent = false;
+        for (let f = 0; f < 900; f++) {
+            clock += TICK_MS;               // advance the boil clock one tick
+            const before = events.length;
+            gb.collapseMap(config.stateMap.collapsing);
+            for (let e = before; e < events.length; e++) {
+                if (events[e].header === 'waterBoiling') sawBoilEvent = true;
+            }
+            const boiling = gb.boilingWater;
+            for (const vid in boiling) {
+                if (firstBoilAt[vid] == null) firstBoilAt[vid] = boiling[vid].startedAt;
+            }
+            for (let i = 0; i < cells.length; i++) {
+                const vid = cells[i].site.voronoiId;
+                if (wasWater[vid] && convertAt[vid] == null && cells[i].id === lavaId) {
+                    convertAt[vid] = clock;
+                }
+            }
+        }
+
+        if (!sawBoilEvent) fail('Session 2: no waterBoiling tier events were emitted (water converted instantly?)');
+        else ok('water emitted tiered boil warnings instead of flashing to lava');
+
+        let measured = 0, badDelay = 0, remainingWater = 0;
+        for (let i = 0; i < cells.length; i++) {
+            if (cells[i].id === water.id) remainingWater++;
+        }
+        for (const vid in convertAt) {
+            if (firstBoilAt[vid] == null) continue;
+            const delay = convertAt[vid] - firstBoilAt[vid];
+            measured++;
+            // Convert fires on the first tick where elapsed >= boilMs, so the delay lands
+            // in [boilMs, boilMs + a couple ticks]. Anything shorter means it skipped the boil.
+            if (delay < boilMs - 1 || delay > boilMs + 3 * TICK_MS) {
+                badDelay++;
+                if (badDelay <= 3) fail('Session 2: cell ' + vid + ' converted after ' + Math.round(delay) + 'ms (expected ~' + boilMs + 'ms boil)');
+            }
+        }
+        if (measured === 0) fail('Session 2: no water cell completed a boil->lava transition in the window');
+        else if (badDelay === 0) ok('all ' + measured + ' boiled cell(s) waited ~' + boilMs + 'ms before converting');
+
+        if (remainingWater > 0) {
+            // Not a hard failure (the front may not reach every cell), just informational.
+            console.log('  note: ' + remainingWater + '/' + totalWater + ' water cells were not reached by the collapse front');
+        }
+    } finally {
+        Date.now = realNow;
+    }
+    if (failures === 0) console.log('Session 2 passed: water slow-boils ~' + boilMs + 'ms before lava.');
+}
+
+try {
+    sessionFireWalk();
+    if (failures === 0) sessionSlowBoil();
+} catch (e) {
+    fail('Unhandled exception: ' + e.message + '\n' + e.stack);
+}
+
+if (failures > 0) {
+    console.log('\nWater-boil/flame test FAILED with ' + failures + ' error(s).');
+    process.exit(1);
+}
+console.log('\nWater-boil/flame test passed.');
+process.exit(0);

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -148,6 +148,9 @@ jobs:
       - name: "Headless Heatwave brutal-round test (tile delta / path guarantee / second wave / Firewalker)"
         run: node .github/scripts/heatwave-test.js
 
+      - name: "Headless water slow-boil + fire-walk test (boil delay before lava / shield strides across water)"
+        run: node .github/scripts/water-boil-flame-test.js
+
       - name: "Game-mode matrix test (every ACTIVE config.gameModes mode: plumbing, full match to gameOver, every-map sweep)"
         run: node .github/scripts/mode-smoke-test.js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- **Water doesn't flash to lava when the world collapses anymore — it slow-boils.** When the closing lava front reaches a patch of water it now spends about three seconds heating up — a tiered simmer → boil → rolling-boil warning with bubbles and rising steam — before it finally turns to lava. That's a few extra seconds to scramble across (or off) the water while it's still safe.
+- **A killstreak fire shield now lets you walk on water.** Carry a flame into water and instead of getting doused on the spot, your shield lets you *stride straight across* — no swimming, with steam hissing off you the whole way. The flame burns down while you cross (just like it does on lava), so a big pond can still snuff it mid-crossing and drop you into the swim. Fire is now a real shortcut across water.
+- **Flames burn out instead of blinking off.** A fire shield running out — on lava or boiling away on water — now fades out with a last steam puff rather than vanishing in a single frame, and burning karts kick up matching effects underfoot: embers on lava, steam on water.
 
 ## v0.37.0 — 2026-06-14
 

--- a/client/scripts/audio.js
+++ b/client/scripts/audio.js
@@ -615,6 +615,7 @@ function stopAllSounds() {
     currentBackgroundMusic = null;
     fadingBackgroundVoice = null;
     stopAllDriftSounds();
+    stopFireWalkSound();
     stopHeatwaveDrone();
 }
 
@@ -957,6 +958,56 @@ function stopDriftSound(id) {
 
 function stopAllDriftSounds() {
     for (var id in driftVoices) { stopDriftSound(id); }
+}
+
+// --- Fire-walk sizzle (synthesized, no MP3) ---
+// One looping voice for the LOCAL kart while its killstreak shield strides over lava or
+// water (unified): white noise through a bandpass that brightens as you move faster, so
+// the shield "sizzles/hisses" against the ground. Modeled on the drift skid — same
+// out-of-activeVoices lifecycle, so it's driven straight from the per-frame loop
+// (updateFireWalkAudio) and rides its gain down to silence on mute rather than cutting.
+var FIREWALK_BASE_VOL = 0.13;
+var fireWalkVoice = null;       // single voice (local kart only) | null
+function setFireWalkSound(id, intensity, level) {
+    var ctx = getCtx();
+    if (!ctx || ctx.state !== "running") { return; }
+    var muted = gameMuted || masterVolume === 0;
+    if (!fireWalkVoice && muted) { return; }
+    var lvl = (level == null) ? 1 : level;
+    var inten = (intensity == null) ? 0.4 : Math.max(0, Math.min(1, intensity));
+    var vol = muted ? 0 : FIREWALK_BASE_VOL * inten * lvl * masterVolume * sfxVolumeScalar;
+    var now = ctx.currentTime;
+    if (!fireWalkVoice) {
+        var src = ctx.createBufferSource();
+        src.buffer = getDriftNoiseBuffer(ctx);   // reuse the shared white-noise bed
+        src.loop = true;
+        var filt = ctx.createBiquadFilter();
+        filt.type = "bandpass";
+        filt.Q.value = 0.8;                       // airy hiss, not a tone
+        var g = ctx.createGain();
+        g.gain.value = 0.0001;                    // wash in from silence
+        src.connect(filt); filt.connect(g); g.connect(sfxBus);
+        try { src.start(); } catch (e) { try { src.disconnect(); } catch (e2) {} return; }
+        fireWalkVoice = { source: src, filter: filt, gain: g };
+    }
+    var freq = 1800 + 2400 * inten;               // brighter sizzle the faster you stride
+    try {
+        fireWalkVoice.filter.frequency.setTargetAtTime(freq, now, 0.06);
+        fireWalkVoice.gain.gain.setTargetAtTime(Math.max(0.0001, vol), now, 0.07);
+    } catch (e) {}
+}
+function stopFireWalkSound(id) {
+    var v = fireWalkVoice;
+    if (!v) { return; }
+    fireWalkVoice = null;
+    var ctx = getCtx();
+    if (!ctx) { try { v.source.stop(); } catch (e) {} return; }
+    var now = ctx.currentTime;
+    try {
+        holdParamNow(v.gain.gain, now);
+        v.gain.gain.linearRampToValueAtTime(0.0001, now + 0.16);
+        v.source.stop(now + 0.2);
+    } catch (e) { try { v.source.stop(); } catch (e2) {} }
 }
 
 // Flame extinguished by water — synthesized one-shot "steam quench" (no MP3 asset),

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -929,6 +929,9 @@ function registerConnectionHandlers(server) {
 		// Antlion burrow/dust FX reset synchronously too (same microtask gotcha):
 		// a dig-down animating across the map swap would render on the new terrain.
 		if (typeof antlionBurrows !== "undefined") { antlionBurrows.length = 0; }
+		// Slow-boil water warnings reset synchronously too (same microtask gotcha): a
+		// prior round's boiling overlay must never bleed onto the fresh map.
+		if (typeof clearBoilingWater === "function") { clearBoilingWater(); }
 		// A new round starts a fresh team scoring ledger (NOT cleared at overview —
 		// the overview is where the just-ended round's ledger is shown).
 		if (typeof teamRoundLedger !== "undefined") { teamRoundLedger = []; }
@@ -1716,6 +1719,12 @@ function registerCombatHandlers(server) {
 			collapseCells(cells);
 		});
 		if (typeof recapMarkMapDirty === "function") { recapMarkMapDirty(); } // map changed -> recap re-snapshots
+	});
+	// Water the collapse has reached but that's slow-boiling toward lava: tier bumps
+	// (simmer->boil->rolling) for the warning overlay. The cell stays water until a
+	// later collapsedCells flips it; setWaterBoiling just drives the animation stage.
+	server.on('waterBoiling', function (updates) {
+		if (typeof setWaterBoiling === "function") { setWaterBoiling(updates); }
 	});
 	// Bunker (battle royale): the goal sinks below a silo door at round start and
 	// rises again for the lone survivor. The tile flips (goal<->ice/normal) arrive

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3888,6 +3888,9 @@ function drawObjects(dt) {
         }
         drawPingCircles();
         drawCollapseShockwaves();
+        // Slow-boil water: tiered simmer->boil->rolling warning over cells the collapse
+        // front has reached but that haven't flipped to lava yet.
+        if (typeof drawBoilingWater === "function") { drawBoilingWater(); }
     }
     if (currentState == config.stateMap.gated ||
         currentState == config.stateMap.racing) {
@@ -6050,6 +6053,8 @@ function drawPlayers(dt) {
     drawDriftSpray(dt);
     // Per-frame drift skid audio (synthesized loop per drifting kart, distance-faded).
     updateDriftAudio();
+    // Per-frame fire-walk sizzle (local kart striding over lava/water on the shield).
+    updateFireWalkAudio();
     // Draw remote players first, then ALL local players (the primary plus any
     // couch co-op slots) on top — so your own karts always read clearly over
     // other players' floating emojis and name labels.
@@ -6085,8 +6090,11 @@ function checkDrawPlayer(player, dt) {
     updateWaterDrip(player);
     if (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing) {
         drawTrail(player);
-        // Swim ripples ride ON TOP of the normal trail while the kart is in water.
-        drawSwimRipple(player);
+        // Swim ripples ride ON TOP of the normal trail while the kart is in water — but
+        // a fire-walker strides across (no swimming), so its shield steams instead.
+        if (!(player.onFire > 0)) {
+            drawSwimRipple(player);
+        }
     }
     if (player.alive == false) {
         drawDeathMessage(player);
@@ -6096,6 +6104,8 @@ function checkDrawPlayer(player, dt) {
         drawPlayer(player, dt);
         // Wet sheen + droplets on top of the kart while it dries off after swimming.
         drawWaterDrip(player);
+        // Flame-walking FX: steam off the shield on water, embers on lava (unified).
+        drawFireWalkFX(player);
     }
 }
 // =========================== Infection zombie body ===========================
@@ -7073,8 +7083,15 @@ function drawDeathMessage(player) {
         gameContext.restore();
     }
 }
+// The shield doesn't snap off — it fades over its final FLAME_FADE_MS as onFire (the
+// live remaining ms) runs down, so a flame burning out on lava OR boiling away on water
+// dies away gracefully instead of vanishing in one frame.
+var FLAME_FADE_MS = 600;
 function drawFire(player) {
     gameContext.save();
+    if (player.onFire < FLAME_FADE_MS) {
+        gameContext.globalAlpha = Math.max(0, player.onFire / FLAME_FADE_MS);
+    }
     // Offset the flame to the player's trailing edge based on facing. Computed
     // continuously from the angle so it works for ANY heading — the old 8-way
     // switch left the flame unplaced (invisible) for the AI racers and for
@@ -7086,6 +7103,80 @@ function drawFire(player) {
     gameContext.beginPath();
     drawFlameColor(player, 55);
     gameContext.restore();
+}
+// Flame-walking FX: while a kart carries the killstreak shield over lava OR water it
+// kicks up a unified plume — pale steam off boiling water, hot embers off lava — that
+// loft and fade as it moves. Purely cosmetic and procedural (seeded by id+time, no
+// stored particle state), drawn in the camera-translated gameplay pass (raw world
+// coords, like drawWaterDrip). The looping sizzle SFX is driven separately, local-only,
+// by updateFireWalkAudio so remote karts don't each spin up a voice.
+function drawFireWalkFX(player) {
+    if (!(player.onFire > 0)) { return; }
+    if (config == null || config.tileMap == null) { return; }
+    var cid = nearestCellIdCached(player);
+    var waterTile = config.tileMap.water;
+    var onWater = (waterTile != null && cid === waterTile.id);
+    var onLava = (cid === config.tileMap.lava.id);
+    if (!onWater && !onLava) { return; }
+    var now = Date.now();
+    var ctx = gameContext;
+    var sx = player.x, sy = player.y, r = player.radius || 7.5;
+    var dim = isLocalId(player.id) ? 1 : NONLOCAL_TRAIL_ALPHA;
+    var idSeed = (player.id && player.id.charCodeAt) ? (player.id.charCodeAt(0) || 0) + (player.id.charCodeAt(1) || 0) : 0;
+    ctx.save();
+    if (onWater) {
+        // Steam plumes lofting straight up as the shield boils the water beneath.
+        var puffs = 6;
+        for (var i = 0; i < puffs; i++) {
+            var seed = i * 53 + idSeed;
+            var ph = ((now * 0.0011) + (i / puffs)) % 1;          // 0 just off the kart -> 1 dissipated
+            var px = sx + Math.sin(seed + now * 0.002) * (r * 0.9);
+            var py = sy - ph * (r * 3.2);
+            ctx.globalAlpha = 0.22 * (1 - ph) * dim;
+            ctx.fillStyle = "rgba(232,240,248,1)";
+            ctx.beginPath();
+            ctx.arc(px, py, 2.5 + ph * 5.5, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    } else {
+        // Lava embers: hot sparks flung up that cool from gold to ember as they rise.
+        var sparks = 5;
+        for (var j = 0; j < sparks; j++) {
+            var s2 = j * 37 + idSeed;
+            var ph2 = ((now * 0.0016) + (j / sparks)) % 1;
+            var ang = s2 * 1.3 + now * 0.003;
+            var ex = sx + Math.cos(ang) * (r * 0.8);
+            var ey = sy - ph2 * (r * 2.6);
+            ctx.globalAlpha = 0.5 * (1 - ph2) * dim;
+            ctx.fillStyle = ph2 < 0.5 ? "rgba(255,210,120,1)" : "rgba(255,120,40,1)";
+            ctx.beginPath();
+            ctx.arc(ex, ey, 1.6 * (1 - ph2) + 0.5, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    }
+    ctx.restore();
+}
+// Once-per-frame, local-kart-only: keep the looping fire-walk sizzle in sync with the
+// local player's footing. A single voice (like the drift skid) that washes in while the
+// shield rides over lava/water and fades out the moment it isn't — unified across both.
+function updateFireWalkAudio() {
+    if (typeof setFireWalkSound !== "function") { return; }
+    var me = (typeof myPlayer !== "undefined") ? myPlayer : null;
+    var active = false;
+    if (me != null && me.alive && me.onFire > 0 && config != null && config.tileMap != null &&
+        (currentState == config.stateMap.racing || currentState == config.stateMap.collapsing)) {
+        var cid = nearestCellIdCached(me);
+        var waterTile = config.tileMap.water;
+        if ((waterTile != null && cid === waterTile.id) || cid === config.tileMap.lava.id) {
+            active = true;
+            var sp = Math.sqrt((me.velX || 0) * (me.velX || 0) + (me.velY || 0) * (me.velY || 0));
+            var inten = Math.max(0.2, Math.min(1, sp / 90));
+            setFireWalkSound(me.id, inten, 1);
+        }
+    }
+    if (!active && typeof stopFireWalkSound === "function") {
+        stopFireWalkSound((me != null) ? me.id : null);
+    }
 }
 
 function drawFlameColor(player, size) {
@@ -8002,6 +8093,72 @@ function drawCollapseShockwaves() {
         gameContext.stroke();
     }
     gameContext.restore();
+}
+// Slow-boil warning overlay: water cells the collapse front has reached but that are
+// still aging toward lava (server gameBoard.advanceBoilingWater, mirrored client-side in
+// boilingCells). Three tiers escalate the warning — stage 0 simmer (faint bubbles),
+// stage 1 boil (bubbles + steam wisps + warm tint), stage 2 rolling (violent churn +
+// strong steam + orange glow pulse, "this is about to be lava"). Procedural + seeded by
+// vid so the churn is stable per cell. Drawn in the camera-translated pass (raw world
+// coords); centered at each cell site (no polygon clip needed — reads clearly as the
+// tile heating up). Self-clears if we somehow draw outside a collapse.
+function drawBoilingWater() {
+    if (currentState != config.stateMap.collapsing) { clearBoilingWater(); return; }
+    if (currentMap == null || currentMap.cells == null) { return; }
+    var now = Date.now();
+    var t = now * 0.001;
+    var ctx = gameContext;
+    for (var i = 0; i < currentMap.cells.length; i++) {
+        var cell = currentMap.cells[i];
+        var b = boilingCells[cell.site.voronoiId];
+        if (b == null) { continue; }
+        var stage = b.stage | 0;                  // 0..2
+        var cx = cell.site.x, cy = cell.site.y;
+        var intensity = (stage + 1) / 3;          // 0.33, 0.66, 1.0
+        var pulse = 0.5 + 0.5 * Math.sin(t * (4 + stage * 3));
+        ctx.save();
+        // Warm radial glow — pale at a simmer, angry orange at a rolling boil.
+        var R = 22 + stage * 4;
+        var warm = stage >= 2 ? "255,90,30" : (stage >= 1 ? "255,150,60" : "255,205,130");
+        var glowA = 0.08 + 0.13 * stage + 0.05 * pulse;
+        var grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, R);
+        grad.addColorStop(0, "rgba(" + warm + "," + glowA.toFixed(3) + ")");
+        grad.addColorStop(1, "rgba(" + warm + ",0)");
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.arc(cx, cy, R, 0, Math.PI * 2);
+        ctx.fill();
+        // Bubbles: rising dots that pop at the surface, more + faster with each tier.
+        var bubbles = 3 + stage * 3;
+        for (var k = 0; k < bubbles; k++) {
+            var seed = (cell.site.voronoiId * 13 + k * 7);
+            var phase = ((t * (0.6 + 0.5 * stage)) + (seed % 100) / 100) % 1;
+            var bx = cx + Math.sin(seed * 1.7 + k) * (R * 0.5);
+            var by = cy + (R * 0.45) - phase * (R * 0.9);     // rise upward, pop near the top
+            var br = (1.0 + stage * 0.7) * (0.4 + 0.6 * (1 - phase));
+            ctx.globalAlpha = 0.5 * (1 - phase) * (0.6 + 0.4 * intensity);
+            ctx.fillStyle = stage >= 2 ? "rgba(255,215,175,1)" : "rgba(222,240,255,1)";
+            ctx.beginPath();
+            ctx.arc(bx, by, Math.max(0.5, br), 0, Math.PI * 2);
+            ctx.fill();
+        }
+        // Steam wisps from a boil on up — pale plumes lofting off the surface.
+        if (stage >= 1) {
+            var wisps = stage * 2;
+            for (var w = 0; w < wisps; w++) {
+                var seed2 = cell.site.voronoiId * 5 + w * 31;
+                var ph = ((t * 0.4) + (seed2 % 100) / 100) % 1;
+                var wx = cx + Math.sin(seed2 + t * 0.6) * (R * 0.4);
+                var wy = cy - ph * (R * 1.3);
+                ctx.globalAlpha = 0.22 * (1 - ph) * intensity;
+                ctx.fillStyle = "rgba(230,238,245,1)";
+                ctx.beginPath();
+                ctx.arc(wx, wy, 3 + ph * 5, 0, Math.PI * 2);
+                ctx.fill();
+            }
+        }
+        ctx.restore();
+    }
 }
 // Lobby-only "practice room" floor treatment: a dashed inset frame over the
 // arena. Races never draw this, so a returning player instantly reads the lobby

--- a/client/scripts/gameboard.js
+++ b/client/scripts/gameboard.js
@@ -1088,7 +1088,34 @@ function collapseCells(cells) {
 			}
 		}
 	}
+	// A converted cell is no longer boiling — drop its warning overlay so it doesn't
+	// linger over the fresh lava.
+	for (var k = 0; k < cells.length; k++) {
+		if (boilingCells[cells[k]] != null) { delete boilingCells[cells[k]]; }
+	}
 	invalidateMapCache();
+}
+
+// Water cells the collapse front has reached but that are still slow-boiling toward
+// lava (server gameBoard.advanceBoilingWater). vid -> { stage, since, stageSince }.
+// Drives the tiered simmer->boil->rolling warning overlay (drawBoilingWater). Cleared
+// as each cell converts (collapseCells) and on every fresh map load (clearBoilingWater).
+var boilingCells = {};
+function setWaterBoiling(updates) {
+	if (updates == null) { return; }
+	for (var k = 0; k < updates.length; k++) {
+		var u = updates[k];
+		if (u == null || u.vid == null) { continue; }
+		var prev = boilingCells[u.vid];
+		boilingCells[u.vid] = {
+			stage: u.stage,
+			since: prev ? prev.since : Date.now(),       // when this cell first started boiling
+			stageSince: Date.now()                       // when it entered the CURRENT tier
+		};
+	}
+}
+function clearBoilingWater() {
+	for (var vid in boilingCells) { delete boilingCells[vid]; }
 }
 function explodedCells(cells) {
 	for (var i = 0; i < currentMap.cells.length; i++) {

--- a/client/scripts/learn.js
+++ b/client/scripts/learn.js
@@ -73,7 +73,7 @@
                 {
                     id: "collapse", name: "The Collapse", icon: tex("lava.png"), anim: "collapse",
                     blurb: "The floor turns to lava and squeezes everyone inward.",
-                    detail: "Once the front-runners are home, the arena turns to lava from the edges inward, shrinking the safe ground and herding everyone toward the middle. It's the round's clock — but when one racer is left, the lava eases up to give them a fair shot at the goal."
+                    detail: "Once the front-runners are home, the arena turns to lava from the edges inward, shrinking the safe ground and herding everyone toward the middle. It's the round's clock — but when one racer is left, the lava eases up to give them a fair shot at the goal. Water is the one exception: when the front reaches it, it slow-boils for a few seconds — bubbling and steaming through a tiered warning — before it finally turns to lava, so a flooded shortcut stays open a little longer than the dry ground around it."
                 },
                 {
                     id: "punching", name: "Punching", icon: emoji("👊"), anim: "punch",
@@ -125,7 +125,7 @@
                   detail: "Ice barely bites — you keep gliding long after you ease off, steering only suggests where you'd like to go, and any shove sends you skating helplessly. There is one trick: hold your punch charge while on ice to DRIFT — you slow slightly and your edge digs in, giving back real steering control (your charge ring frosts over icy blue and you hear the skid hiss while it's working). Drift far enough without your punch landing on anyone — and without burning up in lava — and you're in the running for the Smooth Operator medal." },
                 { id: "tile-water", name: "Water", icon: swatch("#2f6fb0"), anim: "terrainWater",
                   blurb: "Punch to swim — slow but crossable.",
-                  detail: "Deep water barely lets you drift on your own — to really move, PUNCH to swim: each stroke shoves you the way you're steering. It's slow going and strokes spend stamina, so only dive in when the shortcut genuinely pays. Climbing out leaves you dripping wet and sluggish for a moment, water snuffs out a burning kart with a hiss, and where water meets lava the edge hardens into stone you can't cross. In infection rounds zombies can't swim at all, so water is a true escape from the horde." },
+                  detail: "Deep water barely lets you drift on your own — to really move, PUNCH to swim: each stroke shoves you the way you're steering. It's slow going and strokes spend stamina, so only dive in when the shortcut genuinely pays. Climbing out leaves you dripping wet and sluggish for a moment, and where water meets lava the edge hardens into stone you can't cross. Carry a killstreak fire shield in, though, and you don't swim at all — the flame lets you stride straight across with steam hissing off you, burning down as you go just like it would on lava (a wide pond can snuff it mid-crossing and drop you into the swim). In infection rounds zombies can't swim at all, so water is a true escape from the horde." },
                 { id: "tile-lava", name: "Lava", icon: tex("lava.png"), anim: "lavaBurn",
                   blurb: "Touch it and you burn out of the round.",
                   detail: "A fiery dunk and you're done — burned out and respawned, out of the round. The collapse turns the whole arena into this, and a well-aimed punch can post a rival straight into it." },

--- a/server/config.json
+++ b/server/config.json
@@ -185,7 +185,7 @@
             "color": "#A5F2F3"
         },
         "water": {
-            "_doc": "Deep water. Passive drive is almost nil (low acel + high drag) — you barely move unless you PUNCH to swim: a punch on water adds swimImpulse velocity in your held movement direction (scaled up a little by charge), so good swimmers average a speed between slow and normal. Swimming is just a punch, so it costs stamina and still knocks others back (the high drag dampens both ends). Stepping onto water extinguishes your killstreak fire shield (onFire->0). Leaving water leaves you 'dripping': drive cut to dripMoveFactor for dripMs. A water edge that borders lava is a solid stone wall (engine bounce, like an empty-cell rim) — water is otherwise fully walkable. canBeRandomed:false so the 'random' tile never rolls water for v1.",
+            "_doc": "Deep water. Passive drive is almost nil (low acel + high drag) — you barely move unless you PUNCH to swim: a punch on water adds swimImpulse velocity in your held movement direction (scaled up a little by charge), so good swimmers average a speed between slow and normal. Swimming is just a punch, so it costs stamina and still knocks others back (the high drag dampens both ends). A killstreak fire shield (onFire>0) lets you STRIDE across water instead of swimming: the shield rides down on water exactly like it does on lava (steam rises while it burns) and only when it finally expires do you drop into the swim — so fire is a real water-crossing tool. Leaving water leaves you 'dripping': drive cut to dripMoveFactor for dripMs. A water edge that borders lava is a solid stone wall (engine bounce, like an empty-cell rim) — water is otherwise fully walkable. During a collapse water does NOT flash straight to lava: it 'slow-boils' for collapseBoilMs (a tiered simmer->boil->rolling warning) before converting, giving racers a few extra seconds to scramble off. canBeRandomed:false so the 'random' tile never rolls water for v1.",
             "id": 11,
             "brakeCoeff": 0.235,
             "dragCoeff": 0.32,
@@ -194,6 +194,8 @@
             "swimChargeBonus": 0.5,
             "dripMs": 800,
             "dripMoveFactor": 0.6,
+            "collapseBoilMs": 3000,
+            "collapseBoilTiers": 3,
             "canBeRandomed": false,
             "color": "#2f6fb0"
         },

--- a/server/entities/gameBoard.js
+++ b/server/entities/gameBoard.js
@@ -43,6 +43,11 @@ class GameBoard {
 		this.abilityList = {};
 		this.tempSpectatorList = {};
 		this.tileChanges = {};
+		// Water cells the collapse front has reached but that haven't flipped to lava
+		// yet: they "slow-boil" for water.collapseBoilMs first. voronoiId -> { startedAt,
+		// stage } so collapseMap can advance the tiered warning and the client can render
+		// simmer->boil->rolling before the lava conversion. Cleared on round reset.
+		this.boilingWater = {};
 		this.punchList = {};
 		// Active Orbital Beam telegraphs (owner -> locked strike line), so the AI can
 		// steer out of the marked danger band during the fuse. Cleared on round reset
@@ -1783,18 +1788,71 @@ class GameBoard {
 
 		var collapsedCells = [];
 		var cells = this.currentMap.cells;
+		var waterId = c.tileMap.water != null ? c.tileMap.water.id : -999;
 		for (var i = 0; i < cells.length; i++) {
 			if (cells[i].id == c.tileMap.goal.id || cells[i].id == c.tileMap.lava.id || cells[i].id == c.tileMap.empty.id) {
 				continue;
 			}
 			var distance = utils.getMag(this.collapseLoc.x - cells[i].site.x, this.collapseLoc.y - cells[i].site.y);
 			if (this.collapseLine < distance) {
+				// Water doesn't flash to lava — it slow-boils first (a tiered warning),
+				// buying racers a few seconds to scramble off. Register it once; the
+				// advance pass below ages each boiling cell and flips it when it's done.
+				if (cells[i].id == waterId && c.tileMap.water != null) {
+					if (this.boilingWater[cells[i].site.voronoiId] == null) {
+						this.boilingWater[cells[i].site.voronoiId] = { startedAt: now, stage: -1 };
+					}
+					continue;
+				}
 				cells[i].id = c.tileMap.lava.id;
 				this.tileChanges[cells[i].site.voronoiId] = cells[i].id;
 				collapsedCells.push(cells[i].site.voronoiId);
 			}
 		}
+		// Advance any boiling water: emit tier bumps for the warning animation and flip a
+		// cell to lava once it has boiled for the full collapseBoilMs.
+		var boilUpdates = this.advanceBoilingWater(now, collapsedCells);
 		messenger.messageRoomBySig(this.roomSig, 'collapsedCells', collapsedCells);
+		if (boilUpdates.length > 0) {
+			messenger.messageRoomBySig(this.roomSig, 'waterBoiling', boilUpdates);
+		}
+	}
+	// Age the boiling-water registry one tick. Each cell climbs through collapseBoilTiers
+	// stages over collapseBoilMs; a stage bump is pushed to boilUpdates (client warning
+	// animation), and when the timer is up the cell converts to lava (appended to the
+	// shared collapsedCells list so it rides the same broadcast as instant conversions).
+	advanceBoilingWater(now, collapsedCells) {
+		var water = c.tileMap.water;
+		if (water == null) { return []; }
+		var boilMs = water.collapseBoilMs != null ? water.collapseBoilMs : 3000;
+		var tiers = water.collapseBoilTiers != null ? water.collapseBoilTiers : 3;
+		var lavaId = c.tileMap.lava.id;
+		var updates = [];
+		var cells = this.currentMap.cells;
+		for (var vid in this.boilingWater) {
+			var entry = this.boilingWater[vid];
+			var elapsed = now - entry.startedAt;
+			if (elapsed >= boilMs) {
+				// Boil's done: convert the underlying cell to lava.
+				for (var i = 0; i < cells.length; i++) {
+					if (cells[i].site.voronoiId == vid) {
+						cells[i].id = lavaId;
+						this.tileChanges[cells[i].site.voronoiId] = lavaId;
+						collapsedCells.push(cells[i].site.voronoiId);
+						break;
+					}
+				}
+				delete this.boilingWater[vid];
+				continue;
+			}
+			// 0..tiers-1, clamped so the final tier shows before the flip.
+			var stage = Math.min(tiers - 1, Math.floor((elapsed / boilMs) * tiers));
+			if (stage !== entry.stage) {
+				entry.stage = stage;
+				updates.push({ vid: Number(vid), stage: stage });
+			}
+		}
+		return updates;
 	}
 	findRandomGoalTile() {
 		var cells = this.currentMap.cells;
@@ -2383,6 +2441,7 @@ class GameBoard {
 		this.soloCollapseSpeed = c.lastPlayerCollapseSpeed;
 		this.soloStartDistance = this.world.height + 400;
 		this.tileChanges = {};
+		this.boilingWater = {}; // drop any half-boiled water from the previous round
 		this.pendingBeams = {}; // drop any telegraph whose strike timer this reset cancels
 		this.pendingAbilityTimers = []; // bound growth; lobby ones are canceled in clearLobbyAbilities
 		// AI vision-fairness state, reset each round.

--- a/server/entities/player.js
+++ b/server/entities/player.js
@@ -1118,6 +1118,30 @@ class Player extends Circle {
 			return;
 		}
 		if (c.tileMap.water != null && object.id == c.tileMap.water.id) {
+			// Fire-walk: a killstreak fire shield lets you STRIDE across water instead of
+			// swimming. The shield rides DOWN on water exactly like it does on lava (set
+			// fireTimer, then checkFireTimer bleeds it) — steam rises while it burns — and
+			// only when it finally expires do you drop into the deep-water swim below.
+			// Non-zombie only (zombies can't be on fire and can't enter water anyway).
+			if (this.onFire > 0 && this.isZombie != true) {
+				if (this.fireTimer == null) {
+					this.fireTimer = Date.now();
+				}
+				this.checkFireTimer(); // may zero onFire + broadcast onFire:0
+				if (this.onFire > 0) {
+					// Still shielded: walk with solid grip, NOT deep-water swim physics, and
+					// clear onWater so throwChargedPunch fires a normal punch (no swim stroke).
+					var ground = c.tileMap.normal;
+					this.acel = ground.acel;
+					this.dragCoeff = ground.dragCoeff;
+					this.brakeCoeff = ground.brakeCoeff;
+					this.onWater = false;
+					return;
+				}
+				// Shield just burned out over water — final douse cue, then fall through to
+				// the swim physics so this same tick starts treating it as deep water.
+				messenger.messageRoomBySig(this.roomSig, "flameExtinguished", { owner: this.id, x: this.x, y: this.y });
+			}
 			// Deep water. Low acel + high drag (config) make passive drive almost nil —
 			// you barely move unless you PUNCH to swim (throwChargedPunch reads onWater,
 			// set above). Zombies get their infection-modded grip like any other tile.
@@ -1127,15 +1151,6 @@ class Player extends Circle {
 				this.acel = object.acel;
 				this.dragCoeff = object.dragCoeff;
 				this.brakeCoeff = object.brakeCoeff;
-			}
-			// Water douses a killstreak fire shield: drop onFire and tell the room so the
-			// client can stop the flame and play the hiss/steam cue. Does NOT touch the
-			// burn attributor (burnedBy was already cleared above for any non-lava cell).
-			if (this.onFire > 0) {
-				this.onFire = 0;
-				this.fireTimer = null;
-				messenger.messageRoomBySig(this.roomSig, "onFire", { owner: this.id, value: 0 });
-				messenger.messageRoomBySig(this.roomSig, "flameExtinguished", { owner: this.id, x: this.x, y: this.y });
 			}
 			return;
 		}


### PR DESCRIPTION
## What

Two-part water feature.

### Water slow-boil during collapse
Water no longer flashes straight to lava. When the collapse front reaches a water cell it sits in a per-board `boilingWater` registry and ages through a tiered **simmer → boil → rolling-boil** warning (bubbles, rising steam, an intensifying orange glow) over `water.collapseBoilMs` (~3s) before converting — giving racers a few extra seconds to scramble across or off the water.

### Fire-shield water crossing
A killstreak fire shield now lets a kart **stride across water** instead of being doused on contact. The shield rides down on water exactly like on lava (walking grip, no swim stroke), and only once it burns out do you drop into the swim — so a wide pond can still snuff it mid-crossing. Flames now **fade out** over their final ms instead of snapping off, and burning karts kick up unified walking FX + a looping sizzle: **embers on lava, steam on water**.

## Player-facing notes (CHANGELOG)
- **Water doesn't flash to lava when the world collapses anymore — it slow-boils.** ~3s of tiered simmer→boil→rolling warning before it turns to lava.
- **A killstreak fire shield now lets you walk on water.** Stride straight across with steam hissing off you; the flame burns down as you cross, so a big pond can snuff it mid-crossing. Fire is a real shortcut across water.
- **Flames burn out instead of blinking off.** Fading steam puff on burnout (lava or water), embers on lava / steam on water underfoot.

## Implementation
- **Server:** `gameBoard.collapseMap` registers reached water as boiling; `advanceBoilingWater` ages it + emits `waterBoiling`, converts at `collapseBoilMs`. `player.js` water branch rides the fire shield down (full-shield crossing) + emits `flameExtinguished` on burnout. New `water.collapseBoilMs`/`collapseBoilTiers` config knobs. No compressor change (boil rides events, not per-tick arrays).
- **Client:** `boilingCells` registry + `drawBoilingWater` tiered overlay (gameboard.js/draw.js), `drawFire` alpha fade, `drawFireWalkFX` steam/ember particles, `setFireWalkSound`/`stopFireWalkSound` looping sizzle (audio.js, drift-voice pattern). `learn.js` Codex water/collapse entries updated.

## Tests
- New `.github/scripts/water-boil-flame-test.js` (wired into `pr-validation.yml`): asserts the fire-walk physics/extinguish lifecycle **and** that every boiled cell waits ~`collapseBoilMs` before converting.
- Verified locally on rebased base: build ✅, smoke ✅, new test ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)