### PR TITLE
ci: fix client-perf gate + conditional auto-merge (prod/map need approval)

### DIFF
--- a/.github/scripts/perf-client.js
+++ b/.github/scripts/perf-client.js
@@ -95,7 +95,12 @@ const OUT_JSON = process.env.PERF_OUT_JSON || '';
 // on c.brutalTypesForce when this seam injects it).
 const FORCED_BRUTALS = [1007, 1010, 1008, 1009];
 const OVERRIDE = JSON.stringify({
-    aiRacers: { minGrid: 25, maxGrid: 25, testForceBots: 24 }, // testForceBots pins the auto-fill at 24 bots (1H+24=25 karts)
+    // previewBotCount pins the PREVIEW-room fill at 24 bots (1H+24=25 karts) — this
+    // harness reaches the race via the editor preview path (createPreviewRoom), which
+    // fills off c.aiRacers.previewBotCount, NOT testForceBots. testForceBots/minGrid/
+    // maxGrid are kept for the lobby/auto fill path in case it's ever used, but the
+    // preview path needs previewBotCount or the grid never clears the 20-kart floor.
+    aiRacers: { minGrid: 25, maxGrid: 25, testForceBots: 24, previewBotCount: 24 },
     maxPlayersInRoom: 25,                                   // room cap must allow the full grid
     chanceOfBrutalRound: 100,
     chanceForAdditionalBrutal: 100,
@@ -202,9 +207,25 @@ const NAV_RACE_RE = /Execution context was destroyed|Target closed|Navigation|de
         const windows = [];          // every scene-valid window: { scriptPerFrame, taskPerFrame, frames, fps, frameWorkP95, heapMB, brutal, karts }
         let tracedOne = false;
         let nearStall = 0, badWindow = 0;
+        // FAIL FAST when the scenario is broken. Each poll waits up to 45s for a
+        // full-grid race; a CONTENDED runner still reaches one (just slowly), but a
+        // BROKEN scenario (preview never fills the grid, a client throw kills the
+        // render loop, etc.) never will — so burning all MAX_ATTEMPTS (~21 min) only
+        // delays an inevitable failure. If we haven't reached a single race in the
+        // first few attempts, it's breakage not contention: stop and let the
+        // empty-windows path throw immediately.
+        const REACH_RACE_MAX_TRIES = Number(process.env.PERF_REACH_RACE_TRIES) || 3;
+        let reachTries = 0;
         for (let attempt = 1; attempt <= MAX_ATTEMPTS && windows.length < COLLECT; attempt++) {
             const reached = await poll(page, racingFn, 45000, `attempt ${attempt}`);
-            if (!reached) { console.log(`  attempt ${attempt}: no full-grid racing reached`); continue; }
+            if (!reached) {
+                console.log(`  attempt ${attempt}: no full-grid racing reached`);
+                if (!reachedRace && ++reachTries >= REACH_RACE_MAX_TRIES) {
+                    console.log(`  giving up after ${reachTries} attempts without ever reaching a full-grid race — the perf scenario is broken (not runner contention). Failing fast instead of grinding all ${MAX_ATTEMPTS} attempts.`);
+                    break;
+                }
+                continue;
+            }
             reachedRace = true;
             // Stop the preview auto-return so a round that ends mid-window cycles to the
             // next round (staying on play.html) rather than bouncing to the editor —

--- a/.github/scripts/perf-client.js
+++ b/.github/scripts/perf-client.js
@@ -119,12 +119,19 @@ function bootServer() {
             cwd: repoRoot,
             env: { ...process.env, PORT: String(PORT), NODE_ENV: 'development', CHAO_PERF_OVERRIDE: OVERRIDE },
         });
-        let out = '';
-        const onData = (d) => { out += d.toString(); if (/listening on/i.test(out)) resolve(srv); };
+        let out = '', settled = false;
+        const done = (fn, arg) => { if (settled) return; settled = true; clearTimeout(timer); fn(arg); };
+        const onData = (d) => { out += d.toString(); if (/listening on/i.test(out)) done(resolve, srv); };
         srv.stdout.on('data', onData);
         srv.stderr.on('data', onData);
-        srv.on('exit', (c) => reject(new Error(`server exited early (${c}):\n${out}`)));
-        setTimeout(() => reject(new Error(`server boot timeout:\n${out}`)), 20000);
+        srv.on('exit', (c) => done(reject, new Error(`server exited early (${c}):\n${out}`)));
+        // On timeout, kill the spawned server so it can't linger — the outer finally
+        // only kills `srv` once this promise RESOLVES, so a boot that never resolves
+        // would otherwise leak the child.
+        const timer = setTimeout(() => {
+            try { srv.kill('SIGKILL'); } catch (e) {}
+            done(reject, new Error(`server boot timeout:\n${out}`));
+        }, 20000);
     });
 }
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,7 +20,12 @@ name: Auto-merge
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+  # Re-attempt arming when a review lands — covers a sensitive PR approved later and
+  # any transient failure to arm on the initial event. `gh pr merge --auto` is
+  # idempotent, so re-running on an already-armed PR is a harmless no-op.
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: write

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,45 @@
+name: Auto-merge
+
+# Turns on GitHub's native auto-merge for every non-draft PR into main, so a PR
+# merges itself the moment all REQUIRED checks are satisfied — no manual "merge"
+# click for the common case.
+#
+# This is safe to apply blanket because the `merge-gate` required check (see
+# merge-gate.yml) is what actually decides mergeability:
+#   • Normal PR        -> merge-gate goes green when CI passes -> auto-merge fires.
+#   • deploy:prod / map -> merge-gate stays RED until @sjdodge123 approves, so
+#                          auto-merge is armed but parks until that explicit approval.
+# So enabling auto-merge everywhere can never merge a sensitive PR without approval.
+#
+# Squash to match the repo's existing one-commit-per-PR history.
+#
+# Requires the repo setting "Allow auto-merge" to be ON
+# (Settings ▸ General ▸ Pull Requests). If it's off, the enable step no-ops with a
+# warning rather than failing the workflow.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    # Never arm auto-merge on a draft.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if gh pr merge "$PR" --repo "$REPO" --auto --squash; then
+            echo "Auto-merge armed for PR #$PR (will merge once required checks pass)."
+          else
+            echo "::warning::Could not enable auto-merge for PR #$PR. Most likely 'Allow auto-merge' is off in repo settings, or the PR is already mergeable/closed."
+          fi

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -59,9 +59,10 @@ jobs:
               'check-codex-drift',     // warn-only Codex drift nudge (job name)
               'codex-drift-check',     // …also match by workflow name, just in case
             ]);
