### PR TITLE
ci: de-flake start-edges-test (mock the wall-clock) + gitignore local tooling

### DIFF
--- a/.github/scripts/start-edges-test.js
+++ b/.github/scripts/start-edges-test.js
@@ -44,6 +44,17 @@ function ok(msg) { console.log('  ok: ' + msg); }
     };
 })(0xC0FFEE);
 
+// Deterministic monotonic clock, advanced exactly one tick per room.update below.
+// A tight synchronous tick loop otherwise leaves real Date.now frozen-then-jumpy,
+// so the AI decision/cooldown timers that read Date.now fired a VARIABLE number of
+// times run-to-run under CI contention — the root of this test's flaky
+// "only N/6 bots found a non-lava lane" failure. Fixing the clock makes the gated
+// lane-migration reproducible. 150 gated ticks = ~5s of mocked time, comfortably
+// under gatedWaitTime (9s), so this never trips the gated->racing timer early.
+const TICK_MS = config.serverTickSpeed;
+let clock = 1000000;
+Date.now = () => clock;
+
 // A socket.io io stand-in so messenger room broadcasts don't throw.
 require(path.join(repoRoot, 'server', 'messenger.js')).build({
     to() { return { emit() { } }; },
@@ -214,6 +225,7 @@ function runConfig(startEdges, lavaEdge, label) {
     for (let f = 0; f < 150; f++) {
         room.game.currentState = gated;
         room.update(DT);
+        clock += TICK_MS;
         const arrs = [
             compressor.sendPlayerUpdates(room.playerList),
             compressor.sendProjUpdates(room.projectileList),
@@ -269,10 +281,11 @@ function runConfig(startEdges, lavaEdge, label) {
     // ---- racing -> collapsing ----
     try {
         room.game.startRace();
-        for (let f = 0; f < 120; f++) { room.update(DT); }
+        for (let f = 0; f < 120; f++) { room.update(DT); clock += TICK_MS; }
         room.game.startCollapse(W / 2, H / 2);
         for (let f = 0; f < 120; f++) {
             room.update(DT);
+            clock += TICK_MS;
             const a = compressor.sendPlayerUpdates(room.playerList);
             if (!Array.isArray(a)) { fail(label + ': malformed player array while collapsing'); break; }
         }

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,9 @@ changed_maps.txt
 # Local-only portal embed test (see docs/portal-submission-checklist.md)
 embed-test.html
 perf-harness-report.jsonl
+
+# Local-only agent/MCP tooling (machine-specific absolute paths + credentials;
+# must never be committed — see .mcp.json's hardcoded ~/.local and ~/.config paths)
+.mcp.json
+.agents/
+.claude/


### PR DESCRIPTION
## start-edges-test flake

`start-edges-test` seeded `Math.random` but ran on real `Date.now`. In a tight synchronous tick loop the wall-clock is frozen-then-jumpy, so the AI decision/cooldown timers (which read `Date.now`) fired a **variable** number of times run-to-run under CI contention — occasionally stranding a bot on the lava band and tripping the `only N/6 bots found a non-lava lane` assertion. Re-running cleared it: the signature of a timing flake, not a regression. (It's what blocked #340's `merge-gate` until a re-run.)

**Fix:** mock `Date.now` into a monotonic clock advanced exactly one tick per `room.update` — the same convention `ai-telegraph-engine-test` / `ai-swim-test` already use. 150 gated ticks = ~5s of mocked time, well under `gatedWaitTime` (9s), so the gated→racing timer still never fires early.

**Proven locally** (variable real per-tick delay injected):
- real `Date.now`: off-lava count drifts → `5/6, 4/6, 5/6, 5/6` (timing-dependent)
- mocked clock: constant `5/6` regardless of delay — wall-clock no longer affects the outcome

## .gitignore hygiene

`.mcp.json`, `.agents/`, `.claude/` were untracked-but-not-ignored, so a stray `git add -A` could commit them. `.mcp.json` hardcodes machine-specific absolute paths (`~/.local/bin/analytics-mcp` + a gcloud credentials path) that would break MCP startup for others / CI. Ignored all three so they stay local. (Flagged by Codex review.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)