### PR TITLE
fix(hud): keep ability-armed ring clear of team color ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- **In team modes you can tell who's holding an ability again.** The dashed "ability armed" ring now always sits in a clear gap *outside* a kart's Crimson/Jade team glow instead of merging into it — on bigger or cosmetic-skinned karts the two rings used to overlap into one band, hiding whether a teammate or rival was loaded.
 
 ## v0.38.1 — 2026-06-14
 

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -7280,7 +7280,17 @@ function drawAbilityIndicator(x, y, player) {
         case config.tileMap.abilities.swap.id:
         case config.tileMap.abilities.bombTrigger.id:
         default:
-            drawArmedRing(x, y, player.color, player.radius);
+            // Size the armed ring off the SAME skin-scaled radius the team underglow
+            // uses (drawTeamUnderglow: radius * CART_SKIN_VISUAL_SCALE + 5), not the
+            // raw radius — otherwise on skinned/large karts the solid team-colour ring
+            // grows but the dashed ability ring doesn't, the two concentric rings cross,
+            // and "this kart holds an ability" becomes unreadable against the team ring.
+            // When the player is on a team, push the ring out enough to leave a clear
+            // annular gap OUTSIDE the team underglow so the two never read as one band.
+            var skinScale = (cartSkinPainter(player.cart) != null) ? CART_SKIN_VISUAL_SCALE : 1;
+            var onTeam = (player.teamId != null && typeof teamInfo !== "undefined" && teamInfo != null && !player.infected);
+            var armedRadius = player.radius * skinScale + (onTeam ? 4 : 0);
+            drawArmedRing(x, y, player.color, armedRadius);
             break;
     }
 }
@@ -7393,11 +7403,12 @@ function drawCutAimer(x, y, angle, color) {
 }
 
 // "Ability armed" indicator for swap / bomb-trigger / anything else held: a
-// slowly rotating dashed ring that pulses, in the player's colour. Sized off the
-// kart radius so it orbits OUTSIDE the local-player halo (which sits at
-// radius+5 and glows past it) — otherwise the two same-coloured rings merged
-// into one smear when you held an ability. A thin dark backing keeps the dashes
-// legible where they cross the halo's glow.
+// slowly rotating dashed ring that pulses, in the player's colour. The caller
+// passes an already skin-scaled (and, in team modes, outward-nudged) radius; the
+// internal +9 keeps it orbiting OUTSIDE the local-player halo (which sits at
+// radius+5 and glows past it) and outside the team underglow — otherwise the
+// rings merged into one smear when you held an ability. A thin dark backing keeps
+// the dashes legible where they cross the halo's glow.
 function drawArmedRing(x, y, color, radius) {
     var now = Date.now();
     var r = (radius != null ? radius : 6) + 9;


### PR DESCRIPTION
## What

In team modes, the dashed **"ability armed"** ring around a kart could merge into the kart's **Crimson/Jade team underglow**, making it impossible to tell whether a teammate or rival was holding an ability.

### Root cause

`drawArmedRing` sized the ability ring off an **unscaled** `radius + 9`, while `drawTeamUnderglow` scales by `CART_SKIN_VISUAL_SCALE` (`radius * scale + 5`). On larger or cosmetic-skinned karts the team ring grew but the ability ring didn't, so the two concentric rings shrank together, crossed, and read as a single band.

(Both rings draw at `player.x` — the legacy `camera` object is inactive, so `getCameraX/Y()` return 0 and the real camera is the `worldView` `setTransform`. The rings are genuinely concentric, so the conflict is purely geometric.)

### Fix

- Size the armed ring off the **same skin-scaled radius** the team underglow uses.
- When the player is on a team (and not infected), nudge it **+4px outward** so it always sits in a clear annular gap *outside* the team ring.
- **FFA / unskinned behavior is unchanged** (still resolves to `radius + 9`).

## Verification

- `npm run build` ✅
- `node .github/scripts/smoke-test.js` ✅ (booted + ticked 53 maps, no throw)
- Codex review: no actionable correctness issues
- Rebased onto `origin/main` (v0.38.1), re-verified build + smoke

Visual confirmation is best done in a live team-mode round with an ability in hand (smoke can't render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)