### PR TITLE
chore(maps): rename map author sjdodge -> roknua

### DIFF
--- a/client/maps/Async.json
+++ b/client/maps/Async.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "CKlOWFM9uQp79qSGkffaXAOFTnGVSimb",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Async",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/Crossroads.json
+++ b/client/maps/Crossroads.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "IhGFKKNi3Wspfsj0thqkcPj8sbM1KeK6",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Crossroads",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/Damnation.json
+++ b/client/maps/Damnation.json
@@ -1284,7 +1284,7 @@
     }
   ],
   "id": "ByAP6Aqqnqet0qiVyXfcMfWiM7ZkgJoH",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Damnation",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/Duality.json
+++ b/client/maps/Duality.json
@@ -1288,7 +1288,7 @@
     "bottom"
   ],
   "id": "JC6Mv9r4MxTwD1YeTocjgfTXPdSQsAAV",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Duality",
   "email": "sjdodge@outlook.com",
   "parTime": 11.298869999999972

--- a/client/maps/GoldEyes.json
+++ b/client/maps/GoldEyes.json
@@ -1280,7 +1280,7 @@
     }
   ],
   "id": "koT3kksfhpxUSU6Trj5Cdr7iRbhgcnjg",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Gold Eyes",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/GreenerGrass.json
+++ b/client/maps/GreenerGrass.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "wPg3AZRbCGzUYs2Z4d4c4KxC8G6ds1f5",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Greener Grass",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/IcyLake.json
+++ b/client/maps/IcyLake.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "g8lOz86kP5UubpEKdyFvgT3uwzobJs5y",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Icy Lake",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/JollyJaunt.json
+++ b/client/maps/JollyJaunt.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "4LuSsrzKNn4BsTIcmrssCLuEXsBcXRC3",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Jolly Jaunt",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/LavaLakes.json
+++ b/client/maps/LavaLakes.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "LMpoiRPfnXb1Up2IJfUeKqipX2lYrkmD",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Lava Lakes",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/MurderRow.json
+++ b/client/maps/MurderRow.json
@@ -1290,7 +1290,7 @@
     }
   ],
   "id": "Q7e504kLqIRjErfM1MZJo3eq4DZtpvXW",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Murder Row",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/NiceKnowin'Ya.json
+++ b/client/maps/NiceKnowin'Ya.json
@@ -1321,7 +1321,7 @@
     }
   ],
   "id": "Du6w0kOG7iWh7XuB44hRLZbN5D0DVQVA",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Nice Knowin' Ya",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/PathOfPain.json
+++ b/client/maps/PathOfPain.json
@@ -1278,7 +1278,7 @@
     }
   ],
   "id": "GmPDW22YWBFvS75p9qtKaqjxuppDXwwX",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Path Of Pain",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/Pivot.json
+++ b/client/maps/Pivot.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "3YfXOrifeK9nInQY9DmyexvH0scWegtp",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Pivot",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/RaceCondition.json
+++ b/client/maps/RaceCondition.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "vGjEzPVKpYSZ3jaFZSSKxBBWU2Qv8J6q",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Race Condition",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/RandomLakes.json
+++ b/client/maps/RandomLakes.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "MuDUi2Zvi7n9K4hOcqNddsBwt0Qc0t2s",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Random Lakes",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/RiskyBusiness.json
+++ b/client/maps/RiskyBusiness.json
@@ -1284,7 +1284,7 @@
     }
   ],
   "name": "Risky Business",
-  "author": "sjdodge",
+  "author": "roknua",
   "id": "GLQVU04VWE7P66hRDuabyR9xomM1GkWV",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/RushHour.json
+++ b/client/maps/RushHour.json
@@ -1284,7 +1284,7 @@
     }
   ],
   "id": "v3ZVMhDBPb0rEtoC2KJ8eaPVl9jDDife",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Rush Hour",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/SandsOfTime.json