-            // Precise: matches the advisory render gate and any codex-drift variant,
-            // but NOT the required `perf-tick-budget` server-budget test.
-            const ADVISORY_RE = /^client-perf$|codex-drift/i;
+            // Exact name match only — no broad pattern. (A regex like /codex-drift/
+            // would silently exclude a FUTURE required check that happened to contain
+            // that substring; the explicit set above is the single source of truth.)
+            const isAdvisory = (name) => ADVISORY.has(name);
 
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
@@ -77,13 +78,15 @@ jobs:
               owner, repo, pull_number: pr.number, per_page: 100,
             });
             const paths = files.map(f => f.filename);
+            const touchesMap = paths.some(p => p.startsWith('client/maps/'));
+            const touchesNonMap = paths.some(p => !p.startsWith('client/maps/'));
             // Server-created map PRs use a `mapchange-…` branch and an INSERT/UPDATE
-            // title; manual map adds touch only client/maps/*.json. Any of these = a
-            // map submission.
+            // title. But ANY PR that touches client/maps/** is treated as a map
+            // submission — a mixed map+code PR must NOT slip past the content gate
+            // just because it also changed a non-map file.
             const isMapBranch = /^mapchange-/.test(branch);
             const isMapTitle = /^(INSERT|UPDATE) - /.test(title);
-            const onlyMapFiles = paths.length > 0 && paths.every(p => p.startsWith('client/maps/'));
-            const isMap = isMapBranch || isMapTitle || onlyMapFiles;
+            const isMap = isMapBranch || isMapTitle || touchesMap;
 
             const sensitive = isProd || isMap;
             const reasons = [];
@@ -94,19 +97,20 @@ jobs:
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner, repo, pull_number: pr.number, per_page: 100,
               });
