### PR TITLE
fix(mobile): phone layout fixes — create-page overflow, lobby gear/banner, landscape editor & settings + CI guard

### DIFF
--- a/.github/scripts/mobile-layout-test.js
+++ b/.github/scripts/mobile-layout-test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+// Mobile layout gate. Two classes of bug this catches, both reported from a real
+// Pixel-class phone (2026-06-15):
+//
+//   1. HORIZONTAL OVERFLOW — a menu page wider than the phone so it scrolls sideways
+//      and clips its left edge. (The map list shrink-wrapped to a 5-column row via a
+//      leaked `float: left`; the editor's action group ran Copy/Upload off-screen.)
+//      We load each page in real portrait + landscape phone viewports and fail if any
+//      *visible* element extends past the viewport's right edge.
+//
+//   2. HUD OVERLAP — a newly-added HUD element drawn on top of an existing one. (The
+//      lobby status/sign-in banner was added at top-centre, directly over the settings
+//      gear.) The client publishes each top-edge HUD element's rect to window.__hudRects
+//      when loaded with `?hudprobe=1` (see draw.js hudProbeRect); the DOM gear is measured
+//      live and converted into the same logical space. We fail if any two collide.
+//
+// Reuses the button-gate.js harness shape: boot the real server, drive Chromium in a
+// touch/mobile context. Browser-dependent (Playwright + chromium), so it runs in its own
+// CI job alongside button-gate.
+//
+// Run: node .github/scripts/mobile-layout-test.js
+
+const { spawn } = require('child_process');
+const path = require('path');
+const { chromium } = require('playwright');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const PORT = Number(process.env.ML_PORT) || 28914;
+const ORIGIN = `http://localhost:${PORT}`;
+const TOL = 2; // px slack for sub-pixel rounding
+
+const PORTRAIT = { width: 412, height: 915 };   // Pixel-class portrait
+const LANDSCAPE = { width: 915, height: 412 };   // …rotated
+
+let failures = 0;
+const fail = (m) => { console.log('::error::' + m); failures++; };
+const ok = (m) => console.log('  ok: ' + m);
+
+function boot() {
+    return new Promise((res, rej) => {
+        const s = spawn('node', ['index.js'], { cwd: repoRoot, env: { ...process.env, PORT: String(PORT), NODE_ENV: 'development' } });
+        let o = ''; const h = d => { o += d.toString(); if (/listening on/i.test(o)) res(s); };
+        s.stdout.on('data', h); s.stderr.on('data', h);
+        s.on('exit', c => rej(new Error('server exited (' + c + '):\n' + o)));
+        setTimeout(() => rej(new Error('boot timeout:\n' + o)), 20000);
+    });
+}
+
+// Visible elements whose right edge exceeds the viewport (the honest "page scrolls
+// sideways" signal). Ignores intentionally off-screen / zero-size nodes (e.g. the
+// anti-bot honeypot decoy) and elements scrolled inside an overflow:auto container.
+const SCAN = (tol) => {
+    const vw = document.documentElement.clientWidth;
+    const out = [];
+    const els = document.querySelectorAll('body *');
+    for (const el of els) {
+        const cs = getComputedStyle(el);
+        if (cs.display === 'none' || cs.visibility === 'hidden' || cs.position === 'fixed') continue;
+        const r = el.getBoundingClientRect();
+        if (r.width < 8 || r.height < 4) continue;        // decoys / hairlines
+        if (r.left > vw || r.right < 0) continue;         // fully off-screen trap
+        if (r.right > vw + tol) {
+            // Skip if an ancestor is an intentional horizontal scroller (the element
+            // is reachable by scrolling that strip, not by scrolling the page).
+            let p = el.parentElement, scrolled = false;
+            while (p) { const pc = getComputedStyle(p); if ((pc.overflowX === 'auto' || pc.overflowX === 'scroll')) { scrolled = true; break; } p = p.parentElement; }
+            if (scrolled) continue;
+            out.push({ tag: el.tagName.toLowerCase(), id: el.id || null, cls: (el.className && el.className.toString().slice(0, 30)) || null, right: Math.round(r.right), vw });
+        }
+    }
+    return out;
+};
+
+async function checkOverflow(ctx, pageLabel, url, prep) {
+    for (const [oLabel, vp] of [['portrait', PORTRAIT], ['landscape', LANDSCAPE]]) {
+        const p = await ctx.newPage();
+        await p.setViewportSize(vp);
+        await p.goto(url, { waitUntil: 'domcontentloaded' }).catch(() => {});
+        await p.waitForTimeout(500);
+        if (prep) { await prep(p); await p.waitForTimeout(300); }
+        const offenders = await p.evaluate(SCAN, TOL);
+        const docOverflow = await p.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+        if (offenders.length) {
+            fail(`${pageLabel} [${oLabel} ${vp.width}x${vp.height}] overflows by ${docOverflow}px — ${offenders.length} element(s): ` +
+                offenders.slice(0, 6).map(o => `${o.tag}${o.id ? '#' + o.id : ''}${o.cls ? '.' + o.cls.split(' ')[0] : ''}(right=${o.right}>${o.vw})`).join(', '));
+        } else {
+            ok(`${pageLabel} [${oLabel}] no horizontal overflow`);
+        }
+        await p.close();
+    }
+}
+
+function rectsOverlap(a, b) {
+    return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+async function checkLobbyHudOverlap(browser) {
+    for (const [oLabel, vp] of [['landscape', LANDSCAPE], ['portrait', PORTRAIT]]) {
+        const ctx = await browser.newContext({ viewport: vp, deviceScaleFactor: 2, hasTouch: true, isMobile: true });
+        const p = await ctx.newPage();
+        await p.goto(`${ORIGIN}/play.html?hudprobe=1`, { waitUntil: 'domcontentloaded' }).catch(() => {});
+        const reachedLobby = await p.waitForFunction(
+            () => typeof currentState !== 'undefined' && typeof config !== 'undefined' && config.stateMap && currentState === config.stateMap.lobby,
+            { timeout: 15000 }).then(() => true).catch(() => false);
+        if (!reachedLobby) { fail(`lobby HUD [${oLabel}] never reached lobby state — cannot verify overlap`); await ctx.close(); continue; }
+        // Force the touch settings gear visible (headless can't enter fullscreen) and
+        // run its canvas-relative positioner, exactly as fullscreen would.
+        await p.evaluate(() => { const b = document.getElementById('touchSettingsBtn'); if (b) b.classList.add('visible'); if (typeof positionTouchSettingsButton === 'function') positionTouchSettingsButton(); });
+        await p.waitForTimeout(900);
+        const data = await p.evaluate(() => {
+            const cv = document.getElementById('gameCanvas');
+            const cr = cv.getBoundingClientRect();
+            const gear = document.getElementById('touchSettingsBtn');
+            const out = { hudRects: window.__hudRects || [], gear: null };
+            if (gear && cr.width && cr.height) {
+                const gr = gear.getBoundingClientRect();
+                const sx = cr.width / LOGICAL_WIDTH, sy = cr.height / LOGICAL_HEIGHT;
+                out.gear = { name: 'settingsGear', x: (gr.x - cr.x) / sx, y: (gr.y - cr.y) / sy, w: gr.width / sx, h: gr.height / sy };
+            }
+            return out;
+        });
+        const rects = data.hudRects.slice();
+        if (data.gear) rects.push(data.gear);
+        if (!rects.find(r => r.name === 'lobbyStatusCard')) { fail(`lobby HUD [${oLabel}] status card not published — probe wiring broken`); await ctx.close(); continue; }
+        if (!data.gear) { fail(`lobby HUD [${oLabel}] settings gear not found`); await ctx.close(); continue; }
+        const hits = [];
+        for (let i = 0; i < rects.length; i++) for (let j = i + 1; j < rects.length; j++) {
+            if (rectsOverlap(rects[i], rects[j])) hits.push(`${rects[i].name} ✕ ${rects[j].name}`);
+        }
+        if (hits.length) {
+            fail(`lobby HUD [${oLabel}] overlapping elements: ${hits.join('; ')} — rects: ` +
+                JSON.stringify(rects.map(r => ({ n: r.name, x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.w), h: Math.round(r.h) }))));
+        } else {
+            ok(`lobby HUD [${oLabel}] ${rects.length} elements, no overlap (${rects.map(r => r.name).join(', ')})`);
+        }
+        await ctx.close();
+    }
+}
+
+(async () => {
+    let srv, browser;
+    try {
+        srv = await boot();
+        browser = await chromium.launch({ headless: true });
+
+        // --- PART 1: horizontal overflow on the menu pages ---
+        const ctx = await browser.newContext({ hasTouch: true, isMobile: true, deviceScaleFactor: 2 });
+        await checkOverflow(ctx, 'index.html', `${ORIGIN}/index.html`);
+        await checkOverflow(ctx, 'join.html', `${ORIGIN}/join.html`);
+        await checkOverflow(ctx, 'create.html (map list)', `${ORIGIN}/create.html`);
+        await checkOverflow(ctx, 'create.html (editor)', `${ORIGIN}/create.html`, async (p) => {
+            // Enter the editor for real (click the New tile) so create.js initialises
+            // and sizes the drawing canvas to the viewport — toggling classes alone
+            // leaves #createCanvas at its unsized intrinsic width (a false positive).
+            await p.click('#createNew').catch(() => {});
+            await p.waitForFunction(() => {
+                const cw = document.getElementById('createWindow');
+                return cw && !cw.classList.contains('editor-hidden');
+            }, { timeout: 8000 }).catch(() => {});
+            await p.evaluate(() => window.dispatchEvent(new Event('resize')));
+        });
+        await ctx.close();
+
+        // --- PART 2: lobby HUD overlap ---
+        await checkLobbyHudOverlap(browser);
+
+    } catch (e) {
+        fail('harness error: ' + e.message);
+    } finally {
+        if (browser) await browser.close();
+        if (srv) srv.kill();
+    }
+    if (failures) { console.log(`\nFAIL — ${failures} mobile-layout problem(s)`); process.exit(1); }
+    console.log('\nPASS — no horizontal overflow, no lobby HUD overlap');
+})();

