### PR TITLE
fix(deps): force ws@^8.21.0 to clear GHSA-96hv-2xvq-fx4p audit failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chaochao",
-    "version": "0.34.1",
+    "version": "0.44.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chaochao",
-            "version": "0.34.1",
+            "version": "0.44.0",
             "dependencies": {
                 "@octokit/core": "^7.0.6",
                 "@supabase/supabase-js": "^2.108.1",
@@ -2265,9 +2265,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.20.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
         "esbuild": "^0.28.0",
         "playwright": "^1.60.0"
     },
+    "overrides": {
+        "ws": "^8.21.0"
+    },
     "scripts": {
         "build": "node build.js",
         "start": "node index.js",


### PR DESCRIPTION
## Problem
The `Dependency audit` CI check has been failing on `main` (prod gate `npm audit --omit=dev --audit-level=high`) on **GHSA-96hv-2xvq-fx4p** — the `ws` memory-exhaustion DoS. `ws` is pulled in transitively via `socket.io → engine.io` and `socket.io-adapter`. The push that flagged it reported "3 vulnerabilities on the default branch"; this is a pre-existing failure, not introduced by any feature work.

## Why a socket.io bump alone doesn't fix it
Even the latest `socket.io@4.8.3 / engine.io@6.6.8 / socket.io-adapter@2.5.7` still pin `ws@~8.20.1`, which is the top of the vulnerable range (8.0.0–8.20.1). Upstream hasn't released versions that depend on the patched `ws` yet.

## Fix
Add an npm `overrides` entry forcing `ws@^8.21.0` (first patched release). Both `engine.io` and `socket.io-adapter` dedupe to `ws@8.21.0`.

## Verification
- `npm audit --omit=dev --audit-level=high` → **0 vulnerabilities** (was exit 1)
- `npm ls ws --all` → single `ws@8.21.0`, deduped across the chain
- `npm run build` → passes
- `npm run test:smoke` → passes (socket.io works end-to-end)

## Notes
- No CHANGELOG entry: deps/CI-only fix, no `config.json`/`game.js`/`engine.js` change (exempt).
- A separate **esbuild** advisory remains but is a `devDependency`, so the `--omit=dev` prod gate ignores it — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)