-              // Latest review state per reviewer; an owner APPROVED that hasn't been
-              // dismissed/superseded satisfies the gate.
-              const latest = new Map();
-              for (const r of reviews) {
-                if (r.user && (r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED' || r.state === 'DISMISSED')) {
-                  latest.set(r.user.login, r.state);
-                }
-              }
-              const approved = OWNER_APPROVERS.some(u => latest.get(u) === 'APPROVED');
+              // The approval must be on the CURRENT head commit. GitHub does NOT
+              // auto-dismiss a review when new commits are pushed, so without the
+              // commit_id check an owner could approve, then more changes land, and a
+              // stale approval would still let the PR merge. Tying it to pr.head.sha
+              // forces a fresh approval after every push to a sensitive PR.
+              const approved = reviews.some(r =>
+                r.state === 'APPROVED' &&
+                r.commit_id === sha &&
+                r.user && OWNER_APPROVERS.includes(r.user.login)
+              );
               if (!approved) {
                 core.setFailed(
-                  `This PR requires explicit approval from @${OWNER_APPROVERS[0]} before it can merge ` +
-                  `— reason: ${reasons.join(' + ')}. Approve the PR (a review approval) and this gate turns green.`
+                  `This PR requires explicit approval from @${OWNER_APPROVERS[0]} on the latest commit before it can merge ` +
+                  `— reason: ${reasons.join(' + ')}. Approve the PR (a review approval on the current head) and this gate turns green.`
                 );
                 return;
               }
@@ -122,7 +126,22 @@ jobs:
             const MAX_WAIT_MS = 18 * 60 * 1000;
             const POLL_MS = 20 * 1000;
             const deadline = Date.now() + MAX_WAIT_MS;
-            const isAdvisory = (name) => ADVISORY.has(name) || ADVISORY_RE.test(name);
+
+            // EXPECTED-JOB GATE (not just "observed checks are all green"): we will not
+            // trust an all-complete reading until the jobs we KNOW must run on this PR
+            // have actually registered. Otherwise a poll in the sub-second window
+            // before a job posts its check run could see "0 pending" and pass early.
+            // The sentinels are the central, always-present job of each CI workflow:
+            //   • non-map files changed -> pr-validation runs -> expect `smoke-test`
+            //     (all pr-validation jobs are needs-free, so they register together;
+            //      smoke-test present => the whole suite registered)
+            //   • client/maps/** changed -> map-submission runs -> expect `review`
+            // If a sentinel is renamed the gate blocks (times out) rather than passing
+            // blind — fail-safe, not fail-open. Keep these in sync with the CI jobs.
+            const expectedSentinels = [];
+            if (touchesNonMap) expectedSentinels.push('smoke-test');
+            if (touchesMap) expectedSentinels.push('review');
+            core.info(`Expecting sentinel job(s) to register: [${expectedSentinels.join(', ') || '(none)'}].`);
 
             const collect = async () => {
               const runs = await github.paginate(github.rest.checks.listForRef, {
@@ -149,21 +168,27 @@ jobs:
             };
 
             let items = [];
-            let prevCount = -1; // require the completed set to be STABLE across two
-                                // polls before trusting it — guards the brief window
-                                // where not all jobs have registered as check runs yet,
-                                // so we can't "pass" before a still-unregistered job appears.
             while (true) {
               items = await collect();
+              const present = new Set(items.map(i => i.name));
+              const missingSentinels = expectedSentinels.filter(s => !present.has(s));
               const pending = items.filter(i => !i.done);
-              const settled = items.length > 0 && pending.length === 0 && items.length === prevCount;
-              if (settled) break;
-              prevCount = (pending.length === 0) ? items.length : -1;
+              // Ready ONLY when every expected sentinel has registered AND nothing is
+              // still running. Sentinels-present rules out the early-pass race; the
+              // pending check rules out passing while a job is in flight.
+              const ready = missingSentinels.length === 0 && pending.length === 0;
+              if (ready) break;
               if (Date.now() > deadline) {
-                core.setFailed(`Timed out waiting for CI checks to finish: still pending [${pending.map(i => i.name).join(', ') || '(none reported yet)'}].`);
+                const why = missingSentinels.length
+                  ? `expected job(s) never registered: [${missingSentinels.join(', ')}] (renamed? CI never triggered?)`
+                  : `still pending [${pending.map(i => i.name).join(', ') || '(none)'}]`;
+                core.setFailed(`Timed out waiting for CI: ${why}.`);
                 return;
               }
-              core.info(`Waiting on ${pending.length} pending / ${items.length} total check(s): [${pending.map(i => i.name).join(', ') || '(none reported yet)'}] — re-poll in ${POLL_MS / 1000}s`);
+              const waitingFor = missingSentinels.length
+                ? `sentinels not yet registered [${missingSentinels.join(', ')}]`
+                : `${pending.length} pending [${pending.map(i => i.name).join(', ')}]`;
+              core.info(`Waiting: ${waitingFor} (${items.length} non-advisory check(s) seen) — re-poll in ${POLL_MS / 1000}s`);
               await new Promise(r => setTimeout(r, POLL_MS));
             }
 

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,176 @@
+name: Merge gate
+
+# The SINGLE required status check for merging into main. It exists so the merge
+# policy can be CONDITIONAL — something branch protection alone can't express:
+#
+#   • Normal PRs (code/docs/refactors)   -> merge freely once CI is green. No human
+#                                            approval required; auto-merge handles them.
+#   • deploy:prod-labelled PRs           -> HARD BLOCK until @sjdodge123 approves
+#                                            (these skip the nightly window and ship
+#                                            straight to prod, so a human must sign off).
+#   • Map submissions                    -> HARD BLOCK until @sjdodge123 approves
+#                                            (player-submitted content / new map JSON).
+#
+# Why one aggregator instead of requiring each CI job directly: the CI workflows are
+# path-filtered (pr-validation skips pure-map PRs; map-submission only runs on map
+# PRs), so no single CI job runs on EVERY PR. A required check that never runs on a
+# given PR is stuck "pending" forever and deadlocks the merge. This job runs on every
+# PR with no path filter, waits for whatever real checks DID run on this commit, and
+# fails if any of them failed — so it's the one context that's always present and
+# always correct to require. It also applies the human-approval gate above.
+#
+# Re-runs on review submit/dismiss so an approval immediately flips a blocked
+# sensitive PR green (and auto-merge, if enabled elsewhere, then fires).
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+# Cancel an in-flight gate run for the same PR when a newer event arrives (e.g. a
+# fresh push or an approval) so we don't sit waiting on stale CI.
+concurrency:
+  group: merge-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+
+jobs:
+  merge-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate merge policy
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const OWNER_APPROVERS = ['sjdodge123']; // CODEOWNERS for `*`
+            // Checks that are advisory / helpers — never block a merge, so the gate
+            // must not wait on or fail for them.
+            const ADVISORY = new Set([
+              'merge-gate',            // self
+              'client-perf',           // advisory render-perf gate (continue-on-error)
+              'changes',               // path-filter helper for client-perf
+              'check-codex-drift',     // warn-only Codex drift nudge (job name)
+              'codex-drift-check',     // …also match by workflow name, just in case
+            ]);
+            // Precise: matches the advisory render gate and any codex-drift variant,
+            // but NOT the required `perf-tick-budget` server-budget test.
+            const ADVISORY_RE = /^client-perf$|codex-drift/i;
+
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const sha = pr.head.sha;
+
+            // ---- 1. Is this a "sensitive" PR that needs explicit owner approval? ----
+            const labels = (pr.labels || []).map(l => l.name);
+            const isProd = labels.includes('deploy:prod');
+
+            const branch = pr.head.ref || '';
+            const title = pr.title || '';
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const paths = files.map(f => f.filename);
+            // Server-created map PRs use a `mapchange-…` branch and an INSERT/UPDATE
+            // title; manual map adds touch only client/maps/*.json. Any of these = a
+            // map submission.
+            const isMapBranch = /^mapchange-/.test(branch);
+            const isMapTitle = /^(INSERT|UPDATE) - /.test(title);
+            const onlyMapFiles = paths.length > 0 && paths.every(p => p.startsWith('client/maps/'));
+            const isMap = isMapBranch || isMapTitle || onlyMapFiles;
+
+            const sensitive = isProd || isMap;
+            const reasons = [];
+            if (isProd) reasons.push('`deploy:prod` (ships straight to prod)');
+            if (isMap) reasons.push('map submission (player content)');
+
+            if (sensitive) {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner, repo, pull_number: pr.number, per_page: 100,
+              });
+              // Latest review state per reviewer; an owner APPROVED that hasn't been
+              // dismissed/superseded satisfies the gate.
+              const latest = new Map();
+              for (const r of reviews) {
+                if (r.user && (r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED' || r.state === 'DISMISSED')) {
+                  latest.set(r.user.login, r.state);
+                }
+              }
+              const approved = OWNER_APPROVERS.some(u => latest.get(u) === 'APPROVED');
+              if (!approved) {
+                core.setFailed(
+                  `This PR requires explicit approval from @${OWNER_APPROVERS[0]} before it can merge ` +
+                  `— reason: ${reasons.join(' + ')}. Approve the PR (a review approval) and this gate turns green.`
+                );
+                return;
+              }
+              core.info(`Sensitive PR (${reasons.join(' + ')}) — approved by an owner. ✔`);
+            } else {
+              core.info('Not a sensitive PR — no human approval required.');
+            }
+
+            // ---- 2. Wait for the real CI checks on this commit, then gate on them. ----
+            // Poll because this gate often starts before the CI jobs finish. A
+            // contended runner just means we wait a little longer; we cap the wait
+            // well under the old behaviour.
+            const MAX_WAIT_MS = 18 * 60 * 1000;
+            const POLL_MS = 20 * 1000;
+            const deadline = Date.now() + MAX_WAIT_MS;
+            const isAdvisory = (name) => ADVISORY.has(name) || ADVISORY_RE.test(name);
+
+            const collect = async () => {
+              const runs = await github.paginate(github.rest.checks.listForRef, {
+                owner, repo, ref: sha, per_page: 100,
+              });
+              // Commit statuses (older-style) too, in case any check posts as a status.
+              const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+                owner, repo, ref: sha, per_page: 100,
+              });
+              const items = [];
+              for (const r of runs) {
+                if (isAdvisory(r.name)) continue;
+                items.push({ name: r.name, done: r.status === 'completed', conclusion: r.conclusion });
+              }
+              // De-dupe statuses by context, keep the latest (API returns newest first).
+              const seen = new Set();
+              for (const s of statuses) {
+                if (isAdvisory(s.context) || seen.has(s.context)) continue;
+                seen.add(s.context);
+                const done = s.state !== 'pending';
+                items.push({ name: s.context, done, conclusion: s.state === 'success' ? 'success' : (done ? s.state : null) });
+              }
+              return items;
+            };
+
+            let items = [];
+            let prevCount = -1; // require the completed set to be STABLE across two
+                                // polls before trusting it — guards the brief window
+                                // where not all jobs have registered as check runs yet,
+                                // so we can't "pass" before a still-unregistered job appears.
+            while (true) {
+              items = await collect();
+              const pending = items.filter(i => !i.done);
+              const settled = items.length > 0 && pending.length === 0 && items.length === prevCount;
+              if (settled) break;
+              prevCount = (pending.length === 0) ? items.length : -1;
+              if (Date.now() > deadline) {
+                core.setFailed(`Timed out waiting for CI checks to finish: still pending [${pending.map(i => i.name).join(', ') || '(none reported yet)'}].`);
+                return;
+              }
+              core.info(`Waiting on ${pending.length} pending / ${items.length} total check(s): [${pending.map(i => i.name).join(', ') || '(none reported yet)'}] — re-poll in ${POLL_MS / 1000}s`);
+              await new Promise(r => setTimeout(r, POLL_MS));
+            }
+
+            const BAD = new Set(['failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure', 'stale', 'error']);
+            const failed = items.filter(i => BAD.has(i.conclusion));
+            if (failed.length) {
+              core.setFailed(`Required CI failed: ${failed.map(i => `${i.name}=${i.conclusion}`).join(', ')}.`);
+              return;
+            }
+            core.info(`All ${items.length} non-advisory check(s) passed: [${items.map(i => i.name).join(', ')}].`);

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -17,7 +17,9 @@ on:
     # ticks it through the real engine, so these code-oriented checks (bundle
     # build, JS syntax) add nothing. A mixed code+map PR still has non-map files,
     # so paths-ignore does NOT skip it and these checks run as normal. Safe to skip
