### PR TITLE
feat: label human players by color name (combat log + under-kart nametag)

### DIFF
--- a/client/scripts/draw.js
+++ b/client/scripts/draw.js
@@ -3486,9 +3486,7 @@ function drawPlayer(player, dt) {
         drawHeldKey(player);
     }
     drawEmoji(player);
-    if (player.name != null) {
-        drawBotName(player);
-    }
+    drawBotName(player);
     if (player.awake == false) {
         gameContext.save();
         gameContext.drawImage(commentIconSolid, player.x, player.y - 40, commentIconSolid.width * 0.07, commentIconSolid.height * 0.07);
@@ -3992,10 +3990,13 @@ function drawAvatarSkin(player, sprite) {
     gameContext.restore();
 }
 
-// AI racers carry a visible name below the kart so each personality is
-// recognizable. Aligned with the sprite's camera convention (camera offset is 0
-// in the default desktop view). Humans have no name.
+// Every racer carries a visible name below the kart, Discord-style. AI racers
+// show their personality name; human players (name === null) are labelled by the
+// colour they're playing, via Colors.nameFor. Aligned with the sprite's camera
+// convention (camera offset is 0 in the default desktop view).
 function drawBotName(player) {
+    var label = (typeof Colors !== "undefined") ? Colors.nameFor(player) : player.name;
+    if (label == null) { return; }
     // Match the kart sprite / avatar / emote convention (player position + camera
     // offset) so the label stays attached to the kart in dynamic-camera/zoom mode
     // too. (getCameraX/Y is 0 in the default desktop view; non-zero on touch zoom.)
@@ -4009,8 +4010,8 @@ function drawBotName(player) {
     gameContext.strokeStyle = themeColor('inkOutline', 'white');
     gameContext.fillStyle = themeColor('ink', 'black');
     gameContext.font = '11px Times New Roman';
-    gameContext.strokeText(player.name, x, y);
-    gameContext.fillText(player.name, x, y);
+    gameContext.strokeText(label, x, y);
+    gameContext.fillText(label, x, y);
     gameContext.restore();
 }
 

--- a/client/scripts/draw_hud.js
+++ b/client/scripts/draw_hud.js
@@ -285,7 +285,7 @@ function combatLogReset() { combatLog.length = 0; }
 // who later leaves the room still reads correctly in the feed).
 function combatNameOf(id) {
     var p = (typeof playerList !== "undefined" && playerList) ? playerList[id] : null;
-    return (p != null && p.name) ? p.name : "Someone";
+    return (p != null && typeof Colors !== "undefined") ? Colors.nameFor(p) : "Someone";
 }
 
 // Live colour for a name/ring: team colour in teams modes, else the kart colour.

--- a/client/scripts/utils.js
+++ b/client/scripts/utils.js
@@ -90,6 +90,16 @@ Colors.decode = function (input) {
     }
     return "A player";
 }
+// Display label for a player. AI racers keep their personality name; human
+// players (name === null) are labelled by the colour they're playing — decoded
+// from the authoritative server hex, since colour-blind assist may remap .color
+// off-palette (same convention as the "X won the game." headline).
+Colors.nameFor = function (player) {
+    if (player == null) { return "Someone"; }
+    if (player.name != null) { return player.name; }
+    var hex = (player._serverColor != null) ? player._serverColor : player.color;
+    return this.decode(hex);
+}
 
 function getColor() {
     return 'hsl(' + Math.floor(Math.random() * 360) + ', 100%, 50%)';


### PR DESCRIPTION
Anonymous/human players read as "Someone" in the combat log and had no name below their kart — only bots did. Now every human is labelled by the colour they're playing (e.g. "Red"), in both the combat-log feed and a Discord-style translucent nametag below the kart.

## What changed
- **`utils.js`** — new `Colors.nameFor(player)`: bots keep their personality name; humans (`name === null`) decode to their colour name. Decodes from the authoritative server hex (`_serverColor`) so colour-blind-assist remaps don't break the lookup — same convention as the "X won the game." headline.
- **`draw_hud.js`** — `combatNameOf()` routes through `Colors.nameFor`, so the combat log reads e.g. "Red defeated Blue" instead of "Someone defeated Someone."
- **`draw.js`** — the under-kart nametag (`drawBotName`) now draws for everyone (gate removed) and derives its label via the helper. Humans get their colour name below the cart; bots unchanged.

## Scope / notes
- Client/UI-only — no `config.json`/`game.js`/`engine.js` changes, so no CHANGELOG or Codex entry required.
- In-race the client only has a player's colour (no per-player account name is shipped per tick), so **all** humans — guest or signed-in — are labelled by colour. Shipping signed-in display names in-race would be a server-side follow-up.
- The recap montage stays bot-only (its own `name != null` gate is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)