--- a/.github/scripts/mobile-layout-test.js
+++ b/.github/scripts/mobile-layout-test.js
@@ -56,10 +56,13 @@ const SCAN = (tol) => {
     const els = document.querySelectorAll('body *');
     for (const el of els) {
         const cs = getComputedStyle(el);
-        if (cs.display === 'none' || cs.visibility === 'hidden' || cs.position === 'fixed') continue;
+        if (cs.display === 'none' || cs.visibility === 'hidden') continue;
         const r = el.getBoundingClientRect();
         if (r.width < 8 || r.height < 4) continue;        // decoys / hairlines
         if (r.left > vw || r.right < 0) continue;         // fully off-screen trap
+        // NB: position:fixed elements are NOT skipped — a fixed bar/banner that runs
+        // off the right edge is exactly the kind of regression to catch. The size +
+        // off-screen filters above already exclude the off-screen anti-bot decoy.
         if (r.right > vw + tol) {
             // Skip if an ancestor is an intentional horizontal scroller (the element
             // is reachable by scrolling that strip, not by scrolling the page).
@@ -78,7 +81,13 @@ async function checkOverflow(ctx, pageLabel, url, prep) {
         await p.setViewportSize(vp);
         await p.goto(url, { waitUntil: 'domcontentloaded' }).catch(() => {});
         await p.waitForTimeout(500);
-        if (prep) { await prep(p); await p.waitForTimeout(300); }
+        if (prep) {
+            const prepOk = await prep(p);
+            await p.waitForTimeout(300);
+            // prep returns false when it already recorded a failure (e.g. the editor
+            // never opened) — don't scan the wrong page and report a misleading "ok".
+            if (prepOk === false) { await p.close(); continue; }
+        }
         const offenders = await p.evaluate(SCAN, TOL);
         const docOverflow = await p.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
         if (offenders.length) {
@@ -154,11 +163,15 @@ async function checkLobbyHudOverlap(browser) {
             // and sizes the drawing canvas to the viewport — toggling classes alone
             // leaves #createCanvas at its unsized intrinsic width (a false positive).
             await p.click('#createNew').catch(() => {});
-            await p.waitForFunction(() => {
+            const opened = await p.waitForFunction(() => {
                 const cw = document.getElementById('createWindow');
                 return cw && !cw.classList.contains('editor-hidden');
-            }, { timeout: 8000 }).catch(() => {});
+            }, { timeout: 8000 }).then(() => true).catch(() => false);
+            // Don't let a failed editor-enter silently fall back to scanning the map
+            // list (which would report a false "ok") — fail loudly instead.
+            if (!opened) { fail('create.html editor never opened (#createNew) — cannot verify editor overflow'); return false; }
             await p.evaluate(() => window.dispatchEvent(new Event('resize')));
+            return true;
         });
         await ctx.close();
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -331,6 +331,32 @@ jobs:
       - name: Runtime button gate
         run: node .github/scripts/button-gate.js
 
+  mobile-layout:
+    # Mobile layout gate on the LIVE DOM at real phone viewports (portrait +
+    # landscape): no menu page may overflow horizontally (sideways scroll / clipped
+    # controls), and the lobby's top-edge HUD elements must not overlap (the gear vs
+    # the status/sign-in banner). Browser-dependent — mirrors the button-gate setup.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Cache Playwright browser
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Mobile layout gate
+        run: node .github/scripts/mobile-layout-test.js
+
   client-perf:
     # Client render-perf REGRESSION gate (relative, non-blocking). Measures the
     # 25-kart brutal scenario's scripting ms/frame for BOTH the PR head and its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ## Unreleased
 
-(none yet)
+### Bug fixes
+
+- **Phone layout fixes.** On phones the map list and the map editor no longer run off the side of the screen — the map browser fits the screen instead of scrolling sideways with its header clipped, and the editor's action buttons (Preview, Copy, Upload…) all stay on-screen and reachable. The in-game settings gear has also moved out from under the lobby info banner (it now tucks beside the fullscreen button), so they no longer overlap in landscape.
 
 ## v0.45.0 — 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### Bug fixes
 
-- **Phone layout fixes.** On phones the map list and the map editor no longer run off the side of the screen — the map browser fits the screen instead of scrolling sideways with its header clipped, and the editor's action buttons (Preview, Copy, Upload…) all stay on-screen and reachable. Editing in **landscape** now shows a much bigger map: the toolbar packs into a single row instead of stacking, freeing the space for the canvas. The in-game settings gear has also moved out from under the lobby info banner (it now tucks beside the fullscreen button), so they no longer overlap in landscape.
+- **Phone layout fixes.** On phones the map list and the map editor no longer run off the side of the screen — the map browser fits the screen instead of scrolling sideways with its header clipped, and the editor's action buttons (Preview, Copy, Upload…) all stay on-screen and reachable. Editing in **landscape** now shows a much bigger map: the toolbar packs into a single row instead of stacking, freeing the space for the canvas. The in-game **settings menu** also lays its options out in two columns in landscape so they all fit on screen instead of clipping off the top and bottom. And the lobby's **mode/sign-in banner** now stays a readable size on phones instead of shrinking to tiny text. The in-game settings gear has also moved out from under that banner (it now tucks beside the fullscreen button), so they no longer overlap in landscape.
 
 ## v0.45.0 — 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ After each release the same workflow also rolls every `vX.Y.Z` from the current 
 
 ### Bug fixes
 
-- **Phone layout fixes.** On phones the map list and the map editor no longer run off the side of the screen — the map browser fits the screen instead of scrolling sideways with its header clipped, and the editor's action buttons (Preview, Copy, Upload…) all stay on-screen and reachable. The in-game settings gear has also moved out from under the lobby info banner (it now tucks beside the fullscreen button), so they no longer overlap in landscape.
+- **Phone layout fixes.** On phones the map list and the map editor no longer run off the side of the screen — the map browser fits the screen instead of scrolling sideways with its header clipped, and the editor's action buttons (Preview, Copy, Upload…) all stay on-screen and reachable. Editing in **landscape** now shows a much bigger map: the toolbar packs into a single row instead of stacking, freeing the space for the canvas. The in-game settings gear has also moved out from under the lobby info banner (it now tucks beside the fullscreen button), so they no longer overlap in landscape.
 
 ## v0.45.0 — 2026-06-16
 

--- a/client/create.html
+++ b/client/create.html
@@ -655,6 +655,32 @@
         width: auto;
       }
     }
+
+    /* --- responsive: short landscape (phone on its side) -------------------- */
+    /* A landscape phone is WIDER than 768px, so it keeps the desktop side-rail
+       layout — but its height is tiny. There the action bar wraps to 2-3 rows and
+       eats the height the aspect-locked map canvas needs, leaving the map small in
+       a sea of empty space. Pin the bar to a single, horizontally-scrollable row so
+       the canvas reclaims that vertical space (≈+30% taller map). Trim the chrome a
+       touch to fit more of the bar without scrolling. */
+    @media screen and (min-width: 769px) and (max-height: 540px) {
+      #editorTopbar {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        padding: 5px 8px;
+        gap: 4px;
+      }
+      .ed-bar-group { flex: 0 0 auto; gap: 3px; }
+      .ed-bar-divider { margin: 2px 1px; }
+      /* Pack the bar left (drop the push-right spacer) and trim the text buttons so
+         the whole bar fits the phone's width without horizontal scrolling. (The
+         action bar still scrolls if an even narrower phone can't fit it.) */
+      .ed-bar-spacer { display: none; }
+      #editorTopbar .ed-btn { padding: 0 6px; gap: 4px; }
+      #toolRail { padding: 8px; }
+      #canvasWindow { padding: 6px; }
+    }
   </style>
 </head>
 

--- a/client/create.html
+++ b/client/create.html
@@ -436,6 +436,10 @@
       max-width: 1280px;
       margin: 0 auto;
       align-content: start;
+      /* Neutralise the legacy `float: left` from styles.css — a *floated* grid
+         container shrink-wraps to max-content, so on a phone it laid every card
+         out in one wide row (5 columns @ 1212px) and the page scrolled sideways. */
+      float: none;
     }
     #loadWindow.editor-hidden,
     #createWindow.editor-hidden {
