### PR TITLE
fix(map-editor): repair blank map-list thumbnails (startup race)

### DIFF
--- a/client/scripts/create.js
+++ b/client/scripts/create.js
@@ -205,16 +205,32 @@ function showLoadWindow() {
     document.getElementById('createWindow').classList.add('editor-hidden');
     document.body.classList.remove('editor-open');
     updateContinueTile();
-    // (Re)generate load-list thumbnails now that the window is open — by here
-    // config + textured patterns are loaded, so any card whose thumbnail was
-    // rendered blank/flat earlier (map fetched before config/patterns) upgrades
-    // to the textured version. renderMapThumbnail caches, so this is cheap.
+    refreshMapThumbnails();
+}
+
+// (Re)generate any load-list thumbnails that rendered blank or flat-coloured
+// earlier. Card creation (maplisting) races three async sources — the per-map
+// getJSON fetches, the `config` socket event, and the terrain texture images —
+// so a card built before config arrives gets `src=""` (a permanent blank box),
+// and one built before patterns decode gets flat colours (uncached). This walk
+// re-renders and upgrades both. It runs from showLoadWindow AND, crucially, from
+// tryStart() once config+patterns are ready — without that hook nothing ever
+// re-fired after the textures finished loading, leaving the early blanks forever.
+// renderMapThumbnail caches once patterns are ready, so repeat calls are cheap.
+function refreshMapThumbnails() {
+    if (config == null) { return; } // nothing renderable yet; tryStart re-fires us
     for (var i = 0; i < maps.length; i++) {
         var m = maps[i];
         if (m == null || m.id == null) { continue; }
         var btn = document.getElementById(m.id);
         var img = btn ? btn.querySelector('img') : null;
         if (img == null) { continue; }
+        // Retry any card still showing a blank/broken image (empty src, or an
+        // <img> that failed to decode → naturalWidth 0), and refresh flat-coloured
+        // ones to the textured cache. Skip cards already showing a good data URL.
+        var cur = img.getAttribute('src') || '';
+        var blank = cur === '' || img.naturalWidth === 0;
+        if (!blank && cur.indexOf('data:') === 0 && thumbnailCache[m.id] != null) { continue; }
         var url = renderMapThumbnail(m);
         if (url) { img.src = url; }
     }
@@ -432,6 +448,10 @@ function tryStart() {
     loadPatterns();
     gameRunning = true;
     init();
+    // Patterns are now decoded: upgrade any load-list cards that were built before
+    // config/textures arrived (blank or flat-coloured) to the textured thumbnail.
+    // This is the re-render hook the blank-thumbnail race was missing.
+    refreshMapThumbnails();
 }
 
 function loadPatterns() {


### PR DESCRIPTION
## Problem

The map editor's map-list sometimes shows **blank white thumbnails** for some maps — intermittently, and more often on mobile. (Reported with a screenshot showing ~6 blank cards: 4 Suns!, Choose A Path, Damnation, Crossroads, Async, Gold Eyes.)

Live inspection confirmed the blank cards have `<img src="">` (empty string → browser resolves to the page URL → `naturalWidth: 0` → blank box), while every working thumbnail holds a real `data:image/jpeg` URL. So the thumbnail generator handed back `""` for those maps.

## Root cause

An unsynchronized startup race in `client/scripts/create.js`. Cards are built as each map's `getJSON` resolves and call `renderMapThumbnail()` straight into `<img src>`. But that function:
- returns `""` when the `config` socket event hasn't arrived yet, and
- draws flat colours when the terrain texture images haven't decoded yet.

The only repair pass lived in `showLoadWindow()`, skipped empty `src`es (`if (url)`), and **nothing re-fired once `config`/textures finished loading** — so a card that lost the race stayed blank forever. On mobile / cold cache the cached map JSON reliably beats the socket `config` event, which is why it's intermittent and worse on phones.

## Fix

- Extract the repair loop into `refreshMapThumbnails()` that **retries blank/broken images** (empty `src` or `naturalWidth === 0`), upgrades flat-coloured ones, and skips cards already showing a good cached data URL.
- **Call it from `tryStart()`** right after `loadPatterns()` — the patterns-ready hook the race was missing. This is what closes the race for both the blank and flat-colour variants.
- `showLoadWindow()` now delegates to the same function.

## Verification

- **No regression:** on a normal local load all 52 map thumbnails render as data URLs.
- **Repair path:** artificially blanked 6 cards (the real race outcome) → `refreshMapThumbnails()` healed all 5 real maps; the only one left was the static "Create a new map" tile, correctly untouched.
- `npm run build` clean; `smoke-test.js` passes (engine ran on 53 maps).
- Codex review found no issues with the change.

Editor-only UI change → CHANGELOG/Codex-coverage exempt per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)