### PR TITLE
feat(ai): bots solve locked-door maps — fetch keys, open doors, take door shortcuts

### DIFF
--- a/.github/scripts/headless-harness.js
+++ b/.github/scripts/headless-harness.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// Shared headless-test primitives: a mocked clock with a scheduled-timeout queue and a
+// seedable PRNG. A tight synchronous tick loop freezes wall-clock, so AI time-based logic
+// (re-path throttles, anti-stuck timers) and setTimeout callbacks (cooldowns, fuses) never
+// fire unless Date.now is mocked and the clock is advanced per tick — see the
+// headless-test-harness notes. Install the clock BEFORE requiring the game modules when the
+// whole script needs it (ai-fitness drives a full window); a script that only needs it for a
+// single late scenario can install it just before that scenario, since game code reads
+// Date.now()/setTimeout dynamically at call time.
+//
+// installMockClock(startMs) overrides global Date.now/setTimeout/clearTimeout and returns a
+// tickClock(ms) that advances sim time and drains every timeout whose deadline has passed.
+function installMockClock(startMs) {
+    var simNow = (startMs != null) ? startMs : 1e6;
+    var pend = [];
+    Date.now = function () { return simNow; };
+    global.setTimeout = function (fn, d) {
+        var a = Array.prototype.slice.call(arguments, 2);
+        pend.push({ at: simNow + (d || 0), fn: fn, a: a });
+        return pend.length;
+    };
+    global.clearTimeout = function () { };
+    return function tickClock(ms) {
+        simNow += ms;
+        pend.sort(function (a, b) { return a.at - b.at; });
+        while (pend.length && pend[0].at <= simNow) {
+            var t = pend.shift();
+            try { t.fn.apply(null, t.a); } catch (e) { /* match production: a thrown timeout never aborts the tick */ }
+        }
+    };
+}
+
+// Deterministic 32-bit PRNG (mulberry32) — assign to Math.random for a reproducible run.
+function mulberry32(seed) {
+    var a = seed >>> 0;
+    return function () {
+        a |= 0; a = (a + 0x6D2B79F5) | 0;
+        var t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+module.exports = { installMockClock: installMockClock, mulberry32: mulberry32 };

--- a/.github/scripts/locked-door-test.js
+++ b/.github/scripts/locked-door-test.js
@@ -80,6 +80,98 @@ function prepRacer(p) {
     p.awake = true; p.isSpectator = false; p.alive = true; p.isZombie = false; p.reachedGoal = false; p.heldKey = null;
 }
 
+// --- Shared bot-driven scaffolding (scenarios F + G) -------------------------------
+// Build a door-GATED variant of a committed map: lava every goal entrance (frontier cell)
+// except the door (nearest the gate) and — when opts.leaveFarOpen — the farthest one (the
+// long way around). Places the door + a key (opts.keyNearGate: near the gate for a clear
+// shortcut detour; otherwise the farthest reachable cell, a genuine off-route fetch).
+// Returns { map, doorCellIdx, keyCellIdx, gate0, goalSet, reach, adj } or null if the map's
+// geometry can't host the case.
+function buildGatedDoorMap(mapName, opts) {
+    opts = opts || {};
+    const GOAL = config.tileMap.goal.id, LAVA = config.tileMap.lava.id;
+    let map = JSON.parse(fs.readFileSync(path.join(repoRoot, 'client', 'maps', mapName + '.json'), 'utf8'));
+    if (mapFormat.isSitesOnly(map)) { map = mapFormat.reconstruct(map); }
+    const cells = map.cells;
+    const adj = cellGraph.getAdjacency(map);
+    const goalSet = new Set();
+    for (let i = 0; i < cells.length; i++) { if (cells[i].id === GOAL) { goalSet.add(i); } }
+    const frontier = [];
+    goalSet.forEach((gi) => { (adj.neighbors[gi] || []).forEach((n) => { if (!goalSet.has(n) && walkable(cells[n].id) && frontier.indexOf(n) === -1) { frontier.push(n); } }); });
+    if (goalSet.size === 0 || frontier.length < 2) { return null; }
+    const edges = (Array.isArray(map.startEdges) && map.startEdges.length) ? map.startEdges : ['left'];
+    const gateSamples = [];
+    for (const e of edges) { for (const s of cellGraph.edgeSampleOrigins(e)) { gateSamples.push(s); } }
+    const gate0 = gateSamples[0];
+    const dGate = (ci) => Math.hypot(cells[ci].site.x - gate0.x, cells[ci].site.y - gate0.y);
+    frontier.sort((a, b) => dGate(a) - dGate(b));
+    const doorCellIdx = frontier[0];
+    const farCellIdx = opts.leaveFarOpen ? frontier[frontier.length - 1] : -1;
+    for (const fi of frontier) { if (fi !== doorCellIdx && fi !== farCellIdx) { cells[fi].id = LAVA; } }
+    map.doors = [{ x: cells[doorCellIdx].site.x, y: cells[doorCellIdx].site.y }];
+    // Reachable-from-gate flood with the door treated as the wall it'll become.
+    const reach = new Set(), stack = [];
+    for (const s of gateSamples) { const ci = cellGraph.nearestCellIndex(cells, s); if (!reach.has(ci) && (walkable(cells[ci].id) || cells[ci].id === GOAL)) { reach.add(ci); stack.push(ci); } }
+    while (stack.length) {
+        const u = stack.pop();
+        for (const v of (adj.neighbors[u] || [])) {
+            if (reach.has(v) || v === doorCellIdx) { continue; }
+            if (walkable(cells[v].id) || cells[v].id === GOAL) { reach.add(v); stack.push(v); }
+        }
+    }
+    let keyCellIdx = -1, keyBest = opts.keyNearGate ? Infinity : -1;
+    reach.forEach((i) => {
+        if (i === doorCellIdx || !walkable(cells[i].id)) { return; }
+        const d = dGate(i);
+        if (opts.keyNearGate) { if (d > 40 && d < keyBest) { keyBest = d; keyCellIdx = i; } }
+        else if (d > keyBest) { keyBest = d; keyCellIdx = i; }
+    });
+    if (keyCellIdx < 0) { return null; }
+    map.keys = [{ x: cells[keyCellIdx].site.x, y: cells[keyCellIdx].site.y }];
+    return { map: map, doorCellIdx: doorCellIdx, keyCellIdx: keyCellIdx, gate0: gate0, goalSet: goalSet, reach: reach, adj: adj };
+}
+
+// Build a preview room with 5 bots on `map`, warm up the gate, start the race, and drive it
+// for `seconds` (mocked clock via `tickClock`). hooks.onReady(gb) runs ONCE right after
+// startRace, on the FRESH round-start map (before any collapse mutates it) — assert fresh-map
+// invariants there. hooks.onStop(gb, finishers) may return true to stop early. Returns
+// { room, gb, bots, finishers, threw, ok }. Resets the shared event log so pickup/unlock
+// assertions reflect this run, not leakage from earlier scenarios.
+function driveBotField(sig, map, seconds, tickClock, hooks) {
+    hooks = hooks || {};
+    const room = game.getRoom(sig, 6);
+    room.game.gameBoard.isPreview = true;
+    room.game.gameBoard.previewMap = map;
+    const cast = (config.aiRacers && config.aiRacers.cast) || [];
+    const bots = [];
+    for (let i = 0; i < 5; i++) {
+        const b = room.world.createNewBot(sig + '-bot' + i, cast.length ? cast[i % cast.length] : null);
+        room.playerList[b.id] = b; bots.push(b);
+    }
+    room.game.determineGameState(bots[0]);
+    room.game.startLobby(); room.game.startGated();
+    for (let g = 0; g < 30; g++) { tickClock(config.serverTickSpeed); room.update(DT); }
+    room.game.startRace();
+    const gb = room.game.gameBoard;
+    const built = gb.lockedDoors.length === 1 && gb.lockedKeys.length === 1;
+    if (!built) { fail(sig + ': setup did not build exactly one door + key'); }
+    // Fresh round-start map invariants (door stamped, nothing collapsed yet).
+    if (built && hooks.onReady) { hooks.onReady(gb); }
+    events = [];
+    const TICKS = Math.round(seconds / DT);
+    const prevGoal = {}; for (const b of bots) { prevGoal[b.id] = false; }
+    let finishers = 0, threw = false;
+    for (let f = 0; built && f < TICKS; f++) {
+        room.game.notchesToWin = 99;
+        tickClock(config.serverTickSpeed);
+        try { room.update(DT); } catch (e) { threw = true; fail(sig + ': tick threw: ' + e.message + '\n' + e.stack); break; }
+        for (const b of bots) { if (b.reachedGoal && !prevGoal[b.id]) { finishers++; } prevGoal[b.id] = !!b.reachedGoal; }
+        if (hooks.onStop && hooks.onStop(gb, finishers)) { break; }
+        if (room.game.currentState === config.stateMap.gameOver) { break; }
+    }
+    return { room: room, gb: gb, bots: bots, finishers: finishers, threw: threw, ok: built };
+}
+
 // --- Scenario A: init + pickup + unlock --------------------------------------
 (function scenarioA() {
     const sig = 'ld-A';
@@ -237,121 +329,34 @@ function prepRacer(p) {
 // finish, plus that pickup/unlock events actually fired (it solved it, didn't luck across).
 (function scenarioF() {
     const sig = 'ld-F';
-    const GOAL = config.tileMap.goal.id, LAVA = config.tileMap.lava.id;
-
-    // Mocked clock + scheduled timeouts, installed BEFORE driving the loop so AI
-    // time-based logic (re-path throttle, anti-stuck, cooldowns) advances in sim time
-    // and a tight synchronous tick loop doesn't freeze wall-clock (harness memo). Shared
-    // primitives so this doesn't fork yet another copy of the clock/PRNG.
+    // Mocked clock installed BEFORE driving so AI time logic (re-path throttle, anti-stuck,
+    // cooldowns) advances in sim time and the tight synchronous loop doesn't freeze wall-clock.
     const harness = require(path.join(repoRoot, '.github', 'scripts', 'headless-harness.js'));
     const tickClock = harness.installMockClock(5e6);
     Math.random = harness.mulberry32(0x10CCD0);
 
-    let map = JSON.parse(fs.readFileSync(path.join(repoRoot, 'client', 'maps', 'Duality.json'), 'utf8'));
-    if (mapFormat.isSitesOnly(map)) { map = mapFormat.reconstruct(map); }
-    const cells = map.cells;
-    const adj = cellGraph.getAdjacency(map);
-    const isWalk = walkable;
+    // Fully gate Duality's goal (every entrance lava'd but the door); key on the FARTHEST
+    // reachable cell — a genuine off-route fetch the bot must seek out.
+    const built = buildGatedDoorMap('Duality', { leaveFarOpen: false, keyNearGate: false });
+    if (built == null) { fail('F: Duality lacks a multi-entry goal to gate'); return; }
+    const { map, doorCellIdx, gate0, goalSet, reach, adj } = built;
 
-    // Goal region + its walkable, non-goal frontier (the cells you can enter the goal from).
-    const goalSet = new Set();
-    for (let i = 0; i < cells.length; i++) { if (cells[i].id === GOAL) { goalSet.add(i); } }
-    const frontier = new Set();
-    goalSet.forEach((gi) => {
-        const nb = adj.neighbors[gi] || [];
-        for (let k = 0; k < nb.length; k++) { if (!goalSet.has(nb[k]) && isWalk(cells[nb[k]].id)) { frontier.add(nb[k]); } }
-    });
-    const frontierArr = [...frontier];
-    if (goalSet.size === 0 || frontierArr.length < 2) { fail('F: Duality lacks a multi-entry goal to gate (frontier=' + frontierArr.length + ')'); return; }
-
-    // Start-edge gate point (the racers' launch line) for reachability + distance picks.
-    const edges = (Array.isArray(map.startEdges) && map.startEdges.length) ? map.startEdges : ['left'];
-    const gateSamples = [];
-    for (const e of edges) { for (const s of cellGraph.edgeSampleOrigins(e)) { gateSamples.push(s); } }
-    const gate0 = gateSamples[0];
-
-    // Door = the frontier cell nearest the gate (faces the approach); lava every OTHER
-    // frontier cell so the single door is the goal region's ONLY entrance.
-    frontierArr.sort((a, b) => Math.hypot(cells[a].site.x - gate0.x, cells[a].site.y - gate0.y) - Math.hypot(cells[b].site.x - gate0.x, cells[b].site.y - gate0.y));
-    const doorCellIdx = frontierArr[0];
-    for (let i = 1; i < frontierArr.length; i++) { cells[frontierArr[i]].id = LAVA; }
-    const dSite = cells[doorCellIdx].site;
-    map.doors = [{ x: dSite.x, y: dSite.y }];
-
-    // Reachable-from-gate flood over walkable ground with the door treated as the wall it
-    // will become — this is exactly the start-side region a baseline bot can move through.
-    const reach = new Set();
-    const stack = [];
-    for (const s of gateSamples) { const ci = cellGraph.nearestCellIndex(cells, s); if (!reach.has(ci) && (isWalk(cells[ci].id) || cells[ci].id === GOAL)) { reach.add(ci); stack.push(ci); } }
-    while (stack.length) {
-        const u = stack.pop();
-        const nb = adj.neighbors[u] || [];
-        for (let k = 0; k < nb.length; k++) {
-            const v = nb[k];
-            if (reach.has(v)) { continue; }
-            if (v === doorCellIdx) { continue; } // door is shut — a wall
-            if (isWalk(cells[v].id) || cells[v].id === GOAL) { reach.add(v); stack.push(v); }
-        }
-    }
     ok(!reach.has(doorCellIdx) && [...goalSet].every((g) => !reach.has(g)), 'F: with the door shut, the goal region is sealed off from the gate (baseline-impossible)');
-    // The door must be approachable: at least one of its neighbours is start-side-reachable.
-    const doorApproachable = (adj.neighbors[doorCellIdx] || []).some((n) => reach.has(n));
-    ok(doorApproachable, 'F: the door has a start-side-reachable approach cell');
+    ok((adj.neighbors[doorCellIdx] || []).some((n) => reach.has(n)), 'F: the door has a start-side-reachable approach cell');
 
-    // Key = the reachable walkable cell FARTHEST from the gate (a genuine detour off the
-    // racing line, never behind the door), so the bot must seek it out, not stumble on it.
-    let keyIdx = -1, keyD = -1;
-    reach.forEach((i) => {
-        if (i === doorCellIdx || !isWalk(cells[i].id)) { return; }
-        const d = Math.hypot(cells[i].site.x - gate0.x, cells[i].site.y - gate0.y);
-        if (d > keyD) { keyD = d; keyIdx = i; }
+    const res = driveBotField(sig, map, 75, tickClock, {
+        // Fresh round-start map: goal unreachable while shut, reachable once the door opens
+        // (confirms the gate is real and the AI's "would-opening-doors-help?" probe will fire).
+        onReady: (gb) => {
+            ok(cellGraph.findPathToNearestGoal(gb.currentMap, gate0) == null, 'F: live map — goal unreachable with the door shut');
+            ok(cellGraph.findPathToNearestGoal(gb.currentMap, gate0, { passableDoors: true }) != null, 'F: live map — goal reachable if the door were open');
+        },
+        onStop: (gb, fin) => gb.lockedDoors[0].unlocked && fin > 0
     });
-    if (keyIdx < 0) { fail('F: no reachable walkable cell to host the key'); return; }
-    map.keys = [{ x: cells[keyIdx].site.x, y: cells[keyIdx].site.y }];
-
-    // Build the room with a field of bots (real engine, mocked clock, seeded RNG).
-    const room = game.getRoom(sig, 6);
-    room.game.gameBoard.isPreview = true;
-    room.game.gameBoard.previewMap = map;
-    const cast = (config.aiRacers && config.aiRacers.cast) || [];
-    const bots = [];
-    for (let i = 0; i < 5; i++) {
-        const b = room.world.createNewBot(sig + '-bot' + i, cast.length ? cast[i % cast.length] : null);
-        room.playerList[b.id] = b; bots.push(b);
-    }
-    room.game.determineGameState(bots[0]);
-    room.game.startLobby(); room.game.startGated();
-    for (let g = 0; g < 30; g++) { tickClock(config.serverTickSpeed); room.update(DT); }
-    room.game.startRace();
-    const gb = room.game.gameBoard;
-    if (gb.lockedDoors.length !== 1 || gb.lockedKeys.length !== 1) { fail('F: gated map did not build exactly one door + key'); return; }
-
-    // Live cell-graph invariants on the running map: goal unreachable while shut, reachable
-    // once the door is treated as open. (Confirms the gate is real and the AI's own
-    // "would-opening-doors-help?" probe will fire.)
-    ok(cellGraph.findPathToNearestGoal(gb.currentMap, gate0) == null, 'F: live map — goal unreachable with the door shut');
-    ok(cellGraph.findPathToNearestGoal(gb.currentMap, gate0, { passableDoors: true }) != null, 'F: live map — goal reachable if the door were open');
-
-    // Drive the race. Count finish EDGES (rounds may cycle); keep notchesToWin high so a
-    // finish doesn't end the match before others can also solve it. Reset the shared event
-    // log first so the pickup/unlock assertions reflect THIS scenario, not leakage from A/B.
-    events = [];
-    const TICKS = Math.round(75 / DT);
-    const prevGoal = {}; for (const b of bots) { prevGoal[b.id] = false; }
-    let finishers = 0;
-    let threw = false;
-    for (let f = 0; f < TICKS; f++) {
-        room.game.notchesToWin = 99;
-        tickClock(config.serverTickSpeed);
-        try { room.update(DT); } catch (e) { threw = true; fail('F: tick threw: ' + e.message + '\n' + e.stack); break; }
-        for (const b of bots) { if (b.reachedGoal && !prevGoal[b.id]) { finishers++; } prevGoal[b.id] = !!b.reachedGoal; }
-        if (gb.lockedDoors[0].unlocked && finishers > 0) { break; } // solved + at least one through
-        if (room.game.currentState === config.stateMap.gameOver) { break; }
-    }
-    ok(!threw, 'F: door-gated race ticked without throwing');
+    ok(!res.threw, 'F: door-gated race ticked without throwing');
     ok(countEvents('keyPickedUp') >= 1, 'F: a bot picked up the key');
-    ok(gb.lockedDoors[0].unlocked === true || countEvents('doorUnlocked') >= 1, 'F: a bot carried the key to the door and unlocked it');
-    ok(finishers >= 1, 'F: at least one bot reached the goal through the unlocked door (got ' + finishers + ')');
+    ok(res.ok && (res.gb.lockedDoors[0].unlocked === true || countEvents('doorUnlocked') >= 1), 'F: a bot carried the key to the door and unlocked it');
+    ok(res.finishers >= 1, 'F: at least one bot reached the goal through the unlocked door (got ' + res.finishers + ')');
 })();
 
 // --- Scenario G: bot-driven — bots OPT INTO an optional shortcut (split behaviour) -----
@@ -366,83 +371,38 @@ function prepRacer(p) {
 // lava to force the long alternate, so we don't re-assert the unlock on this hostile approach.
 (function scenarioG() {
     const sig = 'ld-G';
-    const GOAL = config.tileMap.goal.id, LAVA = config.tileMap.lava.id;
     const harness = require(path.join(repoRoot, '.github', 'scripts', 'headless-harness.js'));
     const tickClock = harness.installMockClock(9e6);
     Math.random = harness.mulberry32(0xC0FFEE);
 
-    let map = JSON.parse(fs.readFileSync(path.join(repoRoot, 'client', 'maps', 'Duality.json'), 'utf8'));
-    if (mapFormat.isSitesOnly(map)) { map = mapFormat.reconstruct(map); }
-    const cells = map.cells;
-    const adj = cellGraph.getAdjacency(map);
+    // Two-entrance goal: door near the gate (short) + one far entrance left open (the long
+    // way); key near the gate so the detour to grab it is small and the shortcut clearly worth it.
+    const built = buildGatedDoorMap('Duality', { leaveFarOpen: true, keyNearGate: true });
+    if (built == null) { fail('G: Duality goal needs >=2 entrances'); return; }
+    const { map, gate0 } = built;
 
-    const goalSet = new Set();
-    for (let i = 0; i < cells.length; i++) { if (cells[i].id === GOAL) { goalSet.add(i); } }
-    const frontier = [];
-    goalSet.forEach((gi) => { (adj.neighbors[gi] || []).forEach((n) => { if (!goalSet.has(n) && walkable(cells[n].id) && frontier.indexOf(n) === -1) { frontier.push(n); } }); });
-    if (frontier.length < 2) { fail('G: goal needs >=2 entrances (got ' + frontier.length + ')'); return; }
+    const res = driveBotField(sig, map, 80, tickClock, {
+        // Fresh round-start map: the door is a genuine SHORTCUT — goal reachable the long way,
+        // but opening it is meaningfully faster. Compare TIME (estimatePathTime) — the SAME
+        // metric the shortcut decision uses (a geometrically-shorter route across slow tiles
+        // isn't necessarily faster), so this guards the code's actual accept boundary.
+        onReady: (gb) => {
+            const shutRoute = cellGraph.findPathToNearestGoal(gb.currentMap, gate0);
+            const openRoute = cellGraph.findPathToNearestGoal(gb.currentMap, gate0, { passableDoors: true });
+            ok(shutRoute != null, 'G: goal reachable with the door shut (the long way — shortcut is optional, not forced)');
+            const shutTime = shutRoute ? cellGraph.estimatePathTime(gb.currentMap, shutRoute.path) : 0;
+            const openTime = openRoute ? cellGraph.estimatePathTime(gb.currentMap, openRoute.path) : 0;
+            ok(openTime > 0 && shutTime > 0 && openTime < shutTime * 0.85,
+                'G: opening the door is a real shortcut in TIME (open ' + Math.round(openTime * 100) / 100 + 's < shut ' + Math.round(shutTime * 100) / 100 + 's)');
+        }
+    });
 
-    const edges = (Array.isArray(map.startEdges) && map.startEdges.length) ? map.startEdges : ['left'];
-    const gateSamples = [];
-    for (const e of edges) { for (const s of cellGraph.edgeSampleOrigins(e)) { gateSamples.push(s); } }
-    const gate0 = gateSamples[0];
-    const dGate = (ci) => Math.hypot(cells[ci].site.x - gate0.x, cells[ci].site.y - gate0.y);
-
-    // Door = entrance nearest the gate (short); FAR = entrance farthest (the long open way);
-    // lava every other entrance so exactly those two remain.
-    frontier.sort((a, b) => dGate(a) - dGate(b));
-    const doorCellIdx = frontier[0];
-    const farCellIdx = frontier[frontier.length - 1];
-    for (const fi of frontier) { if (fi !== doorCellIdx && fi !== farCellIdx) { cells[fi].id = LAVA; } }
-    map.doors = [{ x: cells[doorCellIdx].site.x, y: cells[doorCellIdx].site.y }];
-
-    // Key near the gate (a small detour on the short side), so fetching it is clearly worth
-    // it versus the long way around — and a bot on the long route would never pass over it.
-    const reach = new Set(), stack = [];
-    for (const s of gateSamples) { const ci = cellGraph.nearestCellIndex(cells, s); if (!reach.has(ci) && (walkable(cells[ci].id) || cells[ci].id === GOAL)) { reach.add(ci); stack.push(ci); } }
-    while (stack.length) { const u = stack.pop(); for (const v of (adj.neighbors[u] || [])) { if (reach.has(v) || v === doorCellIdx) { continue; } if (walkable(cells[v].id) || cells[v].id === GOAL) { reach.add(v); stack.push(v); } } }
-    let keyCellIdx = -1, keyBest = Infinity;
-    reach.forEach((i) => { if (i === doorCellIdx || !walkable(cells[i].id)) { return; } const d = dGate(i); if (d > 40 && d < keyBest) { keyBest = d; keyCellIdx = i; } });
-    if (keyCellIdx < 0) { fail('G: no reachable walkable cell to host the key'); return; }
-    map.keys = [{ x: cells[keyCellIdx].site.x, y: cells[keyCellIdx].site.y }];
-
-    const room = game.getRoom(sig, 6);
-    room.game.gameBoard.isPreview = true; room.game.gameBoard.previewMap = map;
-    const cast = (config.aiRacers && config.aiRacers.cast) || [];
-    const bots = [];
-    for (let i = 0; i < 5; i++) { const b = room.world.createNewBot(sig + '-bot' + i, cast.length ? cast[i % cast.length] : null); room.playerList[b.id] = b; bots.push(b); }
-    room.game.determineGameState(bots[0]);
-    room.game.startLobby(); room.game.startGated();
-    for (let g = 0; g < 30; g++) { tickClock(config.serverTickSpeed); room.update(DT); }
-    room.game.startRace();
-    const gb = room.game.gameBoard;
-    if (gb.lockedDoors.length !== 1 || gb.lockedKeys.length !== 1) { fail('G: setup did not build exactly one door + key'); return; }
-
-    // The door is a genuine SHORTCUT on the LIVE map: goal reachable the long way, but the
-    // door-open route much shorter — so a bot fetching the key is an OPTIONAL choice, not forced.
-    const shutRoute = cellGraph.findPathToNearestGoal(gb.currentMap, gate0);
-    const openRoute = cellGraph.findPathToNearestGoal(gb.currentMap, gate0, { passableDoors: true });
-    ok(shutRoute != null, 'G: goal reachable with the door shut (the long way — shortcut is optional, not forced)');
-    ok(openRoute != null && shutRoute != null && openRoute.distance < shutRoute.distance * 0.85,
-        'G: opening the door is a real shortcut (much shorter than the long way)');
-
-    events = [];
-    const TICKS = Math.round(80 / DT);
-    const prevGoal = {}; for (const b of bots) { prevGoal[b.id] = false; }
-    let finishers = 0, threw = false;
-    for (let f = 0; f < TICKS; f++) {
-        room.game.notchesToWin = 99;
-        tickClock(config.serverTickSpeed);
-        try { room.update(DT); } catch (e) { threw = true; fail('G: tick threw: ' + e.message + '\n' + e.stack); break; }
-        for (const b of bots) { if (b.reachedGoal && !prevGoal[b.id]) { finishers++; } prevGoal[b.id] = !!b.reachedGoal; }
-        if (room.game.currentState === config.stateMap.gameOver) { break; }
-    }
-    ok(!threw, 'G: shortcut map ticked without throwing');
+    ok(!res.threw, 'G: shortcut map ticked without throwing');
     // A bot CHOSE the optional shortcut: it detoured to fetch the key even though the goal was
     // reachable the long way (a bot on the long route never passes the key). Not every bot
     // will — the rest race the open route — which is the intended split.
     ok(countEvents('keyPickedUp') >= 1, 'G: at least one bot chose the optional shortcut (fetched the key)');
-    ok(finishers >= 1, 'G: the field still finishes the race (got ' + finishers + ')');
+    ok(res.finishers >= 1, 'G: the field still finishes the race (got ' + res.finishers + ')');
 })();
 
 if (failures > 0) {

--- a/.github/scripts/locked-door-test.js
+++ b/.github/scripts/locked-door-test.js
@@ -354,6 +354,97 @@ function prepRacer(p) {
     ok(finishers >= 1, 'F: at least one bot reached the goal through the unlocked door (got ' + finishers + ')');
 })();
 
+// --- Scenario G: bot-driven — bots OPT INTO an optional shortcut (split behaviour) -----
+// A controlled two-entrance goal: a door near the gate (the SHORT way in) and one far
+// frontier cell left open (the LONG way around); every other entrance is lava'd so exactly
+// those two exist. The goal is reachable WITHOUT the door (the long way), so a bot is never
+// forced to fetch the key — but opening the near door is a much shorter route. This asserts
+// the SHORTCUT DECISION: at least one bot chooses to detour for the key (it would otherwise
+// never touch it on the long route), and the field still finishes. The carry->unlock->finish
+// mechanics that follow a pickup are the SAME carrier code proven by scenario F, which runs
+// it on a clean (non-lava-flanked) door; here the synthetic door is deliberately ringed by
+// lava to force the long alternate, so we don't re-assert the unlock on this hostile approach.
+(function scenarioG() {
+    const sig = 'ld-G';
+    const GOAL = config.tileMap.goal.id, LAVA = config.tileMap.lava.id;
+    const harness = require(path.join(repoRoot, '.github', 'scripts', 'headless-harness.js'));
+    const tickClock = harness.installMockClock(9e6);
+    Math.random = harness.mulberry32(0xC0FFEE);
+
+    let map = JSON.parse(fs.readFileSync(path.join(repoRoot, 'client', 'maps', 'Duality.json'), 'utf8'));
+    if (mapFormat.isSitesOnly(map)) { map = mapFormat.reconstruct(map); }
+    const cells = map.cells;
+    const adj = cellGraph.getAdjacency(map);
+
+    const goalSet = new Set();
+    for (let i = 0; i < cells.length; i++) { if (cells[i].id === GOAL) { goalSet.add(i); } }
+    const frontier = [];
+    goalSet.forEach((gi) => { (adj.neighbors[gi] || []).forEach((n) => { if (!goalSet.has(n) && walkable(cells[n].id) && frontier.indexOf(n) === -1) { frontier.push(n); } }); });
+    if (frontier.length < 2) { fail('G: goal needs >=2 entrances (got ' + frontier.length + ')'); return; }
+
+    const edges = (Array.isArray(map.startEdges) && map.startEdges.length) ? map.startEdges : ['left'];
+    const gateSamples = [];
+    for (const e of edges) { for (const s of cellGraph.edgeSampleOrigins(e)) { gateSamples.push(s); } }
+    const gate0 = gateSamples[0];
+    const dGate = (ci) => Math.hypot(cells[ci].site.x - gate0.x, cells[ci].site.y - gate0.y);
+
+    // Door = entrance nearest the gate (short); FAR = entrance farthest (the long open way);
+    // lava every other entrance so exactly those two remain.
+    frontier.sort((a, b) => dGate(a) - dGate(b));
+    const doorCellIdx = frontier[0];
+    const farCellIdx = frontier[frontier.length - 1];
+    for (const fi of frontier) { if (fi !== doorCellIdx && fi !== farCellIdx) { cells[fi].id = LAVA; } }
+    map.doors = [{ x: cells[doorCellIdx].site.x, y: cells[doorCellIdx].site.y }];
+
+    // Key near the gate (a small detour on the short side), so fetching it is clearly worth
+    // it versus the long way around — and a bot on the long route would never pass over it.
+    const reach = new Set(), stack = [];
+    for (const s of gateSamples) { const ci = cellGraph.nearestCellIndex(cells, s); if (!reach.has(ci) && (walkable(cells[ci].id) || cells[ci].id === GOAL)) { reach.add(ci); stack.push(ci); } }
+    while (stack.length) { const u = stack.pop(); for (const v of (adj.neighbors[u] || [])) { if (reach.has(v) || v === doorCellIdx) { continue; } if (walkable(cells[v].id) || cells[v].id === GOAL) { reach.add(v); stack.push(v); } } }
+    let keyCellIdx = -1, keyBest = Infinity;
+    reach.forEach((i) => { if (i === doorCellIdx || !walkable(cells[i].id)) { return; } const d = dGate(i); if (d > 40 && d < keyBest) { keyBest = d; keyCellIdx = i; } });
+    if (keyCellIdx < 0) { fail('G: no reachable walkable cell to host the key'); return; }
+    map.keys = [{ x: cells[keyCellIdx].site.x, y: cells[keyCellIdx].site.y }];
+
+    const room = game.getRoom(sig, 6);
+    room.game.gameBoard.isPreview = true; room.game.gameBoard.previewMap = map;
+    const cast = (config.aiRacers && config.aiRacers.cast) || [];
+    const bots = [];
+    for (let i = 0; i < 5; i++) { const b = room.world.createNewBot(sig + '-bot' + i, cast.length ? cast[i % cast.length] : null); room.playerList[b.id] = b; bots.push(b); }
+    room.game.determineGameState(bots[0]);
+    room.game.startLobby(); room.game.startGated();
+    for (let g = 0; g < 30; g++) { tickClock(config.serverTickSpeed); room.update(DT); }
+    room.game.startRace();
+    const gb = room.game.gameBoard;
+    if (gb.lockedDoors.length !== 1 || gb.lockedKeys.length !== 1) { fail('G: setup did not build exactly one door + key'); return; }
+
+    // The door is a genuine SHORTCUT on the LIVE map: goal reachable the long way, but the
+    // door-open route much shorter — so a bot fetching the key is an OPTIONAL choice, not forced.
+    const shutRoute = cellGraph.findPathToNearestGoal(gb.currentMap, gate0);
+    const openRoute = cellGraph.findPathToNearestGoal(gb.currentMap, gate0, { passableDoors: true });
+    ok(shutRoute != null, 'G: goal reachable with the door shut (the long way — shortcut is optional, not forced)');
+    ok(openRoute != null && shutRoute != null && openRoute.distance < shutRoute.distance * 0.85,
+        'G: opening the door is a real shortcut (much shorter than the long way)');
+
+    events = [];
+    const TICKS = Math.round(80 / DT);
+    const prevGoal = {}; for (const b of bots) { prevGoal[b.id] = false; }
+    let finishers = 0, threw = false;
+    for (let f = 0; f < TICKS; f++) {
+        room.game.notchesToWin = 99;
+        tickClock(config.serverTickSpeed);
+        try { room.update(DT); } catch (e) { threw = true; fail('G: tick threw: ' + e.message + '\n' + e.stack); break; }
+        for (const b of bots) { if (b.reachedGoal && !prevGoal[b.id]) { finishers++; } prevGoal[b.id] = !!b.reachedGoal; }
+        if (room.game.currentState === config.stateMap.gameOver) { break; }
+    }
+    ok(!threw, 'G: shortcut map ticked without throwing');
+    // A bot CHOSE the optional shortcut: it detoured to fetch the key even though the goal was
+    // reachable the long way (a bot on the long route never passes the key). Not every bot
+    // will — the rest race the open route — which is the intended split.
+    ok(countEvents('keyPickedUp') >= 1, 'G: at least one bot chose the optional shortcut (fetched the key)');
+    ok(finishers >= 1, 'G: the field still finishes the race (got ' + finishers + ')');
+})();
+
 if (failures > 0) {
     console.log('\nLocked-door test FAILED with ' + failures + ' error(s).');
     process.exit(1);

--- a/.github/scripts/locked-door-test.js
+++ b/.github/scripts/locked-door-test.js
@@ -227,9 +227,137 @@ function prepRacer(p) {
         'E: revealed cell is walkable (normal) after unlock, not the painted lava');
 })();
 
+// --- Scenario F: bot-driven — AI fetches the key + opens the gating door ----------
+// Builds a door-GATED map (the goal region's whole walkable frontier is lava except a
+// single cell, which becomes the door; the matching key sits off on the start side) and
+// drives a field of real bots. A bot that only knows how to path to the goal CANNOT
+// finish — the cell graph proves the goal is unreachable while the door is shut (asserted
+// below), which is exactly the baseline pre-this-feature behaviour. With key-awareness a
+// bot fetches the key, carries it to the door, unlocks it, and finishes. We assert ≥1
+// finish, plus that pickup/unlock events actually fired (it solved it, didn't luck across).
+(function scenarioF() {
+    const sig = 'ld-F';
+    const GOAL = config.tileMap.goal.id, LAVA = config.tileMap.lava.id, DOOR = config.tileMap.door.id;
+
+    // Mocked clock + scheduled timeouts, installed BEFORE driving the loop so AI
+    // time-based logic (re-path throttle, anti-stuck, cooldowns) advances in sim time
+    // and a tight synchronous tick loop doesn't freeze wall-clock (harness memo).
+    let simNow = 5e6; Date.now = () => simNow;
+    const pend = [];
+    global.setTimeout = (fn, d, ...a) => { pend.push({ at: simNow + (d || 0), fn, a }); return pend.length; };
+    global.clearTimeout = () => { };
+    function tickClock(ms) { simNow += ms; pend.sort((a, b) => a.at - b.at); while (pend.length && pend[0].at <= simNow) { const t = pend.shift(); try { t.fn(...t.a); } catch (e) { } } }
+    function mulberry32(seed) { let a = seed >>> 0; return function () { a |= 0; a = (a + 0x6D2B79F5) | 0; let t = Math.imul(a ^ (a >>> 15), 1 | a); t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t; return ((t ^ (t >>> 14)) >>> 0) / 4294967296; }; }
+    Math.random = mulberry32(0x10CCD0);
+
+    let map = JSON.parse(fs.readFileSync(path.join(repoRoot, 'client', 'maps', 'Duality.json'), 'utf8'));
+    if (mapFormat.isSitesOnly(map)) { map = mapFormat.reconstruct(map); }
+    const cells = map.cells;
+    const adj = cellGraph.getAdjacency(map);
+    const isWalk = walkable;
+
+    // Goal region + its walkable, non-goal frontier (the cells you can enter the goal from).
+    const goalSet = new Set();
+    for (let i = 0; i < cells.length; i++) { if (cells[i].id === GOAL) { goalSet.add(i); } }
+    const frontier = new Set();
+    goalSet.forEach((gi) => {
+        const nb = adj.neighbors[gi] || [];
+        for (let k = 0; k < nb.length; k++) { if (!goalSet.has(nb[k]) && isWalk(cells[nb[k]].id)) { frontier.add(nb[k]); } }
+    });
+    const frontierArr = [...frontier];
+    if (goalSet.size === 0 || frontierArr.length < 2) { fail('F: Duality lacks a multi-entry goal to gate (frontier=' + frontierArr.length + ')'); return; }
+
+    // Start-edge gate point (the racers' launch line) for reachability + distance picks.
+    const edges = (Array.isArray(map.startEdges) && map.startEdges.length) ? map.startEdges : ['left'];
+    const gateSamples = [];
+    for (const e of edges) { for (const s of cellGraph.edgeSampleOrigins(e)) { gateSamples.push(s); } }
+    const gate0 = gateSamples[0];
+
+    // Door = the frontier cell nearest the gate (faces the approach); lava every OTHER
+    // frontier cell so the single door is the goal region's ONLY entrance.
+    frontierArr.sort((a, b) => Math.hypot(cells[a].site.x - gate0.x, cells[a].site.y - gate0.y) - Math.hypot(cells[b].site.x - gate0.x, cells[b].site.y - gate0.y));
+    const doorCellIdx = frontierArr[0];
+    for (let i = 1; i < frontierArr.length; i++) { cells[frontierArr[i]].id = LAVA; }
+    const dSite = cells[doorCellIdx].site;
+    map.doors = [{ x: dSite.x, y: dSite.y }];
+
+    // Reachable-from-gate flood over walkable ground with the door treated as the wall it
+    // will become — this is exactly the start-side region a baseline bot can move through.
+    const reach = new Set();
+    const stack = [];
+    for (const s of gateSamples) { const ci = cellGraph.nearestCellIndex(cells, s); if (!reach.has(ci) && (isWalk(cells[ci].id) || cells[ci].id === GOAL)) { reach.add(ci); stack.push(ci); } }
+    while (stack.length) {
+        const u = stack.pop();
+        const nb = adj.neighbors[u] || [];
+        for (let k = 0; k < nb.length; k++) {
+            const v = nb[k];
+            if (reach.has(v)) { continue; }
+            if (v === doorCellIdx) { continue; } // door is shut — a wall
+            if (isWalk(cells[v].id) || cells[v].id === GOAL) { reach.add(v); stack.push(v); }
+        }
+    }
+    ok(!reach.has(doorCellIdx) && [...goalSet].every((g) => !reach.has(g)), 'F: with the door shut, the goal region is sealed off from the gate (baseline-impossible)');
+    // The door must be approachable: at least one of its neighbours is start-side-reachable.
+    const doorApproachable = (adj.neighbors[doorCellIdx] || []).some((n) => reach.has(n));
+    ok(doorApproachable, 'F: the door has a start-side-reachable approach cell');
+
+    // Key = the reachable walkable cell FARTHEST from the gate (a genuine detour off the
+    // racing line, never behind the door), so the bot must seek it out, not stumble on it.
+    let keyIdx = -1, keyD = -1;
+    reach.forEach((i) => {
+        if (i === doorCellIdx || !isWalk(cells[i].id)) { return; }
+        const d = Math.hypot(cells[i].site.x - gate0.x, cells[i].site.y - gate0.y);
+        if (d > keyD) { keyD = d; keyIdx = i; }
+    });
+    if (keyIdx < 0) { fail('F: no reachable walkable cell to host the key'); return; }
+    map.keys = [{ x: cells[keyIdx].site.x, y: cells[keyIdx].site.y }];
+
+    // Build the room with a field of bots (real engine, mocked clock, seeded RNG).
+    const room = game.getRoom(sig, 6);
+    room.game.gameBoard.isPreview = true;
+    room.game.gameBoard.previewMap = map;
+    const cast = (config.aiRacers && config.aiRacers.cast) || [];
+    const bots = [];
+    for (let i = 0; i < 5; i++) {
+        const b = room.world.createNewBot(sig + '-bot' + i, cast.length ? cast[i % cast.length] : null);
+        room.playerList[b.id] = b; bots.push(b);
+    }
+    room.game.determineGameState(bots[0]);
+    room.game.startLobby(); room.game.startGated();
+    for (let g = 0; g < 30; g++) { tickClock(config.serverTickSpeed); room.update(DT); }
+    room.game.startRace();
+    const gb = room.game.gameBoard;
+    if (gb.lockedDoors.length !== 1 || gb.lockedKeys.length !== 1) { fail('F: gated map did not build exactly one door + key'); return; }
+
+    // Live cell-graph invariants on the running map: goal unreachable while shut, reachable
+    // once the door is treated as open. (Confirms the gate is real and the AI's own
+    // "would-opening-doors-help?" probe will fire.)
+    ok(cellGraph.findPathToNearestGoal(gb.currentMap, gate0) == null, 'F: live map — goal unreachable with the door shut');
+    ok(cellGraph.findPathToNearestGoal(gb.currentMap, gate0, { passableDoors: true }) != null, 'F: live map — goal reachable if the door were open');
+
+    // Drive the race. Count finish EDGES (rounds may cycle); keep notchesToWin high so a
+    // finish doesn't end the match before others can also solve it.
+    const TICKS = Math.round(75 / DT);
+    const prevGoal = {}; for (const b of bots) { prevGoal[b.id] = false; }
+    let finishers = 0;
+    let threw = false;
+    for (let f = 0; f < TICKS; f++) {
+        room.game.notchesToWin = 99;
+        tickClock(config.serverTickSpeed);
+        try { room.update(DT); } catch (e) { threw = true; fail('F: tick threw: ' + e.message + '\n' + e.stack); break; }
+        for (const b of bots) { if (b.reachedGoal && !prevGoal[b.id]) { finishers++; } prevGoal[b.id] = !!b.reachedGoal; }
+        if (gb.lockedDoors[0].unlocked && finishers > 0) { break; } // solved + at least one through
+        if (room.game.currentState === config.stateMap.gameOver) { break; }
+    }
+    ok(!threw, 'F: door-gated race ticked without throwing');
+    ok(countEvents('keyPickedUp') >= 1, 'F: a bot picked up the key');
+    ok(gb.lockedDoors[0].unlocked === true || countEvents('doorUnlocked') >= 1, 'F: a bot carried the key to the door and unlocked it');
+    ok(finishers >= 1, 'F: at least one bot reached the goal through the unlocked door (got ' + finishers + ')');
+})();
+
 if (failures > 0) {
     console.log('\nLocked-door test FAILED with ' + failures + ' error(s).');
     process.exit(1);
 }
-console.log('\nLocked-door test passed: pickup -> carry -> unlock, drop-on-death, lava-consume, and goal-decoupling all hold.');
+console.log('\nLocked-door test passed: pickup -> carry -> unlock, drop-on-death, lava-consume, goal-decoupling, and bot key-solving all hold.');
 process.exit(0);

--- a/.github/scripts/locked-door-test.js
+++ b/.github/scripts/locked-door-test.js
@@ -237,18 +237,15 @@ function prepRacer(p) {
 // finish, plus that pickup/unlock events actually fired (it solved it, didn't luck across).
 (function scenarioF() {
     const sig = 'ld-F';
-    const GOAL = config.tileMap.goal.id, LAVA = config.tileMap.lava.id, DOOR = config.tileMap.door.id;
+    const GOAL = config.tileMap.goal.id, LAVA = config.tileMap.lava.id;
 
     // Mocked clock + scheduled timeouts, installed BEFORE driving the loop so AI
     // time-based logic (re-path throttle, anti-stuck, cooldowns) advances in sim time
-    // and a tight synchronous tick loop doesn't freeze wall-clock (harness memo).
-    let simNow = 5e6; Date.now = () => simNow;
-    const pend = [];
-    global.setTimeout = (fn, d, ...a) => { pend.push({ at: simNow + (d || 0), fn, a }); return pend.length; };
-    global.clearTimeout = () => { };
-    function tickClock(ms) { simNow += ms; pend.sort((a, b) => a.at - b.at); while (pend.length && pend[0].at <= simNow) { const t = pend.shift(); try { t.fn(...t.a); } catch (e) { } } }
-    function mulberry32(seed) { let a = seed >>> 0; return function () { a |= 0; a = (a + 0x6D2B79F5) | 0; let t = Math.imul(a ^ (a >>> 15), 1 | a); t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t; return ((t ^ (t >>> 14)) >>> 0) / 4294967296; }; }
-    Math.random = mulberry32(0x10CCD0);
+    // and a tight synchronous tick loop doesn't freeze wall-clock (harness memo). Shared
+    // primitives so this doesn't fork yet another copy of the clock/PRNG.
+    const harness = require(path.join(repoRoot, '.github', 'scripts', 'headless-harness.js'));
+    const tickClock = harness.installMockClock(5e6);
+    Math.random = harness.mulberry32(0x10CCD0);
 
     let map = JSON.parse(fs.readFileSync(path.join(repoRoot, 'client', 'maps', 'Duality.json'), 'utf8'));
     if (mapFormat.isSitesOnly(map)) { map = mapFormat.reconstruct(map); }
@@ -336,7 +333,9 @@ function prepRacer(p) {
     ok(cellGraph.findPathToNearestGoal(gb.currentMap, gate0, { passableDoors: true }) != null, 'F: live map — goal reachable if the door were open');
 
     // Drive the race. Count finish EDGES (rounds may cycle); keep notchesToWin high so a
-    // finish doesn't end the match before others can also solve it.
+    // finish doesn't end the match before others can also solve it. Reset the shared event
+    // log first so the pickup/unlock assertions reflect THIS scenario, not leakage from A/B.
+    events = [];
     const TICKS = Math.round(75 / DT);
     const prevGoal = {}; for (const b of bots) { prevGoal[b.id] = false; }
     let finishers = 0;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### General
 
-- **Bots can now solve locked-door maps.** AI racers understand keys and doors: when a locked door is sealing off the only way to the finish, a bot will break off, fetch the matching key, carry it to the door and unlock it for everyone — then get back to racing. They coordinate so the whole pack doesn't pile onto one key, and the rest wait at the door ready to pour through the moment it opens. This means locked-door maps work in bot-heavy rooms instead of stalling at the barrier.
+- **Bots can now solve locked-door maps.** AI racers understand keys and doors: when a locked door is sealing off the only way to the finish, a bot will break off, fetch the matching key, carry it to the door and unlock it for everyone — then get back to racing. The rest wait at the door ready to pour through the moment it opens, so locked-door maps work in bot-heavy rooms instead of stalling at the barrier. Bots also treat a door as an optional **shortcut**: if the goal is reachable the long way but opening a door would be meaningfully shorter, some bots will peel off to grab the key and cut through while others race the open route — including snapping up a key another racer dropped if it's a worthwhile detour.
 
 ## v0.43.0 — 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### General
+
+- **Bots can now solve locked-door maps.** AI racers understand keys and doors: when a locked door is sealing off the only way to the finish, a bot will break off, fetch the matching key, carry it to the door and unlock it for everyone — then get back to racing. They coordinate so the whole pack doesn't pile onto one key, and the rest wait at the door ready to pour through the moment it opens. This means locked-door maps work in bot-heavy rooms instead of stalling at the barrier.
 
 ## v0.43.0 — 2026-06-15
 

--- a/docs/followups/locked-door-ai.md
+++ b/docs/followups/locked-door-ai.md
@@ -34,6 +34,18 @@ Any `aiController`/`cellGraph` steering or pathing change must be A/B-checked th
 
 Watch for the known traps: `generateHash` needs **numeric** seeds; the cell graph must re-read live `cell.id` (a door that opened mid-round must become walkable); and don't introduce a stuck-probe beeline treadmill on the slow approach to a key (see the bumper-crossing `STUCK_SPEED_MAX` lesson).
 
-## Until this lands
+## Status: LANDED
 
-Bot-heavy locked-door rooms can stall, so **don't put locked-door maps into the default rotation** (or only feature them in human-heavy contexts) until bots can solve them. There is intentionally no failsafe timer.
+Implemented in `server/aiController.js` (objective layer: `computeDoorObjective` + the
+per-tick coordination/lookup build in `update`) and `server/cellGraph.js` (the
+`options.passableDoors` flag used to detect which doors block the goal). A walled bot
+fetches the nearest matching loose key, carries it to the door (driving within
+`unlockRadius` to fire the server-side unlock), then resumes goal pathing; light
+coordination (`KEY_PURSUERS`) keeps the pack from dogpiling one key, and non-pursuers
+stage at the door. Validated by the bot-driven scenario F in
+`.github/scripts/locked-door-test.js` (baseline-impossible invariant + bots actually
+finish) and an A/B of `ai-fitness.js` on the control maps (byte-identical — the change
+is gated behind `gameBoard.hasLockedDoors`, so non-door maps are untouched).
+
+Locked-door maps are now safe for bot-heavy rooms. There is still intentionally no
+failsafe timer — the door only opens via its key.

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -1615,46 +1615,78 @@ function nearestBlockingDoor(bot, ctx, blockingIdx) {
     return best;
 }
 
-// Optional SHORTCUT: the goal is already reachable (goalRoute != null), but fetching a
-// loose key and opening its door might be a shorter way to the finish. Returns a 'shortcut'
-// objective (fetch the key) when worth it, else null (race the open route). Cost: up to 2
-// extra Dijkstra, but only for the nearest SHORTCUT_PURSUERS bots to a loose key (the
-// ration in update()) — or a bot already committed, or one with a key right in front.
+// How many OTHER eligible (empty-handed, racing) bots are strictly closer to this key than
+// `bot` — the bot's pursuit rank. Computed lazily here (only when a bot actually evaluates a
+// key on its re-path) rather than as a per-tick global table, so it costs nothing on the
+// ticks/maps where no shortcut is considered. Optional-shortcut rationing is SAFE (the goal
+// is reachable either way) so capping pursuers can't strand anyone, unlike the mandatory case.
+function shortcutRank(ctx, bot, key) {
+    var rank = 0;
+    var bd = mag(bot.x - key.x, bot.y - key.y);
+    for (var id in ctx.players) {
+        var p = ctx.players[id];
+        if (p === bot || !p.isAI || !p.alive || !p.awake || p.isSpectator || p.isZombie || p.reachedGoal || p.heldKey != null) { continue; }
+        if (mag(p.x - key.x, p.y - key.y) < bd) { rank++; }
+    }
+    return rank;
+}
+
+// Optional SHORTCUT: the goal is already reachable (goalRoute != null), but fetching a loose
+// key and opening its door might be a faster way to the finish. Returns a 'shortcut' objective
+// (with the already-computed bot->key route to reuse) when worth it, else null (race the open
+// route). Per candidate key it costs 2 Dijkstra, bounded to the nearest SHORTCUT_PURSUERS bots
+// (lazy rank), a committed bot, or one with a key right in front; a straight-line prefilter
+// skips clearly-hopeless keys before any Dijkstra.
 function considerShortcut(bot, ctx, baseOpts, goalRoute) {
     if (!Array.isArray(ctx.lockedKeys) || goalRoute == null) { return null; }
     var ai = bot.ai;
     var openDist = goalRoute.distance;
     if (!(openDist > 0)) { return null; }
-    var allowed = ctx.shortcutAllowed != null ? ctx.shortcutAllowed[bot.id] : null;
-    // Aggressive/risk-taking bots accept a smaller saving (higher factor); cautious bots
-    // demand a bigger one — so the field splits organically, not as a uniform decision.
-    var factor = SHORTCUT_FACTOR + (ai.risk - 0.5) * SHORTCUT_RISK_SPREAD;
-    var best = null, bestDist = Infinity, bestKv = null;
+    // Compare TIME, not raw distance: the router and the race both run on tile-weighted time
+    // (sand/water are far slower per pixel), so a geometrically-shorter door route across slow
+    // ground can actually be slower. estimatePathTime walks the path under the real physics.
+    var openTime = cellGraph.estimatePathTime(ctx.map, goalRoute.path);
+    if (!(openTime > 0)) { return null; }
+    // Aggressive bots accept a smaller saving, cautious bots demand a bigger one, so the field
+    // splits organically. Clamp < 1 so a "shortcut" is never accepted when it's not faster.
+    var factor = clamp01(SHORTCUT_FACTOR + (ai.risk - 0.5) * SHORTCUT_RISK_SPREAD);
+    if (factor > 0.97) { factor = 0.97; } else if (factor < 0.4) { factor = 0.4; }
+    var best = null, bestTime = Infinity, bestKv = null, bestRoute = null;
     for (var i = 0; i < ctx.lockedKeys.length; i++) {
         var key = ctx.lockedKeys[i];
         if (key.carriedBy != null || key.used || key.consumed) { continue; }
         var door = ctx.lockedDoors[key.doorIndex];
-        if (door == null || door.unlocked) { continue; }
-        // Consider this key only if the bot is one of its nearest pursuers, has already
-        // committed to it (sticky, avoids flip-flop), or it's right in front of the bot
-        // (a dropped key at your feet is worth grabbing even if you're not the nearest).
+        if (door == null || door.unlocked || door.voronoiId == null) { continue; }
+        // Eligibility: already committed (sticky, avoids flip-flop), the key is right in front
+        // (a dropped key at your feet is worth grabbing), or the bot is one of the key's
+        // nearest pursuers (the ration that produces the split).
         var near = mag(key.x - bot.x, key.y - bot.y);
-        var eligible = (allowed != null && allowed[key.index]) || ai.shortcutKeyIndex === key.index || near <= SHORTCUT_GRAB_RADIUS;
+        var eligible = ai.shortcutKeyIndex === key.index || near <= SHORTCUT_GRAB_RADIUS || shortcutRank(ctx, bot, key) < SHORTCUT_PURSUERS;
         if (!eligible) { continue; }
+        // Cheap straight-line prefilter: reaching the key alone already costs > the whole open
+        // route's geometric length means no shortcut is plausible — skip before any Dijkstra.
+        if (near >= openDist) { continue; }
         var kv = keyCellVoronoiId(ctx, key);
         if (kv == null) { continue; }
         var toKey = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, Object.assign({}, baseOpts, { goalSet: [kv] }));
-        if (toKey == null) { continue; } // key not reachable with the door shut
-        var fromKey = cellGraph.findPathToNearestGoal(ctx.map, { x: key.x, y: key.y }, Object.assign({}, baseOpts, { passableDoors: true }));
+        if (toKey == null) { continue; } // key not reachable with the doors shut
+        // Open ONLY this key's door (a bot holds one key); passableDoors would open every door
+        // and overstate the saving on a multi-door map.
+        var fromKey = cellGraph.findPathToNearestGoal(ctx.map, { x: key.x, y: key.y }, Object.assign({}, baseOpts, { openDoorIds: [door.voronoiId] }));
         if (fromKey == null) { continue; }
-        var scDist = toKey.distance + fromKey.distance; // bot -> key -> (through door) -> goal
-        if (scDist < openDist * factor && scDist < bestDist) {
-            best = key; bestDist = scDist; bestKv = kv;
+        // The shortcut must actually USE this door — else opening it gains nothing and the
+        // carrier's mandatory detour to the door is pure cost the estimate would miss.
+        if (fromKey.path.indexOf(door.voronoiId) === -1) { continue; }
+        // Continuous bot->key->door->goal time vs the open route (drop the duplicated key cell).
+        var scTime = cellGraph.estimatePathTime(ctx.map, toKey.path.concat(fromKey.path.slice(1)));
+        if (scTime > 0 && scTime < openTime * factor && scTime < bestTime) {
+            best = key; bestTime = scTime; bestKv = kv; bestRoute = toKey;
         }
     }
     if (best == null) { return null; }
     var gset = {}; gset[bestKv] = true;
-    return { mode: 'shortcut', goalSet: gset, finalPoint: { x: best.x, y: best.y }, keyIndex: best.index };
+    // Hand back the bot->key route so steerBot reuses it instead of recomputing it.
+    return { mode: 'shortcut', goalSet: gset, finalPoint: { x: best.x, y: best.y }, keyIndex: best.index, route: bestRoute };
 }
 
 // The bot's locked-door objective this re-path, or null to race the goal normally.
@@ -1817,7 +1849,9 @@ function steerBot(bot, ctx, dt) {
                 pathOpts.goalSet = obj.goalSet;
                 ai.doorMode = obj.mode;
                 ai.doorFinalPoint = obj.finalPoint;
-                route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, pathOpts);
+                // A shortcut objective hands back the bot->key route it already computed —
+                // reuse it instead of recomputing the identical search.
+                route = obj.route != null ? obj.route : cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, pathOpts);
             }
         } else {
             ai.shortcutKeyIndex = null;
@@ -2551,44 +2585,17 @@ function update(gameBoard, currentState, dt) {
     // Locked doors + keys. doorIndexByVoronoiId (voronoiId -> door index) lets a route
     // crossing a door cell name which door it is. (The voronoiId -> cell-index map the
     // objective layer also needs is the adjacency cache's own idToIndex, reused directly in
-    // doorApproachCells; no per-tick rebuild.)
-    //
-    // For the MANDATORY case (door is the only way) coordination is implicit — a bot only
-    // pursues a key whose door blocks ITS route, and a grabbed key stops being loose, so
-    // the rest re-evaluate and stage; no ration (a ration there would starve the needed
-    // key). For the OPTIONAL SHORTCUT case the goal is reachable either way, so a ration IS
-    // safe and is exactly what splits the field: only the nearest SHORTCUT_PURSUERS bots to
-    // a loose key consider it as a shortcut, the rest race the open route. (A bot already
-    // committed, or one with a key right in front, bypasses the ration — see considerShortcut.)
+    // doorApproachCells; no per-tick rebuild.) Coordination is implicit and lazy: the
+    // mandatory case rations nothing (a ration would starve the only key), and the optional
+    // shortcut's nearest-N pursuer ration is computed on the fly in considerShortcut
+    // (shortcutRank) only when a bot actually evaluates a key — no per-tick global table.
     var hasLockedDoors = gameBoard.hasLockedDoors === true;
-    var doorIndexByVoronoiId = null, shortcutAllowed = null;
+    var doorIndexByVoronoiId = null;
     if (hasLockedDoors) {
         doorIndexByVoronoiId = {};
         for (var di = 0; di < gameBoard.lockedDoors.length; di++) {
             var dr = gameBoard.lockedDoors[di];
             if (dr != null && dr.voronoiId != null) { doorIndexByVoronoiId[dr.voronoiId] = dr.index; }
-        }
-        var scElig = [];
-        for (var seid in playerList) {
-            var sep = playerList[seid];
-            if (sep.isAI && sep.alive && sep.awake && !sep.isSpectator && !sep.isZombie && !sep.reachedGoal && sep.heldKey == null) {
-                scElig.push(sep);
-            }
-        }
-        shortcutAllowed = {};
-        for (var ski = 0; ski < gameBoard.lockedKeys.length; ski++) {
-            var slk = gameBoard.lockedKeys[ski];
-            if (slk == null || slk.carriedBy != null || slk.used || slk.consumed) { continue; }
-            var ranked = [];
-            for (var rb = 0; rb < scElig.length; rb++) {
-                var rbx = scElig[rb].x - slk.x, rby = scElig[rb].y - slk.y;
-                ranked.push({ id: scElig[rb].id, d2: rbx * rbx + rby * rby });
-            }
-            ranked.sort(function (a, b) { return a.d2 - b.d2; });
-            for (var rr = 0; rr < ranked.length && rr < SHORTCUT_PURSUERS; rr++) {
-                if (shortcutAllowed[ranked[rr].id] == null) { shortcutAllowed[ranked[rr].id] = {}; }
-                shortcutAllowed[ranked[rr].id][slk.index] = true;
-            }
         }
     }
 
@@ -2609,7 +2616,6 @@ function update(gameBoard, currentState, dt) {
         lockedDoors: gameBoard.lockedDoors,
         lockedKeys: gameBoard.lockedKeys,
         doorIndexByVoronoiId: doorIndexByVoronoiId, // path cell -> the door it is (blocking-door detection)
-        shortcutAllowed: shortcutAllowed, // botId -> { keyIndex:true } it may consider as an OPTIONAL shortcut
         staticHazardCells: staticHazardCells, // static bumper cells (harsh path penalty)
         railCells: railCells, // moving-rail swept cells (mild path penalty — timeable)
         barrierEdges: cellGraph.getBarrierBlockedEdges(map), // adjacency edges a solid barrier cuts (route around)

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -178,6 +178,9 @@ function newBotState(profile) {
         escapeStage: 0,    // 1 = gentle (relax+wander-kill), 2 = committed (thread-or-die)
         heldAbilityId: null,// which ability the bot is currently holding
         abilityHeldSince: 0,// ms: when it picked up the held ability (hold-timeout)
+        doorMode: null,     // locked-door objective: 'key'|'door'|'stage' or null (race the goal)
+        doorFinalPoint: null,// {x,y} to home straight onto for the last stretch (key spot / door)
+        hadKey: false,      // was carrying a key last tick (force an instant re-path on pickup/drop)
         pathSeed: 1 + Math.floor(Math.random() * 1e9), // per-bot route-diversity seed
         // Personality knobs (0..1 unless noted).
         skill: clamp01(pick('skill', 0.7) + jitter), // speed + precision + reaction
@@ -640,6 +643,17 @@ var RAIL_PATH_PENALTY = 4;
 // static hazard, but still soft so a barrier in the sole chokepoint never nulls the
 // path (the bot threads it and slides, as it does physically).
 var BARRIER_PATH_PENALTY = 45;
+
+// --- Locked doors + keys (see config.lockedDoor + Room.checkLockedDoors) -------
+// A locked door's home cell is a wall (door.id) until its matching shaped key is
+// carried into it; the cell graph routes AROUND a shut door, so on a door-gated map
+// the bot's goal route comes back null and it would just mill at the barrier. The
+// objective layer below makes a walled bot FETCH the matching key (drive onto it —
+// pickup fires server-side on proximity) then CARRY it to the door (drive within
+// unlockRadius — the unlock fires server-side), after which normal goal pathing
+// resumes. Pickup/unlock are pure proximity in checkLockedDoors; the bot only steers.
+var DOOR_FINAL_APPROACH = 120;  // px: home straight on the key/door point for the last stretch
+var KEY_PURSUERS = 2;           // bots allowed to chase a single loose key (others stage at the door)
 
 var AB = c.tileMap.abilities;
 
@@ -1493,8 +1507,149 @@ function decideLunge(bot, ctx) {
     bot.lungePendingAt = Date.now();
 }
 
+// --- Locked-door objective ----------------------------------------------------
+// All helpers below run only on a door map (ctx.hasLockedDoors). They turn the
+// proximity contract in Room.checkLockedDoors (drive onto a key -> hold it; drive a
+// held key into its door -> unlock) into navigation targets the normal cell-graph
+// pathing then drives to.
+
+// Tiles a route may approach a door across (anything the bot can stand on): not
+// lava, an empty hole, or another shut door.
+function doorRouteWalkable(ctx, id) {
+    return id !== ctx.lavaId && id !== ctx.emptyId && id !== ctx.doorId;
+}
+
+// Walkable cells bordering a door's home cell, as a goalSet for findPathToNearestGoal.
+// A shut door cell is a wall (never relaxed), so a carrier can't path INTO it — it
+// paths to a reachable neighbour and makes the final push toward the door point. The
+// neighbour set is whichever side is reachable from the bot (Dijkstra ignores the
+// far, door-walled side). Returns null if the door cell or its neighbours are gone.
+function doorApproachCells(ctx, door) {
+    if (door == null || door.voronoiId == null || ctx.cellIndexByVoronoiId == null) { return null; }
+    var idx = ctx.cellIndexByVoronoiId[door.voronoiId];
+    if (idx == null) { return null; }
+    var adj = cellGraph.getAdjacency(ctx.map);
+    var nbrs = adj.neighbors[idx];
+    if (!nbrs) { return null; }
+    var set = null;
+    for (var i = 0; i < nbrs.length; i++) {
+        var cell = ctx.map.cells[nbrs[i]];
+        if (cell != null && cell.site != null && doorRouteWalkable(ctx, cell.id)) {
+            if (set == null) { set = {}; }
+            set[cell.site.voronoiId] = true;
+        }
+    }
+    return set;
+}
+
+// The voronoiId of the cell a loose key currently sits in (its goalSet — driving
+// onto that cell brings the bot within pickupRadius).
+function keyCellVoronoiId(ctx, key) {
+    var idx = cellGraph.nearestCellIndex(ctx.map.cells, { x: key.x, y: key.y });
+    var cell = ctx.map.cells[idx];
+    return (cell != null && cell.site != null) ? cell.site.voronoiId : null;
+}
+
+// Door indices whose home cell lies on `path` (voronoiIds) and is still shut — the
+// doors this route must unlock, in path order (nearest-first from the bot).
+function blockingDoorsOnPath(ctx, path) {
+    var out = [];
+    if (!Array.isArray(path) || ctx.doorIndexByVoronoiId == null) { return out; }
+    for (var i = 0; i < path.length; i++) {
+        var di = ctx.doorIndexByVoronoiId[path[i]];
+        if (di == null) { continue; }
+        var door = ctx.lockedDoors[di];
+        if (door != null && !door.unlocked && out.indexOf(di) === -1) { out.push(di); }
+    }
+    return out;
+}
+
+// Nearest loose, un-consumed key this bot is ALLOWED to pursue (light coordination,
+// computed in update) whose door is on the blocking list — falling back to any
+// allowed loose key when none match (better to grab a key than stall).
+function pickKeyToPursue(bot, ctx, blockingIdx) {
+    var allowed = ctx.keyAllowed != null ? ctx.keyAllowed[bot.id] : null;
+    if (allowed == null) { return null; }
+    var best = null, bestD = Infinity, bestMatch = false;
+    for (var i = 0; i < ctx.lockedKeys.length; i++) {
+        var key = ctx.lockedKeys[i];
+        if (key.carriedBy != null || key.used || key.consumed) { continue; }
+        if (!allowed[key.index]) { continue; }
+        var matches = blockingIdx.indexOf(key.doorIndex) !== -1;
+        var d = mag(key.x - bot.x, key.y - bot.y);
+        // Prefer a key that opens a blocking door; among equal match-status, nearest.
+        if ((matches && !bestMatch) || ((matches === bestMatch) && d < bestD)) {
+            best = key; bestD = d; bestMatch = matches;
+        }
+    }
+    return best;
+}
+
+// Nearest still-shut blocking door — where a non-pursuer stages so it's ready to
+// pour through the instant the carrier opens it (instead of milling at a wall).
+function nearestBlockingDoor(bot, ctx, blockingIdx) {
+    var best = null, bestD = Infinity;
+    for (var i = 0; i < blockingIdx.length; i++) {
+        var door = ctx.lockedDoors[blockingIdx[i]];
+        if (door == null || door.unlocked) { continue; }
+        var d = mag(door.x - bot.x, door.y - bot.y);
+        if (d < bestD) { bestD = d; best = door; }
+    }
+    return best;
+}
+
+// The bot's locked-door objective this re-path, or null to race the goal normally.
+//   { mode:'key'|'door'|'stage', goalSet:{voronoiId:true}, finalPoint:{x,y}|null }
+// 'key'  — empty-handed, goal walled by a door: drive onto the matching key.
+// 'door' — carrying a key: drive into its matched door to unlock it.
+// 'stage'— walled but not pursuing a key (another bot has it): wait at the door.
+function computeDoorObjective(bot, ctx, baseOpts) {
+    // Carrying a key -> head to its still-shut door.
+    if (bot.heldKey != null) {
+        var door = ctx.lockedDoors[bot.heldKey.doorIndex];
+        if (door != null && !door.unlocked) {
+            var gs = doorApproachCells(ctx, door);
+            if (gs != null) { return { mode: 'door', goalSet: gs, finalPoint: { x: door.x, y: door.y } }; }
+        }
+        return null; // door already open (or data gone) -> race the goal
+    }
+    // Empty-handed: only engage if the goal is currently UNREACHABLE (a shut door, or
+    // lava, walls us off). If we can already reach a goal, ignore keys and race.
+    var normal = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, baseOpts);
+    if (normal != null) { return null; }
+    // Walled. Would opening the doors free us? Path treating door cells as passable.
+    var openOpts = {};
+    for (var k in baseOpts) { openOpts[k] = baseOpts[k]; }
+    openOpts.passableDoors = true;
+    var opened = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, openOpts);
+    if (opened == null) { return null; } // genuinely lava-walled, not a door — existing fallback handles it
+    var blockingIdx = blockingDoorsOnPath(ctx, opened.path);
+    if (blockingIdx.length === 0) { return null; } // opened up for some non-door reason; nothing to fetch
+    var key = pickKeyToPursue(bot, ctx, blockingIdx);
+    if (key != null) {
+        var kv = keyCellVoronoiId(ctx, key);
+        if (kv != null) {
+            var kset = {}; kset[kv] = true;
+            return { mode: 'key', goalSet: kset, finalPoint: { x: key.x, y: key.y } };
+        }
+    }
+    // No key to chase (not our turn, or all loose keys are spoken for) — stage at the door.
+    var sdoor = nearestBlockingDoor(bot, ctx, blockingIdx);
+    if (sdoor != null) {
+        var sset = doorApproachCells(ctx, sdoor);
+        if (sset != null) { return { mode: 'stage', goalSet: sset, finalPoint: null }; }
+    }
+    return null;
+}
+
 function steerBot(bot, ctx, dt) {
     var ai = bot.ai || (bot.ai = newBotState(bot.profile));
+
+    // Locked-door state change (picked up / lost a key) flips the whole objective —
+    // re-path THIS tick so a carrier turns for its door immediately instead of coasting
+    // on toward the key cell, and a robbed/dropped carrier re-plans at once.
+    var holdingKey = bot.heldKey != null;
+    if (holdingKey !== ai.hadKey) { ai.repathTimer = 0; ai.hadKey = holdingKey; }
 
     // --- Anti-stuck probe: hold an anchor at the last spot the bot made real
     // headway from. While it loiters within STUCK_RADIUS of that anchor (crawling
@@ -1538,6 +1693,12 @@ function steerBot(bot, ctx, dt) {
         // center (collapseLoc), which beats charging a goal tile with lava avoidance off
         // into the advancing collapse front.
         beelining = !ctx.collapsing && (nowProbe - ai.headwayAt) >= BEELINE_AFTER_MS;
+        // On a locked-door objective (fetching a key, carrying it to a door, or staging
+        // at one) the goal-beeline is wrong: it abandons the key and charges the nearest
+        // GOAL tile with avoidance off, driving into the very door wall it can't pass. Let
+        // the door objective run instead — escapes still fire to thread a real pinch, but
+        // the sealed-in goal beeline stays off until the door opens and goal pathing resumes.
+        if (ai.doorMode != null) { beelining = false; }
     }
 
     // --- Re-path on a throttle (and immediately if we have no path) ---
@@ -1562,6 +1723,21 @@ function steerBot(bot, ctx, dt) {
         // safe bunker island instead — otherwise findPathToNearestGoal returns null
         // and the bot just sits there.
         if (ctx.bunkerSafeIds != null) { pathOpts.goalSet = ctx.bunkerSafeIds; }
+        // Locked-door objective: on a door-gated map a walled bot fetches the matching
+        // key, then carries it to the door, instead of trying (and failing) to path to a
+        // goal sealed behind a shut door. The objective just retargets the SAME pathing
+        // (a goalSet of the key cell or the door's reachable neighbours); pickup/unlock
+        // fire server-side on proximity. finalPoint homes the last stretch onto the exact
+        // key spot / door so the proximity radius trips even from the cell's edge.
+        ai.doorMode = null; ai.doorFinalPoint = null;
+        if (ctx.hasLockedDoors && ctx.bunkerSafeIds == null) {
+            var obj = computeDoorObjective(bot, ctx, pathOpts);
+            if (obj != null) {
+                pathOpts.goalSet = obj.goalSet;
+                ai.doorMode = obj.mode;
+                ai.doorFinalPoint = obj.finalPoint;
+            }
+        }
         var route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, pathOpts);
         // If the danger ring walled us off, retry without it so we still aim at a
         // goal (better a tight line than freezing in front of the lava). Keep the
@@ -1614,6 +1790,18 @@ function steerBot(bot, ctx, dt) {
             var im = mag(inX, inY) || 1, om = mag(outX, outY) || 1;
             var turnCos = (inX * outX + inY * outY) / (im * om);
             if (turnCos < TURN_BRAKE_COS) { sharpTurn = true; }
+        }
+        // Locked-door final approach: the route only reaches the key's cell / a door's
+        // neighbour, but pickup/unlock need the bot within pickupRadius/unlockRadius of the
+        // exact point. Once close, steer straight at it so the bot drives onto the key (grab)
+        // or presses into the door (unlock) — avoidance still applies, so it won't cut into
+        // flanking lava. No bend braking here: this last nudge is short and deliberate.
+        if (ai.doorFinalPoint != null) {
+            var fpx = ai.doorFinalPoint.x - bot.x, fpy = ai.doorFinalPoint.y - bot.y;
+            var fpm = mag(fpx, fpy);
+            if (fpm < DOOR_FINAL_APPROACH && fpm > 0.001) {
+                desiredX = fpx / fpm; desiredY = fpy / fpm; sharpTurn = false;
+            }
         }
     } else if (ctx.collapsing && ctx.collapseLoc != null) {
         // Walled off with no reachable goal during a collapse: the collapse closes
@@ -2261,16 +2449,67 @@ function update(gameBoard, currentState, dt) {
         }
     }
 
+    // Locked doors + keys: the lookups the objective layer needs (voronoiId -> door
+    // index / cell index) and light coordination so the field doesn't dogpile one key.
+    // Each loose, un-consumed key is "claimed" by its nearest KEY_PURSUERS eligible bots
+    // (empty-handed racers); the rest stage at the door. Recomputed every tick so a claim
+    // re-assigns the instant a pursuer dies, finishes, or grabs the key.
+    var hasLockedDoors = gameBoard.hasLockedDoors === true;
+    var doorIndexByVoronoiId = null, cellIndexByVoronoiId = null, keyAllowed = null;
+    if (hasLockedDoors) {
+        doorIndexByVoronoiId = {};
+        for (var di = 0; di < gameBoard.lockedDoors.length; di++) {
+            var dr = gameBoard.lockedDoors[di];
+            if (dr != null && dr.voronoiId != null) { doorIndexByVoronoiId[dr.voronoiId] = dr.index; }
+        }
+        cellIndexByVoronoiId = {};
+        for (var cix = 0; cix < map.cells.length; cix++) {
+            if (map.cells[cix] != null && map.cells[cix].site != null) {
+                cellIndexByVoronoiId[map.cells[cix].site.voronoiId] = cix;
+            }
+        }
+        var eligible = [];
+        for (var eid in playerList) {
+            var ep = playerList[eid];
+            if (ep.isAI && ep.alive && ep.awake && !ep.isSpectator && !ep.isZombie && !ep.reachedGoal && ep.heldKey == null) {
+                eligible.push(ep);
+            }
+        }
+        keyAllowed = {};
+        for (var ki = 0; ki < gameBoard.lockedKeys.length; ki++) {
+            var lk = gameBoard.lockedKeys[ki];
+            if (lk == null || lk.carriedBy != null || lk.used || lk.consumed) { continue; }
+            var ranked = eligible.slice().sort((function (key) {
+                return function (b1, b2) {
+                    return mag(b1.x - key.x, b1.y - key.y) - mag(b2.x - key.x, b2.y - key.y);
+                };
+            })(lk));
+            for (var rk = 0; rk < ranked.length && rk < KEY_PURSUERS; rk++) {
+                var bid2 = ranked[rk].id;
+                if (keyAllowed[bid2] == null) { keyAllowed[bid2] = {}; }
+                keyAllowed[bid2][lk.index] = true;
+            }
+        }
+    }
+
     var ctx = {
         map: map,
         lavaId: LAVA,
         emptyId: c.tileMap.empty.id,
+        doorId: c.tileMap.door != null ? c.tileMap.door.id : -999,
         iceId: c.tileMap.ice.id,
         waterId: c.tileMap.water != null ? c.tileMap.water.id : -999,
         siteById: buildSiteIndex(map),
         lavaCells: lavaCells,
         goalTiles: goalTiles, // for zombie intercept (prey are racing to a goal)
         bunkerSafeIds: bunkerSafeIds, // Bunker round: A* homes on these cells (buried goal)
+        // Locked doors + keys (see steerBot's computeDoorObjective).
+        hasLockedDoors: hasLockedDoors,
+        lockedDoors: gameBoard.lockedDoors,
+        lockedKeys: gameBoard.lockedKeys,
+        doorIndexByVoronoiId: doorIndexByVoronoiId, // path cell -> the door it is (blocking-door detection)
+        cellIndexByVoronoiId: cellIndexByVoronoiId, // door voronoiId -> cell index (neighbour lookup)
+        keyAllowed: keyAllowed, // botId -> { keyIndex:true } the bot may pursue (anti-dogpile)
         staticHazardCells: staticHazardCells, // static bumper cells (harsh path penalty)
         railCells: railCells, // moving-rail swept cells (mild path penalty — timeable)
         barrierEdges: cellGraph.getBarrierBlockedEdges(map), // adjacency edges a solid barrier cuts (route around)

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -653,7 +653,6 @@ var BARRIER_PATH_PENALTY = 45;
 // unlockRadius — the unlock fires server-side), after which normal goal pathing
 // resumes. Pickup/unlock are pure proximity in checkLockedDoors; the bot only steers.
 var DOOR_FINAL_APPROACH = 120;  // px: home straight on the key/door point for the last stretch
-var KEY_PURSUERS = 2;           // bots allowed to chase a single loose key (others stage at the door)
 
 var AB = c.tileMap.abilities;
 
@@ -1524,11 +1523,13 @@ function doorRouteWalkable(ctx, id) {
 // paths to a reachable neighbour and makes the final push toward the door point. The
 // neighbour set is whichever side is reachable from the bot (Dijkstra ignores the
 // far, door-walled side). Returns null if the door cell or its neighbours are gone.
+// Reuses the adjacency cache's voronoiId->cell-index table (idToIndex) — no per-tick
+// rebuild of a map that's static for the round.
 function doorApproachCells(ctx, door) {
-    if (door == null || door.voronoiId == null || ctx.cellIndexByVoronoiId == null) { return null; }
-    var idx = ctx.cellIndexByVoronoiId[door.voronoiId];
-    if (idx == null) { return null; }
+    if (door == null || door.voronoiId == null) { return null; }
     var adj = cellGraph.getAdjacency(ctx.map);
+    var idx = adj.idToIndex[door.voronoiId];
+    if (idx == null) { return null; }
     var nbrs = adj.neighbors[idx];
     if (!nbrs) { return null; }
     var set = null;
@@ -1543,7 +1544,9 @@ function doorApproachCells(ctx, door) {
 }
 
 // The voronoiId of the cell a loose key currently sits in (its goalSet — driving
-// onto that cell brings the bot within pickupRadius).
+// onto that cell brings the bot within pickupRadius). In a Voronoi diagram the cell
+// CONTAINING a point is exactly its nearest-site cell, so nearestCellIndex is the
+// correct (and cheap) point->cell resolution here.
 function keyCellVoronoiId(ctx, key) {
     var idx = cellGraph.nearestCellIndex(ctx.map.cells, { x: key.x, y: key.y });
     var cell = ctx.map.cells[idx];
@@ -1564,29 +1567,29 @@ function blockingDoorsOnPath(ctx, path) {
     return out;
 }
 
-// Nearest loose, un-consumed key this bot is ALLOWED to pursue (light coordination,
-// computed in update) whose door is on the blocking list — falling back to any
-// allowed loose key when none match (better to grab a key than stall).
+// Nearest loose, un-consumed key whose door is on the bot's OWN blocking list. A bot
+// only ever pursues a key that unblocks ITS route — never a key for some other door
+// (that would burn the wrong key and leave the door that actually gates it shut, the
+// multi-door stall). With keys restricted to blocking doors, "all bots dogpile one
+// key" self-limits: once a bot grabs it, it's no longer loose, so the rest re-evaluate
+// next re-path and stage at the door — so no separate pursuer ration is needed (and a
+// ration that isn't door-aware would starve the very key a sealed-off bot needs).
 function pickKeyToPursue(bot, ctx, blockingIdx) {
-    var allowed = ctx.keyAllowed != null ? ctx.keyAllowed[bot.id] : null;
-    if (allowed == null) { return null; }
-    var best = null, bestD = Infinity, bestMatch = false;
+    var best = null, bestD = Infinity;
     for (var i = 0; i < ctx.lockedKeys.length; i++) {
         var key = ctx.lockedKeys[i];
         if (key.carriedBy != null || key.used || key.consumed) { continue; }
-        if (!allowed[key.index]) { continue; }
-        var matches = blockingIdx.indexOf(key.doorIndex) !== -1;
+        if (blockingIdx.indexOf(key.doorIndex) === -1) { continue; }
         var d = mag(key.x - bot.x, key.y - bot.y);
-        // Prefer a key that opens a blocking door; among equal match-status, nearest.
-        if ((matches && !bestMatch) || ((matches === bestMatch) && d < bestD)) {
-            best = key; bestD = d; bestMatch = matches;
-        }
+        if (d < bestD) { best = key; bestD = d; }
     }
     return best;
 }
 
 // Nearest still-shut blocking door — where a non-pursuer stages so it's ready to
-// pour through the instant the carrier opens it (instead of milling at a wall).
+// pour through the instant the carrier opens it (instead of milling at a wall). The
+// candidates are doors on the bot's own would-open route, so they're reachable up to
+// the barrier (the bot is on their near side).
 function nearestBlockingDoor(bot, ctx, blockingIdx) {
     var best = null, bestD = Infinity;
     for (var i = 0; i < blockingIdx.length; i++) {
@@ -1602,25 +1605,32 @@ function nearestBlockingDoor(bot, ctx, blockingIdx) {
 //   { mode:'key'|'door'|'stage', goalSet:{voronoiId:true}, finalPoint:{x,y}|null }
 // 'key'  — empty-handed, goal walled by a door: drive onto the matching key.
 // 'door' — carrying a key: drive into its matched door to unlock it.
-// 'stage'— walled but not pursuing a key (another bot has it): wait at the door.
-function computeDoorObjective(bot, ctx, baseOpts) {
-    // Carrying a key -> head to its still-shut door.
-    if (bot.heldKey != null) {
+// 'stage'— walled but no matching key is loose (another bot has it): wait at the door.
+// `goalRoute` is the bot's already-computed plain goal route (null = walled); reused so
+// we don't recompute it here. `carrying` short-circuits to the door (no goal route needed).
+function computeDoorObjective(bot, ctx, baseOpts, goalRoute, carrying) {
+    // Carrying a key -> head to its still-shut door. goalSet is the door's reachable
+    // near-side neighbours; if those are all lava/hole (gs == null) we still return the
+    // 'door' objective with a null goalSet, so pathing falls back to the goal tiles (race
+    // there if some route exists) while finalPoint keeps the door as the homing/beeline
+    // target — so a carrier that gets close unlocks on approach, and a sealed-in one
+    // beelines at its door (delivering the key, or dying and dropping it) instead of idling.
+    if (carrying) {
         var door = ctx.lockedDoors[bot.heldKey.doorIndex];
         if (door != null && !door.unlocked) {
-            var gs = doorApproachCells(ctx, door);
-            if (gs != null) { return { mode: 'door', goalSet: gs, finalPoint: { x: door.x, y: door.y } }; }
+            return { mode: 'door', goalSet: doorApproachCells(ctx, door), finalPoint: { x: door.x, y: door.y } };
         }
         return null; // door already open (or data gone) -> race the goal
     }
-    // Empty-handed: only engage if the goal is currently UNREACHABLE (a shut door, or
-    // lava, walls us off). If we can already reach a goal, ignore keys and race.
-    var normal = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, baseOpts);
-    if (normal != null) { return null; }
+    // Empty-handed: only engage if the goal is currently UNREACHABLE. If the bot can
+    // already reach a goal (goalRoute != null), race it and ignore keys.
+    if (goalRoute != null) { return null; }
+    // During a collapse a null goal route usually means the closing lava ring (not a
+    // door) walled us off — don't divert to chase a key into the advancing front; let
+    // the collapse flee-to-safe-center branch handle it.
+    if (ctx.collapsing) { return null; }
     // Walled. Would opening the doors free us? Path treating door cells as passable.
-    var openOpts = {};
-    for (var k in baseOpts) { openOpts[k] = baseOpts[k]; }
-    openOpts.passableDoors = true;
+    var openOpts = Object.assign({}, baseOpts, { passableDoors: true });
     var opened = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, openOpts);
     if (opened == null) { return null; } // genuinely lava-walled, not a door — existing fallback handles it
     var blockingIdx = blockingDoorsOnPath(ctx, opened.path);
@@ -1633,7 +1643,8 @@ function computeDoorObjective(bot, ctx, baseOpts) {
             return { mode: 'key', goalSet: kset, finalPoint: { x: key.x, y: key.y } };
         }
     }
-    // No key to chase (not our turn, or all loose keys are spoken for) — stage at the door.
+    // No matching key is loose (another bot is carrying it) — stage at the door so we
+    // pour through the moment it opens.
     var sdoor = nearestBlockingDoor(bot, ctx, blockingIdx);
     if (sdoor != null) {
         var sset = doorApproachCells(ctx, sdoor);
@@ -1693,12 +1704,14 @@ function steerBot(bot, ctx, dt) {
         // center (collapseLoc), which beats charging a goal tile with lava avoidance off
         // into the advancing collapse front.
         beelining = !ctx.collapsing && (nowProbe - ai.headwayAt) >= BEELINE_AFTER_MS;
-        // On a locked-door objective (fetching a key, carrying it to a door, or staging
-        // at one) the goal-beeline is wrong: it abandons the key and charges the nearest
-        // GOAL tile with avoidance off, driving into the very door wall it can't pass. Let
-        // the door objective run instead — escapes still fire to thread a real pinch, but
-        // the sealed-in goal beeline stays off until the door opens and goal pathing resumes.
-        if (ai.doorMode != null) { beelining = false; }
+        // On a locked-door objective the goal-beeline target is wrong: it would charge the
+        // nearest GOAL tile with avoidance off, driving into the very door wall it can't
+        // pass. For 'key'/'door' modes the beeline is still useful once sealed in — but it
+        // must aim at the bot's own door target (the key spot it's fetching, or the door it
+        // carries the key to), which the override below points at ai.doorFinalPoint. A
+        // 'stage' bot has no target of its own (it's waiting on another bot's key), so it
+        // just holds at the door — suppress its beeline entirely.
+        if (ai.doorMode === 'stage') { beelining = false; }
     }
 
     // --- Re-path on a throttle (and immediately if we have no path) ---
@@ -1723,6 +1736,11 @@ function steerBot(bot, ctx, dt) {
         // safe bunker island instead — otherwise findPathToNearestGoal returns null
         // and the bot just sits there.
         if (ctx.bunkerSafeIds != null) { pathOpts.goalSet = ctx.bunkerSafeIds; }
+        // Plain goal route. A key-carrier always heads to its door, so skip its goal
+        // search entirely; everyone else computes it once here and the locked-door layer
+        // REUSES it (no duplicate Dijkstra) to decide whether the bot is walled.
+        var carrying = ctx.hasLockedDoors && bot.heldKey != null;
+        var route = carrying ? null : cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, pathOpts);
         // Locked-door objective: on a door-gated map a walled bot fetches the matching
         // key, then carries it to the door, instead of trying (and failing) to path to a
         // goal sealed behind a shut door. The objective just retargets the SAME pathing
@@ -1731,14 +1749,14 @@ function steerBot(bot, ctx, dt) {
         // key spot / door so the proximity radius trips even from the cell's edge.
         ai.doorMode = null; ai.doorFinalPoint = null;
         if (ctx.hasLockedDoors && ctx.bunkerSafeIds == null) {
-            var obj = computeDoorObjective(bot, ctx, pathOpts);
+            var obj = computeDoorObjective(bot, ctx, pathOpts, route, carrying);
             if (obj != null) {
                 pathOpts.goalSet = obj.goalSet;
                 ai.doorMode = obj.mode;
                 ai.doorFinalPoint = obj.finalPoint;
+                route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, pathOpts);
             }
         }
-        var route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, pathOpts);
         // If the danger ring walled us off, retry without it so we still aim at a
         // goal (better a tight line than freezing in front of the lava). Keep the
         // hazard penalty on the retry — it's soft, so it never nulls the path.
@@ -1753,7 +1771,11 @@ function steerBot(bot, ctx, dt) {
             }
             ai.path = route.path;
             ai.waypoints = pts;
-            ai.goal = route.goal;
+            // On a door objective `route.goal` is the key/door cell, not the finish — keep
+            // ai.goal pointing at the real nearest goal tile so goalRank/rubber-band/ability
+            // timing still read true race position (else a far key-detour reads as a rank flip).
+            ai.goal = (ai.doorMode != null && ctx.goalTiles && ctx.goalTiles.length > 0)
+                ? nearestGoalPoint(bot.x, bot.y, ctx.goalTiles) : route.goal;
             // Skip the start cell (≈ current position) so the carrot looks ahead.
             ai.wpIndex = pts.length > 1 ? 1 : 0;
         } else {
@@ -1813,13 +1835,13 @@ function steerBot(bot, ctx, dt) {
         // A zombie with no reachable goal path (it's lava-immune and often sits on
         // lava) still HUNTS — fall through to the intercept override below, which
         // sets desired toward the prey. Don't freeze in the no-path hold.
-    } else if (beelining && ctx.goalTiles && ctx.goalTiles.length > 0) {
-        // No path AND stuck for BEELINE_AFTER_MS: it's sealed off (the goal is lava-walled
-        // from here and a re-path will keep returning null). Don't keep holding — that's
-        // exactly the off-terrain corner freeze where the bot never moves and never dies.
-        // The unconditional beeline override below points `desired` straight at the nearest
-        // goal (with avoidance off) to thread out or die clearing it; just don't fall into
-        // the hold/return branch here.
+    } else if (beelining && ((ctx.goalTiles && ctx.goalTiles.length > 0) || (ai.doorMode != null && ai.doorFinalPoint != null))) {
+        // No path AND stuck for BEELINE_AFTER_MS: it's sealed off (the goal — or, on a door
+        // objective, the bot's key/door target — is lava-walled from here and a re-path will
+        // keep returning null). Don't keep holding — that's exactly the off-terrain corner
+        // freeze where the bot never moves and never dies. The beeline override below points
+        // `desired` straight at the target (with avoidance off) to thread out or die clearing
+        // it (freeing a held key); just don't fall into the hold/return branch here.
     } else {
         // No path and not collapsing: hold position (don't drive blindly). A walled
         // bot isn't "stuck at a pinch", so clear any charging escape and re-anchor
@@ -1890,11 +1912,21 @@ function steerBot(bot, ctx, dt) {
     ctx.riskMult = 1 - 0.45 * ai.risk;
 
     // A last-resort beeline overrides the path/carrot heading and points STRAIGHT at the
-    // nearest goal, so a bot sealed in a corner drives decisively out (or into the walling
-    // lava). Avoidance is turned off just below so nothing bends it back into the pocket.
-    if (beelining && ctx.goalTiles && ctx.goalTiles.length > 0) {
-        var ngb = nearestGoalPoint(bot.x, bot.y, ctx.goalTiles);
-        var bgx = ngb.x - bot.x, bgy = ngb.y - bot.y, bgm = mag(bgx, bgy) || 1;
+    // target, so a bot sealed in a corner drives decisively out (or into the walling lava).
+    // Avoidance is turned off just below so nothing bends it back into the pocket. On a
+    // locked-door objective the target is the bot's OWN door point (the key it's fetching
+    // or the door it's carrying a key to) — NOT the finish, which sits behind a wall it
+    // can't pass; this frees a sealed carrier (deliver the key, or die and drop it).
+    var beelineTarget = null;
+    if (beelining) {
+        if (ai.doorMode != null && ai.doorFinalPoint != null) {
+            beelineTarget = ai.doorFinalPoint;
+        } else if (ctx.goalTiles && ctx.goalTiles.length > 0) {
+            beelineTarget = nearestGoalPoint(bot.x, bot.y, ctx.goalTiles);
+        }
+    }
+    if (beelineTarget != null) {
+        var bgx = beelineTarget.x - bot.x, bgy = beelineTarget.y - bot.y, bgm = mag(bgx, bgy) || 1;
         desiredX = bgx / bgm; desiredY = bgy / bgm;
     }
 
@@ -2449,46 +2481,19 @@ function update(gameBoard, currentState, dt) {
         }
     }
 
-    // Locked doors + keys: the lookups the objective layer needs (voronoiId -> door
-    // index / cell index) and light coordination so the field doesn't dogpile one key.
-    // Each loose, un-consumed key is "claimed" by its nearest KEY_PURSUERS eligible bots
-    // (empty-handed racers); the rest stage at the door. Recomputed every tick so a claim
-    // re-assigns the instant a pursuer dies, finishes, or grabs the key.
+    // Locked doors + keys: the one lookup the objective layer needs — voronoiId -> door
+    // index, so a route crossing a door cell can name which door it is. (The voronoiId ->
+    // cell-index map it also needs is the adjacency cache's own idToIndex, reused directly
+    // in doorApproachCells; no per-tick rebuild.) Coordination is implicit: a bot only
+    // pursues a key whose door blocks ITS route, and the key stops being loose the moment
+    // someone grabs it, so the rest re-evaluate and stage — no pursuer ration needed.
     var hasLockedDoors = gameBoard.hasLockedDoors === true;
-    var doorIndexByVoronoiId = null, cellIndexByVoronoiId = null, keyAllowed = null;
+    var doorIndexByVoronoiId = null;
     if (hasLockedDoors) {
         doorIndexByVoronoiId = {};
         for (var di = 0; di < gameBoard.lockedDoors.length; di++) {
             var dr = gameBoard.lockedDoors[di];
             if (dr != null && dr.voronoiId != null) { doorIndexByVoronoiId[dr.voronoiId] = dr.index; }
-        }
-        cellIndexByVoronoiId = {};
-        for (var cix = 0; cix < map.cells.length; cix++) {
-            if (map.cells[cix] != null && map.cells[cix].site != null) {
-                cellIndexByVoronoiId[map.cells[cix].site.voronoiId] = cix;
-            }
-        }
-        var eligible = [];
-        for (var eid in playerList) {
-            var ep = playerList[eid];
-            if (ep.isAI && ep.alive && ep.awake && !ep.isSpectator && !ep.isZombie && !ep.reachedGoal && ep.heldKey == null) {
-                eligible.push(ep);
-            }
-        }
-        keyAllowed = {};
-        for (var ki = 0; ki < gameBoard.lockedKeys.length; ki++) {
-            var lk = gameBoard.lockedKeys[ki];
-            if (lk == null || lk.carriedBy != null || lk.used || lk.consumed) { continue; }
-            var ranked = eligible.slice().sort((function (key) {
-                return function (b1, b2) {
-                    return mag(b1.x - key.x, b1.y - key.y) - mag(b2.x - key.x, b2.y - key.y);
-                };
-            })(lk));
-            for (var rk = 0; rk < ranked.length && rk < KEY_PURSUERS; rk++) {
-                var bid2 = ranked[rk].id;
-                if (keyAllowed[bid2] == null) { keyAllowed[bid2] = {}; }
-                keyAllowed[bid2][lk.index] = true;
-            }
         }
     }
 
@@ -2508,8 +2513,6 @@ function update(gameBoard, currentState, dt) {
         lockedDoors: gameBoard.lockedDoors,
         lockedKeys: gameBoard.lockedKeys,
         doorIndexByVoronoiId: doorIndexByVoronoiId, // path cell -> the door it is (blocking-door detection)
-        cellIndexByVoronoiId: cellIndexByVoronoiId, // door voronoiId -> cell index (neighbour lookup)
-        keyAllowed: keyAllowed, // botId -> { keyIndex:true } the bot may pursue (anti-dogpile)
         staticHazardCells: staticHazardCells, // static bumper cells (harsh path penalty)
         railCells: railCells, // moving-rail swept cells (mild path penalty — timeable)
         barrierEdges: cellGraph.getBarrierBlockedEdges(map), // adjacency edges a solid barrier cuts (route around)

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -178,9 +178,10 @@ function newBotState(profile) {
         escapeStage: 0,    // 1 = gentle (relax+wander-kill), 2 = committed (thread-or-die)
         heldAbilityId: null,// which ability the bot is currently holding
         abilityHeldSince: 0,// ms: when it picked up the held ability (hold-timeout)
-        doorMode: null,     // locked-door objective: 'key'|'door'|'stage' or null (race the goal)
+        doorMode: null,     // locked-door objective: 'key'|'door'|'stage'|'shortcut' or null (race the goal)
         doorFinalPoint: null,// {x,y} to home straight onto for the last stretch (key spot / door)
         hadKey: false,      // was carrying a key last tick (force an instant re-path on pickup/drop)
+        shortcutKeyIndex: null,// loose key this bot has committed to fetch as an optional shortcut (sticky)
         pathSeed: 1 + Math.floor(Math.random() * 1e9), // per-bot route-diversity seed
         // Personality knobs (0..1 unless noted).
         skill: clamp01(pick('skill', 0.7) + jitter), // speed + precision + reaction
@@ -653,6 +654,16 @@ var BARRIER_PATH_PENALTY = 45;
 // unlockRadius — the unlock fires server-side), after which normal goal pathing
 // resumes. Pickup/unlock are pure proximity in checkLockedDoors; the bot only steers.
 var DOOR_FINAL_APPROACH = 120;  // px: home straight on the key/door point for the last stretch
+// Shortcut-awareness: when the goal IS reachable without a door, a bot may STILL fetch a
+// key + open the door if doing so is meaningfully shorter than the open route. Optional
+// (the goal is reachable either way), so it's safe to ration: only the nearest few bots
+// to a loose key consider it, the rest race the open route — which is what produces a
+// natural split (some take the shortcut, some don't). Per-bot risk varies the bar so it's
+// not a robotic all-or-nothing.
+var SHORTCUT_FACTOR = 0.85;     // base: door route must be <= 85% of the open route length to bother
+var SHORTCUT_RISK_SPREAD = 0.26;// per-bot threshold spread by risk (aggressive bots accept smaller savings)
+var SHORTCUT_PURSUERS = 2;      // nearest eligible bots that consider a given loose key as a shortcut
+var SHORTCUT_GRAB_RADIUS = 90;  // px: a loose key this close is considered regardless of the pursuer ration
 
 var AB = c.tileMap.abilities;
 
@@ -1512,10 +1523,13 @@ function decideLunge(bot, ctx) {
 // held key into its door -> unlock) into navigation targets the normal cell-graph
 // pathing then drives to.
 
-// Tiles a route may approach a door across (anything the bot can stand on): not
-// lava, an empty hole, or another shut door.
+// Tiles a route may approach a door across: anything the bot can stand on (not lava, an
+// empty hole, or another shut door) EXCEPT the goal itself. A carrier must press the door
+// from its NEAR side to unlock it; the goal sits on the far side, so if the goal is
+// reachable another way (a shortcut map) and we allowed it as an "approach" cell, the
+// carrier would just drive to the goal and finish carrying the key — never opening the door.
 function doorRouteWalkable(ctx, id) {
-    return id !== ctx.lavaId && id !== ctx.emptyId && id !== ctx.doorId;
+    return id !== ctx.lavaId && id !== ctx.emptyId && id !== ctx.doorId && id !== ctx.goalId;
 }
 
 // Walkable cells bordering a door's home cell, as a goalSet for findPathToNearestGoal.
@@ -1601,11 +1615,54 @@ function nearestBlockingDoor(bot, ctx, blockingIdx) {
     return best;
 }
 
+// Optional SHORTCUT: the goal is already reachable (goalRoute != null), but fetching a
+// loose key and opening its door might be a shorter way to the finish. Returns a 'shortcut'
+// objective (fetch the key) when worth it, else null (race the open route). Cost: up to 2
+// extra Dijkstra, but only for the nearest SHORTCUT_PURSUERS bots to a loose key (the
+// ration in update()) — or a bot already committed, or one with a key right in front.
+function considerShortcut(bot, ctx, baseOpts, goalRoute) {
+    if (!Array.isArray(ctx.lockedKeys) || goalRoute == null) { return null; }
+    var ai = bot.ai;
+    var openDist = goalRoute.distance;
+    if (!(openDist > 0)) { return null; }
+    var allowed = ctx.shortcutAllowed != null ? ctx.shortcutAllowed[bot.id] : null;
+    // Aggressive/risk-taking bots accept a smaller saving (higher factor); cautious bots
+    // demand a bigger one — so the field splits organically, not as a uniform decision.
+    var factor = SHORTCUT_FACTOR + (ai.risk - 0.5) * SHORTCUT_RISK_SPREAD;
+    var best = null, bestDist = Infinity, bestKv = null;
+    for (var i = 0; i < ctx.lockedKeys.length; i++) {
+        var key = ctx.lockedKeys[i];
+        if (key.carriedBy != null || key.used || key.consumed) { continue; }
+        var door = ctx.lockedDoors[key.doorIndex];
+        if (door == null || door.unlocked) { continue; }
+        // Consider this key only if the bot is one of its nearest pursuers, has already
+        // committed to it (sticky, avoids flip-flop), or it's right in front of the bot
+        // (a dropped key at your feet is worth grabbing even if you're not the nearest).
+        var near = mag(key.x - bot.x, key.y - bot.y);
+        var eligible = (allowed != null && allowed[key.index]) || ai.shortcutKeyIndex === key.index || near <= SHORTCUT_GRAB_RADIUS;
+        if (!eligible) { continue; }
+        var kv = keyCellVoronoiId(ctx, key);
+        if (kv == null) { continue; }
+        var toKey = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, Object.assign({}, baseOpts, { goalSet: [kv] }));
+        if (toKey == null) { continue; } // key not reachable with the door shut
+        var fromKey = cellGraph.findPathToNearestGoal(ctx.map, { x: key.x, y: key.y }, Object.assign({}, baseOpts, { passableDoors: true }));
+        if (fromKey == null) { continue; }
+        var scDist = toKey.distance + fromKey.distance; // bot -> key -> (through door) -> goal
+        if (scDist < openDist * factor && scDist < bestDist) {
+            best = key; bestDist = scDist; bestKv = kv;
+        }
+    }
+    if (best == null) { return null; }
+    var gset = {}; gset[bestKv] = true;
+    return { mode: 'shortcut', goalSet: gset, finalPoint: { x: best.x, y: best.y }, keyIndex: best.index };
+}
+
 // The bot's locked-door objective this re-path, or null to race the goal normally.
-//   { mode:'key'|'door'|'stage', goalSet:{voronoiId:true}, finalPoint:{x,y}|null }
-// 'key'  — empty-handed, goal walled by a door: drive onto the matching key.
-// 'door' — carrying a key: drive into its matched door to unlock it.
-// 'stage'— walled but no matching key is loose (another bot has it): wait at the door.
+//   { mode:'key'|'door'|'stage'|'shortcut', goalSet:{voronoiId:true}|[voronoiId], finalPoint:{x,y}|null }
+// 'key'     — empty-handed, goal WALLED by a door: drive onto the matching key (mandatory).
+// 'door'    — carrying a key: drive into its matched door to unlock it.
+// 'stage'   — walled but no matching key is loose (another bot has it): wait at the door.
+// 'shortcut'— goal reachable, but a key+door is a worthwhile shorter route (optional).
 // `goalRoute` is the bot's already-computed plain goal route (null = walled); reused so
 // we don't recompute it here. `carrying` short-circuits to the door (no goal route needed).
 function computeDoorObjective(bot, ctx, baseOpts, goalRoute, carrying) {
@@ -1622,9 +1679,9 @@ function computeDoorObjective(bot, ctx, baseOpts, goalRoute, carrying) {
         }
         return null; // door already open (or data gone) -> race the goal
     }
-    // Empty-handed: only engage if the goal is currently UNREACHABLE. If the bot can
-    // already reach a goal (goalRoute != null), race it and ignore keys.
-    if (goalRoute != null) { return null; }
+    // Empty-handed and the goal IS reachable: race it — unless fetching a key to open a
+    // door is a worthwhile shorter route (considerShortcut returns null = just race open).
+    if (goalRoute != null) { return considerShortcut(bot, ctx, baseOpts, goalRoute); }
     // During a collapse a null goal route usually means the closing lava ring (not a
     // door) walled us off — don't divert to chase a key into the advancing front; let
     // the collapse flee-to-safe-center branch handle it.
@@ -1710,8 +1767,11 @@ function steerBot(bot, ctx, dt) {
         // must aim at the bot's own door target (the key spot it's fetching, or the door it
         // carries the key to), which the override below points at ai.doorFinalPoint. A
         // 'stage' bot has no target of its own (it's waiting on another bot's key), so it
-        // just holds at the door — suppress its beeline entirely.
-        if (ai.doorMode === 'stage') { beelining = false; }
+        // just holds at the door — suppress its beeline entirely. A 'shortcut' is OPTIONAL
+        // (the goal is reachable the normal way), so never let a bot drive avoidance-off
+        // INTO lava to reach a shortcut key — suppress its beeline too; if it can't make
+        // progress toward the key it'll re-evaluate and just race the open route.
+        if (ai.doorMode === 'stage' || ai.doorMode === 'shortcut') { beelining = false; }
     }
 
     // --- Re-path on a throttle (and immediately if we have no path) ---
@@ -1750,12 +1810,17 @@ function steerBot(bot, ctx, dt) {
         ai.doorMode = null; ai.doorFinalPoint = null;
         if (ctx.hasLockedDoors && ctx.bunkerSafeIds == null) {
             var obj = computeDoorObjective(bot, ctx, pathOpts, route, carrying);
+            // Remember a committed shortcut key (sticky, so the choice doesn't flip-flop as
+            // bots jostle for nearest-rank); cleared the moment the bot isn't shortcutting.
+            ai.shortcutKeyIndex = (obj != null && obj.mode === 'shortcut') ? obj.keyIndex : null;
             if (obj != null) {
                 pathOpts.goalSet = obj.goalSet;
                 ai.doorMode = obj.mode;
                 ai.doorFinalPoint = obj.finalPoint;
                 route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, pathOpts);
             }
+        } else {
+            ai.shortcutKeyIndex = null;
         }
         // If the danger ring walled us off, retry without it so we still aim at a
         // goal (better a tight line than freezing in front of the lava). Keep the
@@ -1814,14 +1879,16 @@ function steerBot(bot, ctx, dt) {
             if (turnCos < TURN_BRAKE_COS) { sharpTurn = true; }
         }
         // Locked-door final approach: the route only reaches the key's cell / a door's
-        // neighbour, but pickup/unlock need the bot within pickupRadius/unlockRadius of the
-        // exact point. Once close, steer straight at it so the bot drives onto the key (grab)
-        // or presses into the door (unlock) — avoidance still applies, so it won't cut into
-        // flanking lava. No bend braking here: this last nudge is short and deliberate.
+        // near-side neighbour (the door cell itself is a wall it can't path INTO), but
+        // pickup/unlock need the bot within pickupRadius/unlockRadius of the exact point.
+        // Home straight at it once the bot is on the LAST leg (it has reached the approach
+        // cell — the remaining gap to the door/key can be a whole cell wide, larger than any
+        // fixed radius) OR within DOOR_FINAL_APPROACH. Avoidance still applies, so it won't
+        // cut into flanking lava. No bend braking here: this last nudge is short and deliberate.
         if (ai.doorFinalPoint != null) {
             var fpx = ai.doorFinalPoint.x - bot.x, fpy = ai.doorFinalPoint.y - bot.y;
             var fpm = mag(fpx, fpy);
-            if (fpm < DOOR_FINAL_APPROACH && fpm > 0.001) {
+            if ((ai.wpIndex >= last || fpm < DOOR_FINAL_APPROACH) && fpm > 0.001) {
                 desiredX = fpx / fpm; desiredY = fpy / fpm; sharpTurn = false;
             }
         }
@@ -2481,19 +2548,47 @@ function update(gameBoard, currentState, dt) {
         }
     }
 
-    // Locked doors + keys: the one lookup the objective layer needs — voronoiId -> door
-    // index, so a route crossing a door cell can name which door it is. (The voronoiId ->
-    // cell-index map it also needs is the adjacency cache's own idToIndex, reused directly
-    // in doorApproachCells; no per-tick rebuild.) Coordination is implicit: a bot only
-    // pursues a key whose door blocks ITS route, and the key stops being loose the moment
-    // someone grabs it, so the rest re-evaluate and stage — no pursuer ration needed.
+    // Locked doors + keys. doorIndexByVoronoiId (voronoiId -> door index) lets a route
+    // crossing a door cell name which door it is. (The voronoiId -> cell-index map the
+    // objective layer also needs is the adjacency cache's own idToIndex, reused directly in
+    // doorApproachCells; no per-tick rebuild.)
+    //
+    // For the MANDATORY case (door is the only way) coordination is implicit — a bot only
+    // pursues a key whose door blocks ITS route, and a grabbed key stops being loose, so
+    // the rest re-evaluate and stage; no ration (a ration there would starve the needed
+    // key). For the OPTIONAL SHORTCUT case the goal is reachable either way, so a ration IS
+    // safe and is exactly what splits the field: only the nearest SHORTCUT_PURSUERS bots to
+    // a loose key consider it as a shortcut, the rest race the open route. (A bot already
+    // committed, or one with a key right in front, bypasses the ration — see considerShortcut.)
     var hasLockedDoors = gameBoard.hasLockedDoors === true;
-    var doorIndexByVoronoiId = null;
+    var doorIndexByVoronoiId = null, shortcutAllowed = null;
     if (hasLockedDoors) {
         doorIndexByVoronoiId = {};
         for (var di = 0; di < gameBoard.lockedDoors.length; di++) {
             var dr = gameBoard.lockedDoors[di];
             if (dr != null && dr.voronoiId != null) { doorIndexByVoronoiId[dr.voronoiId] = dr.index; }
+        }
+        var scElig = [];
+        for (var seid in playerList) {
+            var sep = playerList[seid];
+            if (sep.isAI && sep.alive && sep.awake && !sep.isSpectator && !sep.isZombie && !sep.reachedGoal && sep.heldKey == null) {
+                scElig.push(sep);
+            }
+        }
+        shortcutAllowed = {};
+        for (var ski = 0; ski < gameBoard.lockedKeys.length; ski++) {
+            var slk = gameBoard.lockedKeys[ski];
+            if (slk == null || slk.carriedBy != null || slk.used || slk.consumed) { continue; }
+            var ranked = [];
+            for (var rb = 0; rb < scElig.length; rb++) {
+                var rbx = scElig[rb].x - slk.x, rby = scElig[rb].y - slk.y;
+                ranked.push({ id: scElig[rb].id, d2: rbx * rbx + rby * rby });
+            }
+            ranked.sort(function (a, b) { return a.d2 - b.d2; });
+            for (var rr = 0; rr < ranked.length && rr < SHORTCUT_PURSUERS; rr++) {
+                if (shortcutAllowed[ranked[rr].id] == null) { shortcutAllowed[ranked[rr].id] = {}; }
+                shortcutAllowed[ranked[rr].id][slk.index] = true;
+            }
         }
     }
 
@@ -2502,6 +2597,7 @@ function update(gameBoard, currentState, dt) {
         lavaId: LAVA,
         emptyId: c.tileMap.empty.id,
         doorId: c.tileMap.door != null ? c.tileMap.door.id : -999,
+        goalId: GOAL,
         iceId: c.tileMap.ice.id,
         waterId: c.tileMap.water != null ? c.tileMap.water.id : -999,
         siteById: buildSiteIndex(map),
@@ -2513,6 +2609,7 @@ function update(gameBoard, currentState, dt) {
         lockedDoors: gameBoard.lockedDoors,
         lockedKeys: gameBoard.lockedKeys,
         doorIndexByVoronoiId: doorIndexByVoronoiId, // path cell -> the door it is (blocking-door detection)
+        shortcutAllowed: shortcutAllowed, // botId -> { keyIndex:true } it may consider as an OPTIONAL shortcut
         staticHazardCells: staticHazardCells, // static bumper cells (harsh path penalty)
         railCells: railCells, // moving-rail swept cells (mild path penalty — timeable)
         barrierEdges: cellGraph.getBarrierBlockedEdges(map), // adjacency edges a solid barrier cuts (route around)

--- a/server/aiController.js
+++ b/server/aiController.js
@@ -653,7 +653,16 @@ var BARRIER_PATH_PENALTY = 45;
 // pickup fires server-side on proximity) then CARRY it to the door (drive within
 // unlockRadius — the unlock fires server-side), after which normal goal pathing
 // resumes. Pickup/unlock are pure proximity in checkLockedDoors; the bot only steers.
-var DOOR_FINAL_APPROACH = 120;  // px: home straight on the key/door point for the last stretch
+// px: home straight on the key/door point for the last stretch. It MUST comfortably exceed
+// the server-side trip reach (pickupRadius / unlockRadius + a kart radius from
+// config.lockedDoor) so the homing override engages before the bot considers the approach
+// cell "reached" and stops short of the trip radius — derived from config so retuning the
+// radii can't silently reintroduce door stalls.
+var DOOR_FINAL_APPROACH = (function () {
+    var cfg = c.lockedDoor || {};
+    var reach = Math.max(cfg.pickupRadius || 30, cfg.unlockRadius || 48) + (c.playerBaseRadius || 7.5);
+    return Math.max(120, Math.round(reach * 2));
+})();
 // Shortcut-awareness: when the goal IS reachable without a door, a bot may STILL fetch a
 // key + open the door if doing so is meaningfully shorter than the open route. Optional
 // (the goal is reachable either way), so it's safe to ration: only the nearest few bots
@@ -1581,23 +1590,34 @@ function blockingDoorsOnPath(ctx, path) {
     return out;
 }
 
-// Nearest loose, un-consumed key whose door is on the bot's OWN blocking list. A bot
-// only ever pursues a key that unblocks ITS route — never a key for some other door
-// (that would burn the wrong key and leave the door that actually gates it shut, the
-// multi-door stall). With keys restricted to blocking doors, "all bots dogpile one
-// key" self-limits: once a bot grabs it, it's no longer loose, so the rest re-evaluate
-// next re-path and stage at the door — so no separate pursuer ration is needed (and a
-// ration that isn't door-aware would starve the very key a sealed-off bot needs).
-function pickKeyToPursue(bot, ctx, blockingIdx) {
-    var best = null, bestD = Infinity;
+// Nearest loose, un-consumed, REACHABLE key whose door is on the bot's OWN blocking list,
+// as { key, kv, route }. A bot only ever pursues a key that unblocks ITS route — never a key
+// for some other door (that would burn the wrong key and leave the gating door shut, the
+// multi-door stall). It must also be reachable with the doors shut: on a multi-door map the
+// straight-line-nearest matching key can sit behind ANOTHER shut door, so we walk candidates
+// nearest-first and return the first whose route is non-null (else the bot would beeline,
+// avoidance-off, at an unreachable key). The route is handed back so steerBot reuses it.
+// "All bots dogpile one key" self-limits: once a bot grabs it, it's no longer loose, so the
+// rest re-evaluate and stage — no separate pursuer ration (a non-door-aware one would starve
+// the very key a sealed-off bot needs).
+function pickKeyToPursue(bot, ctx, baseOpts, blockingIdx) {
+    var cands = [];
     for (var i = 0; i < ctx.lockedKeys.length; i++) {
         var key = ctx.lockedKeys[i];
         if (key.carriedBy != null || key.used || key.consumed) { continue; }
         if (blockingIdx.indexOf(key.doorIndex) === -1) { continue; }
-        var d = mag(key.x - bot.x, key.y - bot.y);
-        if (d < bestD) { best = key; bestD = d; }
+        cands.push({ key: key, d: mag(key.x - bot.x, key.y - bot.y) });
     }
-    return best;
+    cands.sort(function (a, b) { return a.d - b.d; });
+    var scOpts = Object.assign({}, baseOpts);
+    for (var ci = 0; ci < cands.length; ci++) {
+        var kv = keyCellVoronoiId(ctx, cands[ci].key);
+        if (kv == null) { continue; }
+        scOpts.goalSet = [kv];
+        var route = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, scOpts);
+        if (route != null) { return { key: cands[ci].key, kv: kv, route: route }; }
+    }
+    return null;
 }
 
 // Nearest still-shut blocking door — where a non-pursuer stages so it's ready to
@@ -1615,18 +1635,20 @@ function nearestBlockingDoor(bot, ctx, blockingIdx) {
     return best;
 }
 
-// How many OTHER eligible (empty-handed, racing) bots are strictly closer to this key than
-// `bot` — the bot's pursuit rank. Computed lazily here (only when a bot actually evaluates a
-// key on its re-path) rather than as a per-tick global table, so it costs nothing on the
-// ticks/maps where no shortcut is considered. Optional-shortcut rationing is SAFE (the goal
-// is reachable either way) so capping pursuers can't strand anyone, unlike the mandatory case.
-function shortcutRank(ctx, bot, key) {
+// How many OTHER empty-handed racers (bots OR humans) are strictly closer to this key than
+// `bot` — the bot's pursuit rank. Humans count: a human nearer the key will likely grab it
+// (pickup is pure proximity), so a bot shouldn't burn a detour contesting it. Computed lazily
+// (only when a bot actually evaluates a key on its re-path), and short-circuits the moment the
+// rank reaches `cap` — the only caller asks `rank < SHORTCUT_PURSUERS`, so counting past it is
+// wasted. Optional-shortcut rationing is SAFE (the goal is reachable either way), so capping
+// pursuers can't strand anyone, unlike the mandatory case.
+function shortcutRank(ctx, bot, key, cap) {
     var rank = 0;
     var bd = mag(bot.x - key.x, bot.y - key.y);
     for (var id in ctx.players) {
         var p = ctx.players[id];
-        if (p === bot || !p.isAI || !p.alive || !p.awake || p.isSpectator || p.isZombie || p.reachedGoal || p.heldKey != null) { continue; }
-        if (mag(p.x - key.x, p.y - key.y) < bd) { rank++; }
+        if (p === bot || !p.alive || !p.awake || p.isSpectator || p.isZombie || p.reachedGoal || p.heldKey != null) { continue; }
+        if (mag(p.x - key.x, p.y - key.y) < bd) { rank++; if (rank >= cap) { return rank; } }
     }
     return rank;
 }
@@ -1648,9 +1670,11 @@ function considerShortcut(bot, ctx, baseOpts, goalRoute) {
     var openTime = cellGraph.estimatePathTime(ctx.map, goalRoute.path);
     if (!(openTime > 0)) { return null; }
     // Aggressive bots accept a smaller saving, cautious bots demand a bigger one, so the field
-    // splits organically. Clamp < 1 so a "shortcut" is never accepted when it's not faster.
-    var factor = clamp01(SHORTCUT_FACTOR + (ai.risk - 0.5) * SHORTCUT_RISK_SPREAD);
-    if (factor > 0.97) { factor = 0.97; } else if (factor < 0.4) { factor = 0.4; }
+    // splits organically. Bounded to [0.4, 0.97] so a "shortcut" is never accepted unless it's
+    // genuinely faster (factor < 1) and a single bot can't demand an absurd saving.
+    var factor = Math.min(0.97, Math.max(0.4, SHORTCUT_FACTOR + (ai.risk - 0.5) * SHORTCUT_RISK_SPREAD));
+    // One reusable options object for the two probes per key (avoids cloning baseOpts 2x/key).
+    var scOpts = Object.assign({}, baseOpts);
     var best = null, bestTime = Infinity, bestKv = null, bestRoute = null;
     for (var i = 0; i < ctx.lockedKeys.length; i++) {
         var key = ctx.lockedKeys[i];
@@ -1661,18 +1685,20 @@ function considerShortcut(bot, ctx, baseOpts, goalRoute) {
         // (a dropped key at your feet is worth grabbing), or the bot is one of the key's
         // nearest pursuers (the ration that produces the split).
         var near = mag(key.x - bot.x, key.y - bot.y);
-        var eligible = ai.shortcutKeyIndex === key.index || near <= SHORTCUT_GRAB_RADIUS || shortcutRank(ctx, bot, key) < SHORTCUT_PURSUERS;
+        var eligible = ai.shortcutKeyIndex === key.index || near <= SHORTCUT_GRAB_RADIUS || shortcutRank(ctx, bot, key, SHORTCUT_PURSUERS) < SHORTCUT_PURSUERS;
         if (!eligible) { continue; }
         // Cheap straight-line prefilter: reaching the key alone already costs > the whole open
         // route's geometric length means no shortcut is plausible — skip before any Dijkstra.
         if (near >= openDist) { continue; }
         var kv = keyCellVoronoiId(ctx, key);
         if (kv == null) { continue; }
-        var toKey = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, Object.assign({}, baseOpts, { goalSet: [kv] }));
+        scOpts.goalSet = [kv]; scOpts.openDoorIds = null;
+        var toKey = cellGraph.findPathToNearestGoal(ctx.map, { x: bot.x, y: bot.y }, scOpts);
         if (toKey == null) { continue; } // key not reachable with the doors shut
         // Open ONLY this key's door (a bot holds one key); passableDoors would open every door
         // and overstate the saving on a multi-door map.
-        var fromKey = cellGraph.findPathToNearestGoal(ctx.map, { x: key.x, y: key.y }, Object.assign({}, baseOpts, { openDoorIds: [door.voronoiId] }));
+        scOpts.goalSet = null; scOpts.openDoorIds = [door.voronoiId];
+        var fromKey = cellGraph.findPathToNearestGoal(ctx.map, { x: key.x, y: key.y }, scOpts);
         if (fromKey == null) { continue; }
         // The shortcut must actually USE this door — else opening it gains nothing and the
         // carrier's mandatory detour to the door is pure cost the estimate would miss.
@@ -1695,6 +1721,10 @@ function considerShortcut(bot, ctx, baseOpts, goalRoute) {
 // 'door'    — carrying a key: drive into its matched door to unlock it.
 // 'stage'   — walled but no matching key is loose (another bot has it): wait at the door.
 // 'shortcut'— goal reachable, but a key+door is a worthwhile shorter route (optional).
+// NOTE for steering, only TWO distinctions are read, not four: beeline is suppressed for
+// 'stage'|'shortcut' (no die-for-it) and allowed for 'key'|'door'; everything else just tests
+// doorMode != null. The four labels are kept for intent/diagnostics — don't assume a reader
+// branches on 'key' vs 'door' (they steer identically) without adding that branch yourself.
 // `goalRoute` is the bot's already-computed plain goal route (null = walled); reused so
 // we don't recompute it here. `carrying` short-circuits to the door (no goal route needed).
 function computeDoorObjective(bot, ctx, baseOpts, goalRoute, carrying) {
@@ -1724,16 +1754,14 @@ function computeDoorObjective(bot, ctx, baseOpts, goalRoute, carrying) {
     if (opened == null) { return null; } // genuinely lava-walled, not a door — existing fallback handles it
     var blockingIdx = blockingDoorsOnPath(ctx, opened.path);
     if (blockingIdx.length === 0) { return null; } // opened up for some non-door reason; nothing to fetch
-    var key = pickKeyToPursue(bot, ctx, blockingIdx);
-    if (key != null) {
-        var kv = keyCellVoronoiId(ctx, key);
-        if (kv != null) {
-            var kset = {}; kset[kv] = true;
-            return { mode: 'key', goalSet: kset, finalPoint: { x: key.x, y: key.y } };
-        }
+    var pick = pickKeyToPursue(bot, ctx, baseOpts, blockingIdx);
+    if (pick != null) {
+        var kset = {}; kset[pick.kv] = true;
+        // Reuse the reachability route pickKeyToPursue already computed (steerBot honours obj.route).
+        return { mode: 'key', goalSet: kset, finalPoint: { x: pick.key.x, y: pick.key.y }, route: pick.route };
     }
-    // No matching key is loose (another bot is carrying it) — stage at the door so we
-    // pour through the moment it opens.
+    // No matching key is loose/reachable (another bot is carrying it, or each is itself sealed
+    // behind another shut door) — stage at the door so we pour through the moment it opens.
     var sdoor = nearestBlockingDoor(bot, ctx, blockingIdx);
     if (sdoor != null) {
         var sset = doorApproachCells(ctx, sdoor);
@@ -2595,6 +2623,10 @@ function update(gameBoard, currentState, dt) {
         doorIndexByVoronoiId = {};
         for (var di = 0; di < gameBoard.lockedDoors.length; di++) {
             var dr = gameBoard.lockedDoors[di];
+            // Doors snap to distinct cell sites, so one cell normally hosts one door. If two
+            // doors ever resolved to the SAME cell (degenerate authoring), last-write-wins here
+            // is benign: that cell is a single wall, and unlocking EITHER door flips the shared
+            // cell to passable, so the route opens regardless of which index we recorded.
             if (dr != null && dr.voronoiId != null) { doorIndexByVoronoiId[dr.voronoiId] = dr.index; }
         }
     }

--- a/server/cellGraph.js
+++ b/server/cellGraph.js
@@ -139,7 +139,10 @@ function buildAdjacency(map) {
         neighbors[ci] = list;
         doorways[ci] = widths;
     }
-    return { neighbors: neighbors, doorways: doorways };
+    // idToIndex (voronoiId -> cell index) is built above for adjacency and exposed here
+    // so callers needing the same lookup (e.g. the locked-door AI resolving a door's home
+    // cell) reuse this cached table instead of rebuilding it per tick.
+    return { neighbors: neighbors, doorways: doorways, idToIndex: idToIndex };
 }
 
 function getAdjacency(map) {

--- a/server/cellGraph.js
+++ b/server/cellGraph.js
@@ -287,7 +287,12 @@ function findPathToNearestGoal(map, point, options) {
     // so runtime routing (bonus-orb racing lines, AI pathing) goes around a shut door. At
     // author/validation time doors are entities, not cells, so this never blocks the
     // submit-time reachability walk (the goal stays reachable through the future door).
+    // options.passableDoors: treat door cells as walkable terrain instead (cost = normal).
+    // The locked-door AI uses this to ask "would the goal be reachable if the doors were
+    // open?" — and reads which door cells the resulting route crosses to learn WHICH doors
+    // it must unlock (the keys to fetch). It never affects live racing routes.
     var DOOR = (c.tileMap.door != null) ? c.tileMap.door.id : -999;
+    var allowDoors = options.passableDoors === true;
 
     var blocked = null;
     if (options.blocked) {
@@ -415,7 +420,7 @@ function findPathToNearestGoal(map, point, options) {
             // Lava and empty holes are impassable; so are caller-blocked cells. The
             // goal is always enterable. The start cell is allowed even if it sits on
             // lava.
-            if ((cells[v].id === LAVA || cells[v].id === EMPTY || cells[v].id === DOOR) && cells[v].id !== GOAL) {
+            if ((cells[v].id === LAVA || cells[v].id === EMPTY || (cells[v].id === DOOR && !allowDoors)) && cells[v].id !== GOAL) {
                 continue;
             }
             if (blocked && blocked[cells[v].site.voronoiId]) {

--- a/server/cellGraph.js
+++ b/server/cellGraph.js
@@ -294,8 +294,19 @@ function findPathToNearestGoal(map, point, options) {
     // The locked-door AI uses this to ask "would the goal be reachable if the doors were
     // open?" — and reads which door cells the resulting route crosses to learn WHICH doors
     // it must unlock (the keys to fetch). It never affects live racing routes.
+    // options.openDoorIds: a narrower form — treat ONLY these door cells (by voronoiId) as
+    // open, the rest stay walls. The shortcut AI uses it to cost the route a carrier of ONE
+    // key would actually get (its single door open, others still shut) — passableDoors would
+    // over-open every door and overstate the saving on a multi-door map.
     var DOOR = (c.tileMap.door != null) ? c.tileMap.door.id : -999;
     var allowDoors = options.passableDoors === true;
+    var openDoorSet = null;
+    if (options.openDoorIds != null) {
+        openDoorSet = {};
+        if (options.openDoorIds.forEach) { options.openDoorIds.forEach(function (id) { openDoorSet[id] = true; }); }
+        else if (Array.isArray(options.openDoorIds)) { for (var od = 0; od < options.openDoorIds.length; od++) { openDoorSet[options.openDoorIds[od]] = true; } }
+        else { for (var ok in options.openDoorIds) { if (options.openDoorIds[ok]) { openDoorSet[ok] = true; } } }
+    }
 
     var blocked = null;
     if (options.blocked) {
@@ -422,8 +433,10 @@ function findPathToNearestGoal(map, point, options) {
             }
             // Lava and empty holes are impassable; so are caller-blocked cells. The
             // goal is always enterable. The start cell is allowed even if it sits on
-            // lava.
-            if ((cells[v].id === LAVA || cells[v].id === EMPTY || (cells[v].id === DOOR && !allowDoors)) && cells[v].id !== GOAL) {
+            // lava. A door cell is a wall unless passableDoors opens all of them, or this
+            // specific door is in openDoorIds.
+            var doorOpen = allowDoors || (openDoorSet != null && openDoorSet[cells[v].site.voronoiId]);
+            if ((cells[v].id === LAVA || cells[v].id === EMPTY || (cells[v].id === DOOR && !doorOpen)) && cells[v].id !== GOAL) {
                 continue;
             }
             if (blocked && blocked[cells[v].site.voronoiId]) {

--- a/server/cellGraph.js
+++ b/server/cellGraph.js
@@ -511,10 +511,9 @@ function estimatePathTime(map, path) {
         return 0;
     }
     var cells = map.cells;
-    var idToIndex = {};
-    for (var i = 0; i < cells.length; i++) {
-        idToIndex[cells[i].site.voronoiId] = i;
-    }
+    // Reuse the adjacency cache's voronoiId->index table instead of rebuilding it per call
+    // (this runs in the AI's per-re-path shortcut hot path on door maps).
+    var idToIndex = getAdjacency(map).idToIndex;
     var pts = [];
     for (var p = 0; p < path.length; p++) {
         var ci = idToIndex[path[p]];


### PR DESCRIPTION
Teaches AI racers to handle the locked-door + key objective (shipped in #315 without AI awareness):

- **Mandatory:** when a locked door gates the only route to the goal, a bot breaks off, fetches the matching key, carries it to the door and unlocks it for everyone, then resumes racing — so locked-door maps no longer stall in bot-heavy rooms (there's intentionally no failsafe timer; the door opens only via its key).
- **Optional shortcut:** when the goal is reachable the long way but opening a door would be a meaningfully faster route, some bots peel off to grab the key and cut through while others race the open route. Per-bot risk varies the savings bar so the field splits organically, and a key dropped right in front of a bot is an opportunistic grab.
- The shortcut decision compares tile-weighted **race time** (`estimatePathTime`), costs the route with only *this* key's door open (not all doors), and requires the door to actually lie on the resulting route — so a bot never burns a key on a route that isn't faster or isn't unblocked by that door.

### How
- `server/aiController.js`: a locked-door objective layer in `steerBot` (`computeDoorObjective` + `considerShortcut`) — fetch key → carry to matched door → resume goal pathing; lazy nearest-N pursuer rationing for the optional shortcut; sealed-in carriers beeline at their own door.
- `server/cellGraph.js`: `options.passableDoors` (all doors open — "would opening doors help?") and `options.openDoorIds` (a single door open — accurate shortcut costing), plus the adjacency cache now exposes `idToIndex`.
- Fully gated behind `gameBoard.hasLockedDoors` — **non-door maps are byte-identical** (proven via A/B ai-fitness on crossroads / FastandSlow / IcyLake).

### Validation
- `.github/scripts/locked-door-test.js`: scenario **F** (mandatory gate — bots fetch the key, open the door, finish; baseline-impossible invariant) and scenario **G** (optional shortcut — a bot opts into the detour, field still finishes), on a shared headless harness (`headless-harness.js`).
- A/B `ai-fitness.js`: control maps byte-identical; a gated door map goes baseline finishers=0 → branch finishes + unlocks.
- Three self-review rounds (`/code-review`) folded in: multi-door reachability, time-vs-distance costing, single-door shortcut costing, perf (no per-tick ration rebuild, route reuse), and cleanup.
- Full PR-validation headless suite + build green, including the new Sentry Turret test after rebase.

Multi-door maps (more than one door/key) remain a documented forward case — no committed map has more than one door yet; the reachability guard covers the main failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)