-    # because main has no required status checks (only a code-owner review gates merge).
+    # for pure-map PRs because the single required status check on main is
+    # `merge-gate` (see merge-gate.yml), which waits for whichever CI workflow
+    # actually ran on the PR — map-submission.yml here — not for this one.
     paths-ignore:
       - 'client/maps/**'
 
@@ -390,8 +392,10 @@ jobs:
           echo "Changed files:"; echo "$files"
           # client/scripts/** = the render hot path; server/compressor.js = the
           # per-tick payload shape the client decodes; server/config.json = tile/FX
-          # tuning the client renders from. Any of these can move scripting ms/frame.
-          if echo "$files" | grep -qE '^(client/scripts/|server/compressor\.js$|server/config\.json$)'; then
+          # tuning the client renders from; the perf harness/compare scripts
+          # themselves must re-run the gate so changes to the measurement are
+          # exercised. Any of these can move (or change how we read) scripting ms/frame.
+          if echo "$files" | grep -qE '^(client/scripts/|server/compressor\.js$|server/config\.json$|\.github/scripts/perf-client\.js$|\.github/scripts/perf-compare\.js$)'; then
             echo "render=true" >> "$GITHUB_OUTPUT"
             echo "-> render-affecting changes detected; client-perf will run."
           else

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -366,7 +366,42 @@ jobs:
       - name: Mobile layout gate
         run: node .github/scripts/mobile-layout-test.js
 
