### PR TITLE
docs(legal): tighten Privacy/ToS copy for public launch

### DIFF
--- a/client/privacy.html
+++ b/client/privacy.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <!--
-  DRAFT — Privacy Policy starter for Chao Chao. NOT legal advice; have it reviewed
-  before publishing. Fill every [BRACKETED] placeholder. Served statically at
-  /privacy.html (Discord Discovery requires a public Privacy Policy URL).
+  Privacy Policy for Chao Chao. Served statically at /privacy.html and used as the public
+  Privacy Policy URL for Discord Activity Discovery. Bump the "Last updated" date on any
+  material change.
 -->
 <html lang="en">
 <head>
@@ -34,7 +34,7 @@
 <body>
 <div class="wrap">
     <h1>Privacy Policy</h1>
-    <p class="meta">Chao Chao · Last updated: <strong>June 21, 2026</strong></p>
+    <p class="meta">Chao Chao · Last updated: <strong>June 23, 2026</strong></p>
 
     <p>This Privacy Policy explains what information <strong>Chao Chao</strong> ("the Game",
     "we", "us") collects, how we use it, and the choices you have. It applies to the Game
@@ -48,7 +48,7 @@
     a multiplayer game and save your progress: a sign-in identity (only if you choose to sign
     in), your in-game progression and cosmetics, and anonymous gameplay analytics. We do not
     sell your data. You can play as a guest with no account. In the Discord Activity we read who
-    is talking to show a speaking indicator — <strong>we never access or record audio</strong>.</p>
+    is talking to show a speaking indicator — <strong>we never access or record audio</strong>.</div>
 
     <h2>1. Information we collect</h2>
 
@@ -118,8 +118,9 @@
     and analytics where consent is required).</p>
 
     <h2>4. How we share information</h2>
-    <p>We do not sell your personal information. We share it only with service providers that help
-    us run the Game, each under its own terms:</p>
+    <p>We do not sell your personal information, and we do not "sell" or "share" it as those terms
+    are defined under California law. We share it only with service providers that help us run the
+    Game, each under its own terms:</p>
     <table>
         <tr><th>Provider</th><th>Purpose</th></tr>
         <tr><td>Discord</td><td>Activity platform, sign-in, voice-activity state, presence (governed also by Discord's Privacy Policy)</td></tr>
@@ -145,7 +146,7 @@
 
     <h2>7. Your rights &amp; choices</h2>
     <ul>
-        <li>Play as a guest and sign in nothing at all.</li>
+        <li>Play entirely as a guest, providing no sign-in information at all.</li>
         <li>Request access to, correction of, export of, or deletion of your account data by
         emailing <a href="mailto:sjdodge@outlook.com">sjdodge@outlook.com</a>.</li>
         <li>Revoke the Game's access from your <a href="https://discord.com/" target="_blank" rel="noopener">Discord</a>

--- a/client/terms.html
+++ b/client/terms.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <!--
-  DRAFT — Terms of Service starter for Chao Chao. NOT legal advice; have it reviewed
-  before publishing. Fill every [BRACKETED] placeholder. Served statically at
-  /terms.html (Discord Discovery requires a public Terms of Service URL).
+  Terms of Service for Chao Chao. Served statically at /terms.html and used as the public
+  Terms of Service URL for Discord Activity Discovery. Bump the "Last updated" date on any
+  material change.
 -->
 <html lang="en">
 <head>
@@ -29,7 +29,7 @@
 <body>
 <div class="wrap">
     <h1>Terms of Service</h1>
-    <p class="meta">Chao Chao · Last updated: <strong>June 21, 2026</strong></p>
+    <p class="meta">Chao Chao · Last updated: <strong>June 23, 2026</strong></p>
 
     <p>These Terms of Service ("Terms") are a binding agreement between you and
     <strong>Steven Dodge</strong> ("we", "us") and govern your use of the
@@ -131,7 +131,15 @@
     regard to its conflict-of-laws rules. Disputes will be resolved in the state or federal
     courts located in <strong>Georgia, USA</strong>, unless your local law requires otherwise.</p>
 
-    <h2>15. Contact</h2>
+    <h2>15. General</h2>
+    <p>If any provision of these Terms is held unenforceable, the remaining provisions stay in full
+    effect. Our failure to enforce a provision is not a waiver of it. You may not assign these Terms
+    without our consent; we may assign them in connection with a transfer or reorganization of the
+    Game. These Terms, together with the <a href="/privacy.html">Privacy Policy</a>, are the entire
+    agreement between you and us regarding the Game and supersede any prior agreements on that
+    subject.</p>
+
+    <h2>16. Contact</h2>
     <p>Steven Dodge · <a href="mailto:sjdodge@outlook.com">sjdodge@outlook.com</a></p>
 
     <footer>


### PR DESCRIPTION
Editorial pass on the public **Privacy Policy** + **Terms of Service** pages ahead of Discord Activity Discovery. No code/mechanic changes — static pages served at `/privacy.html` and `/terms.html`.

**Privacy**
- Removed the internal DRAFT header comment (no placeholders remain)
- Added California "do not sell/share" clarity to the sharing section
- Fixed an awkward guest-rights line
- Fixed a pre-existing malformed `.note` block (closed with `</p>` instead of `</div>`)
- Bumped "Last updated" to June 23, 2026

**Terms**
- Removed the DRAFT header comment
- Added a standard **General** section (severability, no-waiver, assignment, entire agreement)
- Bumped "Last updated" to June 23, 2026

⚠️ **Labeled `deploy:prod`** — this is a sensitive PR, so `merge-gate` stays red until @sjdodge123 approves on the head SHA; on approval + merge it deploys straight to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)