+++ b/client/maps/SandsOfTime.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "ZfvTuW4B5C1qhkxIfWFLbiy6s9ztZnLr",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Sands Of Time",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/Shortcut.json
+++ b/client/maps/Shortcut.json
@@ -1297,7 +1297,7 @@
     }
   ],
   "id": "6J33TN9m6ljvUqD1DeKXx5L13wOeL0G2",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Shortcut",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/Sidewinder.json
+++ b/client/maps/Sidewinder.json
@@ -1288,7 +1288,7 @@
     }
   ],
   "id": "ShX7zRsvzSCj4MQHuxSZJeAk3uzkHNoq",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Sidewinder",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/Strand.json
+++ b/client/maps/Strand.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "MtcNQi0poVyja6yyjUs6umIndyDW3Leb",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Strand",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/SwitchUp.json
+++ b/client/maps/SwitchUp.json
@@ -1270,7 +1270,7 @@
     }
   ],
   "id": "PhJ3QGtz4t2g4rD2omdwreYOr1udnGcl",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "Switch Up",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/TheFlow.json
+++ b/client/maps/TheFlow.json
@@ -1262,7 +1262,7 @@
     "left"
   ],
   "id": "1E8N3EKg4yyIrXcfpQkm1MITxxDUFQUO",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "The Flow",
   "email": "sjdodge@outlook.com",
   "parTime": 46.32869999999936

--- a/client/maps/TheGauntlet.json
+++ b/client/maps/TheGauntlet.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "k6AkT93EeEQMWOAf67P7uisxpOwUGoDV",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "The Gauntlet",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/TheGreatDivide.json
+++ b/client/maps/TheGreatDivide.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "sYOzZ4HoCVGhPbMwDE4RVQUeQ51zrrwe",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "The Great Divide",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/TheIsland.json
+++ b/client/maps/TheIsland.json
@@ -1386,7 +1386,7 @@
     }
   ],
   "id": "yNvimKRtFnRCXp2FcDC5SbNB3FhejTuM",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "The Island",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/TheLobster.json
+++ b/client/maps/TheLobster.json
@@ -1276,7 +1276,7 @@
     }
   ],
   "id": "etyz7pVwCqinBSAdflIFfRUvjShJ6a7t",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "The Lobster",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/ThinBlackLine.json
+++ b/client/maps/ThinBlackLine.json
@@ -1259,7 +1259,7 @@
   ],
   "hazards": [],
   "id": "sfw0szJi9zjYdrejPiWajueO6B8h5s1X",
-  "author": "sjdodge123",
+  "author": "roknua",
   "name": "Thin Black Line",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/ToTheWire.json
+++ b/client/maps/ToTheWire.json
@@ -1272,7 +1272,7 @@
     }
   ],
   "id": "XQ27A06usrkTzpAmEhImoQaWNG0aCmOk",
-  "author": "sjdodge123",
+  "author": "roknua",
   "name": "To The Wire",
   "email": "sjdodge@outlook.com"
 }

--- a/client/maps/WhatGoesUp.json
+++ b/client/maps/WhatGoesUp.json
@@ -1275,7 +1275,7 @@
     "bottom"
   ],
   "id": "7XypAVC7JqAIdgGBesBrqL7CVofe6wsQ",
-  "author": "sjdodge",
+  "author": "roknua",
   "name": "What Goes Up",
   "email": "sjdodge@outlook.com",
   "parTime": 25.76408999999972


### PR DESCRIPTION
Renames the `author` field from `sjdodge` (28 maps) and `sjdodge123` (2 maps) to `roknua` across all 30 affected map JSONs in `client/maps/`.

- Only `author` lines changed; all 30 files re-validated as JSON.
- `email` fields (`sjdodge@outlook.com`) left untouched — real email address, not a username.
- Build + headless smoke test pass (53 maps boot & tick).

No gameplay/config/engine changes — exempt from CHANGELOG (map metadata only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)