+  # Detect whether this PR touches client render-affecting code. The client-perf
+  # job is heavy (two checkouts, two npm ci, two Playwright runs ~ several minutes)
+  # and only meaningful when something that changes per-frame render/JS work moved.
+  # Server-only and content-only PRs (the common case) skip it entirely, so they no
+  # longer wait on the slowest job in the matrix. gh pr view reads the PR's changed
+  # file list directly (no full-history fetch / third-party action needed).
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      render: ${{ steps.filter.outputs.render }}
+    steps:
+      - name: Detect render-affecting changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json files --jq '.files[].path')
+          echo "Changed files:"; echo "$files"
+          # client/scripts/** = the render hot path; server/compressor.js = the
+          # per-tick payload shape the client decodes; server/config.json = tile/FX
+          # tuning the client renders from. Any of these can move scripting ms/frame.
+          if echo "$files" | grep -qE '^(client/scripts/|server/compressor\.js$|server/config\.json$)'; then
+            echo "render=true" >> "$GITHUB_OUTPUT"
+            echo "-> render-affecting changes detected; client-perf will run."
+          else
+            echo "render=false" >> "$GITHUB_OUTPUT"
+            echo "-> no render-affecting changes; client-perf will be skipped."
+          fi
+
   client-perf:
+    needs: changes
+    if: needs.changes.outputs.render == 'true'
     # Client render-perf REGRESSION gate (relative, non-blocking). Measures the
     # 25-kart brutal scenario's scripting ms/frame for BOTH the PR head and its
     # merge base, ON THE SAME RUNNER, back to back — then gates on the delta. A


