### PR TITLE
News banner: graceful headline fallback + map-editor content-drop hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ To re-render a past week's digest with the current formatting, run the `Release 
 
 ### Map editor
 
+- [headline:New Hazards & Boons] **A huge map-editor content drop** — two new hazards and eight new boons to build with: ability-stealing drones, shooting turrets, ziplines, warp pads, launch pads and more.
 - **New hazard: Magpie Drone.** A thieving drone that patrols a rail and **snatches the ability you're holding** the moment it touches you — then flies off carrying your loot in plain sight (you'll see the stolen ability bobbing above it). Get it back by **punching the drone**: a solid hit makes it drop the ability onto the ground as a pad anyone can grab — so a stolen Bomb or Star can change hands mid-race. A re-grabbed ability arms after a brief beat, so mashing punch to free it won't fire it off by accident the instant you scoop it back up. Catch it while you're **empty-handed** and there's nothing to steal, so it just zaps a chunk of your stamina instead. A drone that's already carrying loot is harmless until someone frees it, so the steal → punch → grab-it-back scramble is the whole game. It rides its rail like a Moving Bumper, so you can time your dash through the gap — but if you're holding something good, give it a wide berth. Authors place it from the hazards palette and **draw its patrol rail by dragging the rail-end handle** — aim it and set how far it ranges in one motion, from a short hover to a long sweeping patrol. Rival AI racers carrying an ability now keep their distance from a hungry drone.
 
 ## v0.48.0 — 2026-06-16

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ function loadWeeklyNews() {
         var weekMonday = null;     // week of the topmost release section
         var inWeek = false;        // currently scanning a section in that week
         var headline = null;       // [headline]-marked bullet (first wins)
-        var firstBullet = null;    // fallback: first bullet of the week
+        var firstLead = null;      // fallback: first bullet's bold lead-in
         // Accepts "[headline]" and "[headline:Short Name]" (the optional name
         // only labels the digest title; the banner shows the bullet text). Keep
         // in lockstep with HEADLINE_RE in .github/scripts/changelog-lib.mjs.
@@ -163,12 +163,20 @@ function loadWeeklyNews() {
                 return t.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // [text](url) -> text
                     .replace(/[*`_]/g, '').trim();              // strip emphasis/code
             };
-            if (firstBullet === null) firstBullet = clean(line.slice(2));
+            // Fallback when no bullet is flagged: show the first bullet's BOLD
+            // lead-in (e.g. "New hazard: Magpie Drone") rather than the whole
+            // paragraph truncated mid-sentence. Falls back to the full text when
+            // a bullet has no bold lead-in.
+            if (firstLead === null) {
+                var raw = line.slice(2);
+                var bold = raw.match(/\*\*(.+?)\*\*/);
+                firstLead = clean(bold ? bold[1] : raw);
+            }
             if (headline === null && headlineRe.test(line)) {
                 headline = clean(line.replace(headlineRe, ''));
             }
         }
-        var text = headline || firstBullet;
+        var text = headline || firstLead;
         if (!text || !weekMonday) return null;
         return { headline: truncateHeadline(text), weekTag: 'week-' + weekMonday };
     } catch (e) {


### PR DESCRIPTION
The landing-page **PATCH NOTES** banner was showing the first changelog bullet truncated mid-sentence (this week: *"New hazard: Magpie Drone. A thieving drone that patrols a rail and snatches the ability you're holding — then flies o…"*) because no bullet was tagged `[headline]` and the fallback dumped the whole paragraph.

## Changes
- **`index.js` (`loadWeeklyNews`) — durable fallback:** when no bullet is tagged `[headline]`, the banner now uses the first bullet's **bold lead-in** (e.g. "New hazard: Magpie Drone") instead of the full paragraph truncated mid-sentence. Every future untagged week reads cleanly with no per-week effort.
- **`CHANGELOG.md` — crafted hook for this week:** tagged a concise `[headline:New Hazards & Boons]` lead bullet on v0.49.0 framing the week as the big map-editor drop (two new hazards + eight new boons), 171 visible chars (under the 180 cap). The digest title becomes **"Week of June 15, 2026 — New Hazards & Boons"**.

## Verification
Live banner renders the full hook with no truncation; `build-weekly-digest --week 2026-06-15` yields the new title; `npm run build`, the 10 `changelog-lib` unit tests, `smoke-test.js`, and the heading check all pass. No game-mechanic files touched (`index.js`/`CHANGELOG.md` only) → CHANGELOG-exempt.

`deploy:prod` labelled so the banner fix reaches production immediately on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)