### PR TITLE
feat(client): live connection indicator + WebSocket transport recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ To re-render a past week's digest with the current formatting, run the `Release 
 
 - **Bots fight off antlions too.** The racing bots now swing at an antlion that's right on top of them — knocking it back into the sand — instead of only trying to dodge away, so they no longer get helplessly herded into the lava on sand-heavy maps.
 
+### Quality of Life
+
+- **Connection indicator.** A small ping/latency badge now sits in the bottom-left corner so you can see your connection at a glance — green when it's healthy, amber/red as it climbs. If your connection ever drops onto the slow fallback mode (the cause of "only I was lagging" hitches), it turns into a red "Slow link — tap to fix" chip that reconnects you on the better path; out of a race it also tries to recover on its own.
+
 ## v0.49.1 — 2026-06-20
 
 ### Gameplay & Balance

--- a/build.js
+++ b/build.js
@@ -11,6 +11,7 @@ const bundles = {
         'client/scripts/metrics.js',
         'client/scripts/ads.js',
         'client/scripts/client.js',
+        'client/scripts/connectionHud.js',
         'client/scripts/audio.js',
         'client/scripts/input.js',
         'client/scripts/gamepad.js',

--- a/client/play.html
+++ b/client/play.html
@@ -116,6 +116,7 @@
         <script src="scripts/metrics.js"></script>
         <script src="scripts/ads.js"></script>
         <script src="scripts/client.js"></script>
+        <script src="scripts/connectionHud.js"></script>
         <script src="scripts/audio.js"></script>
         <script src="scripts/input.js"></script>
         <script src="scripts/gamepad.js"></script>

--- a/client/scripts/client.js
+++ b/client/scripts/client.js
@@ -599,6 +599,9 @@ var cosmeticsTrackedThisMatch = false;
 // (which also covers a mid-match join — their match starts at their first race).
 var matchStartedAt = null;
 function registerConnectionHandlers(server) {
+	// Live connection-quality badge + transport recovery. Idempotent, so it also
+	// re-points at a pad slot promoted to primary (registerPrimaryHandlers path).
+	if (typeof connectionHudAttach === "function") { connectionHudAttach(server); }
 	server.on('welcome', function (id) {
 		debugLog("welcome, myID=", id);
 		myID = id;

--- a/client/scripts/connectionHud.js
+++ b/client/scripts/connectionHud.js
@@ -1,0 +1,191 @@
+// connectionHud.js — live connection-quality indicator + transport auto-recovery.
+//
+// Why this exists: a Socket.IO client can silently fall back to (or get stuck on)
+// HTTP long-polling — the slowest transport — when its WebSocket upgrade fails or a
+// live WS drops mid-session (a Cloudflare PoP hiccup, a NAT/middlebox killing the
+// long-lived socket, a transient proxy). See the SOCKET_TRANSPORT_OPTS note in
+// client.js: prod has hit this before. It degrades ONLY the affected client (everyone
+// else stays on WebSocket), so it never shows up as a server-wide incident and is
+// impossible to confirm in-game after the fact — exactly the "only me lagging, and
+// Discord was fine at the same time" report. This surfaces it live: an unobtrusive
+// RTT/transport badge that escalates to a tap-to-fix warning on polling, plus a
+// bounded automatic WebSocket re-upgrade.
+//
+// Decoupled by design: RTT is measured with its OWN ack ping ('cc:netping') and this
+// module NEVER touches timeSinceLastCom. The gameUpdates-fed stall watchdog in
+// client.js must remain the sole authority on "is the game actually frozen" — a
+// polling-but-alive heartbeat must not be allowed to mask a real freeze.
+
+var connHud = {
+	el: null,
+	dot: null,
+	text: null,
+	sock: null,
+	transport: "connecting",
+	rtt: null,
+	pollingSince: 0,
+	pingTimer: null,
+	recoverTried: false,
+	recovering: false
+};
+
+var CONN_PING_MS = 2000;        // RTT sample cadence
+var CONN_POLL_STUCK_MS = 6000;  // stuck on polling this long -> escalate + auto-recover
+var CONN_RTT_WARN = 120;        // ms: amber
+var CONN_RTT_BAD = 250;         // ms: red
+
+function connHudNow() { return Date.now(); }
+
+function connectionHudInit() {
+	if (connHud.el || typeof document === "undefined") { return; }
+	var el = document.createElement("div");
+	el.id = "connHud";
+	el.style.cssText = [
+		"position:fixed", "left:8px", "bottom:8px", "z-index:50",
+		"display:flex", "align-items:center", "gap:6px",
+		"padding:3px 8px", "border-radius:10px",
+		"font:600 11px/1.2 system-ui,Segoe UI,Roboto,sans-serif",
+		"color:#fff", "background:rgba(0,0,0,0.38)", "opacity:0.55",
+		"pointer-events:auto", "user-select:none", "transition:opacity .2s,background .2s"
+	].join(";");
+	var dot = document.createElement("span");
+	dot.style.cssText = "width:8px;height:8px;border-radius:50%;background:#888;flex:0 0 auto";
+	var text = document.createElement("span");
+	text.textContent = "connecting…";
+	el.appendChild(dot);
+	el.appendChild(text);
+	// Tap/click while warning = manual recovery (touch users have no other affordance).
+	el.addEventListener("click", function () {
+		if (connHud.transport === "polling") { connectionHudRecover(true); }
+	});
+	(document.body || document.documentElement).appendChild(el);
+	connHud.el = el;
+	connHud.dot = dot;
+	connHud.text = text;
+	connectionHudRender();
+}
+
+// (Re)bind transport tracking to a socket. The engine.io transport object is
+// recreated on every (re)connect, so this is called again from the 'connect' handler.
+function connectionHudBindTransport(sock) {
+	try {
+		var eng = sock && sock.io && sock.io.engine;
+		if (!eng) { return; }
+		connHud.transport = (eng.transport && eng.transport.name) || "connecting";
+		connectionHudMarkPolling();
+		// Fires when polling successfully upgrades to websocket.
+		eng.on("upgrade", function (t) {
+			connHud.transport = (t && t.name) || connHud.transport;
+			connectionHudMarkPolling();
+			connectionHudRender();
+		});
+	} catch (e) { /* engine internals are best-effort */ }
+}
+
+function connectionHudMarkPolling() {
+	if (connHud.transport === "polling") {
+		if (!connHud.pollingSince) { connHud.pollingSince = connHudNow(); }
+	} else {
+		connHud.pollingSince = 0;
+	}
+}
+
+function connectionHudIsRacing() {
+	try {
+		return typeof currentState !== "undefined" && typeof config !== "undefined" &&
+			config && config.stateMap && currentState === config.stateMap.racing;
+	} catch (e) { return false; }
+}
+
+// Attach the indicator to the primary socket. Idempotent: re-points at the current
+// socket (e.g. when a pad slot is promoted to primary) and only ever runs one timer.
+function connectionHudAttach(sock) {
+	connectionHudInit();
+	connHud.sock = sock;
+	connectionHudBindTransport(sock);
+	sock.on("connect", function () {
+		connHud.recovering = false;
+		connectionHudBindTransport(sock);
+		connectionHudRender();
+	});
+	if (!connHud.pingTimer) {
+		connHud.pingTimer = setInterval(connectionHudTick, CONN_PING_MS);
+	}
+}
+
+function connectionHudTick() {
+	var sock = connHud.sock;
+	if (!sock || !sock.connected) {
+		connHud.rtt = null;
+		connectionHudRender();
+		return;
+	}
+	// RTT sample via ack ping — independent of the gameplay stall watchdog.
+	var t0 = connHudNow();
+	try {
+		sock.timeout(CONN_PING_MS).emit("cc:netping", function (err) {
+			if (err) { return; } // ack timed out -> keep last rtt; render still flags polling
+			connHud.rtt = connHudNow() - t0;
+		});
+	} catch (e) { /* older client without .timeout(): skip RTT, transport still tracked */ }
+
+	connectionHudMarkPolling();
+	// Auto-recover: stuck on polling past the grace window, once per page session, and
+	// only when NOT racing (a reconnect blip mid-race is worse than the polling lag).
+	// During a race the badge stays tappable so the player can choose to recover.
+	if (connHud.transport === "polling" && connHud.pollingSince &&
+		(connHudNow() - connHud.pollingSince) > CONN_POLL_STUCK_MS &&
+		!connHud.recoverTried && !connHud.recovering && !connectionHudIsRacing()) {
+		connectionHudRecover(false);
+	}
+	connectionHudRender();
+}
+
+// Force a WebSocket-first reconnect and re-join the room. The primary socket never
+// re-sends enterGame on its own (client.js's maintenance handler notes this), so we
+// re-emit it on the next connect — mirroring the pad-slot reconnect path.
+function connectionHudRecover() {
+	var sock = connHud.sock;
+	if (!sock || connHud.recovering) { return; }
+	connHud.recovering = true;
+	connHud.recoverTried = true;
+	var roomId = (typeof gameID !== "undefined") ? gameID : null;
+	sock.once("connect", function () {
+		connHud.recovering = false;
+		if (roomId != null) {
+			try { sock.emit("enterGame", roomId); } catch (e) { /* room re-join is best-effort */ }
+		}
+	});
+	// tryAllTransports keeps polling as a fallback, but the retry leads with websocket.
+	try { sock.io.opts.transports = ["websocket", "polling"]; } catch (e) { /* ignore */ }
+	try {
+		sock.disconnect();
+		sock.connect();
+	} catch (e) {
+		connHud.recovering = false;
+	}
+}
+
+function connectionHudRender() {
+	if (!connHud.el) { return; }
+	var t = connHud.transport;
+	var rtt = connHud.rtt;
+	var connected = connHud.sock && connHud.sock.connected;
+	var color, label, warn = false;
+	if (!connected) {
+		color = "#888"; label = "connecting…";
+	} else if (t === "polling") {
+		warn = true; color = "#ff5252";
+		label = connHud.recovering ? "reconnecting…" : "Slow link — tap to fix";
+	} else if (rtt == null) {
+		color = "#888"; label = "— ms";
+	} else {
+		label = rtt + " ms";
+		color = rtt > CONN_RTT_BAD ? "#ff5252" : (rtt > CONN_RTT_WARN ? "#ffb300" : "#4caf50");
+	}
+	connHud.dot.style.background = color;
+	connHud.text.textContent = label;
+	connHud.el.style.background = warn ? "rgba(176,32,32,0.92)" : "rgba(0,0,0,0.38)";
+	connHud.el.style.cursor = warn ? "pointer" : "default";
+	connHud.el.style.opacity = warn ? "1" : "0.55";
+}

--- a/client/scripts/connectionHud.js
+++ b/client/scripts/connectionHud.js
@@ -25,8 +25,8 @@ var connHud = {
 	rtt: null,
 	pollingSince: 0,
 	pingTimer: null,
-	recoverTried: false,
-	recovering: false
+	recovering: false,
+	_boundEngine: null
 };
 
 var CONN_PING_MS = 2000;        // RTT sample cadence
@@ -73,12 +73,18 @@ function connectionHudBindTransport(sock) {
 		if (!eng) { return; }
 		connHud.transport = (eng.transport && eng.transport.name) || "connecting";
 		connectionHudMarkPolling();
-		// Fires when polling successfully upgrades to websocket.
-		eng.on("upgrade", function (t) {
-			connHud.transport = (t && t.name) || connHud.transport;
-			connectionHudMarkPolling();
-			connectionHudRender();
-		});
+		// One 'upgrade' listener per engine. bindTransport runs both directly from
+		// attach and again from the 'connect' handler, and the engine is recreated per
+		// (re)connect — so guard on the engine identity to avoid stacking listeners.
+		if (connHud._boundEngine !== eng) {
+			connHud._boundEngine = eng;
+			// Fires when polling successfully upgrades to websocket.
+			eng.on("upgrade", function (t) {
+				connHud.transport = (t && t.name) || connHud.transport;
+				connectionHudMarkPolling();
+				connectionHudRender();
+			});
+		}
 	} catch (e) { /* engine internals are best-effort */ }
 }
 
@@ -120,50 +126,59 @@ function connectionHudTick() {
 		connectionHudRender();
 		return;
 	}
-	// RTT sample via ack ping — independent of the gameplay stall watchdog.
+	// RTT sample via ack ping — independent of the gameplay stall watchdog. On an ack
+	// timeout (a half-open websocket whose pongs have stopped) blank the RTT rather than
+	// keep showing the last good value: a stale green latency would hide the very stall
+	// this badge exists to surface. Re-render on the ack so the change shows promptly.
 	var t0 = connHudNow();
 	try {
 		sock.timeout(CONN_PING_MS).emit("cc:netping", function (err) {
-			if (err) { return; } // ack timed out -> keep last rtt; render still flags polling
-			connHud.rtt = connHudNow() - t0;
+			connHud.rtt = err ? null : (connHudNow() - t0);
+			connectionHudRender();
 		});
 	} catch (e) { /* older client without .timeout(): skip RTT, transport still tracked */ }
 
 	connectionHudMarkPolling();
-	// Auto-recover: stuck on polling past the grace window, once per page session, and
-	// only when NOT racing (a reconnect blip mid-race is worse than the polling lag).
-	// During a race the badge stays tappable so the player can choose to recover.
+	// Auto-recover: stuck on polling past the grace window, at most once per tab session
+	// (the reload one-shot lives in connectionHudRecover), and only when NOT racing (a
+	// reload mid-race is worse than the polling lag). During a race the badge stays
+	// tappable so the player can choose to recover.
 	if (connHud.transport === "polling" && connHud.pollingSince &&
 		(connHudNow() - connHud.pollingSince) > CONN_POLL_STUCK_MS &&
-		!connHud.recoverTried && !connHud.recovering && !connectionHudIsRacing()) {
+		!connHud.recovering && !connectionHudIsRacing()) {
 		connectionHudRecover(false);
 	}
 	connectionHudRender();
 }
 
-// Force a WebSocket-first reconnect and re-join the room. The primary socket never
-// re-sends enterGame on its own (client.js's maintenance handler notes this), so we
-// re-emit it on the next connect — mirroring the pad-slot reconnect path.
-function connectionHudRecover() {
-	var sock = connHud.sock;
-	if (!sock || connHud.recovering) { return; }
-	connHud.recovering = true;
-	connHud.recoverTried = true;
-	var roomId = (typeof gameID !== "undefined") ? gameID : null;
-	sock.once("connect", function () {
-		connHud.recovering = false;
-		if (roomId != null) {
-			try { sock.emit("enterGame", roomId); } catch (e) { /* room re-join is best-effort */ }
-		}
-	});
-	// tryAllTransports keeps polling as a fallback, but the retry leads with websocket.
-	try { sock.io.opts.transports = ["websocket", "polling"]; } catch (e) { /* ignore */ }
-	try {
-		sock.disconnect();
-		sock.connect();
-	} catch (e) {
-		connHud.recovering = false;
+// Recover a degraded transport by reloading the page. A reload re-runs the whole
+// WebSocket-first connect + matchmake/join flow from scratch and preserves any
+// ?gameid= in the URL, so shared/private rooms re-join correctly — it's the same
+// recovery primitive the maintenance handler and the stall watchdog already use.
+//
+// We deliberately do NOT disconnect+reconnect the live socket: dropping the only
+// client in a room makes the server reap it (hostess.kickFromRoom deletes rooms at
+// clientCount 0), and the re-join would then bounce off roomNotFound to the join
+// page — kicking solo/private-room players out instead of repairing the transport.
+//
+// isManual = the player tapped the chip (always honoured). Automatic recovery runs
+// at most ONCE per tab session: if the reload lands us right back on long-polling the
+// network is simply blocking WebSocket, and reloading again every few seconds would
+// be a worse experience than living on polling with the warning shown.
+function connectionHudRecover(isManual) {
+	if (connHud.recovering) { return; }
+	if (!isManual) {
+		// Auto path needs the one-shot flag to avoid a reload loop on a WebSocket-blocked
+		// network. If storage is unreadable, don't auto-reload at all — under-recovering is
+		// safer than looping, and the player can still tap the chip to force a reload.
+		var alreadyRecovered = true;
+		try { alreadyRecovered = !!sessionStorage.getItem("connHudAutoRecovered"); } catch (e) { return; }
+		if (alreadyRecovered) { return; }
 	}
+	try { sessionStorage.setItem("connHudAutoRecovered", "1"); } catch (e) { /* best-effort */ }
+	connHud.recovering = true;
+	connectionHudRender();
+	try { window.location.reload(); } catch (e) { connHud.recovering = false; }
 }
 
 function connectionHudRender() {

--- a/client/scripts/connectionHud.js
+++ b/client/scripts/connectionHud.js
@@ -171,9 +171,9 @@ function connectionHudRecover(isManual) {
 		// Auto path needs the one-shot flag to avoid a reload loop on a WebSocket-blocked
 		// network. If storage is unreadable, don't auto-reload at all — under-recovering is
 		// safer than looping, and the player can still tap the chip to force a reload.
-		var alreadyRecovered = true;
-		try { alreadyRecovered = !!sessionStorage.getItem("connHudAutoRecovered"); } catch (e) { return; }
-		if (alreadyRecovered) { return; }
+		try {
+			if (sessionStorage.getItem("connHudAutoRecovered")) { return; }
+		} catch (e) { return; }
 	}
 	try { sessionStorage.setItem("connHudAutoRecovered", "1"); } catch (e) { /* best-effort */ }
 	connHud.recovering = true;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,14 @@ const app = express();
 const http = require('http');
 const server = http.createServer(app);
 const { Server } = require("socket.io");
-const io = new Server(server);
+// Heartbeat tuned tighter than the engine.io defaults (25s/20s). A client whose
+// WebSocket silently dies (a Cloudflare PoP hiccup, a NAT/middlebox dropping the
+// long-lived socket) is otherwise invisible for up to ~45s before the server gives
+// up and the client auto-reconnects — and that reconnect is the only chance to get
+// back onto WebSocket instead of limping along on long-polling. At 20s/10s a dead
+// socket is detected in ~30s, halving the worst-case stuck-on-polling window. Kept
+// conservative so a brief stall (mobile backgrounding, a GC pause) won't false-trip.
+const io = new Server(server, { pingInterval: 20000, pingTimeout: 10000 });
 const path = require('path');
 const htmlPath = path.join(__dirname, 'client');
 

--- a/index.js
+++ b/index.js
@@ -8,14 +8,15 @@ const app = express();
 const http = require('http');
 const server = http.createServer(app);
 const { Server } = require("socket.io");
-// Heartbeat tuned tighter than the engine.io defaults (25s/20s). A client whose
-// WebSocket silently dies (a Cloudflare PoP hiccup, a NAT/middlebox dropping the
-// long-lived socket) is otherwise invisible for up to ~45s before the server gives
-// up and the client auto-reconnects — and that reconnect is the only chance to get
-// back onto WebSocket instead of limping along on long-polling. At 20s/10s a dead
-// socket is detected in ~30s, halving the worst-case stuck-on-polling window. Kept
-// conservative so a brief stall (mobile backgrounding, a GC pause) won't false-trip.
-const io = new Server(server, { pingInterval: 20000, pingTimeout: 10000 });
+// Heartbeat: ping a touch more often than the engine.io default (25s) but KEEP the
+// generous 20s pong timeout. A client whose WebSocket silently dies (a Cloudflare PoP
+// hiccup, a NAT/middlebox dropping the long-lived socket) is otherwise invisible for
+// up to ~45s before the server gives up and the client auto-reconnects — and that
+// reconnect is the only chance to get back onto WebSocket instead of limping along on
+// long-polling. At 15s/20s a dead socket is detected in ~35s. We do NOT shorten
+// pingTimeout: mobile browsers (iOS Safari especially) heavily throttle background
+// timers, so a tight timeout would drop players who merely glanced away for a moment.
+const io = new Server(server, { pingInterval: 15000, pingTimeout: 20000 });
 const path = require('path');
 const htmlPath = path.join(__dirname, 'client');
 

--- a/server/messenger.js
+++ b/server/messenger.js
@@ -647,6 +647,13 @@ function checkForMail(client) {
 	client.on('drip', function () {
 		client.emit('drop');
 	});
+	// Round-trip RTT probe for the client-side connection indicator (connectionHud.js).
+	// Ack-based and deliberately separate from 'drip'/'drop' and the gameUpdates stall
+	// watchdog — measuring latency must never feed the "is the game frozen" timer, or a
+	// client limping along on long-polling would look healthy. Just bounce the ack back.
+	client.on('cc:netping', function (cb) {
+		if (typeof cb === 'function') { cb(); }
+	});
 	client.on('sendEmoji', function (emoji) {
 		if (c.emojis.indexOf(emoji) == -1) {
 			return;


### PR DESCRIPTION
## Why
Diagnosed a "network lag, only I was affected, Discord was fine at the same time" report: the classic signature of a Socket.IO client silently stuck on HTTP long-polling instead of WebSocket (per-client, via the Cloudflare→Heroku path; Discord is UDP on a separate path). This failure degrades only the affected client and is invisible server-side — impossible to confirm in-game after the fact. `client.js` already documents prod hitting this before.

## What
- **Connection badge** (`connectionHud.js`): always-visible bottom-left pill showing live RTT + transport, green/amber/red by latency. RTT is measured with its own `cc:netping` ack — deliberately decoupled from the gameUpdates stall watchdog so a polling-but-alive heartbeat can't mask a real freeze.
- **Polling warning + recovery**: on long-polling the pill turns into a red "Slow link — tap to fix" chip. Recovery is a page reload (re-runs the WS-first connect+join flow, preserves `?gameid=`) — guarded one-shot per tab so a WS-blocked network can't reload-loop; out of a race it also recovers on its own.
- **Server heartbeat** (`index.js`): `pingInterval` 25s→15s, `pingTimeout` kept at 20s — faster dead-socket detection (~35s) without dropping timer-throttled mobile tabs.

## Review
Codex + `/code-review` pass; all findings fixed before this PR — notably the recovery no longer disconnects the live socket (which could reap a solo room and bounce the player to the join page via `roomNotFound`).

## Testing
`npm run build` + headless smoke test green. Badge/RTT/transport/warning verified live in Chrome; recovery is reload-based (lower-risk than the disconnect path it replaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