### PR DESCRIPTION
## Why

`client-perf` has failed on **every** PR for ~12 days and is the slowest job in the matrix (~22 min), so PRs wait on a red check that can never pass. Separately, every PR currently needs an explicit code-owner review, so nothing merges hands-off.

This PR fixes the gate and adds conditional auto-merge: **auto-merge most PRs once CI is green, but hard-block `deploy:prod` and map-submission PRs until @sjdodge123 approves.**

## client-perf fix

Since `96c69bd` (2026-06-08) the editor preview path fills bots from `c.aiRacers.previewBotCount` (default 6), ignoring the harness's `testForceBots`/`minGrid`/`maxGrid`. So the gate only ever reached a **7-kart** race — below its 20-kart "full-grid" floor — never qualified a window, retried all 28 attempts (~22 min), and exited 1.

- `perf-client.js`: override now also sets `previewBotCount: 24` → real 25-kart scene (verified locally: reaches racing, produces a real `scriptMsPerFrame`).
- **Fast-fail**: bail in ~2 min if a full-grid race is never reached in the first 3 attempts (broken scenario ≠ contention).
- **Path-gate**: new `changes` job runs `client-perf` only when render-affecting files change (`client/scripts/**`, `server/compressor.js`, `server/config.json`, the perf scripts). Server-only and content-only PRs skip the slowest job entirely.
- `bootServer` kills the child + clears its timer on boot timeout.

## Auto-merge with a conditional human gate

- **`merge-gate.yml`** — the single required status check. Runs on every PR (no path filter, so it can't deadlock). Hard-blocks PRs that are `deploy:prod`-labelled **or** touch `client/maps/**` until an owner approval **on the current head commit** lands, then waits for the real CI checks (gated on each workflow's sentinel job so it can't pass before jobs register) and fails if any failed.
- **`auto-merge.yml`** — arms native auto-merge (squash) on every non-draft PR; re-arms on review/label events. Safe to apply blanket because `merge-gate` decides mergeability.

## Follow-up (manual, after merge)

Branch protection must be repointed to require `merge-gate` and drop the blanket review rule, plus enable "Allow auto-merge". Commands are ready to run once this is on `main`.

## Review

Reviewed by Codex (session `019ee605`); all actionable findings fixed in the final commit (premature-pass race, stale-approval, mixed-map detection, advisory-exclusion precision, harness path-gate, retry triggers, bootServer leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)