@@ -630,6 +634,14 @@
         border-top: thin solid var(--border);
         justify-content: center;
         padding-bottom: calc(8px + var(--safe-bottom));
+      }
+      /* Let the groups themselves wrap. #editorTopbar wraps *groups*, but the
+         6-button action group is a single non-wrapping flex item — its 518px
+         min-content forced the whole editor wider than the phone, pushing
+         Copy/Upload off-screen. Wrapping per-group keeps every button reachable. */
+      #editorTopbar .ed-bar-group {
+        flex-wrap: wrap;
+        justify-content: center;
       }
       .ed-bar-spacer {
         display: none;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1424,12 +1424,15 @@ body.osk-open .gamepad-prompts {
 }
 /* Translucent settings (gear) button — shown only on touch while in fullscreen,
    where the navbar (and its settings controls) is hidden and there's no pad
-   Start button. Sits above the settings modal so it can also toggle it closed. */
+   Start button. Sits above the settings modal so it can also toggle it closed.
+   Top/left are set in JS (positionTouchSettingsButton) so the gear tracks the
+   LETTERBOXED game canvas's top-right corner — stacked under the Fullscreen/Exit
+   touch button and clear of the centred lobby status banner. The 0,0 fallback is
+   never seen: positioning runs before the `.visible` class is toggled on. */
 #touchSettingsBtn {
     position: fixed;
-    top: max(8px, env(safe-area-inset-top));
-    left: 50%;
-    transform: translateX(-50%);
+    top: 0;
+    left: 0;
     width: 48px;
     height: 48px;
     display: none;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1431,9 +1431,16 @@ body.osk-open .gamepad-prompts {
         max-height: 94vh;
         overflow-y: auto;
     }
+    /* Column-MAJOR fill (auto-flow: column over a fixed 5-row track) so the rows
+       run top-to-bottom down the left column then the right — matching the linear
+       DOM order the gamepad/keyboard focus ring walks (moveSettingsFocus ±1). A
+       row-major grid would make D-pad "Down" jump sideways. 5 rows fits the ~7-9
+       settings in two columns; extra tracks collapse to 0 height. */
     .settings-rows {
         display: grid;
         grid-template-columns: 1fr 1fr;
+        grid-template-rows: repeat(5, auto);
+        grid-auto-flow: column;
         gap: 0.4rem 0.6rem;
     }
     .settings-row {
@@ -1449,12 +1456,15 @@ body.osk-open .gamepad-prompts {
    Start button. Sits above the settings modal so it can also toggle it closed.
    Top/left are set in JS (positionTouchSettingsButton) so the gear tracks the
    LETTERBOXED game canvas's top-right corner — stacked under the Fullscreen/Exit
-   touch button and clear of the centred lobby status banner. The 0,0 fallback is
-   never seen: positioning runs before the `.visible` class is toggled on. */
+   touch button and clear of the centred lobby status banner. JS sets `left`,
+   which wins over this `right` fallback; the fallback only applies if the gear is
+   ever revealed before it's positioned (canvas not yet measured) — top-RIGHT keeps
+   it clear of the top-left Emoji button even then, rather than 0,0. */
 #touchSettingsBtn {
     position: fixed;
-    top: 0;
-    left: 0;
+    top: 12px;
+    right: 12px;
+    left: auto;
     width: 48px;
     height: 48px;
     display: none;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1422,6 +1422,28 @@ body.osk-open .gamepad-prompts {
     color: var(--text);
     cursor: pointer;
 }
+/* Short landscape (phone on its side): the single column of ~7 setting rows is
+   taller than the screen, so the top row and the Done button clip off. Lay the
+   rows out in two columns (roughly halves the height) and tighten them, and cap
+   the dialog to the viewport with an internal scroll as a final safety net. */
+@media screen and (max-height: 540px) and (min-width: 640px) {
+    .settings-dialog {
+        max-height: 94vh;
+        overflow-y: auto;
+    }
+    .settings-rows {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.4rem 0.6rem;
+    }
+    .settings-row {
+        padding: 0.4rem 0.7rem;
+        font-size: 0.9rem;
+    }
+    .settings-foot {
+        margin-top: 0.55rem;
+    }
+}
 /* Translucent settings (gear) button — shown only on touch while in fullscreen,
    where the navbar (and its settings controls) is hidden and there's no pad
    Start button. Sits above the settings modal so it can also toggle it closed.

--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3932,6 +3932,7 @@ function drawObjects(dt) {
         drawMapTitle();
     }
     drawSpectatorBanner();
+    hudProbeReset();
     drawHUD();
     drawMouseDriveIndicator();
     drawOffscreenGoalIndicator();
@@ -11324,6 +11325,32 @@ function compareSite(siteA, siteB) {
     return true;
 }
 
+// --- HUD overlap probe (opt-in: ?hudprobe=1) -----------------------------------
+// Publishes the current frame's top-edge HUD element rects (in LOGICAL canvas
+// coords) to window.__hudRects so the headless CI guard (mobile-layout-test.js)
+// can assert no two collide — the exact class of bug where a newly-added lobby
+// banner overlapped the settings gear. Zero cost unless the flag is set.
+var hudProbeOn = (typeof location !== "undefined" && !!location.search &&
+    /[?&]hudprobe=1\b/.test(location.search));
+function hudProbeReset() {
+    if (hudProbeOn && typeof window !== "undefined") {
+        window.__hudRects = [];
+    }
+}
+function hudProbeRect(name, x, y, w, h) {
+    if (!hudProbeOn || typeof window === "undefined" || !window.__hudRects) {
+        return;
+    }
+    // Idempotent per name within a frame: if an element re-draws, keep the latest
+    // rect rather than appending a duplicate (a same-name pair would self-overlap
+    // and false-fail the guard).
+    var rects = window.__hudRects;
+    for (var i = 0; i < rects.length; i++) {
+        if (rects[i].name === name) { rects[i] = { name: name, x: x, y: y, w: w, h: h }; return; }
+    }
+    rects.push({ name: name, x: x, y: y, w: w, h: h });
+}
+
 function drawHUD() {
     drawGameInfo();
     drawRaceTimer();
@@ -12517,6 +12544,8 @@ function drawTouchControls(ctx) {
             ctx.restore();
         }
         drawTouchLabel(window.document.fullscreenElement ? "Exit" : "Fullscreen", exitButton.baseX, exitButton.baseY + exitSize / 2 + 16, ctx);
+        var exHit = exitButton.radius || exitSize / 2;
+        hudProbeRect("touchExit", exitButton.baseX - exHit, exitButton.baseY - exHit, exHit * 2, exHit * 2);
     }
     if (chatButton != null && chatButton.isVisible()) {
         var chatSize = chatButton.iconSize || 34;
@@ -12524,6 +12553,8 @@ function drawTouchControls(ctx) {
         ctx.drawImage(chatToUse, chatButton.baseX - chatSize / 2, chatButton.baseY - chatSize / 2, chatSize, chatSize);
         ctx.restore();
         drawTouchLabel("Emoji", chatButton.baseX, chatButton.baseY + chatSize / 2 + 16, ctx);
+        var chHit = chatButton.radius || chatSize / 2;
+        hudProbeRect("touchEmoji", chatButton.baseX - chHit, chatButton.baseY - chHit, chHit * 2, chHit * 2);
     }
 }
 

--- a/client/scripts/game.js
+++ b/client/scripts/game.js
@@ -627,6 +627,11 @@ function resize() {
     if (typeof layoutTouchControls === "function") {
         layoutTouchControls();
     }
+    // Keep the DOM settings gear pinned to the canvas's top-right as the letterbox
+    // fit changes (orientation / fullscreen / URL-bar collapse).
+    if (typeof positionTouchSettingsButton === "function") {
+        positionTouchSettingsButton();
+    }
 
     camera = {
         active: false,

--- a/client/scripts/gamepad.js
+++ b/client/scripts/gamepad.js
@@ -1410,7 +1410,41 @@ function updateTouchSettingsButtonVisibility() {
         return;
     }
     var touch = (typeof isTouchScreen !== "undefined" && isTouchScreen);
-    touchSettingsBtnEl.classList.toggle("visible", !!(touch && inFullscreen()));
+    var show = !!(touch && inFullscreen());
+    // Position BEFORE revealing so the gear never flashes at the 0,0 CSS fallback.
+    if (show) {
+        positionTouchSettingsButton();
+    }
+    touchSettingsBtnEl.classList.toggle("visible", show);
+}
+
+// Anchor the gear to the LETTERBOXED game canvas's top-right corner, stacked just
+// below the Fullscreen/Exit touch button (drawn in drawTouchControls). The gear was
+// previously pinned to screen-centre (left:50%), which collided with the centred
+// lobby status/sign-in banner. Screen-edge anchoring won't work either — the canvas
+// is letterboxed, so the screen corners fall in the black bars — hence we measure
+// the live canvas rect each layout. The offsets mirror layoutTouchControls()'s
+// top-right corner button (topInset 16 + hit zone 72 ≈ 88px tall, in CSS px).
+function positionTouchSettingsButton() {
+    if (!touchSettingsBtnEl) {
+        return;
+    }
+    var cv = (typeof gameCanvas !== "undefined" && gameCanvas) ||
+        (typeof document !== "undefined" ? document.getElementById("gameCanvas") : null);
+    if (!cv || !cv.getBoundingClientRect) {
+        return;
+    }
+    var r = cv.getBoundingClientRect();
+    if (!r.width || !r.height) {
+        return;
+    }
+    var SIZE = 48;          // matches the CSS width/height
+    var RIGHT_MARGIN = 16;  // layoutTouchControls' `margin`
+    var EXIT_ZONE_H = 88;   // topInset(16) + corner hit zone(72)
+    var GAP = 10;
+    touchSettingsBtnEl.style.left = Math.round(r.right - RIGHT_MARGIN - SIZE) + "px";
+    touchSettingsBtnEl.style.top = Math.round(r.top + EXIT_ZONE_H + GAP) + "px";
+    touchSettingsBtnEl.style.transform = "none";
 }
 
 function toggleTouchSettings() {

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1251,10 +1251,20 @@ function drawLobbyStatusCard() {
     var ctx = gameContext;
     ctx.save();
     var i;
+    // Scale factor that keeps the card a readable PHYSICAL size on small /
+    // letterboxed screens. fitRatio is CSS-px per logical unit (≈0.48 on a
+    // landscape phone, ≥1 on desktop); 1/fitRatio renders the card at its
+    // 1366-baseline physical size, capped at 2x so it never dominates a tiny
+    // canvas. Desktop (fitRatio>=1) gets s=1 → unchanged.
+    var s = 1;
+    if (typeof fitRatio === "number" && fitRatio > 0) {
+        s = Math.max(1, Math.min(2, 1 / fitRatio));
+    }
     var key = (gold || "") + "\u0000" + LOGICAL_WIDTH;
     for (i = 0; i < cells.length; i++) {
         key += "\u0000" + cells[i].label + "\u0001" + cells[i].value + "\u0001" + cells[i].stable;
     }
+    key += " s" + s.toFixed(2);
     var w;
     if (statusCardLayout != null && statusCardLayout.key === key) {
         // Cache hit: reuse widths + pre-ellipsized strings; skip all measuring.
@@ -1290,7 +1300,12 @@ function drawLobbyStatusCard() {
             w = gw;
         }
     }
-    var maxW = LOGICAL_WIDTH - 80;
+    // Cap the SCALED width so the centred card clears both the canvas edge AND the
+    // top-corner touch buttons (emoji left / fullscreen right, each ≈ cssToLogical(88)
+    // wide). Without the corner term the 2x phone scale-up overlapped them in portrait,
+    // where the buttons grow large in logical space.
+    var cornerInset = (typeof cssToLogical === "function") ? cssToLogical(88) : 88;
+    var maxW = Math.min(LOGICAL_WIDTH - 80, LOGICAL_WIDTH - 2 * cornerInset - 24) / s;
     if (w > maxW) {
         var k = maxW / w;
         for (i = 0; i < cells.length; i++) { cells[i].w *= k; }
@@ -1315,8 +1330,14 @@ function drawLobbyStatusCard() {
     }
     var bandH = (gold != null) ? STATUS_CARD_BAND_H : 0;
     var h = bandH + (cells.length ? STATUS_CARD_CELLS_H : 0);
-    var x = (LOGICAL_WIDTH - w) / 2;
-    var y = lobbyBannerRowY(0);
+    // Anchor + scale around the card's top centre, then draw at the origin in base
+    // logical units (every offset below is multiplied by s by the transform).
+    var cardX = (LOGICAL_WIDTH - w * s) / 2;
+    var cardY = lobbyBannerRowY(0);
+    ctx.translate(cardX, cardY);
+    ctx.scale(s, s);
+    var x = 0;
+    var y = 0;
     drawHudPanel(x, y, w, h, {
         fill: hubSurface(),
         alpha: 0.92,
@@ -1377,7 +1398,7 @@ function drawLobbyStatusCard() {
     }
     ctx.restore();
     if (typeof hudProbeRect === "function") {
-        hudProbeRect("lobbyStatusCard", x, y, w, h);
+        hudProbeRect("lobbyStatusCard", cardX, cardY, w * s, h * s);
     }
 }
 

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1264,7 +1264,10 @@ function drawLobbyStatusCard() {
     for (i = 0; i < cells.length; i++) {
         key += "\u0000" + cells[i].label + "\u0001" + cells[i].value + "\u0001" + cells[i].stable;
     }
-    key += " s" + s.toFixed(2);
+    // Key on fitRatio, not the clamped s: the maxW cap below also depends on
+    // cornerInset (= cssToLogical(88)), which keeps varying with fitRatio even once
+    // s has clamped to 2 — so two fits with the same s still need distinct layouts.
+    key += " f" + ((typeof fitRatio === "number" && fitRatio > 0) ? fitRatio.toFixed(3) : "1");
     var w;
     if (statusCardLayout != null && statusCardLayout.key === key) {
         // Cache hit: reuse widths + pre-ellipsized strings; skip all measuring.
@@ -1305,7 +1308,11 @@ function drawLobbyStatusCard() {
     // wide). Without the corner term the 2x phone scale-up overlapped them in portrait,
     // where the buttons grow large in logical space.
     var cornerInset = (typeof cssToLogical === "function") ? cssToLogical(88) : 88;
-    var maxW = Math.min(LOGICAL_WIDTH - 80, LOGICAL_WIDTH - 2 * cornerInset - 24) / s;
+    // Floor the available width so an extreme (sub-real) letterbox where cornerInset
+    // grows past half the canvas can't drive maxW to zero/negative (which would scale
+    // cell widths by a negative factor and invert the card).
+    var avail = Math.max(LOGICAL_WIDTH * 0.4, LOGICAL_WIDTH - 2 * cornerInset - 24);
+    var maxW = Math.min(LOGICAL_WIDTH - 80, avail) / s;
     if (w > maxW) {
         var k = maxW / w;
         for (i = 0; i < cells.length; i++) { cells[i].w *= k; }

--- a/client/scripts/lobbyHub.js
+++ b/client/scripts/lobbyHub.js
@@ -1376,6 +1376,9 @@ function drawLobbyStatusCard() {
         cx += cell.w;
     }
     ctx.restore();
+    if (typeof hudProbeRect === "function") {
+        hudProbeRect("lobbyStatusCard", x, y, w, h);
+    }
 }
 
 // One-shot match-start announcement for brutal MODES: during the ROUND-1 gate

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "test:perf-tick": "node .github/scripts/perf-tick-budget.js",
         "test:perf-client": "node .github/scripts/perf-client.js",
         "test:lint-buttons": "node .github/scripts/lint-button-input.js",
-        "test:button-gate": "node .github/scripts/button-gate.js"
+        "test:button-gate": "node .github/scripts/button-gate.js",
+        "test:mobile-layout": "node .github/scripts/mobile-layout-test.js"
     }
 }


### PR DESCRIPTION
Fixes a batch of mobile layout bugs reported on a Pixel 10 Pro XL, plus a Playwright CI guard so they can't silently regress.

## What players will notice
- **Map list & editor no longer scroll sideways** on phones — the browser fits the screen (header/tabs no longer clipped) and every editor action button (Preview/Copy/Upload) stays on-screen.
- **Landscape map editor shows a ~50% bigger map** — the toolbar packs into a single row instead of stacking 2–3 rows.
- **Settings menu fits in landscape** — options lay out in two columns instead of clipping the top row and the Done button.
- **Lobby mode/sign-in banner is readable on phones** — it was tiny canvas text; now scales to a constant physical size on small/letterboxed screens.
- **Settings gear no longer overlaps the lobby banner** in landscape — moved to the canvas top-right, under the Fullscreen/Exit button.

## Root causes
- **List overflow:** a legacy `float: left` (styles.css) leaked onto the new `#loadWindow` grid; a floated grid shrink-wraps to max-content → a 5-column 1212px row. → `float: none`.
- **Editor controls off-screen:** the 6-button action group was one non-wrapping `.ed-bar-group` (518px min-content). → wrap groups on phones.
- **Tiny landscape map:** landscape phones are >768px (desktop layout) but short, so the toolbar wrapped and stole the aspect-locked canvas's height. → single-row toolbar in short landscape (`min-width:769 + max-height:540`).
- **Gear/banner overlap:** the DOM gear was screen-centred (`left:50%`), only landing on the centred banner because the canvas is letterboxed. → anchor to the canvas top-right, below the Fullscreen/Exit touch button.
- **Tiny banner:** drawn in fixed logical px, shrunk by the letterbox. → scale the card by `s = clamp(1/fitRatio, 1, 2)`, width-capped to clear the canvas edge and corner touch buttons.

## CI guard (new)
`mobile-layout-test.js` (Playwright, mirrors `button-gate`), wired into `pr-validation` as the `mobile-layout` job:
1. No horizontal overflow on index/join/create (list + editor) at portrait + landscape phone viewports.
2. No top-edge lobby HUD overlap (gear vs status/sign-in banner vs emoji/fullscreen), via an opt-in `?hudprobe=1` rect registry the client publishes.

Verified it **fails on the pre-fix tree** and on a forced gear/banner collision; passes on the fix.

## Scope
Client + CI only (no `config.json`/`game.js`/`engine.js`). Build + smoke + the new guard all green. A code-review pass (8 finder angles) was run and its 6 findings addressed in the final commit (incl. making the landscape settings grid column-major so gamepad focus order stays correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)